### PR TITLE
feat(orchestrator): watch TUI reaper action, done/total counts, PR chip, manual refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ plugins/core/                     GENERATED — the Claude Code plugin
 dist/{codex,gemini,cursor}/       GENERATED — the other harnesses
 dist/AGENTS.floor.md              GENERATED — paste/sync into each repo's AGENTS.md
 orchestrator/                     dispatch logic (owned-paths collision, tick)
+orchestrator/watch.jsx            read-only TUI: queue + in-flight tickets + live log tail
 config/schedule.yaml              ONE source of truth for cadences
 config/policy.yaml                budgets, concurrency, escalation
 deploy/gen.mjs                    schedule.yaml -> launchd plists
@@ -243,7 +244,7 @@ Only then start the supervisor on a cadence.
 | Tickets per tick | `--args` in `config/schedule.yaml` | triage 3, dispatch 2 |
 | Concurrent tickets | `max_in_flight` in `config/repos.yaml` | 3 |
 | Spend per run | `--budget`, else `budget.per_ticket_usd` in `config/policy.yaml` | $5 |
-| Daily spend | `budget.per_day_usd` | $60 |
+| Daily spend | `budget.per_day_usd` | $1000 |
 | Which repos | `--repo` on each job | `bj29` only |
 
 ### Auth and "budget" on a subscription
