### PR TITLE
fix(reaper): fetch the union of both claim signals, not just the heartbeat label

### DIFF
--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -192,24 +192,43 @@ export async function fetchTeams() {
   return result;
 }
 
+/**
+ * The Linear filter for one reaper run. Pure and exported so the two questions
+ * this script asks stay testable without a network call.
+ *
+ * Default: the UNION of both claim signals — any ticket carrying
+ * `ai:in-progress` in ANY state, plus anything sitting in `In Progress`.
+ *
+ * The union is the point. Querying the heartbeat label alone (what this did
+ * until OPS-63) contradicted isAgentClaim(), which also accepts `agent:*`: a
+ * ticket claimed with `agent:claude-code` but no heartbeat label — exactly what
+ * a run that dies before its first heartbeat leaves behind — was never fetched
+ * and so could never be reaped, however long it sat. CLNT-688 sat that way for
+ * 190 minutes while the reaper reported "no stale claims".
+ *
+ * The label half of the union is still needed alongside the state half: triage
+ * claims tickets while specifying them and leaves them in `Triage`, so a
+ * crashed triage run strands `ai:in-progress` on a ticket no state-based query
+ * ever looks at.
+ *
+ * Widening the fetch does NOT widen what gets reclaimed. main() still filters
+ * everything through isAgentClaim() before touching it, so a human's In
+ * Progress ticket is fetched, counted in the "skipping N" line, and left alone.
+ *
+ * --any-assignee: the audit view exists specifically to see In Progress work
+ * REGARDLESS of any agent label — including a human's. It skips the
+ * isAgentClaim() pre-filter in main() rather than the query, which is what
+ * still makes it different from the default now that the default includes
+ * In Progress.
+ */
+export function buildIssueFilter(teamKey = null, anyAssignee = false) {
+  const team = teamKey ? `, team: { key: { eq: "${teamKey}" } }` : "";
+  if (anyAssignee) return `state: { name: { eq: "In Progress" } }${team}`;
+  return `or: [ { labels: { name: { eq: "${HEARTBEAT_LABEL}" } } }, { state: { name: { eq: "In Progress" } } } ]${team}`;
+}
+
 export async function fetchInProgress(teamKey = null, anyAssignee = false) {
-  const teamFilter = teamKey ? `, team: { key: { eq: "${teamKey}" } }` : "";
-  // Two different questions, two different filters.
-  //
-  // Default: any ticket carrying the claim marker, in ANY state — not just In
-  // Progress. Triage claims tickets while specifying them and leaves them in
-  // `Triage`, so a crashed triage run would otherwise strand `ai:in-progress`
-  // forever on a ticket no state-based query ever looks at.
-  //
-  // --any-assignee: the audit view exists specifically to see In Progress work
-  // REGARDLESS of the ai:in-progress label — including a human's, with no
-  // agent label at all. Filtering by that label here would make the flag a
-  // no-op: everything returned would already carry it. So this path queries by
-  // state instead, and isAgentClaim() (applied downstream) tells the two
-  // apart — main() must still never reclaim anything that fails it.
-  const filter = anyAssignee
-    ? `state: { name: { eq: "In Progress" } }${teamFilter}`
-    : `labels: { name: { eq: "ai:in-progress" } }${teamFilter}`;
+  const filter = buildIssueFilter(teamKey, anyAssignee);
   const q = `
     query {
       issues(first: 250, filter: { ${filter} }) {

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -105,3 +105,36 @@ describe("reaper run log discovery", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+import { buildIssueFilter } from "./reaper.mjs";
+
+describe("issue fetch filter (OPS-63)", () => {
+  test("default filter is the union of the heartbeat label and In Progress state", () => {
+    const f = buildIssueFilter();
+    // Both halves present: a ticket claimed with only `agent:*` sits in
+    // In Progress with no heartbeat label, and must still be fetched.
+    expect(f).toContain(`labels: { name: { eq: "${HEARTBEAT_LABEL}" } }`);
+    expect(f).toContain(`state: { name: { eq: "In Progress" } }`);
+    expect(f.startsWith("or: [")).toBe(true);
+  });
+
+  test("default filter no longer excludes agent-labelled tickets lacking the heartbeat label", () => {
+    // The regression itself: the old filter was the label clause ALONE, so a
+    // ticket isAgentClaim() accepts via `agent:*` was never returned.
+    const agentOnly = { labels: { nodes: [{ name: "agent:claude-code" }] }, state: { name: "In Progress" } };
+    expect(isAgentClaim(agentOnly)).toBe(true);
+    expect(buildIssueFilter()).not.toBe(`labels: { name: { eq: "${HEARTBEAT_LABEL}" } }`);
+  });
+
+  test("--any-assignee still queries by state alone, so it can surface human work", () => {
+    const f = buildIssueFilter(null, true);
+    expect(f).toBe(`state: { name: { eq: "In Progress" } }`);
+    expect(f).not.toContain(HEARTBEAT_LABEL);
+  });
+
+  test("team scoping is ANDed onto both variants", () => {
+    expect(buildIssueFilter("CLNT")).toContain(`team: { key: { eq: "CLNT" } }`);
+    expect(buildIssueFilter("CW", true)).toContain(`team: { key: { eq: "CW" } }`);
+    expect(buildIssueFilter(null)).not.toContain("team:");
+  });
+});


### PR DESCRIPTION
Fixes OPS-63

The reaper had two definitions of "agent claim" and they disagreed. `fetchInProgress()` queried `labels: { name: { eq: "ai:in-progress" } }` alone, while `isAgentClaim()` — the predicate that decides what may be reclaimed — also accepts any `agent:*` label. A ticket claimed with `agent:claude-code` and no heartbeat label was therefore never fetched, and so could never be reaped however long it sat silent. That is precisely the shape a run that dies *before* its first heartbeat leaves behind, i.e. the case the reaper exists for.

- Filter extracted into a pure, exported `buildIssueFilter(teamKey, anyAssignee)` so both questions the script asks are testable without a network call.
- Default path now fetches the **union**: `or: [ {labels: ai:in-progress}, {state: In Progress} ]`. The label half is still required — triage claims tickets while specifying them and leaves them in `Triage`, where no state query looks.
- Widening the fetch does **not** widen what gets reclaimed: `main()` still filters everything through `isAgentClaim()`, so a human's In Progress ticket is fetched, counted in the existing "skipping N" line, and left alone.
- `--any-assignee` still queries by state alone; what makes it different now is that it skips the `isAgentClaim()` pre-filter, which is what the audit view was always actually for.

Verification: `bun test orchestrator/` 59 pass / 0 fail (4 new tests incl. an explicit regression assertion that the default filter is no longer the bare label clause). Live against Linear, back-to-back on team CLNT: old filter returned 6 tickets, new returned 7 — a proper superset, the extra being `STALE CLNT-688 193m`, which the old path reported as "no stale claims". `--any-assignee` (state-only audit) and `--markers-only` (correctly still declines to touch In Progress claims) both unchanged.