### PR TITLE
feat(orchestrator): reply-detection gate for ai:blocked tickets

### DIFF
--- a/dist/codex/prompts/factory-triage.md
+++ b/dist/codex/prompts/factory-triage.md
@@ -14,6 +14,8 @@ Before working an issue, mark it so it appears in **Agents In Flight** and no ot
 
 Claim one issue at a time as you get to it, not all of them up front — a batch claimed and then abandoned blocks the queue for everything you never reached.
 
+**Answered holds come first.** Before the Triage pile, check for tickets carrying `ai:blocked` (in `Blocked` or `Triage`) that have a comment newer than the label's application — the orchestrator's gate resurfaces exactly these, and a human answer that sits unread costs a round-trip through the slowest part of the pipeline. For each: read the reply, **remove `ai:blocked`**, then re-run promote-or-hold below with the answer in hand (and record the decision in the product-decisions doc where it belongs). If the reply doesn't actually resolve the hold, comment a sharper question and **re-add `ai:blocked`** — removing and re-adding is required, not optional: the fresh label event is what resets the orchestrator's reply detection, and a hold that keeps the old label event gets re-examined every tick forever.
+
 For each issue in `Triage` state (plus any `Todo` issue missing the `ai:agent-ready` label):
 
 1. **Sanity check** — is it a duplicate of an existing issue, already fixed in the codebase or git history, or obsolete? If so, say which and mark it (duplicate → link + cancel, fixed → comment with evidence + close). Confirm with me before canceling anything non-obvious.

--- a/dist/cursor/commands/factory-triage.md
+++ b/dist/cursor/commands/factory-triage.md
@@ -10,6 +10,8 @@ Before working an issue, mark it so it appears in **Agents In Flight** and no ot
 
 Claim one issue at a time as you get to it, not all of them up front — a batch claimed and then abandoned blocks the queue for everything you never reached.
 
+**Answered holds come first.** Before the Triage pile, check for tickets carrying `ai:blocked` (in `Blocked` or `Triage`) that have a comment newer than the label's application — the orchestrator's gate resurfaces exactly these, and a human answer that sits unread costs a round-trip through the slowest part of the pipeline. For each: read the reply, **remove `ai:blocked`**, then re-run promote-or-hold below with the answer in hand (and record the decision in the product-decisions doc where it belongs). If the reply doesn't actually resolve the hold, comment a sharper question and **re-add `ai:blocked`** — removing and re-adding is required, not optional: the fresh label event is what resets the orchestrator's reply detection, and a hold that keeps the old label event gets re-examined every tick forever.
+
 For each issue in `Triage` state (plus any `Todo` issue missing the `ai:agent-ready` label):
 
 1. **Sanity check** — is it a duplicate of an existing issue, already fixed in the codebase or git history, or obsolete? If so, say which and mark it (duplicate → link + cancel, fixed → comment with evidence + close). Confirm with me before canceling anything non-obvious.

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -18,6 +18,7 @@ import path from "node:path";
 import { gql } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
 import { parseOwnedPaths, pathsCollide } from "./owned-paths.mjs";
+import { AI_BLOCKED, answeredHeldTickets } from "./reply-detection.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
 
 const argv = process.argv.slice(2);