@@ -281,6 +282,17 @@ Three properties, in order of how much they matter:
 bun deploy/gen.mjs             # render enabled jobs (currently: none)
 bun deploy/gen.mjs --install   # copy to ~/Library/LaunchAgents and load
 ```
+
+### The monitor — a bird's-eye view across repos
+
+`orchestrator/run.mjs` shows you one job's full output; `orchestrator/watch.jsx` shows you the state across every repo at once — queue depth, which tickets are in flight or in review, and a live tail of the selected ticket's session log. Read-only: it never spawns an agent or writes anything, it only re-reads what `queue.mjs` and `~/.factory/logs/*.jsonl` already expose.
+
+```bash
+bun run watch                  # or: bun orchestrator/watch.jsx
+bun orchestrator/watch.jsx --repo bj29
+```
+
+`↑`/`↓` selects a ticket, `←`/`→` switches repo, `q` quits.
 
 Never hand-edit a generated plist — the next regeneration silently reverts it.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,90 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "factory",
+      "dependencies": {
+        "ink": "^7.1.1",
+        "react": "^19.2.8",
+      },
+    },
+  },
+  "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@6.1.1", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@7.1.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
+    "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+  }
+}

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -28,15 +28,10 @@ budget:
   # --args): they bound how much of a window one tick can consume.
   per_ticket_usd: 15.00     # generous — a triage run that explores a codebase
                             # legitimately passes $5 notional
-  per_day_usd: 600.00       # enforced in every gate (lib/spend.mjs): today's
+  per_day_usd: 1000.00      # enforced in every gate (lib/spend.mjs): today's
                             # logs are summed per tick; at the cap it drains —
                             # running tickets finish, nothing new starts.
-                            # Raised from 200 on 2026-08-04: a day of building
-                            # and testing the loop itself passed it by lunch,
-                            # and it is a runaway guard in notional units, not
-                            # a wallet. The binding limit on subscription auth
-                            # is the 5-hour usage window, which nothing here
-                            # can see — that is what the per-tick caps are for.
+                            # Raised to 1000 on 2026-08-04.
   on_exhausted: drain
 
 limits:

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -92,8 +92,9 @@ repos:
   #   - dispatch must never target them; concurrent agents there share ports and
   #     databases
   #
-  # They graduate to full entries when CW-363 (coach-wattz) and CLNT-609
-  # (legalease) land their worktree scripts.
+  # coach-wattz graduates when CW-363 lands its worktree scripts. legalease
+  # (CLNT-609) and cashsaas (CLNT-791) already have — their entries below carry
+  # worktree_up/down/warm like bj29's, and are no longer report_only.
   # --------------------------------------------------------------------------
 
   - name: coach-wattz
@@ -148,5 +149,13 @@ repos:
     team: CLNT
     project: CashMap
     base: develop
+
+    # Worktrees — satisfies PC-15 (CLNT-791): bin/worktree-up.sh/down.sh/warm.sh,
+    # deterministic per-ticket ports + database, seeded warm template.
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
     worktree_root: ~/Develop/.worktrees/cashsaas
-    report_only: true            # PC-15 pending — no ticket yet
+
+    # What "verified" means. Agents run this before any PR.
+    verify: npm run typecheck && npm run lint && npm run format:check

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -66,6 +66,21 @@ const QUERY = `
     }
   }`;
 
+// Finished work, for the done/total readout. Kept out of QUERY on purpose: the
+// active-issue query feeds gates and dispatch decisions, and mixing hundreds of
+// Done tickets into `nodes` would push live work past the 250-issue page long
+// before the project gets big enough to notice any other way.
+const CLOSED_QUERY = `
+  query($team: String!, $project: String!) {
+    issues(first: 250, filter: {
+      team: { key: { eq: $team } },
+      project: { name: { eq: $project } },
+      state: { type: { in: ["completed", "canceled"] } }
+    }) {
+      nodes { state { type } }
+    }
+  }`;
+
 /**
  * Open PRs that a merge run could actually act on: not drafts, and not already
  * escalated to a human. Returns [] rather than throwing when `gh` is missing or
@@ -89,6 +104,11 @@ for (const repo of repos) {
   if (!GATE && !JSON_OUT) console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}  ->  ${repo.base}`));
 
   const nodes = (await gql(QUERY, { team: repo.team, project: repo.project }))?.issues?.nodes ?? [];
+  const closed = (await gql(CLOSED_QUERY, { team: repo.team, project: repo.project }))?.issues?.nodes ?? [];
+  const done = closed.filter((i) => i.state?.type === "completed").length;
+  const total = nodes.length + closed.length;
+  // Either page hitting its 250 cap means these are floors, not counts.
+  const countCapped = nodes.length === 250 || closed.length === 250;
   const labels = (i) => (i.labels?.nodes ?? []).map((l) => l.name);
   const state = (i) => i.state?.name ?? "?";
 
@@ -128,6 +148,7 @@ for (const repo of repos) {
   line("In Progress", inProgress.length);
   line("In Review", inReview.length, inReview.length ? c.cyan : (s) => s);
   line("Blocked", blocked.length, blocked.length ? c.red : (s) => s);
+  line("Done / project total", `${done}/${total}${countCapped ? "+" : ""}`, c.dim);
 
   // What dispatch would actually pick up, honouring Owned Paths against what is
   // already running. Sorted the way §7 sorts: priority asc, then created asc.
@@ -154,6 +175,12 @@ for (const repo of repos) {
 
   summary.push({
     repo: repo.name,
+    // Team key, so the monitor can scope actions like the reaper without
+    // re-reading config/repos.yaml itself.
+    team: repo.team,
+    done,
+    total,
+    countCapped,
     triage: triage.length + notReady.length,
     // Triage-state only. The stage processes Triage tickets; gating on the
     // combined count kept the gate open for Todo-without-agent-ready tickets

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -131,9 +131,16 @@ for (const repo of repos) {
 
   // What dispatch would actually pick up, honouring Owned Paths against what is
   // already running. Sorted the way §7 sorts: priority asc, then created asc.
+  //
+  // report_only repos have no worktree tooling — dispatch must never target
+  // them (see config/repos.yaml). Forcing slotsFree to 0 here is what keeps
+  // the dispatch gate closed for them; without it the gate reports "work
+  // available" from Linear state alone, run.mjs spawns tick.mjs, and tick.mjs
+  // immediately exits 2 because the repo can't be dispatched — a FAIL every
+  // tick for a repo that was never eligible to begin with.
   const inFlightPaths = inProgress.flatMap((i) => parseOwnedPaths(i.description ?? ""));
   const sorted = [...ready].sort((a, b) => (a.priority || 99) - (b.priority || 99));
-  const slotsFree = Math.max(0, (repo.max_in_flight ?? defaultCap) - inProgress.length);
+  const slotsFree = repo.report_only ? 0 : Math.max(0, (repo.max_in_flight ?? defaultCap) - inProgress.length);
   const free = [];
   const busyPaths = [...inFlightPaths];
   for (const t of sorted) {
@@ -159,6 +166,11 @@ for (const repo of repos) {
     blocked: blocked.length,
     slotsFree,
     startable: free.map((t) => t.identifier),
+    // Identifier + title only — enough for a monitor (orchestrator/watch.jsx)
+    // to render a ticket list without re-querying Linear itself.
+    inProgressTickets: inProgress.map((t) => ({ identifier: t.identifier, title: t.title })),
+    inReviewTickets: inReview.map((t) => ({ identifier: t.identifier, title: t.title })),
+    blockedTickets: blocked.map((t) => ({ identifier: t.identifier, title: t.title })),
   });
 
   if (quiet) continue;
@@ -166,6 +178,8 @@ for (const repo of repos) {
   if (free.length) {
     console.log(c.dim(`\n  dispatch would start (cap ${repo.max_in_flight}, ${inProgress.length} running, ${slotsFree} slot(s) free):`));
     for (const t of free) console.log(`    ${c.green(t.identifier.padEnd(10))} ${t.title.slice(0, 60)}`);
+  } else if (repo.report_only && ready.length) {
+    console.log(c.dim(`\n  report_only — dispatch is disabled here by design (${ready.length} ready ticket(s) would otherwise start)`));
   } else if (ready.length && slotsFree === 0) {
     // Distinguish "no room" from "nothing fits". Reporting the Owned Paths
     // reason when the cap is simply full sends you reading glob sets for a

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -58,7 +58,7 @@ const QUERY = `
       state: { type: { nin: ["completed", "canceled"] } }
     }) {
       nodes {
-        identifier title description priority
+        identifier title description priority url
         state { name type }
         assignee { name }
         labels(first: 20) { nodes { name } }
@@ -193,11 +193,12 @@ for (const repo of repos) {
     blocked: blocked.length,
     slotsFree,
     startable: free.map((t) => t.identifier),
-    // Identifier + title only — enough for a monitor (orchestrator/watch.jsx)
-    // to render a ticket list without re-querying Linear itself.
-    inProgressTickets: inProgress.map((t) => ({ identifier: t.identifier, title: t.title })),
-    inReviewTickets: inReview.map((t) => ({ identifier: t.identifier, title: t.title })),
-    blockedTickets: blocked.map((t) => ({ identifier: t.identifier, title: t.title })),
+    // Identifier + title + url — enough for a monitor (orchestrator/watch.jsx)
+    // to render a ticket list and deep-link into Linear without re-querying
+    // Linear itself.
+    inProgressTickets: inProgress.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
+    inReviewTickets: inReview.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
+    blockedTickets: blocked.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
   });
 
   if (quiet) continue;

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -153,15 +153,27 @@ export async function fetchTeams() {
   return result;
 }
 
-export async function fetchInProgress(teamKey = null) {
+export async function fetchInProgress(teamKey = null, anyAssignee = false) {
   const teamFilter = teamKey ? `, team: { key: { eq: "${teamKey}" } }` : "";
-  // Any ticket carrying the claim marker, in ANY state — not just In Progress.
-  // Triage claims tickets while specifying them and leaves them in `Triage`, so
-  // a crashed triage run would otherwise strand `ai:in-progress` forever on a
-  // ticket no state-based query ever looks at.
+  // Two different questions, two different filters.
+  //
+  // Default: any ticket carrying the claim marker, in ANY state — not just In
+  // Progress. Triage claims tickets while specifying them and leaves them in
+  // `Triage`, so a crashed triage run would otherwise strand `ai:in-progress`
+  // forever on a ticket no state-based query ever looks at.
+  //
+  // --any-assignee: the audit view exists specifically to see In Progress work
+  // REGARDLESS of the ai:in-progress label — including a human's, with no
+  // agent label at all. Filtering by that label here would make the flag a
+  // no-op: everything returned would already carry it. So this path queries by
+  // state instead, and isAgentClaim() (applied downstream) tells the two
+  // apart — main() must still never reclaim anything that fails it.
+  const filter = anyAssignee
+    ? `state: { name: { eq: "In Progress" } }${teamFilter}`
+    : `labels: { name: { eq: "ai:in-progress" } }${teamFilter}`;
   const q = `
     query {
-      issues(first: 250, filter: { labels: { name: { eq: "ai:in-progress" } }${teamFilter} }) {
+      issues(first: 250, filter: { ${filter} }) {
         nodes {
           id identifier title url startedAt updatedAt
           team { key }
@@ -324,7 +336,7 @@ Options:
   console.log(`=== Stale-claim reaper [${mode}] threshold=${args.minutes}min ===\n`);
 
   const teams = await fetchTeams();
-  let issues = await fetchInProgress(args.team);
+  let issues = await fetchInProgress(args.team, args.anyAssignee);
   const now = new Date();
   const cutoff = new Date(now.getTime() - args.minutes * 60 * 1000);
 
@@ -380,6 +392,16 @@ Options:
     const whoStr = who.padEnd(16);
     const titleStr = (issue.title || "").slice(0, 44);
     console.log(`  STALE ${id} ${ageStr}m  ${whoStr} ${titleStr}`);
+
+    // Enforced here, not just by the upstream fetch: --any-assignee queries by
+    // state so it can show human work for audit purposes, which means a stale
+    // ticket in `considered` may not be an agent claim at all. Unassigning a
+    // human's ticket because they didn't comment in 45 minutes would be far
+    // worse than the crashed agent this reaper exists to clean up after.
+    if (!isAgentClaim(issue)) {
+      console.log(`        (no agent claim label — a human's work, not touching it)`);
+      continue;
+    }
 
     const teamKey = issue.team?.key;
     const team = teams[teamKey];

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -61,6 +61,10 @@ const cap = repo.max_in_flight ?? policy?.concurrency?.max_in_flight_per_repo ??
 // of the same weekly allowance.
 const HARNESS = val("--harness") ?? "claude";
 if (!Bun.which(HARNESS)) { console.error(`harness "${HARNESS}" is not on PATH`); process.exit(2); }
+// linear.md's agent:* taxonomy names the harness that actually holds the
+// claim (agent:claude-code, agent:gemini, ...) — it must track HARNESS, not
+// assume claude, or a ticket run on agy gets labelled as if Claude did it.
+const AGENT_LABEL = `agent:${HARNESS === "claude" ? "claude-code" : HARNESS}`;
 
 const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
 if (!TIMEOUT_BIN) console.log(c.yellow("  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped"));
@@ -155,7 +159,7 @@ async function claim(t) {
   const keep = (t.labels?.nodes ?? [])
     .filter((l) => l.name !== "ai:agent-ready")
     .map((l) => allLabels.find((x) => x.name === l.name)?.id).filter(Boolean);
-  const want = [...new Set([...keep, labelId("ai:in-progress"), labelId("agent:claude-code")].filter(Boolean))];
+  const want = [...new Set([...keep, labelId("ai:in-progress"), labelId(AGENT_LABEL)].filter(Boolean))];
   await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
     { id: t.id, in: { stateId: inProgressId, assigneeId: me.id, labelIds: want } });
   // Linear has no compare-and-swap; this read-back IS the concurrency control.
@@ -241,7 +245,11 @@ async function runTicket(t) {
     const why = (up.stderr || up.stdout || "").trim().split("\n").pop();
     console.log(c.red(`  ${t.identifier} worktree-up failed: ${why}`));
     results.push({ id: t.identifier, ok: false, why: "worktree-up failed" });
-    await unclaim(t, `worktree-up failed: ${why}`);
+    // Must not throw: an unhandled rejection here kills the whole rolling
+    // loop via Promise.race in the main dispatch loop below, taking down
+    // every OTHER in-flight ticket's tracking with it. Same guard as the
+    // other two unclaim() call sites.
+    await unclaim(t, `worktree-up failed: ${why}`).catch(() => {});
     noteEnvFailure("worktree-up");
     return;
   }

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -95,6 +95,17 @@ export function formatIssueCounts(done, total, capped) {
 }
 
 /**
+ * The desktop-app deep link for a Linear issue URL. Linear's macOS app
+ * registers the linear:// scheme; handing `open` an https://linear.app URL
+ * lands in the browser instead. Anything that isn't a linear.app URL comes
+ * back null so the caller falls back to opening the https URL as-is.
+ */
+export function linearDeepLink(url) {
+  const m = /^https:\/\/linear\.app\/(.+)$/.exec(String(url ?? ""));
+  return m ? `linear://${m[1]}` : null;
+}
+
+/**
  * What a reaper.mjs run concluded, parsed from its stdout. The number gates the
  * TUI's confirm step: --apply is only offered when the dry run found something
  * to reclaim, so a stray keypress on a clean queue can never write to Linear.

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -1,0 +1,90 @@
+/**
+ * Pure helpers for orchestrator/watch.jsx — kept apart from the Ink rendering
+ * so the parsing logic (the part actually worth getting wrong) has real tests.
+ *
+ * Log lines come from two harnesses in two different shapes: Claude's
+ * stream-json ({type:"assistant"|"result", ...}) and agy's step-update
+ * envelope ({event:"step_update"|"result", ...}). tick.mjs normalises both
+ * inline for its own console output; this mirrors that same normalisation
+ * read-only, from the .jsonl files tick.mjs already writes to ~/.factory/logs.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const trim = (s, n) => String(s ?? "").replace(/\s+/g, " ").slice(0, n);
+
+function resultEntry(ok, turns, cost, said) {
+  return { kind: "result", ok, turns: turns ?? 0, cost: cost ?? 0, said: trim(said, 120) };
+}
+
+/** One raw .jsonl line -> zero or more display entries. Never throws. */
+export function parseLogLine(rawLine) {
+  const line = String(rawLine ?? "").trim();
+  if (!line.startsWith("{")) return [];
+  let e;
+  try { e = JSON.parse(line); } catch { return []; }
+
+  if (e.type === "assistant") {
+    return (e.message?.content ?? [])
+      .filter((p) => p.type === "tool_use")
+      .map((p) => ({ kind: "tool", tool: p.name, detail: trim(p.input?.command ?? p.input?.file_path ?? p.input?.description, 66) }));
+  }
+  if (e.type === "result" || (typeof e.num_turns === "number" && "subtype" in e)) {
+    return [resultEntry(e.subtype === "success" && !e.is_error && (e.num_turns ?? 0) > 0, e.num_turns, e.total_cost_usd, e.result)];
+  }
+
+  if (e.event === "step_update") {
+    const s = e.step_update ?? {};
+    if (s.step_type === "tool" && s.state === "ACTIVE") {
+      const par = s.tool_info?.parameters ?? {};
+      return [{ kind: "tool", tool: s.tool_name ?? "tool", detail: trim(par.CommandLine ?? par.command ?? par.AbsolutePath ?? par.path, 66) }];
+    }
+    return [];
+  }
+  const env = e.event === "result" ? e.result : ("status" in e && "num_turns" in e ? e : null);
+  if (env) return [resultEntry(String(env.status).toLowerCase() === "success", env.num_turns, env.total_cost_usd, env.response)];
+
+  return [];
+}
+
+/** A display entry -> one line of text for the log-tail pane. */
+export function formatEntry(entry) {
+  if (entry.kind === "tool") return entry.detail ? `${entry.tool} ${entry.detail}` : entry.tool;
+  const cost = `${entry.turns} turns ~$${entry.cost.toFixed(2)}`;
+  if (entry.ok) return `done — ${cost}`;
+  return entry.said ? `FAILED — ${cost} — ${entry.said}` : `FAILED — ${cost}`;
+}
+
+/** Newest log file for a ticket, by mtime — a ticket can be retried, leaving older logs behind. */
+export function latestLogForTicket(logDir, repo, identifier) {
+  let best = null;
+  let bestMtime = -Infinity;
+  let files;
+  try { files = new Bun.Glob(`${repo}-${identifier}-*.jsonl`).scanSync(logDir); } catch { return null; }
+  for (const f of files) {
+    const full = path.join(logDir, f);
+    const mtime = Bun.file(full).lastModified;
+    if (mtime > bestMtime) { bestMtime = mtime; best = full; }
+  }
+  return best;
+}
+
+/** Last `maxEntries` formatted lines from a log file. Missing/unreadable file -> []. */
+export function tailFormattedLines(filePath, maxEntries = 40) {
+  if (!filePath) return [];
+  let text;
+  try { text = readFileSync(filePath, "utf8"); } catch { return []; }
+  const entries = text.split("\n").flatMap(parseLogLine);
+  return entries.slice(-maxEntries).map(formatEntry);
+}
+
+/** Running + in-review tickets from one queue.mjs --json summary entry, in display order. */
+export function buildTicketRows(summary) {
+  const running = (summary?.inProgressTickets ?? []).map((t) => ({ ...t, status: "running" }));
+  const review = (summary?.inReviewTickets ?? []).map((t) => ({ ...t, status: "review" }));
+  return [...running, ...review];
+}
+
+export function formatSpend(spent, perDay) {
+  return `$${(spent ?? 0).toFixed(2)} / $${(perDay ?? 0).toFixed(2)}`;
+}

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -88,3 +88,20 @@ export function buildTicketRows(summary) {
 export function formatSpend(spent, perDay) {
   return `$${(spent ?? 0).toFixed(2)} / $${(perDay ?? 0).toFixed(2)}`;
 }
+
+/** Project progress for the stat strip. `capped` means the counts are floors (a 250-issue page filled up). */
+export function formatIssueCounts(done, total, capped) {
+  return `${done ?? 0}/${total ?? 0}${capped ? "+" : ""}`;
+}
+
+/**
+ * What a reaper.mjs run concluded, parsed from its stdout. The number gates the
+ * TUI's confirm step: --apply is only offered when the dry run found something
+ * to reclaim, so a stray keypress on a clean queue can never write to Linear.
+ */
+export function parseReaperOutput(text) {
+  const s = String(text ?? "");
+  const m = /===\s+(?:Would reclaim|Reclaimed):\s+(\d+)/.exec(s);
+  if (m) return { stale: Number(m[1]) };
+  return { stale: 0 };
+}

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -95,6 +95,71 @@ export function formatIssueCounts(done, total, capped) {
 }
 
 /**
+ * The pipeline stages, in pipeline order. Kept here so the TUI and the status
+ * scan below can never disagree about what a "stage" is.
+ */
+export const STAGES = ["triage", "dispatch", "merge"];
+
+// Newest-result parses are cached per (file, mtime) so the 3s poll re-reads a
+// finished stage log zero times instead of every tick.
+const stageResultCache = new Map();
+
+/**
+ * What each stage is doing right now, from log mtimes alone — no process
+ * tracking. tick.mjs streams jsonl continuously while an agent runs, so a
+ * stage log touched within `activeMs` means that stage is running this moment.
+ * triage/merge write `<repo>-factory-<stage>-*.jsonl`; dispatch writes the
+ * per-ticket `<repo>-<ID>-*.jsonl` logs, so its footprint is any ticket log.
+ *
+ * Returns [{ stage, active, ageMs, lastResult }] in STAGES order; ageMs is
+ * null when a stage has never run, lastResult only filled for idle stages.
+ */
+export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_000 } = {}) {
+  return STAGES.map((stage) => {
+    const glob = stage === "dispatch" ? `${repo}-*-*.jsonl` : `${repo}-factory-${stage}-*.jsonl`;
+    let best = null;
+    let bestMtime = -Infinity;
+    try {
+      for (const f of new Bun.Glob(glob).scanSync(logDir)) {
+        if (stage === "dispatch" && f.includes("-factory-")) continue;
+        const full = path.join(logDir, f);
+        const mtime = Bun.file(full).lastModified;
+        if (mtime > bestMtime) { bestMtime = mtime; best = full; }
+      }
+    } catch { /* no log dir yet */ }
+    if (!best) return { stage, active: false, ageMs: null, lastResult: null };
+
+    const ageMs = Math.max(0, now - bestMtime);
+    const active = ageMs < activeMs;
+    let lastResult = null;
+    if (!active) {
+      const key = `${best}:${bestMtime}`;
+      if (stageResultCache.has(key)) {
+        lastResult = stageResultCache.get(key);
+      } else {
+        try {
+          const entries = readFileSync(best, "utf8").split("\n").flatMap(parseLogLine);
+          lastResult = [...entries].reverse().find((e) => e.kind === "result") ?? null;
+        } catch { lastResult = null; }
+        stageResultCache.set(key, lastResult);
+        if (stageResultCache.size > 64) stageResultCache.delete(stageResultCache.keys().next().value);
+      }
+    }
+    return { stage, active, ageMs, lastResult };
+  });
+}
+
+/** "42s" / "7m" / "3h12m" / "never" — coarse on purpose, it's a glance. */
+export function formatAge(ms) {
+  if (ms == null) return "never";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return `${Math.floor(ms / 1000)}s`;
+  if (mins < 60) return `${mins}m`;
+  const rest = mins % 60;
+  return `${Math.floor(mins / 60)}h${rest ? `${rest}m` : ""}`;
+}
+
+/**
  * The desktop-app deep link for a Linear issue URL. Linear's macOS app
  * registers the linear:// scheme; handing `open` an https://linear.app URL
  * lands in the browser instead. Anything that isn't a linear.app URL comes

--- a/orchestrator/watch-lib.mjs
+++ b/orchestrator/watch-lib.mjs
@@ -149,6 +149,19 @@ export function stageStatuses(logDir, repo, { now = Date.now(), activeMs = 90_00
   });
 }
 
+/**
+ * The [start, end) slice of a list that fits `max` rows while keeping
+ * `selected` visible — the selection stays centred once the list scrolls.
+ * This is what keeps a long ticket list scrolling INSIDE the TUI instead of
+ * overflowing the terminal and pushing frames into scrollback.
+ */
+export function visibleWindow(count, selected, max) {
+  if (max <= 0) return [0, 0];
+  if (count <= max) return [0, count];
+  const start = Math.max(0, Math.min(selected - Math.floor(max / 2), count - max));
+  return [start, start + max];
+}
+
 /** "42s" / "7m" / "3h12m" / "never" — coarse on purpose, it's a glance. */
 export function formatAge(ms) {
   if (ms == null) return "never";

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   parseLogLine, formatEntry, tailFormattedLines, latestLogForTicket, buildTicketRows, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink,
+  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge,
 } from "./watch-lib.mjs";
 
 test("ignores blank lines and non-JSON noise", () => {
@@ -161,4 +161,46 @@ test("linearDeepLink maps linear.app URLs to the desktop scheme, null otherwise"
     .toBe("linear://watt-mind/issue/CLNT-810/clean-up-blog-routing");
   expect(linearDeepLink("https://example.com/issue/X-1")).toBeNull();
   expect(linearDeepLink(undefined)).toBeNull();
+});
+
+test("stageStatuses: fresh log = active, old log = idle with the last result", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
+  const result = JSON.stringify({ type: "result", subtype: "success", is_error: false, num_turns: 4, total_cost_usd: 0.5, result: "ok" });
+  writeFileSync(path.join(dir, "bj29-factory-triage-20260804-120000.jsonl"), result);
+  writeFileSync(path.join(dir, "bj29-CLNT-1-20260804-120000.jsonl"), result);
+  const now = Date.now();
+
+  // Written milliseconds ago -> triage and dispatch active, merge never ran.
+  const live = stageStatuses(dir, "bj29", { now });
+  expect(live.map((s) => [s.stage, s.active])).toEqual([["triage", true], ["dispatch", true], ["merge", false]]);
+  expect(live[2].ageMs).toBeNull();
+
+  // Same files viewed from 10 minutes later -> idle, with the parsed result.
+  const idle = stageStatuses(dir, "bj29", { now: now + 10 * 60_000 });
+  expect(idle[0].active).toBe(false);
+  expect(idle[0].lastResult?.ok).toBe(true);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("stageStatuses: dispatch ignores factory-stage logs; failures surface", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
+  const fail = JSON.stringify({ type: "result", subtype: "error_max_turns", is_error: true, num_turns: 2, total_cost_usd: 0.1, result: "boom" });
+  writeFileSync(path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"), fail);
+  const later = { now: Date.now() + 10 * 60_000 };
+  const s = stageStatuses(dir, "bj29", later);
+  expect(s[1]).toEqual({ stage: "dispatch", active: false, ageMs: null, lastResult: null });
+  expect(s[2].lastResult?.ok).toBe(false);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("stageStatuses tolerates a missing log dir", () => {
+  expect(stageStatuses("/no/such/dir", "bj29").every((s) => s.ageMs === null)).toBe(true);
+});
+
+test("formatAge is coarse and never negative-weird", () => {
+  expect(formatAge(null)).toBe("never");
+  expect(formatAge(42_000)).toBe("42s");
+  expect(formatAge(7 * 60_000)).toBe("7m");
+  expect(formatAge(3 * 3600_000 + 12 * 60_000)).toBe("3h12m");
+  expect(formatAge(2 * 3600_000)).toBe("2h");
 });

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   parseLogLine, formatEntry, tailFormattedLines, latestLogForTicket, buildTicketRows, formatSpend,
+  formatIssueCounts, parseReaperOutput,
 } from "./watch-lib.mjs";
 
 test("ignores blank lines and non-JSON noise", () => {
@@ -132,4 +133,25 @@ test("buildTicketRows tolerates a summary with no tickets", () => {
 test("formatSpend rounds to cents", () => {
   expect(formatSpend(4.2, 40)).toBe("$4.20 / $40.00");
   expect(formatSpend(7 * 1.1, 10)).toBe("$7.70 / $10.00");
+});
+
+test("formatIssueCounts renders done/total and marks capped counts as floors", () => {
+  expect(formatIssueCounts(41, 57, false)).toBe("41/57");
+  expect(formatIssueCounts(250, 400, true)).toBe("250/400+");
+  expect(formatIssueCounts(undefined, undefined, false)).toBe("0/0");
+});
+
+test("parseReaperOutput reads the reclaim count from a dry run", () => {
+  const out = "=== Stale-claim reaper [DRY RUN] threshold=45min ===\n\n  STALE CW-12  61m  agent  title\n\n=== Would reclaim: 2 | Healthy: 3 ===\nRun again with --apply to reclaim these.";
+  expect(parseReaperOutput(out)).toEqual({ stale: 2 });
+});
+
+test("parseReaperOutput reads the count from an --apply run", () => {
+  expect(parseReaperOutput("=== Reclaimed: 1 | Healthy: 0 ===")).toEqual({ stale: 1 });
+});
+
+test("parseReaperOutput treats a clean queue or garbage as nothing to reclaim", () => {
+  expect(parseReaperOutput("=== No stale claims among 4 in progress. ===")).toEqual({ stale: 0 });
+  expect(parseReaperOutput("")).toEqual({ stale: 0 });
+  expect(parseReaperOutput(null)).toEqual({ stale: 0 });
 });

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   parseLogLine, formatEntry, tailFormattedLines, latestLogForTicket, buildTicketRows, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge,
+  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge, visibleWindow,
 } from "./watch-lib.mjs";
 
 test("ignores blank lines and non-JSON noise", () => {
@@ -203,4 +203,12 @@ test("formatAge is coarse and never negative-weird", () => {
   expect(formatAge(7 * 60_000)).toBe("7m");
   expect(formatAge(3 * 3600_000 + 12 * 60_000)).toBe("3h12m");
   expect(formatAge(2 * 3600_000)).toBe("2h");
+});
+
+test("visibleWindow keeps the selection in view and clamps at both ends", () => {
+  expect(visibleWindow(5, 2, 10)).toEqual([0, 5]);      // fits — no scrolling
+  expect(visibleWindow(20, 0, 6)).toEqual([0, 6]);      // top
+  expect(visibleWindow(20, 10, 6)).toEqual([7, 13]);    // centred mid-list
+  expect(visibleWindow(20, 19, 6)).toEqual([14, 20]);   // bottom clamp
+  expect(visibleWindow(20, 5, 0)).toEqual([0, 0]);      // degenerate pane
 });

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * bun test
+ *
+ * The log parser is the one part of watch.jsx that can silently show nothing
+ * (or crash on a malformed line) without anyone noticing until they need it —
+ * it gets real tests. Fixtures are trimmed real lines from both harnesses'
+ * ~/.factory/logs output.
+ */
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  parseLogLine, formatEntry, tailFormattedLines, latestLogForTicket, buildTicketRows, formatSpend,
+} from "./watch-lib.mjs";
+
+test("ignores blank lines and non-JSON noise", () => {
+  expect(parseLogLine("")).toEqual([]);
+  expect(parseLogLine("   ")).toEqual([]);
+  expect(parseLogLine("not json")).toEqual([]);
+});
+
+test("ignores malformed JSON instead of throwing", () => {
+  expect(() => parseLogLine('{"type":"assistant", broken')).not.toThrow();
+  expect(parseLogLine('{"type":"assistant", broken')).toEqual([]);
+});
+
+test("claude: extracts a tool_use call from an assistant message", () => {
+  const line = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "npm run lint" } }] },
+  });
+  expect(parseLogLine(line)).toEqual([{ kind: "tool", tool: "Bash", detail: "npm run lint" }]);
+});
+
+test("claude: a text-only assistant message yields no entries", () => {
+  const line = JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "thinking..." }] } });
+  expect(parseLogLine(line)).toEqual([]);
+});
+
+test("claude: a successful result", () => {
+  const line = JSON.stringify({ type: "result", subtype: "success", is_error: false, num_turns: 12, total_cost_usd: 1.5, result: "done" });
+  const [entry] = parseLogLine(line);
+  expect(entry.kind).toBe("result");
+  expect(entry.ok).toBe(true);
+  expect(formatEntry(entry)).toBe("done — 12 turns ~$1.50");
+});
+
+test("claude: a failed result includes the trimmed message", () => {
+  const line = JSON.stringify({ type: "result", subtype: "error_max_turns", is_error: true, num_turns: 3, total_cost_usd: 0.4, result: "Unknown command" });
+  const [entry] = parseLogLine(line);
+  expect(entry.ok).toBe(false);
+  expect(formatEntry(entry)).toBe("FAILED — 3 turns ~$0.40 — Unknown command");
+});
+
+test("agy: extracts an ACTIVE tool step_update", () => {
+  const line = JSON.stringify({
+    event: "step_update",
+    step_update: { step_type: "tool", state: "ACTIVE", tool_name: "run_command", tool_info: { parameters: { CommandLine: "bun test" } } },
+  });
+  expect(parseLogLine(line)).toEqual([{ kind: "tool", tool: "run_command", detail: "bun test" }]);
+});
+
+test("agy: a DONE step_update produces no entry (only ACTIVE tool steps do)", () => {
+  const line = JSON.stringify({ event: "step_update", step_update: { step_type: "tool", state: "DONE", tool_name: "run_command" } });
+  expect(parseLogLine(line)).toEqual([]);
+});
+
+test("agy: a wrapped result event", () => {
+  const line = JSON.stringify({ event: "result", result: { status: "SUCCESS", num_turns: 5, total_cost_usd: 2, response: "ok" } });
+  const [entry] = parseLogLine(line);
+  expect(entry.ok).toBe(true);
+  expect(formatEntry(entry)).toBe("done — 5 turns ~$2.00");
+});
+
+test("agy: an ERROR status formats as failed", () => {
+  const line = JSON.stringify({ event: "result", result: { status: "ERROR", num_turns: 1, total_cost_usd: 0, error: "quota reached" } });
+  const [entry] = parseLogLine(line);
+  expect(entry.ok).toBe(false);
+});
+
+test("tailFormattedLines reads a file, formats every entry, and caps at maxEntries", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
+  const file = path.join(dir, "sample.jsonl");
+  const lines = [];
+  for (let i = 0; i < 5; i++) {
+    lines.push(JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: `f${i}.ts` } }] } }));
+  }
+  writeFileSync(file, lines.join("\n"));
+  expect(tailFormattedLines(file, 2)).toEqual(["Read f3.ts", "Read f4.ts"]);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("tailFormattedLines returns [] for a missing file rather than throwing", () => {
+  expect(tailFormattedLines("/no/such/file.jsonl")).toEqual([]);
+  expect(tailFormattedLines(null)).toEqual([]);
+});
+
+test("latestLogForTicket picks the newest matching file by mtime", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
+  writeFileSync(path.join(dir, "bj29-CLNT-1-20260101000000..jsonl"), "{}");
+  await new Promise((r) => setTimeout(r, 5));
+  writeFileSync(path.join(dir, "bj29-CLNT-1-20260102000000..jsonl"), "{}");
+  writeFileSync(path.join(dir, "bj29-CLNT-2-20260103000000..jsonl"), "{}"); // different ticket, must not match
+  const found = latestLogForTicket(dir, "bj29", "CLNT-1");
+  expect(found).toBe(path.join(dir, "bj29-CLNT-1-20260102000000..jsonl"));
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("latestLogForTicket returns null when nothing matches", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "watch-lib-"));
+  expect(latestLogForTicket(dir, "bj29", "CLNT-999")).toBeNull();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("buildTicketRows tags running and in-review tickets and preserves order", () => {
+  const summary = {
+    inProgressTickets: [{ identifier: "CLNT-1", title: "a" }],
+    inReviewTickets: [{ identifier: "CLNT-2", title: "b" }, { identifier: "CLNT-3", title: "c" }],
+  };
+  expect(buildTicketRows(summary)).toEqual([
+    { identifier: "CLNT-1", title: "a", status: "running" },
+    { identifier: "CLNT-2", title: "b", status: "review" },
+    { identifier: "CLNT-3", title: "c", status: "review" },
+  ]);
+});
+
+test("buildTicketRows tolerates a summary with no tickets", () => {
+  expect(buildTicketRows({})).toEqual([]);
+});
+
+test("formatSpend rounds to cents", () => {
+  expect(formatSpend(4.2, 40)).toBe("$4.20 / $40.00");
+  expect(formatSpend(7 * 1.1, 10)).toBe("$7.70 / $10.00");
+});

