### PR TITLE
fix(ticket): never sleep-poll for CI, and drop ai:agent-ready on claim

### DIFF
--- a/dist/codex/prompts/factory-ticket.md
+++ b/dist/codex/prompts/factory-ticket.md
@@ -12,8 +12,9 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** if this changed anything a user sees or touches: spawn `ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, file the rest to `Triage`.
-5. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
-6. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
+5. **Never `sleep` to wait for CI.** Use `gh pr checks <PR> --watch --fail-fast` — it returns the moment checks settle and exits non-zero on the first failure. Sleep-polling is blocked by the harness, and a blocked tool call **kills the run**: four tickets died exactly this way overnight (`sleep 480`, `sleep 240`, `for i in $(seq 1 40)`), after 55–106 turns and ~$22 of work already done, leaving branches pushed and no PR. The same rule applies to any wait — poll a condition with a real command, never a fixed sleep.
+6. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
+7. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
 
 ## Don't
 

--- a/dist/cursor/commands/factory-ticket.md
+++ b/dist/cursor/commands/factory-ticket.md
@@ -8,8 +8,9 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** if this changed anything a user sees or touches: spawn `ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, file the rest to `Triage`.
-5. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
-6. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
+5. **Never `sleep` to wait for CI.** Use `gh pr checks <PR> --watch --fail-fast` — it returns the moment checks settle and exits non-zero on the first failure. Sleep-polling is blocked by the harness, and a blocked tool call **kills the run**: four tickets died exactly this way overnight (`sleep 480`, `sleep 240`, `for i in $(seq 1 40)`), after 55–106 turns and ~$22 of work already done, leaving branches pushed and no PR. The same rule applies to any wait — poll a condition with a real command, never a fixed sleep.
+6. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
+7. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
 
 ## Don't
 

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -140,7 +140,14 @@ const labelId = (n) => allLabels.find((l) => l.name === n)?.id;
 if (!inProgressId) { console.error("no 'In Progress' state on team " + repo.team); process.exit(1); }
 
 async function claim(t) {
-  const keep = (t.labels?.nodes ?? []).map((l) => allLabels.find((x) => x.name === l.name)?.id).filter(Boolean);
+  // Drop ai:agent-ready on claim. It means "waiting to be picked up", so
+  // keeping it alongside ai:in-progress leaves the ticket asserting two
+  // lifecycle states at once — and it survives all the way to Done, where
+  // CLNT-675 sat carrying both ai:needs-review and ai:agent-ready. One flag,
+  // one value; the same rule the triage hold now follows.
+  const keep = (t.labels?.nodes ?? [])
+    .filter((l) => l.name !== "ai:agent-ready")
+    .map((l) => allLabels.find((x) => x.name === l.name)?.id).filter(Boolean);
   const want = [...new Set([...keep, labelId("ai:in-progress"), labelId("agent:claude-code")].filter(Boolean))];
   await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
     { id: t.id, in: { stateId: inProgressId, assigneeId: me.id, labelIds: want } });

--- a/plugins/core/commands/factory-ticket.md
+++ b/plugins/core/commands/factory-ticket.md
@@ -14,8 +14,9 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** if this changed anything a user sees or touches: spawn `ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, file the rest to `Triage`.
-5. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
-6. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
+5. **Never `sleep` to wait for CI.** Use `gh pr checks <PR> --watch --fail-fast` — it returns the moment checks settle and exits non-zero on the first failure. Sleep-polling is blocked by the harness, and a blocked tool call **kills the run**: four tickets died exactly this way overnight (`sleep 480`, `sleep 240`, `for i in $(seq 1 40)`), after 55–106 turns and ~$22 of work already done, leaving branches pushed and no PR. The same rule applies to any wait — poll a condition with a real command, never a fixed sleep.
+6. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
+7. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
 
 ## Don't
 

--- a/shared/commands/factory-ticket.md
+++ b/shared/commands/factory-ticket.md
@@ -14,8 +14,9 @@ The dispatcher (`orchestrator/tick.mjs`) has done the setup: the ticket is `In P
 2. **Implement**, touching only files matching its `Owned Paths`. Work discovered outside that set becomes a new `Triage` issue — never a widening of this one.
 3. **Verify** with the ticket's exact `Verification Command`. Never proceed past failing output; never weaken a test to get green.
 4. **UX critique** if this changed anything a user sees or touches: spawn `ux-critic`, fix in-scope `FIX-FIRST` findings, maximum 2 rounds, file the rest to `Triage`.
-5. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
-6. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
+5. **Never `sleep` to wait for CI.** Use `gh pr checks <PR> --watch --fail-fast` — it returns the moment checks settle and exits non-zero on the first failure. Sleep-polling is blocked by the harness, and a blocked tool call **kills the run**: four tickets died exactly this way overnight (`sleep 480`, `sleep 240`, `for i in $(seq 1 40)`), after 55–106 turns and ~$22 of work already done, leaving branches pushed and no PR. The same rule applies to any wait — poll a condition with a real command, never a fixed sleep.
+6. **Push and open a PR** against the repo's base branch with `Fixes <ISSUE-ID>` in the body. Move the ticket to `In Review` + `ai:needs-review`, remove `ai:in-progress`, and post the verification output and PR link to the ticket. For user-facing changes attach before/after screenshots to the ticket — never commit them to the repo.
+7. **Heartbeat** the ticket at each phase change and at least every 20 minutes, saying what changed. Silence for 45 minutes and the reaper takes the ticket back.
 
 ## Don't
 


### PR DESCRIPTION
From a review of all 130 overnight runs (~$381 notional).

### Four ticket runs died on a denied `sleep`

CLNT-625, CLNT-652, CLNT-675 and CLNT-647 each tried to wait for CI by sleeping — `sleep 480`, `sleep 240`, `for i in $(seq 1 40)`. The harness blocks sleep-polling, and a blocked tool call **ends the run**. They died at 106, 65, 70 and 55 turns for **~$22.37**, after the work was already done, leaving branches pushed and PRs unannounced.

`factory-merge.md` already says "Never `sleep` and re-poll" and prescribes `gh pr checks --watch --fail-fast`. `factory-ticket.md` never said it. Added as its own step.

**This is live**: ten runs in the last 25 minutes have already issued sleep-shaped commands.

### claim() left two lifecycle flags on at once

`ai:agent-ready` was kept when `ai:in-progress` was added, so a ticket asserted both states, and the stale flag rode all the way to completion — CLNT-675 is `Done` carrying both `ai:needs-review` and `ai:agent-ready`. Same one-flag-one-value rule the triage hold now follows.

`bun test` 24 pass.