### PR TITLE
feat(orchestrator): let dispatch run on any harness, and raise the caps for it

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -36,7 +36,11 @@ repos:
 
     # Concurrency. Merges are always serialized regardless; this caps how many
     # ticket agents run at once, and each one costs a worktree on disk.
-    max_in_flight: 5
+    #
+    # NOTE: this is a cap on the REPO, not on a supervisor. Two supervisors on
+    # different harnesses share it — a second one adds capacity only if there
+    # are free slots for it to claim, which is why this went up with agy.
+    max_in_flight: 8
 
     # Surfaces where a diff is never auto-merged, on top of the global
     # escalation list in policy.yaml. This is a CLNT revenue-share client
@@ -112,9 +116,9 @@ repos:
     worktree_root: ~/Develop/.worktrees/legalease
     verify: cd legalease && ../.venv/bin/python manage.py check && ../.venv/bin/python manage.py test main.tests
 
-    # Lower than bj29 on purpose: this repo has never had a ticket dispatched
-    # into it. Raise once a few land clean.
-    max_in_flight: 4
+    # Raised with bj29 for the second (agy) supervisor; see the note there —
+    # the cap is per repo, not per supervisor.
+    max_in_flight: 8
 
     # Surfaces where a diff is never auto-merged, on top of the global list in
     # policy.yaml. Without these, escalate.mjs has nothing to check and the

--- a/config/schedule.yaml
+++ b/config/schedule.yaml
@@ -26,6 +26,10 @@ defaults:
   #   bun orchestrator/run.mjs --repo legalease --only triage,dispatch,merge --apply
   # in two terminals, each stoppable on its own.
   repo: bj29
+  # Which agent CLI runs the stages. `agy` (Antigravity) is a different
+  # provider's quota, so a second supervisor on it adds capacity without
+  # drawing further on the Claude allowance.
+  harness: claude
   label_prefix: com.wattmind
   log_dir: ~/Library/Logs
   # Don't fire a burst of catch-up runs when the laptop wakes from sleep.
@@ -87,7 +91,7 @@ jobs:
     every: 5m
     gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate triage
     dry_command: bun orchestrator/queue.mjs --repo {{repo}}
-    command: runners/run-agent.sh --repo {{repo}} --command factory-triage --read-only --args "5"
+    command: runners/run-agent.sh --harness {{harness}} --repo {{repo}} --command factory-triage --read-only --args "5"
     enabled: false
     why: >
       Turns Triage tickets into ai:agent-ready ones by exploring the codebase,
@@ -116,7 +120,7 @@ jobs:
     every: 5m
     gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate dispatch
     dry_command: bun orchestrator/queue.mjs --repo {{repo}}
-    command: bun orchestrator/tick.mjs --repo {{repo}} --apply
+    command: bun orchestrator/tick.mjs --repo {{repo}} --harness {{harness}} --apply
     enabled: false
     why: >
       One OS PROCESS PER TICKET: tick.mjs claims, builds the worktree via
@@ -149,7 +153,7 @@ jobs:
     every: 10m
     gate_command: bun orchestrator/queue.mjs --repo {{repo}} --gate merge
     dry_command: bun orchestrator/queue.mjs --repo {{repo}}
-    command: runners/run-agent.sh --repo {{repo}} --command factory-merge
+    command: runners/run-agent.sh --harness {{harness}} --repo {{repo}} --command factory-merge
     enabled: false
     why: >
       Reviews In Review PRs as their CI finishes, fixes what is mechanical,