--- a/orchestrator/watch-lib.test.mjs
+++ b/orchestrator/watch-lib.test.mjs
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   parseLogLine, formatEntry, tailFormattedLines, latestLogForTicket, buildTicketRows, formatSpend,
-  formatIssueCounts, parseReaperOutput,
+  formatIssueCounts, parseReaperOutput, linearDeepLink,
 } from "./watch-lib.mjs";
 
 test("ignores blank lines and non-JSON noise", () => {
@@ -154,4 +154,11 @@ test("parseReaperOutput treats a clean queue or garbage as nothing to reclaim", 
   expect(parseReaperOutput("=== No stale claims among 4 in progress. ===")).toEqual({ stale: 0 });
   expect(parseReaperOutput("")).toEqual({ stale: 0 });
   expect(parseReaperOutput(null)).toEqual({ stale: 0 });
+});
+
+test("linearDeepLink maps linear.app URLs to the desktop scheme, null otherwise", () => {
+  expect(linearDeepLink("https://linear.app/watt-mind/issue/CLNT-810/clean-up-blog-routing"))
+    .toBe("linear://watt-mind/issue/CLNT-810/clean-up-blog-routing");
+  expect(linearDeepLink("https://example.com/issue/X-1")).toBeNull();
+  expect(linearDeepLink(undefined)).toBeNull();
 });

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -25,7 +25,7 @@ import { ROOT } from "../lib/schedule.mjs";
 import { todaysSpendUSD } from "../lib/spend.mjs";
 import {
   buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge,
+  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge, visibleWindow,
 } from "./watch-lib.mjs";
 
 const LOG_DIR = path.join(homedir(), ".factory/logs");
@@ -125,6 +125,33 @@ function StageStrip({ stages }) {
   );
 }
 
