### PR TITLE
perf(ticket): run implementation agents on sonnet, keep the merge gate on opus

### DIFF
--- a/plugins/core/commands/factory-ticket.md
+++ b/plugins/core/commands/factory-ticket.md
@@ -1,7 +1,7 @@
 ---
 description: Implement exactly one already-claimed Linear ticket in the current worktree
 argument-hint: <ISSUE-ID>
-model: opus
+model: sonnet
 ---
 
 Implement **one** ticket: $ARGUMENTS. You are already in its worktree, and the ticket is already claimed for you.

--- a/shared/commands/factory-ticket.md
+++ b/shared/commands/factory-ticket.md
@@ -1,7 +1,7 @@
 ---
 description: Implement exactly one already-claimed Linear ticket in the current worktree
 argument-hint: <ISSUE-ID>
-model: opus
+model: sonnet
 ---
 
 Implement **one** ticket: $ARGUMENTS. You are already in its worktree, and the ticket is already claimed for you.


### PR DESCRIPTION
Last night's 130 runs cost ~$381 notional. Ticket implementation was **54 runs on opus for ~$223** — the largest single line, and ~20% of a weekly Max20 allowance.

`factory-ticket.md` moves to sonnet.

### What was already sonnet

`factory-triage`, `factory-work`, `factory-audit` and `factory-retro`. Worth stating plainly: **the nightly triage overspend was not a model problem** — triage was already on sonnet, and $89 across 54 runs was pure volume from the re-triage loop, which the `Blocked`+`ai:blocked` parking fix addresses directly.

### What stays on opus, on purpose

`factory-merge`. It reads every diff before anything lands in a client repo, decides what escalates, and is the last thing between an agent and `develop`. 19 runs and $65 last night — under a fifth of ticket spend — for the step where being wrong costs the most. Cheap to implement, expensive to review.

`--fallback-model sonnet` was already configured, so the common path now matches what the fallback already assumed.

`bun test` 24 pass.