--- a/lib/schedule.mjs
+++ b/lib/schedule.mjs
@@ -31,21 +31,26 @@ if (typeof Bun === "undefined") {
  * The alternative — a second copy of every job per repo in schedule.yaml — is
  * how a schedule file drifts, because the copies are edited one at a time.
  */
-function withRepo(cmd, repo) {
-  return typeof cmd === "string" ? cmd.replaceAll("{{repo}}", repo) : cmd;
+function withVars(cmd, vars) {
+  if (typeof cmd !== "string") return cmd;
+  let out = cmd;
+  for (const [k, v] of Object.entries(vars)) out = out.replaceAll(`{{${k}}}`, v);
+  return out;
 }
 
-export function parseSchedule(text, repo = null) {
+export function parseSchedule(text, repo = null, harness = null) {
   const doc = Bun.YAML.parse(text) ?? {};
   const defaults = doc.defaults ?? {};
   const target = repo ?? defaults.repo;
+  const agent = harness ?? defaults.harness ?? "claude";
+  const vars = { repo: target, harness: agent };
   const jobs = (doc.jobs ?? []).map((j) => ({
     ...j,
-    command: withRepo(j.command, target),
-    dry_command: withRepo(j.dry_command, target),
-    gate_command: withRepo(j.gate_command, target),
+    command: withVars(j.command, vars),
+    dry_command: withVars(j.dry_command, vars),
+    gate_command: withVars(j.gate_command, vars),
   }));
-  return { defaults, jobs, repo: target };
+  return { defaults, jobs, repo: target, harness: agent };
 }
 
 /** "15m" / "6h" / "90s" -> seconds */
@@ -55,6 +60,6 @@ export function toSeconds(every) {
   return Number(m[1]) * { s: 1, m: 60, h: 3600 }[m[2]];
 }
 
-export function loadSchedule(repo = null) {
-  return parseSchedule(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"), repo);
+export function loadSchedule(repo = null, harness = null) {
+  return parseSchedule(readFileSync(path.join(ROOT, "config/schedule.yaml"), "utf8"), repo, harness);
 }

--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -40,7 +40,8 @@ const ONLY = (val("--only") || "").split(",").map((s) => s.trim()).filter(Boolea
 // One supervisor per repo. Run two of these side by side to work two repos at
 // once — they share nothing but the machine, and either can be stopped alone.
 const REPO = val("--repo");
-const { jobs, repo: TARGET } = loadSchedule(REPO);
+const HARNESS = val("--harness");
+const { jobs, repo: TARGET, harness: AGENT } = loadSchedule(REPO, HARNESS);
 
 const c = {
   dim: (s) => `\x1b[2m${s}\x1b[0m`,
@@ -89,7 +90,7 @@ for (const j of selected) {
 
 const commandFor = (j) => (APPLY ? j.command : j.dry_command);
 
-console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
+console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} · ${c.cyan(AGENT)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
 console.log(c.dim(`${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`));
 for (const j of selected) console.log(`  ${c.cyan(j.name)}  every ${j.every}  ${c.dim(commandFor(j))}`);
 console.log();

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -55,6 +55,13 @@ const cap = repo.max_in_flight ?? policy?.concurrency?.max_in_flight_per_repo ??
 // Same probe as run-agent.sh: the wall-clock cap is a safety feature, and a
 // safety feature that crashes every spawn on a machine without coreutils is
 // worse than saying plainly that the cap is off.
+// Which agent CLI runs the tickets. Claude by default; `agy` (Antigravity)
+// draws on a different provider's quota entirely, which is the point — a
+// second supervisor on a second harness adds capacity without spending more
+// of the same weekly allowance.
+const HARNESS = val("--harness") ?? "claude";
+if (!Bun.which(HARNESS)) { console.error(`harness "${HARNESS}" is not on PATH`); process.exit(2); }
+
 const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
 if (!TIMEOUT_BIN) console.log(c.yellow("  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped"));
 
@@ -255,16 +262,29 @@ async function runTicket(t) {
     // Spawned without a shell: the prompt is a markdown document full of
     // backticks and quotes, and there is no quoting of it into `bash -lc`
     // that stays correct as the command body is edited.
-    const claudeArgs = [
-      "-p", promptFor(t.identifier),
-      "--output-format", "stream-json", "--verbose",
-      "--max-budget-usd", budget,
-      "--fallback-model", "sonnet",
-    ];
-    // The frontmatter's `model:` used to be applied by the slash command;
-    // inlining the body means passing it explicitly or silently downgrading.
-    if (COMMAND_MODEL) claudeArgs.push("--model", COMMAND_MODEL);
-    const envArgs = ["-u", "ANTHROPIC_API_KEY", "-u", "CLAUDECODE", "-u", "CLAUDE_CODE_ENTRYPOINT", "claude", ...claudeArgs];
+    // Flags differ per harness; the PROMPT does not. That is the whole reason
+    // the command bodies are harness-neutral markdown, and why run-agent.sh
+    // can already drive agy. Mirrors run-agent.sh's non-claude invocation.
+    const harnessArgs = HARNESS === "claude"
+      ? [
+          "-p", promptFor(t.identifier),
+          "--output-format", "stream-json", "--verbose",
+          "--max-budget-usd", budget,
+          "--fallback-model", "sonnet",
+          // The frontmatter's `model:` used to be applied by the slash command;
+          // inlining the body means passing it explicitly or silently downgrading.
+          ...(COMMAND_MODEL ? ["--model", COMMAND_MODEL] : []),
+        ]
+      : [
+          "-p", promptFor(t.identifier),
+          "--output-format", "stream-json",
+          "--dangerously-skip-permissions",
+          // agy's print mode defaults to 5 minutes — far shorter than a real
+          // ticket. Left at the default the run is cut off mid-work and looks
+          // like a hang rather than a timeout.
+          "--print-timeout", `${Math.max(1, maxMin - 2)}m`,
+        ];
+    const envArgs = ["-u", "ANTHROPIC_API_KEY", "-u", "CLAUDECODE", "-u", "CLAUDE_CODE_ENTRYPOINT", HARNESS, ...harnessArgs];
     const [bin, args] = TIMEOUT_BIN
       ? [TIMEOUT_BIN, ["-k", "30s", `${maxMin}m`, "env", ...envArgs]]
       : ["env", envArgs];
@@ -285,6 +305,22 @@ async function runTicket(t) {
             console.log(`${c.dim(clock())} ${tag} ${p.name} ${c.dim(d)}`);
           }
         }
+      }
+      // agy reports the same facts under different names: {event:"step_update"}
+      // for tool calls and a nested {event:"result", result:{status:"SUCCESS",
+      // response, num_turns}} envelope. Normalise rather than branching twice.
+      if (HARNESS !== "claude") {
+        const s = e.event === "step_update" ? (e.step_update ?? {}) : null;
+        if (s?.step_type === "tool" && s.state === "ACTIVE") {
+          const par = s.tool_info?.parameters ?? {};
+          const d = String(par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path ?? "").replace(/\s+/g, " ").slice(0, 66);
+          console.log(`${c.dim(clock())} ${tag} ${s.tool_name ?? "tool"} ${c.dim(d)}`);
+        }
+        const env = e.event === "result" ? e.result : ("status" in e && "num_turns" in e ? e : null);
+        if (!env) return;
+        e = { subtype: String(env.status).toLowerCase() === "success" ? "success" : String(env.status ?? "?"),
+              is_error: String(env.status).toLowerCase() !== "success",
+              num_turns: env.num_turns, total_cost_usd: env.total_cost_usd ?? 0, result: env.response ?? "" };
       }
       if (e.type === "result" || "num_turns" in e) {
         const turns = e.num_turns ?? 0;


### PR DESCRIPTION
`run-agent.sh` could already drive `agy` (Antigravity) for triage and merge. `tick.mjs` hard-coded `claude`, so the stage that does the actual work couldn't use it.

- `tick.mjs` takes `--harness`, mirrors run-agent.sh's non-claude invocation (`--dangerously-skip-permissions`, `--print-timeout` set below the wall-clock cap, since agy's print mode defaults to 5 minutes and would cut a ticket off mid-work), and normalises agy's nested `{event:"result", result:{status, num_turns}}` envelope into the same shape the claude path already reports.
- `schedule.yaml` gains a `{{harness}}` token beside `{{repo}}`; one job set serves both. `run.mjs` takes `--harness` and names it in the banner.
- `max_in_flight` raised bj29 5→8, legalease 4→8.

### The cap is per repo, not per supervisor

Worth stating because it's the thing that makes or breaks this: both supervisors compute free slots from the same Linear `In Progress` count against the same `max_in_flight`. A second supervisor on a second harness therefore adds **no** capacity on its own — it just races the first for the same slots. Raising the cap is what actually adds parallelism; the harness is what decides whose quota pays for it.

### Verified

`bun test` 24 pass. `run.mjs --repo legalease --harness agy --list` renders `run-agent.sh --harness agy` for triage and `tick.mjs --harness agy` for dispatch. `tick.mjs --repo legalease --harness agy` dry-runs and reports `cap 8 · 4 running · 4 slot(s)`.

**Not yet verified:** no ticket has actually been implemented end-to-end by agy. The flags mirror the working run-agent.sh path, but the first run should be a single `--ticket` rather than an unattended loop.