@@ -115,14 +116,23 @@ for (const repo of repos) {
   // `ai:blocked` in Triage means a previous tick already decided this one needs
   // a human. Counting it as triage work is how the stage ends up re-deriving
   // the same hold every 5 minutes — the same shape as the merge stage
-  // re-reviewing escalated PRs. It reappears the moment the label comes off.
-  const triage = nodes.filter((i) => state(i) === "Triage" && !labels(i).includes("ai:blocked"));
-  const triageHeld = nodes.filter((i) => state(i) === "Triage" && labels(i).includes("ai:blocked"));
+  // re-reviewing escalated PRs. It reappears the moment the label comes off —
+  // or, below, the moment a reply lands after the label was applied.
+  const triage = nodes.filter((i) => state(i) === "Triage" && !labels(i).includes(AI_BLOCKED));
+  const triageHeld = nodes.filter((i) => state(i) === "Triage" && labels(i).includes(AI_BLOCKED));
   const ready = nodes.filter((i) => state(i) === "Todo" && labels(i).includes("ai:agent-ready") && !i.assignee);
   const notReady = nodes.filter((i) => state(i) === "Todo" && !labels(i).includes("ai:agent-ready"));
   const inProgress = nodes.filter((i) => state(i) === "In Progress");
   const inReview = nodes.filter((i) => state(i) === "In Review");
   const blocked = nodes.filter((i) => state(i) === "Blocked");
+
+  // Held tickets someone has replied to since the hold. These re-enter the
+  // triage stage's queue: the agent reads the answer, removes ai:blocked, and
+  // re-runs promote-or-hold. The second query only fires when the cheap query
+  // shows a held ticket at all.
+  const heldAny = nodes.filter((i) => ["Triage", "Blocked"].includes(state(i)) && labels(i).includes(AI_BLOCKED));
+  const answeredIds = heldAny.length ? await answeredHeldTickets(repo) : new Set();
+  const answered = heldAny.filter((i) => answeredIds.has(i.identifier));
 
   // GitHub is the source of truth for what is waiting to merge, not Linear.
   // Gating the merge stage on `In Review` tickets meant a finished PR whose
@@ -143,6 +153,7 @@ for (const repo of repos) {
 
   line("Triage (unspecified)", triage.length, triage.length > 20 ? c.yellow : (s) => s);
   if (triageHeld.length) line("Triage, held for you", triageHeld.length, c.red);
+  if (answered.length) line("Held, reply received", answered.length, c.green);
   line("Todo, not ready", notReady.length);
   line("READY to dispatch", ready.length, ready.length ? c.green : c.red);
   line("In Progress", inProgress.length);
@@ -186,6 +197,9 @@ for (const repo of repos) {
     // combined count kept the gate open for Todo-without-agent-ready tickets
     // the stage never touches, spawning a no-op agent every tick.
     triageState: triage.length,
+    // Held tickets with a reply newer than their ai:blocked application — the
+    // triage stage re-examines these, so they open the triage gate too.
+    answered: answered.length,
     ready: ready.length,
     inProgress: inProgress.length,
     inReview: inReview.length,
@@ -199,6 +213,7 @@ for (const repo of repos) {
     inProgressTickets: inProgress.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
     inReviewTickets: inReview.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
     blockedTickets: blocked.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
+    answeredTickets: answered.map((t) => ({ identifier: t.identifier, title: t.title, url: t.url })),
   });
 
   if (quiet) continue;
@@ -231,7 +246,10 @@ for (const repo of repos) {
   }
   if (blocked.length) {
     console.log(c.red(`\n  BLOCKED — needs a human:`));
-    for (const t of blocked) console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}`);
+    for (const t of blocked) {
+      const tag = answeredIds.has(t.identifier) ? c.green("  <- reply received, triage will re-examine") : "";
+      console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}${tag}`);
+    }
   }
 }
 
