### PR TITLE
feat(orchestrator): blocked-ticket digest + manual unblock sweep with TUI actions

### DIFF
--- a/config/schedule.yaml
+++ b/config/schedule.yaml
@@ -113,6 +113,40 @@ jobs:
       Compiles once so that N worktrees don't. Cheapest thing to run before a
       dispatch batch; the gate only fires when the cache is >=15 commits behind.
 
+  # 1c. UNBLOCK. `ai:blocked` used to be a one-way door; reply detection
+  #     (OPS-65) catches answered questions, and these two catch the rest:
+  #     the digest surfaces every hold's question in one read-only report, and
+  #     the sweep re-examines holds for evidence that resolved them without a
+  #     comment (dependency merged, credential documented, code moved on).
+  #
+  #     BOTH ARE MANUAL-START BY DESIGN (OPS-67), not just disabled-for-now:
+  #     the digest from the watch TUI's `b` or this CLI, the sweep from the
+  #     TUI's `u` (spawns immediately, no dry step — it is Linear-write-only
+  #     and rule-bound to touch nothing without new evidence) or run-agent.sh.
+  #     Listed here so the verbs have one canonical spelling and don't become
+  #     orphans like the reaper once was.
+  - name: unblock-digest
+    every: 24h
+    dry_command: bun orchestrator/digest.mjs
+    command: bun orchestrator/digest.mjs
+    enabled: false
+    why: >
+      Read-only report of every ai:blocked ticket with its blocking question,
+      hold age, and ANSWERED markers. There is no push channel for it yet, so
+      scheduling it would print to a log nobody reads — run it when you want
+      the picture.
+  - name: unblock
+    every: 24h
+    dry_command: bun orchestrator/digest.mjs --repo {{repo}}
+    command: runners/run-agent.sh --harness {{harness}} --repo {{repo}} --command factory-unblock --read-only --args "10"
+    enabled: false
+    why: >
+      Agent pass over held tickets, oldest first: releases a hold only on new
+      evidence (dependency Done, answer now in docs, premise gone from the
+      code) and otherwise leaves silently — never re-derives or re-comments a
+      hold. Read-only against the repo; writes only to Linear. Manual-start
+      until it has earned schedule trust like everything else here.
+
   # 2. EXECUTE. Rolling dispatch under the per-repo in-flight cap; Owned Paths
   #    decide what can run together. The gate refuses to spawn when the cap is
   #    full or nothing is startable, so an agent never wakes to learn nothing.

