### PR TITLE
fix(orchestrator): release claims on interrupt; one supervisor per repo; higher concurrency

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -75,8 +75,11 @@ repos:
     team: CLNT
     project: Legalease
     base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/legalease
-    report_only: true            # PC-15 pending — see CLNT-609
+    verify: cd legalease && ../.venv/bin/python manage.py check && ../.venv/bin/python manage.py test main.tests
+    max_in_flight: 3
 
   - name: cashsaas
     path: ~/Develop/cashsaas

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -34,8 +34,9 @@ repos:
     smoke_workflow: smoke-dev.yml
     smoke_url: https://bj29-dev.projects.watt-mind.com
 
-    # Concurrency. 3 in flight, merges always serialized.
-    max_in_flight: 3
+    # Concurrency. Merges are always serialized regardless; this caps how many
+    # ticket agents run at once, and each one costs a worktree on disk.
+    max_in_flight: 5
 
     # Surfaces where a diff is never auto-merged, on top of the global
     # escalation list in policy.yaml. This is a CLNT revenue-share client
@@ -79,7 +80,10 @@ repos:
     worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/legalease
     verify: cd legalease && ../.venv/bin/python manage.py check && ../.venv/bin/python manage.py test main.tests
-    max_in_flight: 3
+
+    # Lower than bj29 on purpose: this repo has never had a ticket dispatched
+    # into it. Raise once a few land clean.
+    max_in_flight: 4
 
   - name: cashsaas
     path: ~/Develop/cashsaas

--- a/config/schedule.yaml
+++ b/config/schedule.yaml
@@ -20,6 +20,12 @@
 # └──────────────────────────────────────────────────────────────────────────┘
 
 defaults:
+  # Which repo the {{repo}} token in every command resolves to when the caller
+  # does not say. One supervisor per repo is the unit of parallelism:
+  #   bun orchestrator/run.mjs --repo bj29     --only triage,dispatch,merge --apply
+  #   bun orchestrator/run.mjs --repo legalease --only triage,dispatch,merge --apply
+  # in two terminals, each stoppable on its own.
+  repo: bj29
   label_prefix: com.wattmind
   log_dir: ~/Library/Logs
   # Don't fire a burst of catch-up runs when the laptop wakes from sleep.
@@ -49,7 +55,7 @@ jobs:
 
   # ============================================================================
   # The loop. Commands are repo-AGNOSTIC verbs; `--repo` supplies the targets,
-  # so adding legalease later is `--repo bj29,legalease` rather than a second
+  # so adding legalease later is `--repo {{repo}},legalease` rather than a second
   # copy of every job. Repo-specific knowledge lives in the repo (AGENTS.md,
   # docs/product-decisions.md) and in config/repos.yaml — never in the command.
   #
@@ -79,9 +85,9 @@ jobs:
   #    it once you have watched a few passes.
   - name: triage
     every: 5m
-    gate_command: bun orchestrator/queue.mjs --repo bj29 --gate triage
-    dry_command: bun orchestrator/queue.mjs --repo bj29
-    command: runners/run-agent.sh --repo bj29 --command factory-triage --read-only --args "3"
+    gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate triage
+    dry_command: bun orchestrator/queue.mjs --repo {{repo}}
+    command: runners/run-agent.sh --repo {{repo}} --command factory-triage --read-only --args "5"
     enabled: false
     why: >
       Turns Triage tickets into ai:agent-ready ones by exploring the codebase,
@@ -95,9 +101,9 @@ jobs:
   #     ~9 minutes of wall clock for three tickets before any code got written.
   - name: warm
     every: 2h
-    gate_command: bun orchestrator/warm.mjs --repo bj29 --gate
-    dry_command: bun orchestrator/warm.mjs --repo bj29
-    command: bun orchestrator/warm.mjs --repo bj29 --apply
+    gate_command: bun orchestrator/warm.mjs --repo {{repo}} --gate
+    dry_command: bun orchestrator/warm.mjs --repo {{repo}}
+    command: bun orchestrator/warm.mjs --repo {{repo}} --apply
     enabled: false
     why: >
       Compiles once so that N worktrees don't. Cheapest thing to run before a
@@ -108,9 +114,9 @@ jobs:
   #    full or nothing is startable, so an agent never wakes to learn nothing.
   - name: dispatch
     every: 5m
-    gate_command: bun orchestrator/queue.mjs --repo bj29 --gate dispatch
-    dry_command: bun orchestrator/queue.mjs --repo bj29
-    command: bun orchestrator/tick.mjs --repo bj29 --apply
+    gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate dispatch
+    dry_command: bun orchestrator/queue.mjs --repo {{repo}}
+    command: bun orchestrator/tick.mjs --repo {{repo}} --apply
     enabled: false
     why: >
       One OS PROCESS PER TICKET: tick.mjs claims, builds the worktree via
@@ -125,9 +131,9 @@ jobs:
   #     tickets that have also gone quiet, so a live agent keeps its slot.
   - name: reconcile
     every: 10m