@@ -255,8 +273,10 @@ if (GATE) {
   // Exit 1 = idle, skip. Anything else is a real error and stops the loop.
   const has = {
     // Only spawn a triage agent when a Triage-STATE ticket is waiting — the
-    // stage never touches Todo tickets, ready or not.
-    triage: (s) => s.triageState > 0,
+    // stage never touches Todo tickets, ready or not. A held ticket whose
+    // question got answered is triage work again: the stage reads the reply
+    // and re-runs promote-or-hold.
+    triage: (s) => s.triageState > 0 || s.answered > 0,
     // Don't dispatch with no free slot or nothing startable — an agent that
     // wakes to find the cap full has burned a run to learn nothing.
     dispatch: (s) => s.slotsFree > 0 && s.startable.length > 0,

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -1,0 +1,91 @@
+/**
+ * Reply detection for held tickets. `ai:blocked` is applied with a comment
+ * "phrased so one reply unblocks it" — but nothing used to watch for the
+ * reply, so the label was a one-way door. Per-agent identity doesn't exist yet
+ * (OPS-40): agent and human comments share one Linear account, so detection
+ * cannot be author-based. The signal is a comment created after the label was
+ * last ADDED (a fresh re-add resets the clock — factory-triage re-adds the
+ * label when it re-holds, which is what keeps this from firing forever on an
+ * unanswered sharper question).
+ */
+import { gql } from "./reaper.mjs";
+
+export const AI_BLOCKED = "ai:blocked";
+
+// Blocking is comment-then-label within seconds, but the order occasionally
+// flips (label-then-comment, observed up to ~10s apart). The slack keeps the
+// agent's own hold comment from reading as the human's answer. Cost of the
+// window: a reply posted within 2 minutes of the hold goes unseen until any
+// later comment lands — humans answering a held ticket that fast are rare.
+export const REPLY_GRACE_MS = 2 * 60 * 1000;
+
+const LABEL_IDS_QUERY = `
+  query($name: String!) {
+    issueLabels(first: 20, filter: { name: { eq: $name } }) { nodes { id } }
+  }`;
+
+// Comments + label history for held tickets only. Kept out of the queue's main
+// issue query on purpose: this costs per-issue nested pagination, so it runs
+// as a second query and only when the cheap query shows a held ticket at all.
+const HELD_QUERY = `
+  query($team: String!, $project: String!, $label: String!) {
+    issues(first: 100, filter: {
+      team: { key: { eq: $team } },
+      project: { name: { eq: $project } },
+      labels: { name: { eq: $label } },
+      state: { type: { nin: ["completed", "canceled"] } }
+    }) {
+      nodes {
+        identifier
+        state { name }
+        comments(first: 100) { nodes { createdAt } }
+        history(first: 100) { nodes { createdAt addedLabelIds } }
+      }
+    }
+  }`;
+
+/**
+ * Pure decision: which of these held issues has a comment newer than the most
+ * recent ai:blocked label-add, beyond the grace window? Returns a Set of
+ * identifiers.
+ *
+ * Conservative on missing evidence: a ticket with no label-add event in the
+ * fetched history window (label applied at creation, or paged out) or no
+ * comments is NOT answered. Wrongly resurfacing a hold re-derives it every
+ * 5 minutes; wrongly leaving one held costs what it costs today.
+ */
+export function answeredIdentifiers(heldNodes, labelIds, graceMs = REPLY_GRACE_MS) {
+  const answered = new Set();
+  for (const t of heldNodes ?? []) {
+    // Only the two documented hold shapes. An In Progress ticket carrying a
+    // stale ai:blocked is the reconciler's drift to explain, not triage work.
+    if (!["Triage", "Blocked"].includes(t.state?.name)) continue;
+    const adds = (t.history?.nodes ?? [])
+      .filter((h) => (h.addedLabelIds ?? []).some((id) => labelIds.has(id)))
+      .map((h) => Date.parse(h.createdAt));
+    const comments = (t.comments?.nodes ?? []).map((n) => Date.parse(n.createdAt));
+    if (!adds.length || !comments.length) continue;
+    if (Math.max(...comments) > Math.max(...adds) + graceMs) answered.add(t.identifier);
+  }
+  return answered;
+}
+
+// ai:blocked is a workspace label today, but collecting every id matching the
+// name keeps this correct if it ever becomes per-team. Fetched once per
+// process, shared across repos.
+let _blockedLabelIds = null;
+async function blockedLabelIds() {
+  if (!_blockedLabelIds) {
+    const r = await gql(LABEL_IDS_QUERY, { name: AI_BLOCKED });
+    _blockedLabelIds = new Set((r?.issueLabels?.nodes ?? []).map((n) => n.id));
+  }
+  return _blockedLabelIds;
+}
+
+/** Identifiers of the repo's held tickets that someone has replied to. */
+export async function answeredHeldTickets(repo) {
+  const ids = await blockedLabelIds();
+  if (!ids.size) return new Set();
+  const held = (await gql(HELD_QUERY, { team: repo.team, project: repo.project, label: AI_BLOCKED }))?.issues?.nodes ?? [];
+  return answeredIdentifiers(held, ids);
+}

--- a/orchestrator/reply-detection.test.mjs
+++ b/orchestrator/reply-detection.test.mjs
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { answeredIdentifiers, REPLY_GRACE_MS } from "./reply-detection.mjs";
+
+const LABEL_ID = "label-ai-blocked";
+const IDS = new Set([LABEL_ID]);
+const T0 = Date.parse("2026-08-04T12:00:00.000Z");
+const iso = (ms) => new Date(ms).toISOString();
+
+/** A held issue: label-add events and comments given as offsets from T0. */
+function issue({ id = "CLNT-1", state = "Blocked", adds = [], comments = [], addedIds = [LABEL_ID] } = {}) {
+  return {
+    identifier: id,
+    state: { name: state },
+    comments: { nodes: comments.map((ms) => ({ createdAt: iso(T0 + ms) })) },
+    history: { nodes: adds.map((ms) => ({ createdAt: iso(T0 + ms), addedLabelIds: addedIds })) },
+  };
+}
+
+describe("answeredIdentifiers", () => {
+  test("comment well after the label-add is answered", () => {
+    const held = [issue({ adds: [0], comments: [-2000, 30 * 60_000] })];
+    expect(answeredIdentifiers(held, IDS)).toEqual(new Set(["CLNT-1"]));
+  });
+
+  test("the blocking comment itself does not trigger — before or slightly after the label", () => {
+    // comment-then-label (the usual order) and label-then-comment ~10s later
+    // (observed on CLNT-887 et al.) both stay inside the grace window.
+    const before = issue({ id: "A", adds: [0], comments: [-1500] });
+    const after = issue({ id: "B", adds: [0], comments: [10_000] });
+    expect(answeredIdentifiers([before, after], IDS)).toEqual(new Set());
+  });
+
+  test("grace boundary: answered strictly beyond REPLY_GRACE_MS", () => {
+    const at = issue({ id: "AT", adds: [0], comments: [REPLY_GRACE_MS] });
+    const past = issue({ id: "PAST", adds: [0], comments: [REPLY_GRACE_MS + 1] });
+    expect(answeredIdentifiers([at, past], IDS)).toEqual(new Set(["PAST"]));
+  });
+
+  test("re-adding the label resets the clock", () => {
+    // Held at 0, answered at +10m, triage re-held at +11m with a sharper
+    // question: not answered again until a comment lands after the re-add.
+    const held = [issue({ adds: [0, 11 * 60_000], comments: [-1000, 10 * 60_000, 11 * 60_000 - 5000] })];
+    expect(answeredIdentifiers(held, IDS)).toEqual(new Set());
+  });
+
+  test("conservative on missing evidence: no label-add event or no comments", () => {
+    const noEvent = issue({ id: "NOEV", adds: [], comments: [60 * 60_000] });
+    const otherLabel = issue({ id: "OTHER", adds: [0], comments: [60 * 60_000], addedIds: ["some-other-label"] });
+    const noComments = issue({ id: "NOC", adds: [0], comments: [] });
+    expect(answeredIdentifiers([noEvent, otherLabel, noComments], IDS)).toEqual(new Set());
+  });
+
+  test("only Triage and Blocked states count", () => {
+    const inProgress = issue({ id: "IP", state: "In Progress", adds: [0], comments: [60 * 60_000] });
+    const backlog = issue({ id: "BL", state: "Backlog", adds: [0], comments: [60 * 60_000] });
+    const triage = issue({ id: "TR", state: "Triage", adds: [0], comments: [60 * 60_000] });
+    expect(answeredIdentifiers([inProgress, backlog, triage], IDS)).toEqual(new Set(["TR"]));
+  });
+
+  test("tolerates missing nested fields", () => {
+    const bare = { identifier: "BARE", state: { name: "Blocked" } };
+    expect(answeredIdentifiers([bare], IDS)).toEqual(new Set());
+    expect(answeredIdentifiers(null, IDS)).toEqual(new Set());
+  });
+});

--- a/plugins/core/commands/factory-triage.md
+++ b/plugins/core/commands/factory-triage.md
@@ -16,6 +16,8 @@ Before working an issue, mark it so it appears in **Agents In Flight** and no ot
 
 Claim one issue at a time as you get to it, not all of them up front — a batch claimed and then abandoned blocks the queue for everything you never reached.
 
+**Answered holds come first.** Before the Triage pile, check for tickets carrying `ai:blocked` (in `Blocked` or `Triage`) that have a comment newer than the label's application — the orchestrator's gate resurfaces exactly these, and a human answer that sits unread costs a round-trip through the slowest part of the pipeline. For each: read the reply, **remove `ai:blocked`**, then re-run promote-or-hold below with the answer in hand (and record the decision in the product-decisions doc where it belongs). If the reply doesn't actually resolve the hold, comment a sharper question and **re-add `ai:blocked`** — removing and re-adding is required, not optional: the fresh label event is what resets the orchestrator's reply detection, and a hold that keeps the old label event gets re-examined every tick forever.
+
 For each issue in `Triage` state (plus any `Todo` issue missing the `ai:agent-ready` label):
 
 1. **Sanity check** — is it a duplicate of an existing issue, already fixed in the codebase or git history, or obsolete? If so, say which and mark it (duplicate → link + cancel, fixed → comment with evidence + close). Confirm with me before canceling anything non-obvious.

--- a/shared/commands/factory-triage.md
+++ b/shared/commands/factory-triage.md
@@ -16,6 +16,8 @@ Before working an issue, mark it so it appears in **Agents In Flight** and no ot
 
 Claim one issue at a time as you get to it, not all of them up front — a batch claimed and then abandoned blocks the queue for everything you never reached.
 
+**Answered holds come first.** Before the Triage pile, check for tickets carrying `ai:blocked` (in `Blocked` or `Triage`) that have a comment newer than the label's application — the orchestrator's gate resurfaces exactly these, and a human answer that sits unread costs a round-trip through the slowest part of the pipeline. For each: read the reply, **remove `ai:blocked`**, then re-run promote-or-hold below with the answer in hand (and record the decision in the product-decisions doc where it belongs). If the reply doesn't actually resolve the hold, comment a sharper question and **re-add `ai:blocked`** — removing and re-adding is required, not optional: the fresh label event is what resets the orchestrator's reply detection, and a hold that keeps the old label event gets re-examined every tick forever.
+
 For each issue in `Triage` state (plus any `Todo` issue missing the `ai:agent-ready` label):
 
 1. **Sanity check** — is it a duplicate of an existing issue, already fixed in the codebase or git history, or obsolete? If so, say which and mark it (duplicate → link + cancel, fixed → comment with evidence + close). Confirm with me before canceling anything non-obvious.


### PR DESCRIPTION
Fixes OPS-65

`ai:blocked` was a one-way door: agents hold tickets with a question "phrased so one reply unblocks it", but nothing watched for the reply. This teaches the queue to notice.

## What changed

- **`orchestrator/reply-detection.mjs`** (new): a held ticket counts as *answered* when its newest comment postdates the most recent `ai:blocked` label-add by >2 minutes. Author-based detection is impossible until per-agent identity (OPS-40) exists — agent and human comments share one account. The grace window absorbs the observed label-then-comment ordering flips (up to ~10s in live data). Conservative on missing evidence: no label-add event in the history window, or no comments, means not answered. Only `Triage`/`Blocked` states count.
- **`orchestrator/queue.mjs`**: fetches comments+history for held tickets via a second query that only fires when the cheap query shows a held ticket; answered tickets open the `--gate triage` predicate, get their own display line and a marker in the BLOCKED section, and are exposed as `answered`/`answeredTickets` in `--json`.
- **`shared/commands/factory-triage.md`** (+emitted copies): triage processes answered holds first — read the reply, remove `ai:blocked`, re-run promote-or-hold; re-holding must re-add the label so the fresh label event resets the reply clock.

## Verification

- `bun run check` — 23 emitted files in sync
- `bun test` — 62 pass (7 new in `reply-detection.test.mjs`: grace boundary, re-add resets clock, conservative fallbacks, state filtering)
- Live: detected genuine answered holds across repos (CLNT-610, CLNT-821/822, CLNT-889, CLNT-809, CLNT-90); `--gate triage` exits 0 on legalease which has 0 Triage tickets but 2 answered holds, and the coach-wattz blocked pile (23 tickets, no replies) stays silent.