### PR TITLE
feat(orchestrator): persistent reaper logs + startup backstop in run.mjs

### DIFF
--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -25,9 +25,48 @@
  *     bun orchestrator/reaper.mjs --any-assignee      # audit unlabeled ones too
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, appendFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+
+export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
+
+/**
+ * When the reaper last ran, from its own log files' mtimes — null when never.
+ * run.mjs uses this at startup to decide whether the factory has been off
+ * long enough that stale claims may have piled up unreaped.
+ */
+export function latestReaperRunMs(logDir = REAPER_LOG_DIR) {
+  let best = null;
+  try {
+    for (const f of readdirSync(logDir)) {
+      if (!/^reaper-\d{8}-\d{6}\.log$/.test(f)) continue;
+      const m = statSync(path.join(logDir, f)).mtimeMs;
+      if (best === null || m > best) best = m;
+    }
+  } catch { /* no log dir yet */ }
+  return best;
+}
+
+/**
+ * Tee console output to ~/.factory/logs/reaper-<stamp>.log so every run —
+ * supervisor tick, watch.jsx keybinding, or bare CLI — leaves a record. A
+ * reclaim nobody was watching used to leave no trace beyond the Linear
+ * comment. Logging must never break the run: append failures are swallowed.
+ */
+function teeToLogFile() {
+  const d = new Date();
+  const p2 = (n) => String(n).padStart(2, "0");
+  const stamp = `${d.getFullYear()}${p2(d.getMonth() + 1)}${p2(d.getDate())}-${p2(d.getHours())}${p2(d.getMinutes())}${p2(d.getSeconds())}`;
+  const file = path.join(REAPER_LOG_DIR, `reaper-${stamp}.log`);
+  try { mkdirSync(REAPER_LOG_DIR, { recursive: true }); } catch { return; }
+  const wrap = (orig) => (...args) => {
+    orig(...args);
+    try { appendFileSync(file, args.join(" ") + "\n"); } catch { /* keep running */ }
+  };
+  console.log = wrap(console.log.bind(console));
+  console.error = wrap(console.error.bind(console));
+}
 
 export const IN_PROGRESS = "in progress";
 export const RECLAIM_TO = "todo";
@@ -332,8 +371,10 @@ Options:
     process.exit(0);
   }
 
+  teeToLogFile();
+
   const mode = args.apply ? "APPLY" : "DRY RUN";
-  console.log(`=== Stale-claim reaper [${mode}] threshold=${args.minutes}min ===\n`);
+  console.log(`=== Stale-claim reaper [${mode}] threshold=${args.minutes}min${args.team ? ` team=${args.team}` : ""} ===\n`);
 
   const teams = await fetchTeams();
   let issues = await fetchInProgress(args.team, args.anyAssignee);

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -80,3 +80,28 @@ describe("lastActivity timestamp parsing", () => {
     expect(activity).toEqual(new Date("2026-08-03T11:00:00Z"));
   });
 });
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { latestReaperRunMs } from "./reaper.mjs";
+
+describe("reaper run log discovery", () => {
+  test("latestReaperRunMs picks the newest reaper log and ignores other files", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "reaper-"));
+    writeFileSync(path.join(dir, "reaper-20260804-120000.log"), "old");
+    writeFileSync(path.join(dir, "bj29-factory-merge-20260804-120000.jsonl"), "not a reaper log");
+    const t0 = latestReaperRunMs(dir);
+    expect(t0).not.toBeNull();
+    writeFileSync(path.join(dir, "reaper-20260804-130000.log"), "new");
+    expect(latestReaperRunMs(dir)).toBeGreaterThanOrEqual(t0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("latestReaperRunMs returns null when the dir is missing or empty", () => {
+    expect(latestReaperRunMs("/no/such/dir")).toBeNull();
+    const dir = mkdtempSync(path.join(tmpdir(), "reaper-"));
+    expect(latestReaperRunMs(dir)).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -27,6 +27,7 @@
  */
 import { spawn } from "node:child_process";
 import { loadSchedule, toSeconds, ROOT } from "../lib/schedule.mjs";
+import { latestReaperRunMs } from "./reaper.mjs";
 
 const argv = process.argv.slice(2);
 const has = (f) => argv.includes(f);
@@ -177,6 +178,26 @@ function shutdown() {
 }
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
+
+// Startup backstop: the reaper matters most at exactly the moment the factory
+// comes back up — agents crash while the supervisor is down, and their stale
+// claims sit unreaped until something runs it. If this session doesn't include
+// the linear-reaper job and no reaper has run anywhere in the last hour
+// (known from its own logs in ~/.factory/logs/reaper-*.log), run one pass
+// before the first job pass. Dry unless the supervisor itself is --apply —
+// starting a watched dry session must not silently unassign tickets.
+const REAPER_BACKSTOP_MIN = 60;
+if (!selected.some((j) => j.name === "linear-reaper")) {
+  const last = latestReaperRunMs();
+  const ageMin = last === null ? Infinity : (Date.now() - last) / 60_000;
+  if (ageMin > REAPER_BACKSTOP_MIN) {
+    const ageStr = last === null ? "never" : `${Math.round(ageMin)}m ago`;
+    console.log(`${c.dim(clock())} ${c.yellow("reaper")} last ran ${ageStr} — backstop ${APPLY ? "apply" : "dry"} pass first`);
+    const { code, out } = await probe(`bun orchestrator/reaper.mjs${APPLY ? " --apply" : ""}`);
+    for (const l of out.split("\n")) if (l.trim()) console.log(c.dim(`  │ ${l}`));
+    if (code !== 0) console.log(`${c.dim(clock())} ${c.red("reaper backstop failed")} ${c.dim(`exit ${code}`)}`);
+  }
+}
 
 // Start the first pass, but DO NOT await it before scheduling.
 //


### PR DESCRIPTION
Fixes OPS-62

- **Every reaper run now leaves a record**: `main()` tees all console output to `~/.factory/logs/reaper-<YYYYMMDD-HHMMSS>.log` — supervisor tick, watch.jsx `x` keybinding, or bare CLI alike. Append failures are swallowed so logging can never break a run. Header now also names the team scope.
- **`latestReaperRunMs()`** exported: newest `reaper-*.log` mtime, null when never.
- **Startup backstop**: when `run.mjs` starts without `linear-reaper` among its selected jobs and no reaper has run in 60+ minutes, it runs one pass before the first job pass — dry unless the supervisor itself is `--apply` (starting a watched dry session must not silently unassign tickets). Output streams like any job.

Verification: 55/55 tests green (new `latestReaperRunMs` coverage). Live: a dry `reaper.mjs --team OPS` produced a log file byte-matching console output; `run.mjs --only triage --once` with logs absent printed `reaper last ran never — backstop dry pass first` and streamed the pass; the immediate second start skipped (the backstop's own log satisfies the freshness check — self-sealing).