### PR TITLE
fix(orchestrator): enforce in code what lived in YAML and prose

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -5,6 +5,7 @@ concurrency:
   # Per repo, not global. The ceiling isn't tooling, it's dependency structure:
   # when ticket B needs A's output you cannot parallelize it, and that's most
   # real work. 3-5 genuinely independent streams is realistic.
+  # This is the FALLBACK; a repo's own max_in_flight in repos.yaml wins.
   max_in_flight_per_repo: 3
   # Merging is never parallel. Two PRs landing in one base within seconds
   # produce a base-CI failure that belongs to neither.
@@ -27,7 +28,9 @@ budget:
   # --args): they bound how much of a window one tick can consume.
   per_ticket_usd: 15.00     # generous — a triage run that explores a codebase
                             # legitimately passes $5 notional
-  per_day_usd: 200.00       # advisory only; nothing enforces it across runs yet
+  per_day_usd: 200.00       # enforced by tick.mjs: today's logs are summed on
+                            # every refill; at the cap it drains — running
+                            # tickets finish, nothing new starts
   on_exhausted: drain
 
 limits:
@@ -44,7 +47,8 @@ limits:
 circuit_breaker:
   # Two consecutive environment/build failures (not ticket-specific ones) stop
   # dispatch. A broken worktree template otherwise converts the whole queue into
-  # Blocked in minutes.
+  # Blocked in minutes. Enforced by tick.mjs (worktree-up failures trip it);
+  # factory-work.md carries the same rule for interactive runs.
   consecutive_env_failures: 2
 
 escalation:

--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -55,6 +55,14 @@ for i in $(seq 60); do curl -sf localhost:4222 >/dev/null && break; sleep 2; don
 
 Measured on real runs: single `sleep 180` and `sleep 75` calls, plus a `sleep 60` after starting a dev server that was ready in a fraction of that. Each one is a per-ticket process sitting idle while holding a concurrency slot.
 
+### Shell globs
+
+Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.ts`. zsh expands the unquoted form against the current directory and **errors** when nothing matches there, killing the command before grep runs. Seen repeatedly in real transcripts.
+
+### Linear labels
+
+`type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y`. Nothing else resolves — `type:chore` fails the mutation. `area:*` values are per-team; check an existing ticket in the same project rather than inventing one.
+
 ### Secrets
 
 Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a Linear comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.

--- a/dist/codex/prompts/factory-merge.md
+++ b/dist/codex/prompts/factory-merge.md
@@ -28,6 +28,8 @@ Then check CI with `gh pr checks <PR> --watch --fail-fast` — it returns the mo
 - **FIX** — CI red, merge conflicts, or blocking review findings that are mechanical to fix (a real bug, missing error handling, a failing test).
 - **ESCALATE** — never auto-merge, regardless of CI or review outcome: diffs touching auth/authz, payments/money, credentials/secrets handling, destructive DB migrations, prod infra config, or anything in a `CLNT` repo touching security. Also escalate when the fix would require changing the ticket's intent. Report these to me with the findings, **notify me** rather than only writing it in the final report, and stop there.
 
+  Where the factory checkout is available (`~/Develop/factory`), run the mechanical half first: `bun ~/Develop/factory/orchestrator/escalate.mjs --repo <name> --pr <PR>` checks the diff against the repo's `escalate_paths` in `config/repos.yaml`. Exit 2 means ESCALATE, no judgment call needed. Exit 0 clears only the path list — the behavior-based judgment below still applies. If the script isn't available, apply the repo's `escalate_paths` from `config/repos.yaml` by hand against the changed-file list.
+
   The test for "touching" is whether the diff **changes security-relevant behavior**, not whether the file sits near security code — read literally as file-adjacency the list swallows most PRs in an app where auth is everywhere, which trains both of us to rubber-stamp. For grey-zone diffs (near those surfaces but apparently behavior-neutral), run `/security-review` on the branch and attach the output; clean output plus green CI supports merging a behavior-neutral diff, but no tool output ever overrides the list. Genuinely ambiguous → escalate; that costs one message, a wrong merge costs a client incident.
 
 ### 3. Fix loop (for FIX)
@@ -40,7 +42,7 @@ Match the repo's existing merge style from `git log` (this workflow's repos gene
 
 **Merge one PR at a time.** Two merges landing in the same base within seconds produce a base-CI failure that belongs to neither PR and costs more to untangle than the parallelism saved.
 
-After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`, delete the remote branch, and remove the local worktree for that ticket (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too).
+After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown (`git push origin --delete <branch>`, `git branch -D <branch>`).
 
 If base CI or the smoke check breaks after a merge, stop merging further PRs immediately, notify me, and fix or revert first. On an auto-deploying branch a red smoke check means the environment is down right now, not that a test is flaky.
 

