### PR TITLE
fix(orchestrator): install timers before the first pass, not after it

### DIFF
--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -178,9 +178,22 @@ function shutdown() {
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 
-await Promise.all(selected.map(runJob));
+// Start the first pass, but DO NOT await it before scheduling.
+//
+// `dispatch` is deliberately long-running: rolling refill keeps tick.mjs alive
+// for as long as tickets are in flight, which is hours. Awaiting the first pass
+// before installing timers therefore meant the timers were never installed at
+// all — the supervisor silently degraded into a one-shot the moment dispatch
+// picked up a ticket. legalease ran merge exactly once, at 08:54, and never
+// again while twelve green PRs piled up behind it; the loop looked alive
+// because dispatch's agents kept printing.
+//
+// Overlap is already handled per job by the `running` set, so a timer that
+// fires while its own job is still going skips rather than stacks.
+const firstPass = Promise.all(selected.map(runJob)).catch(() => {});
 
 if (ONCE) {
+  await firstPass;
   console.log(`\n${c.bold("one pass complete.")} ${completed} ok, ${failed} failed.`);
   process.exit(failed ? 1 : 0);
 }


### PR DESCRIPTION
**The supervisor has not been a scheduler.** It ran one pass of each job and then stopped scheduling.

```js
await Promise.all(selected.map(runJob));        // waits for every job's first pass
...
for (const job of selected) setInterval(...);   // never reached
```

`dispatch` is deliberately long-running — rolling refill keeps `tick.mjs` alive for as long as tickets are in flight, which is hours. So the await never resolved and **no job ever got a timer**: not merge, not triage, not janitor, not the reaper.

Observed on legalease today: supervisor started 08:54:52, merge ran once at 08:54:54, and there was no second merge pass for the next 45 minutes while twelve PRs — all green, all `mergeStateStatus: CLEAN`, none escalated — sat open. The loop looked healthy because dispatch's ticket agents kept streaming output; the only job still running was the one holding the scheduler.

Timers now install first. Per-job overlap protection (the `running` set) already existed, so a timer firing while its own job is still going skips rather than stacks.

Verified — `next in 10m` and `watching` now print while the first pass is still running:
```
09:53:56 start reconcile ...
09:53:56 start merge ...
  reconcile: next in 10m
  merge: next in 10m
watching — Ctrl-C to stop.
09:53:57 done  reconcile (0.7s)
```
`--once` still awaits the pass and exits. `bun test` 24 pass.