+const SHORTCUTS = [
+  ["↑ ↓", "select a ticket"],
+  ["← →", "switch repo"],
+  ["o", "open the selected ticket in Linear (desktop app, browser fallback)"],
+  ["r", "refresh queue + spend now"],
+  ["x", "run the stale-claim reaper (dry run) for this repo's team"],
+  ["y", "confirm reaper --apply — only offered when the dry run found stale claims"],
+  ["?", "this help"],
+  ["esc", "close an open pane; quit when none is open"],
+  ["q", "quit"],
+];
+
+function HelpPane() {
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text bold color="cyan">keyboard shortcuts</Text>
+      {SHORTCUTS.map(([keys, what]) => (
+        <Text key={keys}>
+          <Text bold color="cyan">{keys.padEnd(6)}</Text>
+          {what}
+        </Text>
+      ))}
+      <Text dimColor>esc close</Text>
+    </Box>
+  );
+}
+
 /**
  * Runs orchestrator/reaper.mjs and takes over the main pane while the output
  * is up. Dry runs happen on `x` alone; the `stale` count parsed from that dry
@@ -163,12 +190,20 @@ async function runReaperProcess(team, apply) {
   return { out, err };
 }
 
-function TicketList({ rows, ready, selected }) {
+function TicketList({ rows, ready, selected, height }) {
+  // Budget in rows: 1 header, 2 per ticket, 3 for the ready section, 2 for
+  // the more-above/below markers. Never let the list outgrow the pane — an
+  // overgrown frame is what pushes the TUI into terminal scrollback.
+  const readyReserve = ready?.length > 0 ? 3 : 0;
+  const maxRows = Math.max(1, Math.floor((height - 1 - readyReserve - 2) / 2));
+  const [start, end] = visibleWindow(rows.length, selected, maxRows);
   return (
     <Box flexDirection="column" width="42%" marginRight={1}>
       <Text dimColor>in flight</Text>
       {rows.length === 0 && <Text dimColor>  nothing running or in review</Text>}
-      {rows.map((t, i) => {
+      {start > 0 && <Text dimColor>  ▲ {start} more</Text>}
+      {rows.slice(start, end).map((t, idx) => {
+        const i = start + idx;
         const isSel = i === selected;
         const dot = t.status === "running" ? "●" : "◐";
         const dotColor = t.status === "running" ? "green" : "yellow";
@@ -182,6 +217,7 @@ function TicketList({ rows, ready, selected }) {
           </Box>
         );
       })}
+      {end < rows.length && <Text dimColor>  ▼ {rows.length - end} more</Text>}
       {ready?.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           <Text dimColor>ready to dispatch</Text>
@@ -192,13 +228,14 @@ function TicketList({ rows, ready, selected }) {
   );
 }
 
-function LogTail({ ticket, lines }) {
+function LogTail({ ticket, lines, height }) {
+  const shown = lines.slice(-Math.max(1, height - 1));
   return (
     <Box flexDirection="column" width="58%">
       <Text dimColor>{ticket ? `log tail — ${ticket}` : "log tail"}</Text>
       {!ticket && <Text dimColor>  select a ticket to tail its log</Text>}
       {ticket && lines.length === 0 && <Text dimColor>  no log yet</Text>}
-      {lines.map((line, i) => (
+      {shown.map((line, i) => (
         <Text key={i} wrap="truncate-end">{line}</Text>
       ))}
     </Box>
@@ -215,11 +252,16 @@ function App() {
   const [spend, setSpend] = useState(0);
   const [reaper, setReaper] = useState(null); // { phase, team, lines, stale }
   const [stages, setStages] = useState(null);
+  const [showHelp, setShowHelp] = useState(false);
   const rowIdxRef = useRef(rowIdx);
   rowIdxRef.current = rowIdx;
   const pollRef = useRef(null);
   const { stdout } = useStdout();
-  const width = Math.max(70, Math.min(140, stdout?.columns ?? 100));
+  const width = Math.max(70, stdout?.columns ?? 100);
+  const height = Math.max(12, stdout?.rows ?? 40);
+  // Rows left for the ticket-list/log panes: borders 2, title 1, tabs 2,
+  // queue strip 1, stage strip 1, pane margins 2, footer 1.
+  const paneHeight = Math.max(4, height - 10);
 
   useEffect(() => {
     let cancelled = false;
@@ -297,6 +339,11 @@ function App() {
 
   useInput((input, key) => {
     if (input === "q" || (key.ctrl && input === "c")) process.exit(0);
+    if (showHelp) {
+      if (key.escape || input === "?") setShowHelp(false);
+      return;
+    }
+    if (input === "?") { setShowHelp(true); return; }
     if (reaper) {
       // The pane owns the keyboard while it's up: esc closes it (instead of
       // quitting), y confirms --apply, and only off a dry run that found work.
@@ -324,18 +371,20 @@ function App() {
   });
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} width={width}>
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} width={width} height={height}>
       <Text bold>factory — foreground monitor</Text>
       <RepoTabs repos={summaries.map((s) => s.repo)} selected={repoIdx} />
       <QueueStrip summary={summary} />
       <StageStrip stages={stages} />
-      <Box marginTop={1} marginBottom={1}>
-        {reaper ? (
+      <Box marginTop={1} marginBottom={1} flexGrow={1}>
+        {showHelp ? (
+          <HelpPane />
+        ) : reaper ? (
           <ReaperPane reaper={reaper} />
         ) : (
           <>
-            <TicketList rows={rows} ready={summary?.startable} selected={rowIdx} />
-            <LogTail ticket={selectedTicket} lines={logLines} />
+            <TicketList rows={rows} ready={summary?.startable} selected={rowIdx} height={paneHeight} />
+            <LogTail ticket={selectedTicket} lines={logLines} height={paneHeight} />
           </>
         )}
       </Box>
@@ -345,11 +394,16 @@ function App() {
           {error ? <Text color="red">  ! {error.slice(0, 50)}</Text> : null}
         </Text>
         <Text dimColor>
-          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · o open · r refresh · x reaper · q quit
+          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ? shortcuts · q quit
         </Text>
       </Box>
     </Box>
   );
 }
 
+// Fullscreen: take over the terminal's alternate screen buffer (the htop/vim
+// behaviour), so the shell prompt and scrollback are untouched underneath and
+// come back intact on exit — however the process ends.
+process.stdout.write("\x1b[?1049h\x1b[H");
+process.on("exit", () => process.stdout.write("\x1b[?1049l"));
 render(<App />);

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -25,7 +25,7 @@ import { ROOT } from "../lib/schedule.mjs";
 import { todaysSpendUSD } from "../lib/spend.mjs";
 import {
   buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend,
-  formatIssueCounts, parseReaperOutput, linearDeepLink,
+  formatIssueCounts, parseReaperOutput, linearDeepLink, stageStatuses, formatAge,
 } from "./watch-lib.mjs";
 
 const LOG_DIR = path.join(homedir(), ".factory/logs");
@@ -92,6 +92,35 @@ function QueueStrip({ summary }) {
       <StatChip label="blocked" value={summary.blocked} tone={summary.blocked ? "bad" : undefined} />
       <StatChip label="PRs" value={summary.openPRs} tone={summary.openPRs ? "warn" : undefined} />
       <StatChip label="done" value={formatIssueCounts(summary.done, summary.total, summary.countCapped)} />
+    </Box>
+  );
+}
+
+/**
+ * triage -> dispatch -> merge, with a live dot on whatever is running right
+ * now (log written < 90s ago) and "how long since it last ran, and did it
+ * end well" for the rest.
+ */
+function StageStrip({ stages }) {
+  if (!stages) return null;
+  return (
+    <Box>
+      <Text dimColor>stages </Text>
+      {stages.map((s) => {
+        const failed = s.lastResult && !s.lastResult.ok;
+        return (
+          <Box key={s.stage} marginRight={2}>
+            {s.active ? (
+              <Text color="green">● {s.stage}</Text>
+            ) : (
+              <Text dimColor>
+                ○ {s.stage} <Text>{formatAge(s.ageMs)}</Text>
+                {failed ? <Text color="red" bold> FAIL</Text> : null}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
     </Box>
   );
 }
@@ -185,6 +214,7 @@ function App() {
   const [logLines, setLogLines] = useState([]);
   const [spend, setSpend] = useState(0);
   const [reaper, setReaper] = useState(null); // { phase, team, lines, stale }
+  const [stages, setStages] = useState(null);
   const rowIdxRef = useRef(rowIdx);
   rowIdxRef.current = rowIdx;
   const pollRef = useRef(null);
@@ -226,6 +256,14 @@ function App() {
   const summary = summaries[repoIdx];
   const rows = buildTicketRows(summary ?? {});
   const selectedTicket = rows[rowIdx]?.identifier ?? null;
+
+  useEffect(() => {
+    if (!summary?.repo) { setStages(null); return; }
+    const scan = () => setStages(stageStatuses(LOG_DIR, summary.repo));
+    scan();
+    const id = setInterval(scan, LOG_POLL_MS);
+    return () => clearInterval(id);
+  }, [summary?.repo]);
 
   useEffect(() => {
     const tail = () => {
@@ -290,6 +328,7 @@ function App() {
       <Text bold>factory — foreground monitor</Text>
       <RepoTabs repos={summaries.map((s) => s.repo)} selected={repoIdx} />
       <QueueStrip summary={summary} />
+      <StageStrip stages={stages} />
       <Box marginTop={1} marginBottom={1}>
         {reaper ? (
           <ReaperPane reaper={reaper} />

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -1,0 +1,222 @@
+#!/usr/bin/env bun
+/**
+ * Foreground monitor — a read-only window onto what tick.mjs / run.mjs are
+ * doing right now: queue depth per repo (via `queue.mjs --json`), which
+ * tickets are in flight or in review, and a live tail of the selected
+ * ticket's session log under ~/.factory/logs.
+ *
+ *   bun orchestrator/watch.jsx
+ *   bun orchestrator/watch.jsx --repo bj29
+ *
+ * Never spawns an agent and never writes anywhere — it only re-reads the
+ * same state queue.mjs and the log files already expose. This is the
+ * bird's-eye view across repos and in-flight tickets; run.mjs is still the
+ * place to watch one job's full dry/apply output.
+ */
+import React, { useEffect, useRef, useState } from "react";
+import { render, Box, Text, useInput, useStdout } from "ink";
+import { homedir } from "node:os";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { ROOT } from "../lib/schedule.mjs";
+import { todaysSpendUSD } from "../lib/spend.mjs";
+import { buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend } from "./watch-lib.mjs";
+
+const LOG_DIR = path.join(homedir(), ".factory/logs");
+const QUEUE_POLL_MS = 20_000;
+const LOG_POLL_MS = 3_000;
+
+const argv = process.argv.slice(2);
+const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+const REPO_FILTER = val("--repo");
+
+const policy = (() => {
+  try { return Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8")); } catch { return {}; }
+})();
+const PER_DAY_USD = policy?.budget?.per_day_usd ?? 0;
+
+const clock = () => new Date().toTimeString().slice(0, 8);
+
+async function fetchQueue() {
+  const args = ["orchestrator/queue.mjs", "--json"];
+  if (REPO_FILTER) args.push("--repo", REPO_FILTER);
+  const p = Bun.spawn(["bun", ...args], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([
+    new Response(p.stdout).text(),
+    new Response(p.stderr).text(),
+    p.exited,
+  ]);
+  if (code !== 0) throw new Error(err.trim() || `queue.mjs exited ${code}`);
+  return JSON.parse(out);
+}
+
+function StatChip({ label, value, tone }) {
+  const color = tone === "warn" ? "yellow" : tone === "bad" ? "red" : tone === "good" ? "green" : undefined;
+  return (
+    <Box marginRight={2}>
+      <Text dimColor>{label} </Text>
+      <Text color={color} bold={Boolean(tone)}>{value}</Text>
+    </Box>
+  );
+}
+
+function RepoTabs({ repos, selected }) {
+  if (repos.length < 2) return null;
+  return (
+    <Box marginBottom={1}>
+      {repos.map((r, i) => (
+        <Box key={r} marginRight={2}>
+          <Text bold={i === selected} color={i === selected ? "green" : undefined} dimColor={i !== selected}>
+            {i === selected ? "▶ " : "  "}{r}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function QueueStrip({ summary }) {
+  if (!summary) return <Text dimColor>waiting for queue.mjs…</Text>;
+  return (
+    <Box>
+      <StatChip label="running" value={summary.inProgress} />
+      <StatChip label="ready" value={summary.ready} tone={summary.ready ? "good" : undefined} />
+      <StatChip label="review" value={summary.inReview} tone={summary.inReview ? "warn" : undefined} />
+      <StatChip label="triage" value={summary.triage} />
+      <StatChip label="blocked" value={summary.blocked} tone={summary.blocked ? "bad" : undefined} />
+    </Box>
+  );
+}
+
+function TicketList({ rows, ready, selected }) {
+  return (
+    <Box flexDirection="column" width="42%" marginRight={1}>
+      <Text dimColor>in flight</Text>
+      {rows.length === 0 && <Text dimColor>  nothing running or in review</Text>}
+      {rows.map((t, i) => {
+        const isSel = i === selected;
+        const dot = t.status === "running" ? "●" : "◐";
+        const dotColor = t.status === "running" ? "green" : "yellow";
+        return (
+          <Box key={t.identifier} flexDirection="column" marginBottom={0}>
+            <Text inverse={isSel}>
+              <Text color={dotColor}>{dot}</Text> {t.identifier}{" "}
+              <Text dimColor>{t.status === "running" ? "running" : "in review"}</Text>
+            </Text>
+            <Text dimColor wrap="truncate-end">  {t.title}</Text>
+          </Box>
+        );
+      })}
+      {ready?.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>ready to dispatch</Text>
+          <Text dimColor wrap="truncate-end">  {ready.join(" · ")}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function LogTail({ ticket, lines }) {
+  return (
+    <Box flexDirection="column" width="58%">
+      <Text dimColor>{ticket ? `log tail — ${ticket}` : "log tail"}</Text>
+      {!ticket && <Text dimColor>  select a ticket to tail its log</Text>}
+      {ticket && lines.length === 0 && <Text dimColor>  no log yet</Text>}
+      {lines.map((line, i) => (
+        <Text key={i} wrap="truncate-end">{line}</Text>
+      ))}
+    </Box>
+  );
+}
+
+function App() {
+  const [summaries, setSummaries] = useState([]);
+  const [error, setError] = useState(null);
+  const [lastPoll, setLastPoll] = useState(null);
+  const [repoIdx, setRepoIdx] = useState(0);
+  const [rowIdx, setRowIdx] = useState(0);
+  const [logLines, setLogLines] = useState([]);
+  const [spend, setSpend] = useState(0);
+  const rowIdxRef = useRef(rowIdx);
+  rowIdxRef.current = rowIdx;
+  const { stdout } = useStdout();
+  const width = Math.max(70, Math.min(140, stdout?.columns ?? 100));
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await fetchQueue();
+        if (cancelled) return;
+        setSummaries(data);
+        setError(null);
+        setLastPoll(clock());
+        setRowIdx((prev) => {
+          const rows = buildTicketRows(data[Math.min(repoIdx, data.length - 1)] ?? {});
+          return Math.min(prev, Math.max(0, rows.length - 1));
+        });
+      } catch (e) {
+        if (!cancelled) setError(String(e.message ?? e));
+      }
+    };
+    poll();
+    const id = setInterval(poll, QUEUE_POLL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+    // repoIdx intentionally omitted — clamping reads the latest via closure
+    // over the freshest `data`, not a stale repoIdx from mount time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => setSpend(todaysSpendUSD(LOG_DIR)), LOG_POLL_MS);
+    setSpend(todaysSpendUSD(LOG_DIR));
+    return () => clearInterval(id);
+  }, []);
+
+  const summary = summaries[repoIdx];
+  const rows = buildTicketRows(summary ?? {});
+  const selectedTicket = rows[rowIdx]?.identifier ?? null;
+
+  useEffect(() => {
+    const tail = () => {
+      if (!selectedTicket || !summary) { setLogLines([]); return; }
+      const file = latestLogForTicket(LOG_DIR, summary.repo, selectedTicket);
+      setLogLines(tailFormattedLines(file, 30));
+    };
+    tail();
+    const id = setInterval(tail, LOG_POLL_MS);
+    return () => clearInterval(id);
+  }, [selectedTicket, summary?.repo]);
+
+  useInput((input, key) => {
+    if (input === "q" || key.escape || (key.ctrl && input === "c")) process.exit(0);
+    if (key.leftArrow) { setRepoIdx((i) => Math.max(0, i - 1)); setRowIdx(0); }
+    if (key.rightArrow) { setRepoIdx((i) => Math.min(summaries.length - 1, i + 1)); setRowIdx(0); }
+    if (key.upArrow) setRowIdx((i) => Math.max(0, i - 1));
+    if (key.downArrow) setRowIdx((i) => Math.min(rows.length - 1, i + 1));
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} width={width}>
+      <Text bold>factory — foreground monitor</Text>
+      <RepoTabs repos={summaries.map((s) => s.repo)} selected={repoIdx} />
+      <QueueStrip summary={summary} />
+      <Box marginTop={1} marginBottom={1}>
+        <TicketList rows={rows} ready={summary?.startable} selected={rowIdx} />
+        <LogTail ticket={selectedTicket} lines={logLines} />
+      </Box>
+      <Box justifyContent="space-between">
+        <Text dimColor>
+          spend {formatSpend(spend, PER_DAY_USD)} today
+          {error ? <Text color="red">  ! {error.slice(0, 50)}</Text> : null}
+        </Text>
+        <Text dimColor>
+          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · q quit
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+render(<App />);

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -25,7 +25,7 @@ import { ROOT } from "../lib/schedule.mjs";
 import { todaysSpendUSD } from "../lib/spend.mjs";
 import {
   buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend,
-  formatIssueCounts, parseReaperOutput,
+  formatIssueCounts, parseReaperOutput, linearDeepLink,
 } from "./watch-lib.mjs";
 
 const LOG_DIR = path.join(homedir(), ".factory/logs");
@@ -268,6 +268,16 @@ function App() {
     }
     if (key.escape) process.exit(0);
     if (input === "r") { pollRef.current?.(); setSpend(todaysSpendUSD(LOG_DIR)); }
+    if (input === "o") {
+      const url = rows[rowIdx]?.url;
+      if (url) {
+        // Desktop app first; if the linear:// handler isn't registered, `open`
+        // exits non-zero and the https URL goes to the browser instead.
+        const deep = linearDeepLink(url);
+        const p = Bun.spawn(["open", deep ?? url], { stdout: "ignore", stderr: "ignore" });
+        if (deep) p.exited.then((code) => { if (code !== 0) Bun.spawn(["open", url], { stdout: "ignore", stderr: "ignore" }); });
+      }
+    }
     if (input === "x" && summary?.team) startReaper(summary.team, false);
     if (key.leftArrow) { setRepoIdx((i) => Math.max(0, i - 1)); setRowIdx(0); }
     if (key.rightArrow) { setRepoIdx((i) => Math.max(0, Math.min(summaries.length - 1, i + 1))); setRowIdx(0); }
@@ -296,7 +306,7 @@ function App() {
           {error ? <Text color="red">  ! {error.slice(0, 50)}</Text> : null}
         </Text>
         <Text dimColor>
-          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · r refresh · x reaper · q quit
+          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · o open · r refresh · x reaper · q quit
         </Text>
       </Box>
     </Box>

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -8,10 +8,13 @@
  *   bun orchestrator/watch.jsx
  *   bun orchestrator/watch.jsx --repo bj29
  *
- * Never spawns an agent and never writes anywhere — it only re-reads the
- * same state queue.mjs and the log files already expose. This is the
- * bird's-eye view across repos and in-flight tickets; run.mjs is still the
- * place to watch one job's full dry/apply output.
+ * Never spawns an agent, and writes nowhere with ONE deliberate exception:
+ * pressing `x` runs the stale-claim reaper for the selected repo's team —
+ * dry-run first, and `--apply` only after a second explicit `y`, only when the
+ * dry run found something to reclaim. Everything else re-reads the same state
+ * queue.mjs and the log files already expose. This is the bird's-eye view
+ * across repos and in-flight tickets; run.mjs is still the place to watch one
+ * job's full dry/apply output.
  */
 import React, { useEffect, useRef, useState } from "react";
 import { render, Box, Text, useInput, useStdout } from "ink";
@@ -20,7 +23,10 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
 import { todaysSpendUSD } from "../lib/spend.mjs";
-import { buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend } from "./watch-lib.mjs";
+import {
+  buildTicketRows, latestLogForTicket, tailFormattedLines, formatSpend,
+  formatIssueCounts, parseReaperOutput,
+} from "./watch-lib.mjs";
 
 const LOG_DIR = path.join(homedir(), ".factory/logs");
 const QUEUE_POLL_MS = 20_000;
@@ -84,8 +90,48 @@ function QueueStrip({ summary }) {
       <StatChip label="review" value={summary.inReview} tone={summary.inReview ? "warn" : undefined} />
       <StatChip label="triage" value={summary.triage} />
       <StatChip label="blocked" value={summary.blocked} tone={summary.blocked ? "bad" : undefined} />
+      <StatChip label="PRs" value={summary.openPRs} tone={summary.openPRs ? "warn" : undefined} />
+      <StatChip label="done" value={formatIssueCounts(summary.done, summary.total, summary.countCapped)} />
     </Box>
   );
+}
+
+/**
+ * Runs orchestrator/reaper.mjs and takes over the main pane while the output
+ * is up. Dry runs happen on `x` alone; the `stale` count parsed from that dry
+ * run is what unlocks the `y` -> --apply step.
+ */
+function ReaperPane({ reaper }) {
+  const title = {
+    dry: `reaper — dry run (team ${reaper.team})…`,
+    "dry-done": `reaper — dry run (team ${reaper.team})`,
+    applying: `reaper — applying (team ${reaper.team})…`,
+    applied: `reaper — reclaimed (team ${reaper.team})`,
+    error: "reaper — failed",
+  }[reaper.phase];
+  const canApply = reaper.phase === "dry-done" && reaper.stale > 0;
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={reaper.phase === "error" ? "red" : "yellow"} paddingX={1}>
+      <Text bold color={reaper.phase === "error" ? "red" : "yellow"}>{title}</Text>
+      {reaper.lines.length === 0 && <Text dimColor>running…</Text>}
+      {reaper.lines.map((line, i) => (
+        <Text key={i} wrap="truncate-end">{line}</Text>
+      ))}
+      <Text dimColor>{canApply ? "y reclaim these · " : ""}esc close</Text>
+    </Box>
+  );
+}
+
+async function runReaperProcess(team, apply) {
+  const args = ["orchestrator/reaper.mjs", "--team", team];
+  if (apply) args.push("--apply");
+  const p = Bun.spawn(["bun", ...args], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+  const [out, err] = await Promise.all([
+    new Response(p.stdout).text(),
+    new Response(p.stderr).text(),
+    p.exited,
+  ]);
+  return { out, err };
 }
 
 function TicketList({ rows, ready, selected }) {
@@ -138,8 +184,10 @@ function App() {
   const [rowIdx, setRowIdx] = useState(0);
   const [logLines, setLogLines] = useState([]);
   const [spend, setSpend] = useState(0);
+  const [reaper, setReaper] = useState(null); // { phase, team, lines, stale }
   const rowIdxRef = useRef(rowIdx);
   rowIdxRef.current = rowIdx;
+  const pollRef = useRef(null);
   const { stdout } = useStdout();
   const width = Math.max(70, Math.min(140, stdout?.columns ?? 100));
 
@@ -160,6 +208,7 @@ function App() {
         if (!cancelled) setError(String(e.message ?? e));
       }
     };
+    pollRef.current = poll;
     poll();
     const id = setInterval(poll, QUEUE_POLL_MS);
     return () => { cancelled = true; clearInterval(id); };
@@ -189,10 +238,39 @@ function App() {
     return () => clearInterval(id);
   }, [selectedTicket, summary?.repo]);
 
+  const startReaper = async (team, apply) => {
+    setReaper({ phase: apply ? "applying" : "dry", team, lines: [], stale: 0 });
+    try {
+      const { out, err } = await runReaperProcess(team, apply);
+      const text = (out + (err ? `\n${err}` : "")).trimEnd();
+      setReaper({
+        phase: apply ? "applied" : "dry-done",
+        team,
+        lines: text.split("\n").filter((l) => l.trim() !== "").slice(-16),
+        stale: parseReaperOutput(out).stale,
+      });
+      // A reclaim changes the queue right now — don't leave the strip stale
+      // for up to 20s claiming the ticket is still In Progress.
+      if (apply) pollRef.current?.();
+    } catch (e) {
+      setReaper({ phase: "error", team, lines: [String(e.message ?? e)], stale: 0 });
+    }
+  };
+
   useInput((input, key) => {
-    if (input === "q" || key.escape || (key.ctrl && input === "c")) process.exit(0);
+    if (input === "q" || (key.ctrl && input === "c")) process.exit(0);
+    if (reaper) {
+      // The pane owns the keyboard while it's up: esc closes it (instead of
+      // quitting), y confirms --apply, and only off a dry run that found work.
+      if (key.escape) setReaper(null);
+      if (input === "y" && reaper.phase === "dry-done" && reaper.stale > 0) startReaper(reaper.team, true);
+      return;
+    }
+    if (key.escape) process.exit(0);
+    if (input === "r") { pollRef.current?.(); setSpend(todaysSpendUSD(LOG_DIR)); }
+    if (input === "x" && summary?.team) startReaper(summary.team, false);
     if (key.leftArrow) { setRepoIdx((i) => Math.max(0, i - 1)); setRowIdx(0); }
-    if (key.rightArrow) { setRepoIdx((i) => Math.min(summaries.length - 1, i + 1)); setRowIdx(0); }
+    if (key.rightArrow) { setRepoIdx((i) => Math.max(0, Math.min(summaries.length - 1, i + 1))); setRowIdx(0); }
     if (key.upArrow) setRowIdx((i) => Math.max(0, i - 1));
     if (key.downArrow) setRowIdx((i) => Math.min(rows.length - 1, i + 1));
   });
@@ -203,8 +281,14 @@ function App() {
       <RepoTabs repos={summaries.map((s) => s.repo)} selected={repoIdx} />
       <QueueStrip summary={summary} />
       <Box marginTop={1} marginBottom={1}>
-        <TicketList rows={rows} ready={summary?.startable} selected={rowIdx} />
-        <LogTail ticket={selectedTicket} lines={logLines} />
+        {reaper ? (
+          <ReaperPane reaper={reaper} />
+        ) : (
+          <>
+            <TicketList rows={rows} ready={summary?.startable} selected={rowIdx} />
+            <LogTail ticket={selectedTicket} lines={logLines} />
+          </>
+        )}
       </Box>
       <Box justifyContent="space-between">
         <Text dimColor>
@@ -212,7 +296,7 @@ function App() {
           {error ? <Text color="red">  ! {error.slice(0, 50)}</Text> : null}
         </Text>
         <Text dimColor>
-          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · q quit
+          {lastPoll ? `updated ${lastPoll}` : "loading…"}  ↑↓ select · ←→ repo · r refresh · x reaper · q quit
         </Text>
       </Box>
     </Box>

--- a/package.json
+++ b/package.json
@@ -4,11 +4,18 @@
   "type": "module",
   "scripts": {
     "supervise": "bun orchestrator/run.mjs",
+    "watch": "bun orchestrator/watch.jsx",
     "emit": "bun build/emit.mjs",
     "check": "bun build/emit.mjs --check",
     "link": "bun build/emit.mjs --link",
     "schedule": "bun deploy/gen.mjs",
     "test": "bun test"
   },
-  "engines": { "bun": ">=1.3" }
+  "engines": {
+    "bun": ">=1.3"
+  },
+  "dependencies": {
+    "ink": "^7.1.1",
+    "react": "^19.2.8"
+  }
 }


### PR DESCRIPTION
Fixes OPS-58

Four additions to the watch.jsx foreground monitor:

- **Reaper from the TUI**: `x` runs `reaper.mjs --team <selected repo's team>` dry-run and shows the output in a pane; `y` re-runs with `--apply`, offered only when the dry run found stale claims (`parseReaperOutput` gates it). Esc closes the pane without quitting; Esc only quits when no pane is open. Header contract updated — this is the TUI's one deliberate write path.
- **Project totals**: `queue.mjs --json` now emits `done`/`total`/`countCapped` per repo (separate `CLOSED_QUERY` so Done tickets can't crowd live work out of the 250-issue page) plus the repo's `team` key; the strip shows `done 169/234`.
- **Open PR chip**: surfaces the existing `openPRs` field in the stat strip.
- **Manual refresh**: `r` re-polls queue and spend immediately.

Verification: `bun test orchestrator/` — 45 pass, 0 fail. `queue.mjs --repo bj29 --json` shows the new fields. TUI driven under a pty: chips render, `x` produced a live CLNT dry-run pane ("No stale claims among 9 in progress"), apply correctly not offered, Esc closed the pane.