### PR TITLE
fix(harness): point agy at the repo with --add-dir

### DIFF
--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -279,6 +279,12 @@ async function runTicket(t) {
           "-p", promptFor(t.identifier),
           "--output-format", "stream-json",
           "--dangerously-skip-permissions",
+          // agy does not take its repo context from the working directory the
+          // way claude does — it looks for an IDE "active workspace" and, not
+          // finding one headless, asks which repository to use and stops. It
+          // then reports status SUCCESS for having asked. --add-dir is what
+          // actually points it at the worktree.
+          "--add-dir", wt,
           // agy's print mode defaults to 5 minutes — far shorter than a real
           // ticket. Left at the default the run is cut off mid-work and looks
           // like a hang rather than a timeout.

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -216,9 +216,13 @@ else
     # agy's print mode defaults to a 5-minute timeout, which is far shorter
     # than a real stage: triage explores a codebase, dispatch compiles. Left at
     # the default the run is cut off mid-work and looks like a hang.
+    # agy takes its repo context from --add-dir, not from cwd: headless it finds
+    # no IDE "active workspace", asks which repository to target, and stops —
+    # reporting SUCCESS for having asked.
     $RUN_CAP $ENV_PREFIX "$HARNESS" -p "$BODY" \
       --output-format stream-json \
       --dangerously-skip-permissions \
+      --add-dir "$REPO_PATH" \
       --print-timeout "$(( MAX_MIN - 2 ))m" \
       $MODEL_ARGS
   ) 2>&1 | (cd "$ROOT" && bun runners/report.mjs --log "$LOG" --harness "$HARNESS")


### PR DESCRIPTION
The first real agy run under a supervisor did nothing and reported success.

`agy` does not take repo context from the working directory the way `claude` does. Headless it finds no IDE "active workspace", so it asked *"There's no active workspace set, so I don't know which repository to target. Which repo should I run this against?"* — and returned `status: SUCCESS`, 1 turn, 8s, 44,620 tokens. run-agent.sh had `cd`'d into the repo first; agy was running `git -C ~/Develop remote -v` regardless.

`--add-dir` is what actually scopes it. Added in both call sites: `run-agent.sh` (triage/merge/audit) and `tick.mjs` (ticket dispatch, pointed at the ticket's worktree).

Verified directly:
```
agy -p 'Print only the output of: git rev-parse --show-toplevel' --add-dir ~/Develop/legalease
  → /Users/hdkiller/Develop/legalease
```

**Residual, not fixed here:** agy reports `SUCCESS` for a run that only asked a clarifying question, and the factory's success test (subtype success + turns > 0) accepts it at 1 turn. --add-dir removes the common cause, but a stage that stops to ask will still be recorded as ok.

`bun test` 24 pass.