--- a/dist/cursor/commands/factory-merge.md
+++ b/dist/cursor/commands/factory-merge.md
@@ -24,6 +24,8 @@ Then check CI with `gh pr checks <PR> --watch --fail-fast` — it returns the mo
 - **FIX** — CI red, merge conflicts, or blocking review findings that are mechanical to fix (a real bug, missing error handling, a failing test).
 - **ESCALATE** — never auto-merge, regardless of CI or review outcome: diffs touching auth/authz, payments/money, credentials/secrets handling, destructive DB migrations, prod infra config, or anything in a `CLNT` repo touching security. Also escalate when the fix would require changing the ticket's intent. Report these to me with the findings, **notify me** rather than only writing it in the final report, and stop there.
 
+  Where the factory checkout is available (`~/Develop/factory`), run the mechanical half first: `bun ~/Develop/factory/orchestrator/escalate.mjs --repo <name> --pr <PR>` checks the diff against the repo's `escalate_paths` in `config/repos.yaml`. Exit 2 means ESCALATE, no judgment call needed. Exit 0 clears only the path list — the behavior-based judgment below still applies. If the script isn't available, apply the repo's `escalate_paths` from `config/repos.yaml` by hand against the changed-file list.
+
   The test for "touching" is whether the diff **changes security-relevant behavior**, not whether the file sits near security code — read literally as file-adjacency the list swallows most PRs in an app where auth is everywhere, which trains both of us to rubber-stamp. For grey-zone diffs (near those surfaces but apparently behavior-neutral), run `/security-review` on the branch and attach the output; clean output plus green CI supports merging a behavior-neutral diff, but no tool output ever overrides the list. Genuinely ambiguous → escalate; that costs one message, a wrong merge costs a client incident.
 
 ### 3. Fix loop (for FIX)
@@ -36,7 +38,7 @@ Match the repo's existing merge style from `git log` (this workflow's repos gene
 
 **Merge one PR at a time.** Two merges landing in the same base within seconds produce a base-CI failure that belongs to neither PR and costs more to untangle than the parallelism saved.
 