--- a/dist/codex/prompts/factory-unblock.md
+++ b/dist/codex/prompts/factory-unblock.md
@@ -1,0 +1,28 @@
+# factory-unblock
+
+> Re-examine held (ai:blocked) tickets for new evidence and release the ones that no longer need a human
+
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via the mapping in `~/Develop/hdkiller/docs/orgs/linear.md` §1. Use the Linear MCP; on failure retry once then fall back to `linear_common` GraphQL per the global rule.
+
+Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
+
+Tickets whose question has already been **answered by a reply** are the triage stage's job (the orchestrator's reply-detection gate resurfaces them) — if you find one, handle it exactly as `factory-triage` would rather than skipping it, but it counts against your cap.
+
+## Claim what you are examining
+
+Same protocol as triage: before working an issue, set `assignee` to yourself and add `ai:in-progress` + `agent:<your-harness>`; leave the state alone. Remove `ai:in-progress` when you finish that issue. One at a time, not a batch up front.
+
+For each held ticket:
+
+1. **Reconstruct the hold** — read the blocking comment and what it says is missing. If the hold never stated what it needs, treat that as the finding: comment the specific question it should have asked, re-add `ai:blocked` (remove first if present — the fresh label event resets the orchestrator's reply clock), and move on.
+2. **Hunt for new evidence** — has anything changed since the hold?
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in the repo's `docs/product-decisions.md`, `docs/`, the Linear project Overview, or a newer ticket in the same area;
+   - a missing credential/env detail is now in `~/Develop/hdkiller/docs` (servers, applications, guides);
+   - the code moved enough that the premise of the hold is gone (verify in the actual codebase — read-only).
+3. **With evidence: release the hold.** Remove `ai:blocked`, comment one line citing the evidence (link the ticket/PR/doc), then re-run triage's promote-or-hold: promote to `Todo` + `ai:agent-ready` only if the full §5 template is solid against the current code; otherwise leave it in `Triage` for the triage stage to spec. Never promote on a guess — a wrongly released hold hands an implementation agent a question a human was supposed to answer.
+4. **Without evidence: leave silently.** No comment, no label churn, no re-stating the question. A sweep that re-derives the same hold on every run is the exact pathology this pipeline keeps having to un-learn (CLNT-504 collected ten identical hold comments). The ticket stays exactly as it was.
+
+Do **not** start implementing anything, and never remove `ai:blocked` just because the hold is old — age is not evidence.
+
+Finish with one batch report: a table of every ticket examined (identifier, held since, verdict: `released → todo` / `released → triage` / `answered, handled` / `still held` + one-line reason), followed by the count of holds that remain waiting on a human. One message, not a ping per ticket.

--- a/dist/cursor/commands/factory-unblock.md
+++ b/dist/cursor/commands/factory-unblock.md
@@ -1,0 +1,24 @@
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via the mapping in `~/Develop/hdkiller/docs/orgs/linear.md` §1. Use the Linear MCP; on failure retry once then fall back to `linear_common` GraphQL per the global rule.
+
+Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
+
+Tickets whose question has already been **answered by a reply** are the triage stage's job (the orchestrator's reply-detection gate resurfaces them) — if you find one, handle it exactly as `factory-triage` would rather than skipping it, but it counts against your cap.
+
+## Claim what you are examining
+
+Same protocol as triage: before working an issue, set `assignee` to yourself and add `ai:in-progress` + `agent:<your-harness>`; leave the state alone. Remove `ai:in-progress` when you finish that issue. One at a time, not a batch up front.
+
+For each held ticket:
+
+1. **Reconstruct the hold** — read the blocking comment and what it says is missing. If the hold never stated what it needs, treat that as the finding: comment the specific question it should have asked, re-add `ai:blocked` (remove first if present — the fresh label event resets the orchestrator's reply clock), and move on.
+2. **Hunt for new evidence** — has anything changed since the hold?
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in the repo's `docs/product-decisions.md`, `docs/`, the Linear project Overview, or a newer ticket in the same area;
+   - a missing credential/env detail is now in `~/Develop/hdkiller/docs` (servers, applications, guides);
+   - the code moved enough that the premise of the hold is gone (verify in the actual codebase — read-only).
+3. **With evidence: release the hold.** Remove `ai:blocked`, comment one line citing the evidence (link the ticket/PR/doc), then re-run triage's promote-or-hold: promote to `Todo` + `ai:agent-ready` only if the full §5 template is solid against the current code; otherwise leave it in `Triage` for the triage stage to spec. Never promote on a guess — a wrongly released hold hands an implementation agent a question a human was supposed to answer.
+4. **Without evidence: leave silently.** No comment, no label churn, no re-stating the question. A sweep that re-derives the same hold on every run is the exact pathology this pipeline keeps having to un-learn (CLNT-504 collected ten identical hold comments). The ticket stays exactly as it was.
+
+Do **not** start implementing anything, and never remove `ai:blocked` just because the hold is old — age is not evidence.
+
+Finish with one batch report: a table of every ticket examined (identifier, held since, verdict: `released → todo` / `released → triage` / `answered, handled` / `still held` + one-line reason), followed by the count of holds that remain waiting on a human. One message, not a ping per ticket.

--- a/dist/pi/prompts/factory-triage.md
+++ b/dist/pi/prompts/factory-triage.md
@@ -14,6 +14,8 @@ Before working an issue, mark it so it appears in **Agents In Flight** and no ot
 
 Claim one issue at a time as you get to it, not all of them up front — a batch claimed and then abandoned blocks the queue for everything you never reached.
 
+**Answered holds come first.** Before the Triage pile, check for tickets carrying `ai:blocked` (in `Blocked` or `Triage`) that have a comment newer than the label's application — the orchestrator's gate resurfaces exactly these, and a human answer that sits unread costs a round-trip through the slowest part of the pipeline. For each: read the reply, **remove `ai:blocked`**, then re-run promote-or-hold below with the answer in hand (and record the decision in the product-decisions doc where it belongs). If the reply doesn't actually resolve the hold, comment a sharper question and **re-add `ai:blocked`** — removing and re-adding is required, not optional: the fresh label event is what resets the orchestrator's reply detection, and a hold that keeps the old label event gets re-examined every tick forever.
+
 For each issue in `Triage` state (plus any `Todo` issue missing the `ai:agent-ready` label):
 
 1. **Sanity check** — is it a duplicate of an existing issue, already fixed in the codebase or git history, or obsolete? If so, say which and mark it (duplicate → link + cancel, fixed → comment with evidence + close). Confirm with me before canceling anything non-obvious.

--- a/dist/pi/prompts/factory-unblock.md
+++ b/dist/pi/prompts/factory-unblock.md
@@ -1,0 +1,28 @@
+# factory-unblock
+
+> Re-examine held (ai:blocked) tickets for new evidence and release the ones that no longer need a human
+
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via the mapping in `~/Develop/hdkiller/docs/orgs/linear.md` §1. Use the Linear MCP; on failure retry once then fall back to `linear_common` GraphQL per the global rule.
+
+Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
+
+Tickets whose question has already been **answered by a reply** are the triage stage's job (the orchestrator's reply-detection gate resurfaces them) — if you find one, handle it exactly as `factory-triage` would rather than skipping it, but it counts against your cap.
+
+## Claim what you are examining
+
+Same protocol as triage: before working an issue, set `assignee` to yourself and add `ai:in-progress` + `agent:<your-harness>`; leave the state alone. Remove `ai:in-progress` when you finish that issue. One at a time, not a batch up front.
+
+For each held ticket:
+
+1. **Reconstruct the hold** — read the blocking comment and what it says is missing. If the hold never stated what it needs, treat that as the finding: comment the specific question it should have asked, re-add `ai:blocked` (remove first if present — the fresh label event resets the orchestrator's reply clock), and move on.
+2. **Hunt for new evidence** — has anything changed since the hold?
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in the repo's `docs/product-decisions.md`, `docs/`, the Linear project Overview, or a newer ticket in the same area;
+   - a missing credential/env detail is now in `~/Develop/hdkiller/docs` (servers, applications, guides);
+   - the code moved enough that the premise of the hold is gone (verify in the actual codebase — read-only).
+3. **With evidence: release the hold.** Remove `ai:blocked`, comment one line citing the evidence (link the ticket/PR/doc), then re-run triage's promote-or-hold: promote to `Todo` + `ai:agent-ready` only if the full §5 template is solid against the current code; otherwise leave it in `Triage` for the triage stage to spec. Never promote on a guess — a wrongly released hold hands an implementation agent a question a human was supposed to answer.
+4. **Without evidence: leave silently.** No comment, no label churn, no re-stating the question. A sweep that re-derives the same hold on every run is the exact pathology this pipeline keeps having to un-learn (CLNT-504 collected ten identical hold comments). The ticket stays exactly as it was.
+
+Do **not** start implementing anything, and never remove `ai:blocked` just because the hold is old — age is not evidence.
+
+Finish with one batch report: a table of every ticket examined (identifier, held since, verdict: `released → todo` / `released → triage` / `answered, handled` / `still held` + one-line reason), followed by the count of holds that remain waiting on a human. One message, not a ping per ticket.

--- a/orchestrator/digest.mjs
+++ b/orchestrator/digest.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+/**
+ * Blocked-tickets digest — every ai:blocked hold, its question, and its age.
+ *
+ *   bun orchestrator/digest.mjs               # every configured repo
+ *   bun orchestrator/digest.mjs --repo bj29
+ *
+ * Read-only, writes nothing to Linear. The real failure mode of a hold isn't
+ * that no agent revisits it — it's that the one-reply question never reached
+ * a human. This is the report that surfaces those questions in one place,
+ * oldest hold first, with an ANSWERED marker on tickets whose reply the
+ * triage gate (reply-detection.mjs) will pick up on its next tick.
+ *
+ * Manual-start by design (watch TUI `b`, or this CLI) — see the unblock-digest
+ * entry in config/schedule.yaml.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { gql } from "./reaper.mjs";
+import { ROOT } from "../lib/schedule.mjs";
+import { AI_BLOCKED, blockedLabelIds, holdInfo } from "./reply-detection.mjs";
+
+const argv = process.argv.slice(2);
+const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+
+const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
+if (!repos.length) {
+  console.error(only.length ? `no repo named "${only}" in config/repos.yaml` : "no repos configured");
+  process.exit(2);
+}
+
+// Plain text when piped — the watch TUI renders this output inside an Ink
+// pane, where ANSI escapes would come through as garbage.
+const tty = process.stdout.isTTY;
+const c = {
+  dim: (s) => (tty ? `\x1b[2m${s}\x1b[0m` : s),
+  bold: (s) => (tty ? `\x1b[1m${s}\x1b[0m` : s),
+  green: (s) => (tty ? `\x1b[32m${s}\x1b[0m` : s),
+  red: (s) => (tty ? `\x1b[31m${s}\x1b[0m` : s),
+};
+
+// Same shape reply-detection queries, plus comment bodies — the digest is the
+// one consumer that needs the question's text, so the heavier payload lives
+// here and not in the every-5-minutes gate.
+const DIGEST_QUERY = `
+  query($team: String!, $project: String!, $label: String!) {
+    issues(first: 100, filter: {
+      team: { key: { eq: $team } },
+      project: { name: { eq: $project } },
+      labels: { name: { eq: $label } },
+      state: { type: { nin: ["completed", "canceled"] } }
+    }) {
+      nodes {
+        identifier title url
+        state { name }
+        comments(first: 100) { nodes { createdAt body } }
+        history(first: 100) { nodes { createdAt addedLabelIds } }
+      }
+    }
+  }`;
+
+const DAY = 24 * 60 * 60 * 1000;
+const age = (ms) => {
+  if (ms == null) return "?";
+  const d = Date.now() - ms;
+  if (d >= DAY) return `${Math.floor(d / DAY)}d`;
+  if (d >= 60 * 60_000) return `${Math.floor(d / 3_600_000)}h`;
+  return `${Math.max(1, Math.floor(d / 60_000))}m`;
+};
+const excerpt = (body, n = 110) => {
+  const s = String(body ?? "").replace(/\s+/g, " ").trim();
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+};
+
+const ids = await blockedLabelIds();
+let totalHeld = 0;
+let totalAnswered = 0;
+
+for (const repo of repos) {
+  const nodes = (await gql(DIGEST_QUERY, { team: repo.team, project: repo.project, label: AI_BLOCKED }))?.issues?.nodes ?? [];
+  const held = nodes
+    .map((n) => ({ node: n, info: holdInfo(n, ids) }))
+    .filter((h) => h.info)
+    // Oldest hold first; unknown hold times sink to the bottom rather than
+    // masquerading as the most urgent.
+    .sort((a, b) => (a.info.heldAtMs ?? Infinity) - (b.info.heldAtMs ?? Infinity));
+
+  console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project} — ${held.length} held`));
+  if (!held.length) { console.log(c.dim("  nothing held — no ai:blocked tickets")); continue; }
+
+  for (const { node, info } of held) {
+    totalHeld++;
+    const answered = Boolean(info.reply);
+    if (answered) totalAnswered++;
+    const marker = answered
+      ? c.green(`  ANSWERED ${age(info.reply.atMs)} ago — triage will re-examine`)
+      : "";
+    console.log(`  ${c.red(node.identifier.padEnd(10))} held ${age(info.heldAtMs)}${marker}`);
+    console.log(c.dim(`    ${excerpt(node.title, 100)}`));
+    if (info.question?.body) console.log(`    Q: ${excerpt(info.question.body)}`);
+    else console.log(c.dim(`    (no blocking comment found — the hold never said what it needs)`));
+  }
+}
+
+console.log(c.bold(`\n${totalHeld} held ticket(s)`) + (totalAnswered
+  ? c.green(`, ${totalAnswered} answered and waiting for the next triage tick`)
+  : c.dim(", none answered — every hold above is waiting on a human reply")));
+console.log();

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -70,11 +70,49 @@ export function answeredIdentifiers(heldNodes, labelIds, graceMs = REPLY_GRACE_M
   return answered;
 }
 
+/**
+ * Everything the digest wants to say about one held issue, from the same raw
+ * shape answeredIdentifiers reads (comments + history; comments may carry
+ * `body` when the caller's query asked for it):
+ *
+ *   heldAtMs   when ai:blocked was last added; null when no add event is in
+ *              the history window (label applied at creation, or paged out)
+ *   question   newest comment at hold time (within the grace window) — the
+ *              agent's blocking question; null when the hold has no comment
+ *   reply      newest comment after the grace window — someone answered;
+ *              null when nobody has
+ *
+ * Pure; returns null for issues that aren't in a hold state at all.
+ */
+export function holdInfo(node, labelIds, graceMs = REPLY_GRACE_MS) {
+  if (!["Triage", "Blocked"].includes(node?.state?.name)) return null;
+  const adds = (node.history?.nodes ?? [])
+    .filter((h) => (h.addedLabelIds ?? []).some((id) => labelIds.has(id)))
+    .map((h) => Date.parse(h.createdAt));
+  const heldAtMs = adds.length ? Math.max(...adds) : null;
+  const comments = (node.comments?.nodes ?? [])
+    .map((n) => ({ atMs: Date.parse(n.createdAt), body: n.body ?? null }))
+    .sort((a, b) => a.atMs - b.atMs);
+  let question = null;
+  let reply = null;
+  if (heldAtMs != null) {
+    for (const c of comments) {
+      if (c.atMs <= heldAtMs + graceMs) question = c;
+      else reply = c;
+    }
+  } else if (comments.length) {
+    // No add event to anchor on: the newest comment is the best guess at the
+    // question, and reply detection stays conservatively off.
+    question = comments[comments.length - 1];
+  }
+  return { identifier: node.identifier, heldAtMs, question, reply };
+}
+
 // ai:blocked is a workspace label today, but collecting every id matching the
 // name keeps this correct if it ever becomes per-team. Fetched once per
 // process, shared across repos.
 let _blockedLabelIds = null;
-async function blockedLabelIds() {
+export async function blockedLabelIds() {
   if (!_blockedLabelIds) {
     const r = await gql(LABEL_IDS_QUERY, { name: AI_BLOCKED });
     _blockedLabelIds = new Set((r?.issueLabels?.nodes ?? []).map((n) => n.id));

--- a/orchestrator/reply-detection.test.mjs
+++ b/orchestrator/reply-detection.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { answeredIdentifiers, REPLY_GRACE_MS } from "./reply-detection.mjs";
+import { answeredIdentifiers, holdInfo, REPLY_GRACE_MS } from "./reply-detection.mjs";
 
 const LABEL_ID = "label-ai-blocked";
 const IDS = new Set([LABEL_ID]);
@@ -61,5 +61,47 @@ describe("answeredIdentifiers", () => {
     const bare = { identifier: "BARE", state: { name: "Blocked" } };
     expect(answeredIdentifiers([bare], IDS)).toEqual(new Set());
     expect(answeredIdentifiers(null, IDS)).toEqual(new Set());
+  });
+});
+
+describe("holdInfo", () => {
+  const withBodies = ({ comments, ...spec }) => ({
+    ...issue(spec),
+    comments: { nodes: comments.map(([ms, body]) => ({ createdAt: iso(T0 + ms), body })) },
+  });
+
+  test("splits the blocking question from the reply", () => {
+    const node = withBodies({ adds: [0], comments: [[-1500, "need a decision on X"], [60 * 60_000, "go with option A"]] });
+    const info = holdInfo(node, IDS);
+    expect(info.heldAtMs).toBe(T0);
+    expect(info.question.body).toBe("need a decision on X");
+    expect(info.reply.body).toBe("go with option A");
+  });
+
+  test("a label-then-comment hold keeps its comment as the question, not a reply", () => {
+    const node = withBodies({ adds: [0], comments: [[10_000, "blocked: which env?"]] });
+    const info = holdInfo(node, IDS);
+    expect(info.question.body).toBe("blocked: which env?");
+    expect(info.reply).toBeNull();
+  });
+
+  test("no add event: newest comment is the question guess, heldAtMs null, no reply ever", () => {
+    const node = withBodies({ adds: [], comments: [[0, "old"], [60 * 60_000, "newest"]] });
+    const info = holdInfo(node, IDS);
+    expect(info.heldAtMs).toBeNull();
+    expect(info.question.body).toBe("newest");
+    expect(info.reply).toBeNull();
+  });
+
+  test("non-hold states return null", () => {
+    expect(holdInfo(issue({ state: "In Progress", adds: [0], comments: [0] }), IDS)).toBeNull();
+    expect(holdInfo(undefined, IDS)).toBeNull();
+  });
+
+  test("agrees with answeredIdentifiers on the grace boundary", () => {
+    const at = issue({ id: "AT", adds: [0], comments: [REPLY_GRACE_MS] });
+    const past = issue({ id: "PAST", adds: [0], comments: [REPLY_GRACE_MS + 1] });
+    expect(holdInfo(at, IDS).reply).toBeNull();
+    expect(holdInfo(past, IDS).reply).not.toBeNull();
   });
 });

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -8,13 +8,19 @@
  *   bun orchestrator/watch.jsx
  *   bun orchestrator/watch.jsx --repo bj29
  *
- * Never spawns an agent, and writes nowhere with ONE deliberate exception:
- * pressing `x` runs the stale-claim reaper for the selected repo's team —
- * dry-run first, and `--apply` only after a second explicit `y`, only when the
- * dry run found something to reclaim. Everything else re-reads the same state
- * queue.mjs and the log files already expose. This is the bird's-eye view
- * across repos and in-flight tickets; run.mjs is still the place to watch one
- * job's full dry/apply output.
+ * Read-only, with TWO deliberate exceptions:
+ *   `x` runs the stale-claim reaper for the selected repo's team — dry-run
+ *       first, `--apply` only after a second explicit `y`, only when the dry
+ *       run found something to reclaim;
+ *   `u` launches the unblock sweep agent (factory-unblock) for the selected
+ *       repo — immediately, no dry step: the sweep is Linear-write-only and
+ *       rule-bound to touch nothing without new evidence, so the guard lives
+ *       in the command, not in a confirm keystroke. It shows up in the agents
+ *       section like any stage agent, tailable from here.
+ * (`b` shows the blocked-tickets digest, which is read-only like the rest.)
+ * Everything else re-reads the same state queue.mjs and the log files already
+ * expose. This is the bird's-eye view across repos and in-flight tickets;
+ * run.mjs is still the place to watch one job's full dry/apply output.
  */
 import React, { useEffect, useRef, useState } from "react";
 import { render, Box, Text, useInput, useStdout } from "ink";
@@ -146,6 +152,8 @@ const SHORTCUTS = [
   ["r", "refresh queue + spend now"],
   ["x", "run the stale-claim reaper (dry run) for this repo's team"],
   ["y", "confirm reaper --apply — only offered when the dry run found stale claims"],
+  ["b", "blocked-tickets digest for this repo — every hold, its question, its age"],
+  ["u", "launch the unblock sweep agent for this repo (spawns immediately, no dry run)"],
   ["?", "this help"],
   ["esc", "close an open pane; quit when none is open"],
   ["q", "quit"],
@@ -188,6 +196,53 @@ function ReaperPane({ reaper }) {
         <Text key={i} wrap="truncate-end">{line}</Text>
       ))}
       <Text dimColor>{canApply ? "y reclaim these · " : ""}esc close</Text>
+    </Box>
+  );
+}
+
+/**
+ * Blocked-tickets digest (`b`) — read-only output of orchestrator/digest.mjs,
+ * shown in place of the ticket panes. Long digests scroll off; the CLI is the
+ * place for the full report, this is the glance.
+ */
+function DigestPane({ digest, height }) {
+  const title = {
+    running: `blocked digest (${digest.repo})…`,
+    done: `blocked digest (${digest.repo})`,
+    error: "blocked digest — failed",
+  }[digest.phase];
+  const shown = digest.lines.slice(0, Math.max(1, height - 2));
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={digest.phase === "error" ? "red" : "cyan"} paddingX={1}>
+      <Text bold color={digest.phase === "error" ? "red" : "cyan"}>{title}</Text>
+      {digest.lines.length === 0 && <Text dimColor>running…</Text>}
+      {shown.map((line, i) => (
+        <Text key={i} wrap="truncate-end">{line}</Text>
+      ))}
+      {digest.lines.length > shown.length && <Text dimColor>… {digest.lines.length - shown.length} more — run `bun orchestrator/digest.mjs` for the full report</Text>}
+      <Text dimColor>esc close</Text>
+    </Box>
+  );
+}
+
+/**
+ * Confirmation that `u` actually spawned the sweep. The run itself is not
+ * awaited here — run-agent.sh writes `<repo>-factory-unblock-<stamp>.jsonl`,
+ * so the agents section picks it up within a poll and its log is tailable
+ * like any stage agent's.
+ */
+function UnblockPane({ unblock }) {
+  const failed = unblock.phase === "error";
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={failed ? "red" : "green"} paddingX={1}>
+      <Text bold color={failed ? "red" : "green"}>
+        {failed ? "unblock sweep — failed to launch" : `unblock sweep launched (${unblock.repo})`}
+      </Text>
+      {unblock.lines.map((line, i) => (
+        <Text key={i} wrap="truncate-end">{line}</Text>
+      ))}
+      {!failed && <Text dimColor>it will appear under agents shortly — select it there to tail its log</Text>}
+      <Text dimColor>esc close</Text>
     </Box>
   );
 }
