### PR TITLE
fix(orchestrator): protect Cashsaas escalation surfaces

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -159,3 +159,19 @@ repos:
 
     # What "verified" means. Agents run this before any PR.
     verify: npm run typecheck && npm run lint && npm run format:check
+
+    # Surfaces where a path match alone requires human review. This is narrow on
+    # purpose: ordinary BI UI, analytics, and documentation work stays eligible
+    # for the normal merge policy judgment.
+    escalate_paths:
+      # Schema changes can be destructive; retain migration history as protected.
+      - schema.prisma
+      - migrations/**
+      # Production image, compose deployment, and CI/CD workflow changes.
+      - Dockerfile
+      - docker-compose.yml
+      - .github/workflows/**
+      # Credential configuration and the authentication/authorization boundary.
+      - .env.example
+      - src/auth/**
+      - src/server/serverMiddleware.ts

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -1,7 +1,55 @@
 import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
 import { matchEscalations } from "./escalate.mjs";
 
 const globs = ["app/src/payment/**", "app/src/auth/**", "app/migrations/**"];
+const repos = Bun.YAML.parse(
+  readFileSync(new URL("../config/repos.yaml", import.meta.url), "utf8"),
+).repos;
+const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_paths;
+
+test("cashsaas config protects its destructive, deployment, credential, and auth boundaries", () => {
+  expect(cashsaasGlobs).toBeDefined();
+
+  const hits = matchEscalations(
+    [
+      "schema.prisma",
+      "migrations/20260804120000_remove_legacy_data/migration.sql",
+      "Dockerfile",
+      "docker-compose.yml",
+      ".github/workflows/deploy.yml",
+      ".env.example",
+      "src/auth/verifyCurrentPassword.ts",
+      "src/server/serverMiddleware.ts",
+    ],
+    cashsaasGlobs,
+  );
+
+  expect(hits.map((hit) => hit.file)).toEqual([
+    "schema.prisma",
+    "migrations/20260804120000_remove_legacy_data/migration.sql",
+    "Dockerfile",
+    "docker-compose.yml",
+    ".github/workflows/deploy.yml",
+    ".env.example",
+    "src/auth/verifyCurrentPassword.ts",
+    "src/server/serverMiddleware.ts",
+  ]);
+});
+
+test("cashsaas config leaves ordinary dashboard, analytics, and docs changes unflagged", () => {
+  expect(
+    matchEscalations(
+      [
+        "src/dashboard/DashboardPage.tsx",
+        "src/analytics/queries.ts",
+        "docs/SESSION_HANDOFF.md",
+        "README.md",
+      ],
+      cashsaasGlobs,
+    ),
+  ).toEqual([]);
+});
 
 test("flags a file under an escalate glob", () => {
   const hits = matchEscalations(["app/src/payment/stripe.ts"], globs);


### PR DESCRIPTION
## Summary
- configure narrow Cashsaas escalation paths for destructive schema, deployment, secret configuration, and auth boundaries
- test representative protected and ordinary paths against the repository configuration

## Verification
- `bun test orchestrator/escalate.test.mjs`
- `bun orchestrator/escalate.mjs --repo cashsaas --pr 140` (exits 2 as expected)

Fixes CLNT-877