-After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`, delete the remote branch, and remove the local worktree for that ticket (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too).
+After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown (`git push origin --delete <branch>`, `git branch -D <branch>`).
 
 If base CI or the smoke check breaks after a merge, stop merging further PRs immediately, notify me, and fix or revert first. On an auto-deploying branch a red smoke check means the environment is down right now, not that a test is flaky.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ The plugin is a convenience layer, not the safety floor. It reaches Claude Code 
 
 | Failure | Why it is tolerated | Mitigation |
 | :--- | :--- | :--- |
-| Crashed agent holds a ticket | Reaper is not on a timer (§2.7) | Run it by hand; re-enable when runs are unattended |
+| Crashed agent holds a ticket | Reaper is not on a timer (§2.7) | `tick.mjs` un-claims its own failed runs (back to Todo, with a comment); the reaper covers crashes tick can't see — run it by hand |
 | Agents indistinguishable from the human in Linear | Shared API key | OPS-40 — the dispatcher is the natural place to inject per-agent keys |
 | Orphaned worktrees | Merge stage sometimes skipped | `janitor.mjs`, hourly gate |
 | Stale spec against moved code | Runner fetches but never pulls — the main checkout holds uncommitted human work | Warns with commits-behind; rebasing under someone is worse |

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -18,37 +18,6 @@ Prefer removing the need over documenting the workaround. An env var or a script
 
 ## Open
 
-### F-1 · zsh glob-expands unquoted `--include=*.ts`
-
-**Seen:** 2 occurrences, `bj29-factory-work-20260803-230342`
-**Symptom:** `(eval):1: no matches found: --include=*.ts` — the agent's `grep -rn "..." app/src --include=*.ts` dies before grep runs.
-
-zsh expands `*.ts` against the *current directory* and errors when nothing matches, unlike bash which passes the literal through. Every agent doing a scoped grep hits it.
-
-**Fix options, in order of preference:**
-1. Set `NO_NOMATCH` for agent shells so unmatched globs pass through literally (removes the need entirely).
-2. Or a line in `shared/floor.md`: quote glob arguments — `--include='*.ts'`.
-
-Option 1 is preferred because it cannot be forgotten. Option 2 is a rule; rules decay.
-
-### F-2 · `gh pr merge --delete-branch` fails while the worktree exists
-
-**Seen:** 1 occurrence — recorded early because the cause is structural, not incidental.
-**Symptom:** `failed to delete local branch fix/CLNT-611-blog-banner-image: cannot delete branch ... checked out at <worktree>`
-
-Git refuses to delete a branch that is checked out in a worktree. The merge stage deletes the branch before tearing the worktree down, so it will fail every single time a ticket is merged from a worktree.
-
-**Fix:** merge stage should run `worktree-down.sh <TICKET>` *before* `--delete-branch`, or drop `--delete-branch` and let the janitor handle both. Belongs in `shared/commands/factory-merge.md`.
-
-### F-3 · Non-canonical Linear labels are attempted
-
-**Seen:** 1 occurrence (`type:chore`)
-**Symptom:** `Could not resolve label(s): "type:chore"`
-
-`type:*` has eight canonical values (`bug feature ui-ux security performance maintenance docs a11y`) and `chore` is not one of them. The agent had no list in front of it.
-
-**Fix:** put the canonical `type:*` and `area:*` values in `shared/floor.md`, where every harness sees them, rather than only in `linear.md` which an agent may not have loaded.
-
 ### F-8 · Agents `sleep` to wait for CI instead of watching it
 
 **Seen:** `sleep 150; gh pr checks 166`, `sleep 180; echo done`, `sleep 60; echo done` across multiple runs.
@@ -78,6 +47,18 @@ Raising `--print-timeout` alone would trade a short hang for a long one: a wedge
 ---
 
 ## Fixed
+
+### F-1 · zsh glob-expands unquoted `--include=*.ts` — `fixed` (OPS-41)
+
+`(eval):1: no matches found: --include=*.ts` — zsh expands `*.ts` against the current directory and errors when nothing matches, killing the command before grep runs. Fixed as a floor rule (§Shell globs): quote glob arguments. The preferred fix — `NO_NOMATCH` for agent shells — isn't reachable from the runner: it's a zsh `setopt`, not an environment variable, and the harness's Bash tool starts shells from the user's own profile. If unquoted globs persist in transcripts, the next step is setting it in `~/.zshenv`.
+
+### F-2 · `gh pr merge --delete-branch` fails while the worktree exists — `fixed` (OPS-41)
+
+Git refuses to delete a branch checked out in a worktree, so the flag failed on every worktree-based merge. `factory-merge.md` now orders cleanup explicitly: worktree-down first, then delete the branch, and says not to use `--delete-branch`.
+
+### F-3 · Non-canonical Linear labels are attempted — `fixed` (OPS-41)
+
+`Could not resolve label(s): "type:chore"`. The eight canonical `type:*` values are now in `shared/floor.md` (§Linear labels), where every harness sees them.
 
 ### F-4 · Stale warm cache made every worktree pay a full compile — `fixed`
 

--- a/orchestrator/escalate.mjs
+++ b/orchestrator/escalate.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Mechanical escalation check: does a PR touch this repo's `escalate_paths`?
+ *
+ *   bun orchestrator/escalate.mjs --repo bj29 --pr 123
+ *
+ * Exit 0  — no escalate path touched; the merge stage's normal judgment applies
+ * Exit 2  — a listed surface is in the diff; NEVER auto-merge, hand to a human
+ * Exit 1+ — couldn't answer (gh failed, unknown repo); treat as escalate
+ *
+ * This turns the `escalate_paths` lists in config/repos.yaml from documentation
+ * into a gate. It is deliberately one-directional: a match here forces
+ * escalation, but a clean exit never overrides the global judgment list in
+ * policy.yaml (auth, payments, secrets…) — path matching can't see whether a
+ * diff CHANGES security-relevant behavior, only where it lives.
+ */
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import path from "node:path";
+import { globsOverlap } from "./owned-paths.mjs";
+import { ROOT } from "../lib/schedule.mjs";
+
+/** Which changed files hit which escalate globs? Pure, for tests. */
+export function matchEscalations(files, globs) {
+  const hits = [];
+  for (const f of files) {
+    const matched = globs.filter((g) => globsOverlap(f, g));
+    if (matched.length) hits.push({ file: f, globs: matched });
+  }
+  return hits;
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+
+  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
+  const pr = val("--pr");
+  if (!repo || !pr) { console.error(`usage: bun orchestrator/escalate.mjs --repo <name> --pr <number>`); process.exit(3); }
+
+  const globs = repo.escalate_paths ?? [];
+  if (!globs.length) { console.log(`${repo.name}: no escalate_paths configured — nothing to check mechanically`); process.exit(0); }
+
+  const repoPath = String(repo.path).replace(/^~/, homedir());
+  const diff = spawnSync("gh", ["pr", "diff", pr, "--name-only"], { cwd: repoPath, encoding: "utf8" });
+  if (diff.status !== 0) {
+    console.error(`gh pr diff failed: ${(diff.stderr || "").trim()}`);
+    console.error(`cannot see the diff => treat as ESCALATE, not as clean`);
+    process.exit(3);
+  }
+
+  const files = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  const hits = matchEscalations(files, globs);
+  if (hits.length) {
+    console.log(`ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`);
+    for (const h of hits) console.log(`  ${h.file}  (${h.globs.join(", ")})`);
+    process.exit(2);
+  }
+  console.log(`PR #${pr}: none of ${files.length} changed file(s) hit escalate_paths — mechanical check clean (judgment list still applies)`);
+  process.exit(0);
+}

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { matchEscalations } from "./escalate.mjs";
+
+const globs = ["app/src/payment/**", "app/src/auth/**", "app/migrations/**"];
+
+test("flags a file under an escalate glob", () => {
+  const hits = matchEscalations(["app/src/payment/stripe.ts"], globs);
+  expect(hits.length).toBe(1);
+  expect(hits[0].globs).toEqual(["app/src/payment/**"]);
+});
+
+test("clean diff passes", () => {
+  expect(matchEscalations(["app/src/pages/Home.tsx", "README.md"], globs)).toEqual([]);
+});
+
+test("a single protected file among many still escalates", () => {
+  const hits = matchEscalations(
+    ["docs/notes.md", "app/migrations/0042_add_index.sql", "app/src/ui/Button.tsx"],
+    globs,
+  );
+  expect(hits.map((h) => h.file)).toEqual(["app/migrations/0042_add_index.sql"]);
+});
+
+test("settings glob with wildcard filename matches", () => {
+  const hits = matchEscalations(
+    ["legalease/legalease/settings_prod.py"],
+    ["legalease/legalease/settings*.py"],
+  );
+  expect(hits.length).toBe(1);
+});
+
+test("empty glob list never escalates", () => {
+  expect(matchEscalations(["anything.ts"], [])).toEqual([]);
+});

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -31,6 +31,8 @@ const GATE = val("--gate");
 const JSON_OUT = argv.includes("--json");
 
 const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