@@ -289,6 +344,8 @@ function App() {
   const [logLines, setLogLines] = useState([]);
   const [spend, setSpend] = useState(0);
   const [reaper, setReaper] = useState(null); // { phase, team, lines, stale }
+  const [digest, setDigest] = useState(null); // { phase, repo, lines }
+  const [unblock, setUnblock] = useState(null); // { phase, repo, lines }
   const [stages, setStages] = useState(null);
   const [agents, setAgents] = useState([]);
   const [ticketAges, setTicketAges] = useState({});
@@ -387,6 +444,42 @@ function App() {
     }
   };
 
+  const startDigest = async (repo) => {
+    setDigest({ phase: "running", repo, lines: [] });
+    try {
+      const p = Bun.spawn(["bun", "orchestrator/digest.mjs", "--repo", repo], { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+      const [out, err, code] = await Promise.all([
+        new Response(p.stdout).text(), new Response(p.stderr).text(), p.exited,
+      ]);
+      const text = (code === 0 ? out : out + `\n${err}`).trimEnd();
+      setDigest({ phase: code === 0 ? "done" : "error", repo, lines: text.split("\n").filter((l) => l.trim() !== "") });
+    } catch (e) {
+      setDigest({ phase: "error", repo, lines: [String(e.message ?? e)] });
+    }
+  };
+
+  // No dry step and no confirm, on purpose (the header says why). Launch is
+  // fire-and-forget: the sweep's own log under ~/.factory/logs is the record,
+  // and the agents section is where to watch it. Only a spawn that dies within
+  // 3s (harness missing, bad flags) is reported back here.
+  const startUnblock = (repo) => {
+    try {
+      const p = Bun.spawn(["bash", "runners/run-agent.sh", "--repo", repo, "--command", "factory-unblock", "--read-only", "--args", "10"],
+        { cwd: ROOT, stdout: "pipe", stderr: "pipe" });
+      setUnblock({ phase: "launched", repo, lines: [] });
+      const born = Date.now();
+      p.exited.then(async (code) => {
+        if (code !== 0 && Date.now() - born < 3000) {
+          const err = await new Response(p.stderr).text();
+          const out = await new Response(p.stdout).text();
+          setUnblock({ phase: "error", repo, lines: (out + "\n" + err).trim().split("\n").slice(-8) });
+        }
+      });
+    } catch (e) {
+      setUnblock({ phase: "error", repo, lines: [String(e.message ?? e)] });
+    }
+  };
+
   useInput((input, key) => {
     if (input === "q" || (key.ctrl && input === "c")) process.exit(0);
     if (showHelp) {
@@ -394,6 +487,14 @@ function App() {
       return;
     }
     if (input === "?") { setShowHelp(true); return; }
+    if (digest) {
+      if (key.escape) setDigest(null);
+      return;
+    }
+    if (unblock) {
+      if (key.escape) setUnblock(null);
+      return;
+    }
     if (reaper) {
       // The pane owns the keyboard while it's up: esc closes it (instead of
       // quitting), y confirms --apply, and only off a dry run that found work.
@@ -414,6 +515,8 @@ function App() {
       }
     }
     if (input === "x" && summary?.team) startReaper(summary.team, false);
+    if (input === "b" && summary?.repo) startDigest(summary.repo);
+    if (input === "u" && summary?.repo) startUnblock(summary.repo);
     if (key.leftArrow) { setRepoIdx((i) => Math.max(0, i - 1)); setRowIdx(0); }
     if (key.rightArrow) { setRepoIdx((i) => Math.max(0, Math.min(summaries.length - 1, i + 1))); setRowIdx(0); }
     if (key.upArrow) setRowIdx(Math.max(0, selIdx - 1));
@@ -435,6 +538,10 @@ function App() {
           <HelpPane />
         ) : reaper ? (
           <ReaperPane reaper={reaper} />
+        ) : digest ? (
+          <DigestPane digest={digest} height={paneHeight} />
+        ) : unblock ? (
+          <UnblockPane unblock={unblock} />
         ) : (
           <>
             <TicketList stageAgents={stageAgents} rows={rows} ready={summary?.startable} ages={ticketAges} selected={selIdx} height={paneHeight} />

--- a/plugins/core/commands/factory-unblock.md
+++ b/plugins/core/commands/factory-unblock.md
@@ -1,0 +1,30 @@
+---
+description: Re-examine held (ai:blocked) tickets for new evidence and release the ones that no longer need a human
+argument-hint: [optional: issue IDs or a max count]
+model: sonnet
+---
+
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via the mapping in `~/Develop/hdkiller/docs/orgs/linear.md` §1. Use the Linear MCP; on failure retry once then fall back to `linear_common` GraphQL per the global rule.
+
+Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
+
+Tickets whose question has already been **answered by a reply** are the triage stage's job (the orchestrator's reply-detection gate resurfaces them) — if you find one, handle it exactly as `factory-triage` would rather than skipping it, but it counts against your cap.
+
+## Claim what you are examining
+
+Same protocol as triage: before working an issue, set `assignee` to yourself and add `ai:in-progress` + `agent:<your-harness>`; leave the state alone. Remove `ai:in-progress` when you finish that issue. One at a time, not a batch up front.
+
+For each held ticket:
+
+1. **Reconstruct the hold** — read the blocking comment and what it says is missing. If the hold never stated what it needs, treat that as the finding: comment the specific question it should have asked, re-add `ai:blocked` (remove first if present — the fresh label event resets the orchestrator's reply clock), and move on.
+2. **Hunt for new evidence** — has anything changed since the hold?
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in the repo's `docs/product-decisions.md`, `docs/`, the Linear project Overview, or a newer ticket in the same area;
+   - a missing credential/env detail is now in `~/Develop/hdkiller/docs` (servers, applications, guides);
+   - the code moved enough that the premise of the hold is gone (verify in the actual codebase — read-only).
+3. **With evidence: release the hold.** Remove `ai:blocked`, comment one line citing the evidence (link the ticket/PR/doc), then re-run triage's promote-or-hold: promote to `Todo` + `ai:agent-ready` only if the full §5 template is solid against the current code; otherwise leave it in `Triage` for the triage stage to spec. Never promote on a guess — a wrongly released hold hands an implementation agent a question a human was supposed to answer.
+4. **Without evidence: leave silently.** No comment, no label churn, no re-stating the question. A sweep that re-derives the same hold on every run is the exact pathology this pipeline keeps having to un-learn (CLNT-504 collected ten identical hold comments). The ticket stays exactly as it was.
+
+Do **not** start implementing anything, and never remove `ai:blocked` just because the hold is old — age is not evidence.
+
+Finish with one batch report: a table of every ticket examined (identifier, held since, verdict: `released → todo` / `released → triage` / `answered, handled` / `still held` + one-line reason), followed by the count of holds that remain waiting on a human. One message, not a ping per ticket.

--- a/shared/commands/factory-unblock.md
+++ b/shared/commands/factory-unblock.md
@@ -1,0 +1,30 @@
+---
+description: Re-examine held (ai:blocked) tickets for new evidence and release the ones that no longer need a human
+argument-hint: [optional: issue IDs or a max count]
+model: sonnet
+---
+
+Re-examine the `ai:blocked` holds for the repository I'm currently in: some blockers resolve without anyone commenting on the ticket — the dependency merged, the credential got documented, the code moved on — and this sweep is what notices. Resolve the team from the repo via the mapping in `~/Develop/hdkiller/docs/orgs/linear.md` §1. Use the Linear MCP; on failure retry once then fall back to `linear_common` GraphQL per the global rule.
+
+Target: every open ticket in `Blocked` or `Triage` carrying `ai:blocked`, **oldest hold first** — the longest-stuck ticket has waited longest for this look. Interpret $ARGUMENTS as specific issue IDs or a max count; default is up to 10.
+
+Tickets whose question has already been **answered by a reply** are the triage stage's job (the orchestrator's reply-detection gate resurfaces them) — if you find one, handle it exactly as `factory-triage` would rather than skipping it, but it counts against your cap.
+
+## Claim what you are examining
+
+Same protocol as triage: before working an issue, set `assignee` to yourself and add `ai:in-progress` + `agent:<your-harness>`; leave the state alone. Remove `ai:in-progress` when you finish that issue. One at a time, not a batch up front.
+
+For each held ticket:
+
+1. **Reconstruct the hold** — read the blocking comment and what it says is missing. If the hold never stated what it needs, treat that as the finding: comment the specific question it should have asked, re-add `ai:blocked` (remove first if present — the fresh label event resets the orchestrator's reply clock), and move on.
+2. **Hunt for new evidence** — has anything changed since the hold?
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in the repo's `docs/product-decisions.md`, `docs/`, the Linear project Overview, or a newer ticket in the same area;
+   - a missing credential/env detail is now in `~/Develop/hdkiller/docs` (servers, applications, guides);
+   - the code moved enough that the premise of the hold is gone (verify in the actual codebase — read-only).
+3. **With evidence: release the hold.** Remove `ai:blocked`, comment one line citing the evidence (link the ticket/PR/doc), then re-run triage's promote-or-hold: promote to `Todo` + `ai:agent-ready` only if the full §5 template is solid against the current code; otherwise leave it in `Triage` for the triage stage to spec. Never promote on a guess — a wrongly released hold hands an implementation agent a question a human was supposed to answer.
+4. **Without evidence: leave silently.** No comment, no label churn, no re-stating the question. A sweep that re-derives the same hold on every run is the exact pathology this pipeline keeps having to un-learn (CLNT-504 collected ten identical hold comments). The ticket stays exactly as it was.
+
+Do **not** start implementing anything, and never remove `ai:blocked` just because the hold is old — age is not evidence.
+
+Finish with one batch report: a table of every ticket examined (identifier, held since, verdict: `released → todo` / `released → triage` / `answered, handled` / `still held` + one-line reason), followed by the count of holds that remain waiting on a human. One message, not a ping per ticket.


### PR DESCRIPTION
Fixes OPS-67

Replaces #22, which GitHub auto-closed when #18's branch (its stacked base) was deleted on merge; the branch is now rebased onto main.

Covers the two hold cases reply detection (#18) can't see: blockers that resolved *without* a comment, and blocking questions the human never saw. Both are **manual-start by design** — no scheduling, launched from the CLI or the watch TUI, with no dry/confirm step.

## What's new

- **`orchestrator/digest.mjs`** — read-only digest of every `ai:blocked` ticket: hold age (from the label-add event via new `holdInfo()` in `reply-detection.mjs`), the blocking question's text, and ANSWERED markers. Oldest hold first; colors only on a TTY so the TUI pane gets plain text. Live run: 61 held tickets across 4 repos, 6 answered.
- **`shared/commands/factory-unblock.md`** (+6 emitted copies) — agent sweep, oldest hold first, capped by args (default 10). Releases a hold only on *new evidence* (dependency Done, answer now in docs, premise gone from code); otherwise leaves silently — no comment, no label churn, so it can never re-derive the same hold daily. Never implements; repo access read-only.
- **`config/schedule.yaml`** — both jobs adopted as `enabled: false` entries documented as manual-start (reaper precedent). `deploy/gen.mjs` renders 0 jobs, unchanged.
- **watch TUI** — `b` opens a digest pane for the selected repo (read-only, esc closes); `u` immediately launches the sweep via `run-agent.sh --command factory-unblock --read-only --args 10` — fire-and-forget, spawn failures within 3s reported back, run appears in the agents section with a tailable log.

## Verification

- `bun run check` — 26 emitted files in sync; `bun test` — 67 pass (5 new `holdInfo` tests)
- `bun deploy/gen.mjs` — accepts the new entries, renders 0 jobs
- Digest verified live against all 4 repos; TUI verified under a pty — `b` renders the digest pane with real data
- Not live-fired: the `u` launch (would spawn a real budgeted agent); mirrors the reaper spawn pattern