-    gate_command: bun orchestrator/reconcile.mjs --repo bj29 --gate
-    dry_command: bun orchestrator/reconcile.mjs --repo bj29
-    command: bun orchestrator/reconcile.mjs --repo bj29 --apply
+    gate_command: bun orchestrator/reconcile.mjs --repo {{repo}} --gate
+    dry_command: bun orchestrator/reconcile.mjs --repo {{repo}}
+    command: bun orchestrator/reconcile.mjs --repo {{repo}} --apply
     enabled: false
     why: >
       Positive evidence, not silence: an open PR means the implementation phase
@@ -141,9 +147,9 @@ jobs:
   #    seconds produce a base-CI failure belonging to neither.
   - name: merge
     every: 10m
-    gate_command: bun orchestrator/queue.mjs --repo bj29 --gate merge
-    dry_command: bun orchestrator/queue.mjs --repo bj29
-    command: runners/run-agent.sh --repo bj29 --command factory-merge
+    gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate merge
+    dry_command: bun orchestrator/queue.mjs --repo {{repo}}
+    command: runners/run-agent.sh --repo {{repo}} --command factory-merge
     enabled: false
     why: >
       Reviews In Review PRs as their CI finishes, fixes what is mechanical,
@@ -157,9 +163,9 @@ jobs:
   #    nothing notices until the disk does. bj29 had 20 of them at 89% full.
   - name: janitor
     every: 1h
-    gate_command: bun orchestrator/janitor.mjs --repo bj29 --gate
-    dry_command: bun orchestrator/janitor.mjs --repo bj29
-    command: bun orchestrator/janitor.mjs --repo bj29 --apply
+    gate_command: bun orchestrator/janitor.mjs --repo {{repo}} --gate
+    dry_command: bun orchestrator/janitor.mjs --repo {{repo}}
+    command: bun orchestrator/janitor.mjs --repo {{repo}} --apply
     enabled: false
     why: >
       Calls the repo's worktree-down.sh WITHOUT --force, so anything holding

--- a/lib/schedule.mjs
+++ b/lib/schedule.mjs
@@ -23,9 +23,29 @@ if (typeof Bun === "undefined") {
   );
 }
 