+const defaultCap = policy?.concurrency?.max_in_flight_per_repo ?? 3;
 const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
 
 if (!repos.length) {
@@ -95,7 +97,7 @@ for (const repo of repos) {
   // already running. Sorted the way §7 sorts: priority asc, then created asc.
   const inFlightPaths = inProgress.flatMap((i) => parseOwnedPaths(i.description ?? ""));
   const sorted = [...ready].sort((a, b) => (a.priority || 99) - (b.priority || 99));
-  const slotsFree = Math.max(0, (repo.max_in_flight ?? 3) - inProgress.length);
+  const slotsFree = Math.max(0, (repo.max_in_flight ?? defaultCap) - inProgress.length);
   const free = [];
   const busyPaths = [...inFlightPaths];
   for (const t of sorted) {
@@ -110,6 +112,10 @@ for (const repo of repos) {
   summary.push({
     repo: repo.name,
     triage: triage.length + notReady.length,
+    // Triage-state only. The stage processes Triage tickets; gating on the
+    // combined count kept the gate open for Todo-without-agent-ready tickets
+    // the stage never touches, spawning a no-op agent every tick.
+    triageState: triage.length,
     ready: ready.length,
     inProgress: inProgress.length,
     inReview: inReview.length,
@@ -149,8 +155,9 @@ if (GATE) {
   // Exit 0 = there is work for this stage, so the supervisor should run it.
   // Exit 1 = idle, skip. Anything else is a real error and stops the loop.
   const has = {
-    // Only spawn a triage agent when something is actually unspecified.
-    triage: (s) => s.triage > 0,
+    // Only spawn a triage agent when a Triage-STATE ticket is waiting — the
+    // stage never touches Todo tickets, ready or not.
+    triage: (s) => s.triageState > 0,
     // Don't dispatch with no free slot or nothing startable — an agent that
     // wakes to find the cap full has burned a run to learn nothing.
     dispatch: (s) => s.slotsFree > 0 && s.startable.length > 0,

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -37,6 +37,7 @@ const ONE = val("--ticket");
 
 const expand = (p) => String(p ?? "").replace(/^~/, homedir());
 const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
 const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
 if (!repo) { console.error(`--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`); process.exit(2); }
 if (repo.report_only) { console.error(`${repo.name} is report_only — no worktree tooling, dispatch is unsafe here`); process.exit(2); }
@@ -48,7 +49,13 @@ const c = {
 };
 const clock = () => new Date().toTimeString().slice(0, 8);
 const repoPath = expand(repo.path);
-const cap = repo.max_in_flight ?? 3;
+const cap = repo.max_in_flight ?? policy?.concurrency?.max_in_flight_per_repo ?? 3;
+
+// Same probe as run-agent.sh: the wall-clock cap is a safety feature, and a
+// safety feature that crashes every spawn on a machine without coreutils is
+// worse than saying plainly that the cap is off.
+const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
+if (!TIMEOUT_BIN) console.log(c.yellow("  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped"));
 
 const Q = `query($t:String!,$p:String!){ issues(first:250, filter:{
     team:{key:{eq:$t}}, project:{name:{eq:$p}},
@@ -108,6 +115,7 @@ if (!APPLY) {
 const me = (await gql(`query{ viewer{ id name } }`))?.viewer;
 const states = (await gql(`query($t:String!){ team(id:$t){ states(first:50){ nodes{ id name } } } }`, { t: repo.team }))?.team?.states?.nodes ?? [];
 const inProgressId = states.find((s) => s.name.toLowerCase() === "in progress")?.id;
+const todoId = states.find((s) => s.name.toLowerCase() === "todo")?.id;
 const allLabels = (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))?.issueLabels?.nodes ?? [];
 const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
 if (!inProgressId) { console.error("no 'In Progress' state on team " + repo.team); process.exit(1); }
@@ -120,6 +128,33 @@ async function claim(t) {
   // Linear has no compare-and-swap; this read-back IS the concurrency control.
   const back = (await gql(`query($id:String!){ issue(id:$id){ assignee{id} } }`, { id: t.id }))?.issue;
   return back?.assignee?.id === me.id;
+}
+
+/**
+ * A failed run must not keep its claim. With the reaper off a timer, a ticket
+ * left In Progress after its process died consumes a cap slot until a human
+ * notices — three failures and dispatch throughput is silently zero.
+ *
+ * Only rolls back tickets that still look like OUR claim (In Progress, assigned
+ * to us, ai:in-progress present). An agent that legitimately moved its ticket —
+ * to Blocked with a question, or to In Review with a PR — keeps that state.
+ */
+async function unclaim(t, why, log) {
+  const cur = (await gql(
+    `query($id:String!){ issue(id:$id){ state{name} assignee{id} labels(first:20){nodes{id name}} } }`,
+    { id: t.id }))?.issue;
+  if (!cur || cur.state?.name !== "In Progress" || cur.assignee?.id !== me.id) return false;
+  if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
+
+  const keep = (cur.labels?.nodes ?? [])
+    .filter((l) => l.name !== "ai:in-progress" && !l.name.startsWith("agent:"))
+    .map((l) => l.id);
+  await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+    { id: t.id, in: { stateId: todoId ?? undefined, assigneeId: null, labelIds: keep } });
+  await gql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+    { in: { issueId: t.id, body: `Dispatch run failed, claim released back to Todo.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}` } });
+  console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} ${c.yellow("un-claimed")} ${c.dim(`— ${why}`)}`);
+  return true;
 }
 
 // ------------------------------------------------------------------ warm ----
@@ -149,28 +184,41 @@ mkdirSync(LOG_DIR, { recursive: true });
 const stamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 15);
 const results = [];
 
-function runTicket(t) {
+// CIRCUIT BREAKER (policy.circuit_breaker). Environment failures — the
+// worktree template refusing to build — are not ticket-specific: left running,
+// a broken template converts the whole queue into failed claims in minutes.
+const ENV_FAIL_LIMIT = policy?.circuit_breaker?.consecutive_env_failures ?? 2;
+let envFailures = 0;
+let tripped = false;
+
+async function runTicket(t) {
   const up = spawnSync("/bin/bash", [repo.worktree_up, t.identifier], { cwd: repoPath, encoding: "utf8" });
   if (up.status !== 0) {
     const why = (up.stderr || up.stdout || "").trim().split("\n").pop();
     console.log(c.red(`  ${t.identifier} worktree-up failed: ${why}`));
     results.push({ id: t.identifier, ok: false, why: "worktree-up failed" });
-    return Promise.resolve();
+    await unclaim(t, `worktree-up failed: ${why}`);
+    if (++envFailures >= ENV_FAIL_LIMIT && !tripped) {
+      tripped = true;
+      console.log(c.red(`\n  CIRCUIT BREAKER: ${envFailures} consecutive environment failures — no further tickets will be claimed this run. Fix the worktree template first.\n`));
+    }
+    return;
   }
+  envFailures = 0;
   const wt = path.join(expand(repo.worktree_root), t.identifier);
   console.log(`${c.dim(clock())} ${c.cyan(t.identifier)} worktree ready ${c.dim(wt)}`);
 
   const log = path.join(LOG_DIR, `${repo.name}-${t.identifier}-${stamp}.jsonl`);
   const out = createWriteStream(log);
-  const budget = String(cfg.budget?.per_ticket_usd ?? 15);
+  const budget = String(cfg.budget?.per_ticket_usd ?? policy?.budget?.per_ticket_usd ?? 15);
   // Same hard cap as run-agent.sh: a wedged ticket must not hold its slot
   // forever. TERM at the limit, KILL 30s later.
-  const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
   const maxMin = policy?.limits?.max_run_minutes ?? 45;
+  const capPrefix = TIMEOUT_BIN ? `${TIMEOUT_BIN} -k 30s ${maxMin}m ` : "";
 
-  return new Promise((resolve) => {
+  await new Promise((resolve) => {
     const child = spawn("/bin/bash", ["-lc",
-      `timeout -k 30s ${maxMin}m env -u ANTHROPIC_API_KEY -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude -p ` +
+      `${capPrefix}env -u ANTHROPIC_API_KEY -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude -p ` +
       `"/factory-ticket ${t.identifier}" --output-format stream-json --verbose ` +
       `--max-budget-usd ${budget} --fallback-model sonnet`],
       { cwd: wt, stdio: ["ignore", "pipe", "pipe"] });
@@ -192,7 +240,7 @@ function runTicket(t) {
       if (e.type === "result" || "num_turns" in e) {
         const ok = e.subtype === "success" && !e.is_error && (e.num_turns ?? 0) > 0;
         console.log(`${c.dim(clock())} ${tag} ${ok ? c.green("done") : c.red("FAILED")} ${c.dim(`${e.num_turns ?? 0} turns ~$${(e.total_cost_usd ?? 0).toFixed(2)}`)}`);
-        results.push({ id: t.identifier, ok, log });
+        results.push({ id: t.identifier, ok, log, why: ok ? undefined : `run ended ${e.subtype ?? "?"}${e.is_error ? " (error)" : ""}` });
         recorded = true;
       }
     };
@@ -204,7 +252,7 @@ function runTicket(t) {
       for (const line of lines) processLine(line);
     });
     child.stderr.on("data", (d) => out.write(d));
-    child.on("close", (code) => {
+    child.on("close", async (code) => {
       // The final "result" line isn't guaranteed a trailing newline, so
       // whatever is still in `buf` when the process exits needs a look too —
       // otherwise a clean exit with no trailing "\n" silently reports nothing.
@@ -218,6 +266,10 @@ function runTicket(t) {
         results.push({ id: t.identifier, ok: false, log, why: `no result emitted (exit ${code})` });
       }
       out.end();
+      // A failed run must not keep its claim (unclaim() checks the ticket
+      // still looks like ours — Blocked/In Review moves are left alone).
+      const r = results.findLast((x) => x.id === t.identifier);
+      if (r && !r.ok) await unclaim(t, r.why ?? "run failed", log).catch(() => {});
       resolve();
     });
   });
@@ -226,13 +278,54 @@ function runTicket(t) {
 // --------------------------------------------------------- rolling loop -----
 const running = new Map();   // identifier -> promise
 const seen = new Set();      // everything we have claimed this run
+const warned = new Set();    // skip-warnings already printed, so refills don't repeat them
 let startedCount = 0;
+let drained = false;
+
+/**
+ * budget.per_day_usd, enforced (it used to say "advisory only"). Sums
+ * total_cost_usd across today's run logs — notional units on subscription
+ * auth, so this is a runaway guard, not a wallet. `on_exhausted: drain`:
+ * running tickets finish, nothing new starts.
+ */
+function todaysSpendUSD() {
+  const today = new Date().toISOString().slice(0, 10);
+  let sum = 0;
+  for (const f of new Bun.Glob("*.jsonl").scanSync(LOG_DIR)) {
+    const full = path.join(LOG_DIR, f);
+    if (new Date(Bun.file(full).lastModified).toISOString().slice(0, 10) !== today) continue;
+    for (const line of readFileSync(full, "utf8").split("\n")) {
+      if (!line.includes('"total_cost_usd"')) continue;
+      try { sum += JSON.parse(line).total_cost_usd ?? 0; } catch {}
+    }
+  }
+  return sum;
+}
 
 async function fill() {
-  if (startedCount >= MAX) return;
+  if (startedCount >= MAX || tripped) return;
+  const perDay = policy?.budget?.per_day_usd;
+  if (perDay) {
+    const spent = todaysSpendUSD();
+    if (spent >= perDay) {
+      if (!drained) console.log(c.yellow(`\n  day budget reached (~$${spent.toFixed(2)} of $${perDay} notional) — draining: running tickets finish, nothing new starts.\n`));
+      drained = true;
+      return;
+    }
+  }
   const state = await fetchState();
   const free = Math.min(cap - state.inProgress.length, MAX - startedCount);
   if (free <= 0) return;
+
+  // Same warning the dry run prints — without it, "READY is high but nothing
+  // starts" is invisible in exactly the mode that matters (see F-7).
+  for (const t of state.ready) {
+    if (warned.has(t.identifier) || seen.has(t.identifier)) continue;
+    if (!parseOwnedPaths(t.description ?? "").length) {
+      warned.add(t.identifier);
+      console.log(c.yellow(`  skip ${t.identifier} — no parseable Owned Paths`));
+    }
+  }
 
   const picked = selectable(state, seen, free);
   if (!picked.length) return;
@@ -270,5 +363,6 @@ while (running.size) {
 console.log(c.bold("\nsummary"));
 for (const r of results) console.log(`  ${r.ok ? c.green("ok  ") : c.red("FAIL")} ${r.id}${r.log ? c.dim("  " + r.log.replace(homedir(), "~")) : ""}${r.why ? c.dim("  " + r.why) : ""}`);
 const failed = results.filter((r) => !r.ok).length;
+if (tripped) console.log(c.red(`circuit breaker tripped — dispatch stopped after ${envFailures} consecutive environment failures.`));
 console.log(c.dim(`\n${results.length - failed} ok, ${failed} failed, ${startedCount} started. Merging is a separate stage.\n`));
-process.exit(failed ? 1 : 0);
+process.exit(failed || tripped ? 1 : 0);

--- a/plugins/core/commands/factory-merge.md
+++ b/plugins/core/commands/factory-merge.md
@@ -30,6 +30,8 @@ Then check CI with `gh pr checks <PR> --watch --fail-fast` — it returns the mo
 - **FIX** — CI red, merge conflicts, or blocking review findings that are mechanical to fix (a real bug, missing error handling, a failing test).
 - **ESCALATE** — never auto-merge, regardless of CI or review outcome: diffs touching auth/authz, payments/money, credentials/secrets handling, destructive DB migrations, prod infra config, or anything in a `CLNT` repo touching security. Also escalate when the fix would require changing the ticket's intent. Report these to me with the findings, **notify me** rather than only writing it in the final report, and stop there.
 
+  Where the factory checkout is available (`~/Develop/factory`), run the mechanical half first: `bun ~/Develop/factory/orchestrator/escalate.mjs --repo <name> --pr <PR>` checks the diff against the repo's `escalate_paths` in `config/repos.yaml`. Exit 2 means ESCALATE, no judgment call needed. Exit 0 clears only the path list — the behavior-based judgment below still applies. If the script isn't available, apply the repo's `escalate_paths` from `config/repos.yaml` by hand against the changed-file list.
+
   The test for "touching" is whether the diff **changes security-relevant behavior**, not whether the file sits near security code — read literally as file-adjacency the list swallows most PRs in an app where auth is everywhere, which trains both of us to rubber-stamp. For grey-zone diffs (near those surfaces but apparently behavior-neutral), run `/security-review` on the branch and attach the output; clean output plus green CI supports merging a behavior-neutral diff, but no tool output ever overrides the list. Genuinely ambiguous → escalate; that costs one message, a wrong merge costs a client incident.
 
 ### 3. Fix loop (for FIX)
@@ -42,7 +44,7 @@ Match the repo's existing merge style from `git log` (this workflow's repos gene
 
 **Merge one PR at a time.** Two merges landing in the same base within seconds produce a base-CI failure that belongs to neither PR and costs more to untangle than the parallelism saved.
 
-After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`, delete the remote branch, and remove the local worktree for that ticket (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too).
+After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown (`git push origin --delete <branch>`, `git branch -D <branch>`).
 
 If base CI or the smoke check breaks after a merge, stop merging further PRs immediately, notify me, and fix or revert first. On an auto-deploying branch a red smoke check means the environment is down right now, not that a test is flaky.
 

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -44,15 +44,17 @@ case "$REPO" in
     for r in ${REPO//,/ }; do
       echo
       echo "=============================== $r ==============================="
-      sub="$0 --repo $r --command $COMMAND"
-      [[ -n "$BUDGET"     ]] && sub="$sub --budget $BUDGET"
-      [[ -n "$ARGS"       ]] && sub="$sub --args \"$ARGS\""
-      [[ "$DRY"      == 1 ]] && sub="$sub --dry"
-      [[ "$READONLY" == 1 ]] && sub="$sub --read-only"
-      [[ "$USE_API"  == 1 ]] && sub="$sub --use-api"
-      [[ -n "$MODEL"      ]] && sub="$sub --model $MODEL"
-      [[ "$HARNESS" != "claude" ]] && sub="$sub --harness $HARNESS"
-      eval "$sub" || rc=$?
+      # Rebuild argv with `set --` (bash 3.2 has no arrays under set -u) rather
+      # than eval on a string — an --args value containing a quote must survive.
+      set -- --repo "$r" --command "$COMMAND"
+      [[ -n "$BUDGET"     ]] && set -- "$@" --budget "$BUDGET"
+      [[ -n "$ARGS"       ]] && set -- "$@" --args "$ARGS"
+      [[ "$DRY"      == 1 ]] && set -- "$@" --dry
+      [[ "$READONLY" == 1 ]] && set -- "$@" --read-only
+      [[ "$USE_API"  == 1 ]] && set -- "$@" --use-api
+      [[ -n "$MODEL"      ]] && set -- "$@" --model "$MODEL"
+      [[ "$HARNESS" != "claude" ]] && set -- "$@" --harness "$HARNESS"
+      "$0" "$@" || rc=$?
     done
     exit $rc
     ;;

--- a/shared/commands/factory-merge.md
+++ b/shared/commands/factory-merge.md
@@ -30,6 +30,8 @@ Then check CI with `gh pr checks <PR> --watch --fail-fast` — it returns the mo
 - **FIX** — CI red, merge conflicts, or blocking review findings that are mechanical to fix (a real bug, missing error handling, a failing test).
 - **ESCALATE** — never auto-merge, regardless of CI or review outcome: diffs touching auth/authz, payments/money, credentials/secrets handling, destructive DB migrations, prod infra config, or anything in a `CLNT` repo touching security. Also escalate when the fix would require changing the ticket's intent. Report these to me with the findings, **notify me** rather than only writing it in the final report, and stop there.
 
+  Where the factory checkout is available (`~/Develop/factory`), run the mechanical half first: `bun ~/Develop/factory/orchestrator/escalate.mjs --repo <name> --pr <PR>` checks the diff against the repo's `escalate_paths` in `config/repos.yaml`. Exit 2 means ESCALATE, no judgment call needed. Exit 0 clears only the path list — the behavior-based judgment below still applies. If the script isn't available, apply the repo's `escalate_paths` from `config/repos.yaml` by hand against the changed-file list.
+
   The test for "touching" is whether the diff **changes security-relevant behavior**, not whether the file sits near security code — read literally as file-adjacency the list swallows most PRs in an app where auth is everywhere, which trains both of us to rubber-stamp. For grey-zone diffs (near those surfaces but apparently behavior-neutral), run `/security-review` on the branch and attach the output; clean output plus green CI supports merging a behavior-neutral diff, but no tool output ever overrides the list. Genuinely ambiguous → escalate; that costs one message, a wrong merge costs a client incident.
 
 ### 3. Fix loop (for FIX)
@@ -42,7 +44,7 @@ Match the repo's existing merge style from `git log` (this workflow's repos gene
 
 **Merge one PR at a time.** Two merges landing in the same base within seconds produce a base-CI failure that belongs to neither PR and costs more to untangle than the parallelism saved.
 
-After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`, delete the remote branch, and remove the local worktree for that ticket (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too).
+After each merge: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown (`git push origin --delete <branch>`, `git branch -D <branch>`).
 
 If base CI or the smoke check breaks after a merge, stop merging further PRs immediately, notify me, and fix or revert first. On an auto-deploying branch a red smoke check means the environment is down right now, not that a test is flaky.
 

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -55,6 +55,14 @@ for i in $(seq 60); do curl -sf localhost:4222 >/dev/null && break; sleep 2; don
 
 Measured on real runs: single `sleep 180` and `sleep 75` calls, plus a `sleep 60` after starting a dev server that was ready in a fraction of that. Each one is a per-ticket process sitting idle while holding a concurrency slot.
 
+### Shell globs
+
+Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.ts`. zsh expands the unquoted form against the current directory and **errors** when nothing matches there, killing the command before grep runs. Seen repeatedly in real transcripts.
+
+### Linear labels
+
+`type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y`. Nothing else resolves — `type:chore` fails the mutation. `area:*` values are per-team; check an existing ticket in the same project rather than inventing one.
+
 ### Secrets
 
 Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a Linear comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.


### PR DESCRIPTION
Fixes OPS-41

Review of the factory found safety properties declared in `policy.yaml`/prose but enforced nowhere, plus three friction-log fixes never applied.

## Dispatcher (`tick.mjs`, `queue.mjs`)
- **Un-claim on failure** — a failed run returns its ticket to Todo (unassigned, `ai:in-progress` dropped, failure comment + log path). Previously a dead ticket held a cap slot until the reaper (not on a timer) or a human noticed. Rollback only fires when the ticket still looks like our claim — Blocked/In Review moves by the agent are left alone.
- **Circuit breaker** — `policy.circuit_breaker.consecutive_env_failures` is now read: consecutive worktree-up failures stop claiming, exit non-zero.
- **Day budget enforced** — `budget.per_day_usd` (was "advisory only"): today's `total_cost_usd` summed from `~/.factory/logs` on each refill; at the cap the run drains.
- **Triage gate** fires on Triage-state tickets only; it previously counted Todo-without-`ai:agent-ready` and would spawn a no-op agent every 5 minutes forever.
- **Apply-mode skip visibility** — "no parseable Owned Paths" now prints in apply mode too (dry-only before; F-7's blind spot).
- `timeout`/`gtimeout` probed instead of assumed; `max_in_flight_per_repo` is the real fallback cap; per-ticket budget read from policy.yaml (the old read targeted repos.yaml, which has no budget key — silent 15 default).

## Mechanical escalation
New `orchestrator/escalate.mjs --repo X --pr N`: PR changed-files vs the repo's `escalate_paths` globs (reuses owned-paths matching, tested). Exit 2 = never auto-merge. Wired into `factory-merge.md`; a clean exit never overrides the behavior-based judgment list.

## Friction log F-1/F-2/F-3 closed
Merge order fixed (worktree-down before branch delete — `--delete-branch` failed on every worktree merge), glob-quoting and canonical `type:*` labels added to the floor. `run-agent.sh` multi-repo loop rebuilds argv with `set --` instead of `eval`.

## Verification
`bun test` (24 pass), `bun build/emit.mjs --check` clean, `bun deploy/gen.mjs` renders, dry `tick.mjs`/gates/escalate smoke-tested against live Linear.