-export function parseSchedule(text) {
+/**
+ * Commands are repo-agnostic verbs; `{{repo}}` is where the target goes.
+ *
+ * One supervisor per repo is the unit of parallelism: two terminals, each
+ * running the same job set against a different repo, each stoppable on its own.
+ * The alternative — a second copy of every job per repo in schedule.yaml — is
+ * how a schedule file drifts, because the copies are edited one at a time.
+ */
+function withRepo(cmd, repo) {
+  return typeof cmd === "string" ? cmd.replaceAll("{{repo}}", repo) : cmd;
+}
+
+export function parseSchedule(text, repo = null) {
   const doc = Bun.YAML.parse(text) ?? {};
-  return { defaults: doc.defaults ?? {}, jobs: doc.jobs ?? [] };
+  const defaults = doc.defaults ?? {};
+  const target = repo ?? defaults.repo;
+  const jobs = (doc.jobs ?? []).map((j) => ({
+    ...j,
+    command: withRepo(j.command, target),
+    dry_command: withRepo(j.dry_command, target),
+    gate_command: withRepo(j.gate_command, target),
+  }));
+  return { defaults, jobs, repo: target };
 }
 
 /** "15m" / "6h" / "90s" -> seconds */
@@ -35,6 +55,6 @@ export function toSeconds(every) {
   return Number(m[1]) * { s: 1, m: 60, h: 3600 }[m[2]];
 }
 
-export function loadSchedule() {
-  return parseSchedule(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"));
+export function loadSchedule(repo = null) {
+  return parseSchedule(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"), repo);
 }

--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -37,7 +37,10 @@ const ONCE = has("--once");
 const ALL = has("--all");
 const ONLY = (val("--only") || "").split(",").map((s) => s.trim()).filter(Boolean);
 
-const { jobs } = loadSchedule();
+// One supervisor per repo. Run two of these side by side to work two repos at
+// once — they share nothing but the machine, and either can be stopped alone.
+const REPO = val("--repo");
+const { jobs, repo: TARGET } = loadSchedule(REPO);
 
 const c = {
   dim: (s) => `\x1b[2m${s}\x1b[0m`,
@@ -86,7 +89,7 @@ for (const j of selected) {
 
 const commandFor = (j) => (APPLY ? j.command : j.dry_command);
 
-console.log(c.bold(`\nfactory supervisor — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
+console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
 console.log(c.dim(`${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`));
 for (const j of selected) console.log(`  ${c.cyan(j.name)}  every ${j.every}  ${c.dim(commandFor(j))}`);
 console.log();

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -261,6 +261,8 @@ async function runTicket(t) {
       ? [TIMEOUT_BIN, ["-k", "30s", `${maxMin}m`, "env", ...envArgs]]
       : ["env", envArgs];
     const child = spawn(bin, args, { cwd: wt, stdio: ["ignore", "pipe", "pipe"] });
+    children.add(child);
+    child.on("close", () => children.delete(child));
 
     let buf = "";
     let recorded = false;
@@ -329,6 +331,42 @@ async function runTicket(t) {
 
 // --------------------------------------------------------- rolling loop -----
 const running = new Map();   // identifier -> promise
+const inFlight = new Map();  // identifier -> ticket, for releasing claims on interrupt
+const children = new Set();  // spawned agent processes, so shutdown can stop them explicitly
+let shuttingDown = false;
+
+/**
+ * Ctrl-C must not leave claims behind.
+ *
+ * The agent processes share our process group, so the same Ctrl-C that stops
+ * the supervisor already stopped them — but the code that releases a claim on
+ * failure lives in THIS process, in each child's close handler. Exiting
+ * immediately skipped it, and three tickets claimed seconds before a Ctrl-C
+ * stayed `In Progress` with nothing running: dispatch slots held by ghosts
+ * until a human noticed, since the reaper needs 45 minutes of silence first.
+ *
+ * So: stop claiming, stop the children, give their own handlers a moment to
+ * release cleanly, then release whatever is still held and leave.
+ */
+async function shutdown(sig) {
+  if (shuttingDown) process.exit(130);   // second Ctrl-C: the operator means it
+  shuttingDown = true;
+  console.log(c.yellow(`\n  ${sig} — releasing ${inFlight.size} claim(s) before exit. Ctrl-C again to abandon them.`));
+
+  for (const ch of children) { try { ch.kill("SIGTERM"); } catch {} }
+
+  const deadline = Date.now() + 10_000;
+  while (running.size && Date.now() < deadline) await Bun.sleep(250);
+
+  for (const [id, t] of [...inFlight]) {
+    await unclaim(t, `dispatcher interrupted (${sig}) before the run finished`).catch(() => {});
+    console.log(c.dim(`  released ${id}`));
+  }
+  console.log(c.dim(`\nstopped. Claims released; worktrees left in place for the next dispatch.\n`));
+  process.exit(130);
+}
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
 const seen = new Set();      // everything we have claimed this run
 const warned = new Set();    // skip-warnings already printed, so refills don't repeat them
 let startedCount = 0;
@@ -355,7 +393,7 @@ function todaysSpendUSD() {
 }
 
 async function fill() {
-  if (startedCount >= MAX || tripped) return;
+  if (startedCount >= MAX || tripped || shuttingDown) return;
   const perDay = policy?.budget?.per_day_usd;
   if (perDay) {
     const spent = todaysSpendUSD();
@@ -393,7 +431,8 @@ async function fill() {
 
   for (const t of claimed) {
     startedCount++;
-    const p = runTicket(t).finally(() => running.delete(t.identifier));
+    inFlight.set(t.identifier, t);
+    const p = runTicket(t).finally(() => { running.delete(t.identifier); inFlight.delete(t.identifier); });
     running.set(t.identifier, p);
   }
 }


### PR DESCRIPTION
Fixes OPS-46

### Claims survived a Ctrl-C as ghosts (OPS-46)

Agent processes share the dispatcher's process group, so Ctrl-C stops them — but the code that releases a claim lives in the parent, in each child's `close` handler, and `tick.mjs` had no signal handling. CLNT-619, CLNT-625 and CLNT-613 were claimed at 23:25:14, the supervisor stopped seconds later, and all three sat `In Progress` with nothing running, holding every slot. The reaper needs 45 minutes of silence before it can help.

SIGINT/SIGTERM now stop claiming, stop the children explicitly, wait up to 10s for their handlers to release cleanly, then release the rest. Second Ctrl-C exits immediately.

**Verified against a live interrupt:**
```
01:28:21 CLNT-625 claimed
01:28:29 CLNT-625 worktree ready
  SIGINT — releasing 1 claim(s) before exit. Ctrl-C again to abandon them.
01:28:30 [CLNT-625] FAILED  no result (exit 143)
01:28:30 CLNT-625 un-claimed — no result emitted (exit 143)
```
Linear after: `CLNT-625 | Todo | assignee None`.

### One supervisor per repo

Commands were repo-agnostic verbs with the repo hard-coded into each one, so a second repo meant a second copy of the job set — which is how a schedule file drifts. They now carry a `{{repo}}` token that `lib/schedule.mjs` fills in, and `run.mjs` takes `--repo`. Two terminals, two repos, each stoppable alone. `deploy/gen.mjs` reads the same loader, so watched and unattended modes still can't disagree.

### Concurrency

bj29 5 concurrent tickets (was 3), triage 5 per tick (was 3). legalease enters at 4 — nothing has ever been dispatched into it.

### Note on authorship

`config/repos.yaml` in this diff is **not my change** — another agent wired legalease as a full target while I was working, and my `git add -A` swept it in. I verified it rather than dropping it: `bin/worktree-up.sh`, `worktree-down.sh` and `worktree-common.sh` are on `origin/develop` via merged PR watt-mind/legalease#79, so PC-15 genuinely holds now. `tick.mjs --repo legalease` dry-runs clean and would start 3 tickets with disjoint Owned Paths.

`bun test` 24 pass.