### PR TITLE
Browser isolation: one Chrome per agent, from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Only then start the supervisor on a cadence.
 | Tickets per tick | `--args` in `config/schedule.yaml` | triage 3, dispatch 2 |
 | Concurrent tickets | `max_in_flight` in `config/repos.yaml` | 3 |
 | Spend per run | `--budget`, else `budget.per_ticket_usd` in `config/policy.yaml` | $5 |
-| Daily spend | `budget.per_day_usd` | $1000 |
+| Daily spend | `budget.per_day_usd` | $2000 |
 | Which repos | `--repo` on each job | `bj29` only |
 
 ### Auth and "budget" on a subscription
@@ -321,6 +321,16 @@ bun orchestrator/economics.mjs --roll        # append to the permanent rollup
 > **Every harness streams a different schema, and a parser that only knows Claude fails silently.** codex, agy and pi report no cost field, so summing `total_cost_usd` scored them as `$0 / 0 turns / no result` — indistinguishable from a harness that genuinely did nothing. On 2026-08-04 that hid 109 codex and 50 agy runs (35% of all runs) from `lib/spend.mjs`, and the per-day gate was measuring two thirds of the factory while reporting it as the whole.
 >
 > So all four schemas normalise into one `Run` record in `lib/transcript.mjs`, the budget gate imports the same parser, and harnesses that report no cost get priced from their token counts and labelled as the estimate they are. Being wrong by a constant factor is fine; being blind to a whole harness is not. Tests: `bun test lib/transcript.test.mjs` — the fixture per harness is the point.
+
+### Browser isolation — one Chrome per agent, from git
+
+Concurrent Claude agents used to share one chrome-devtools-mcp profile: ten tickets dispatched in the same second all raced for one `SingletonLock`, first Chrome won, and everyone else burned turns on `browser is already running` — 95 errors across 26 runs. The fix is structural, not prompt-level, and it lives in this repo:
+
+- **`config/mcp/claude.json`** defines the browser server the factory passes to every Claude spawn via `--mcp-config`: `--isolated` (temp profile per session, auto-cleaned — collisions become impossible), `--headless`, and webp screenshot caps (`--screenshotFormat=webp --screenshotQuality=70 --screenshotMaxWidth=1280`) that shrink the factory's single biggest context cost 4–6x at the source, while an agent that truly needs a pixel-perfect PNG can still request one per-call.
+- **Deliberately NOT `--strict-mcp-config`.** Strict mode also drops the claude.ai connectors, and losing the Linear MCP severs the control plane — verified empirically on 2026-08-04: 0 Linear tools under strict, 52 without it. The global chrome-devtools *plugin* is disabled in `~/.claude/settings.json` instead, so exactly one browser server loads.
+- **`orchestrator/chrome-sweep.mjs`** cleans up what the wall-clock cap leaves behind: a killed run's MCP server dies without closing its Chrome, which reparents to launchd and keeps running. The sweep kills only processes that pass three fences (agent profile dir in the command line, browser main process, reparented to PID 1 — a live agent's Chrome still has its MCP server as parent) and clears stale `Singleton*` locks nobody holds. Dry-run by default; `--apply` to act. The one unforgivable failure — killing the human's actual Chrome — has a test per fence.
+
+Verified end to end: two parallel headless sessions each launched their own Chrome and navigated with zero contention. After the next batch, `bun run economics -- --since 1d` should show browser-collision errors at zero and `take_screenshot` payloads down ~4–6x.
 
 ## Why `Owned Paths` and not keyword matching
 

--- a/config/mcp/claude.json
+++ b/config/mcp/claude.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.6.0",
+        "--isolated",
+        "--headless",
+        "--viewport=1280x720",
+        "--screenshotFormat=webp",
+        "--screenshotQuality=70",
+        "--screenshotMaxWidth=1280",
+        "--acceptInsecureCerts",
+        "--no-usage-statistics"
+      ]
+    }
+  }
+}

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -34,10 +34,10 @@ budget:
                             # merge session ran out mid-review with a 13-PR
                             # backlog still open; run-agent.sh applies this
                             # instead of per_ticket_usd for factory-merge only.
-  per_day_usd: 1000.00      # enforced in every gate (lib/spend.mjs): today's
+  per_day_usd: 2000.00      # enforced in every gate (lib/spend.mjs): today's
                             # logs are summed per tick; at the cap it drains —
                             # running tickets finish, nothing new starts.
-                            # Raised to 1000 on 2026-08-04.
+                            # Raised to 1000 on 2026-08-04, then to 2000 same day.
   on_exhausted: drain
 
 limits:

--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -84,9 +84,9 @@ A tool result is not paid for once. It stays in the context window and is re-sen
 
 ### Browsers
 
-The browser profile is **shared between concurrently running agents**. `browser is already running for .../chrome-profile` means another agent has it — that is contention, not a crash, and it was hit 95 times across 26 runs.
+Factory-spawned sessions get their **own isolated headless Chrome** (via `--mcp-config`, `config/mcp/claude.json` in the factory repo) — a temp profile per session, screenshots served as capped webp. There is nothing to share and nothing to fight over.
 
-Do not retry the call and do not kill the other agent's browser. Attach to what is already there (`list_pages` then `select_page`, or open a new tab), or if you need genuine isolation, launch with an isolated profile of your own.
+If a browser tool still errors: report it and continue with non-browser verification — never retry in a loop, and **never kill another process's Chrome**; a killed browser mid-flight destroys another agent's verification run. `browser is already running for .../chrome-profile` means you are running outside the factory config (interactive session, older harness) where the profile IS shared — attach to the running browser (`list_pages`, then work in your own new page) rather than fighting the lock.
 
 ### Shell globs
 

--- a/orchestrator/chrome-sweep.mjs
+++ b/orchestrator/chrome-sweep.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+/**
+ * Kill Chrome instances orphaned by dead agent runs.
+ *
+ *   bun orchestrator/chrome-sweep.mjs           # dry run
+ *   bun orchestrator/chrome-sweep.mjs --apply
+ *
+ * Every agent session gets its own Chrome via chrome-devtools-mcp --isolated
+ * (config/mcp/claude.json). When a run is killed at the wall-clock cap — or the
+ * harness crashes — the MCP server dies without closing its browser, and the
+ * Chrome reparents to launchd and keeps running: memory held, and for the
+ * legacy shared profile, a SingletonLock that blocks every later launch. One
+ * such lock sat under ~/.cache/chrome-devtools-mcp for hours on 2026-08-04.
+ *
+ * SAFETY: this must never touch the human's actual Chrome. Three fences, all
+ * required to match:
+ *   1. the command line names a chrome-devtools-mcp or puppeteer profile dir —
+ *      a normal Chrome never does;
+ *   2. it is the browser MAIN process (no --type= flag), so helpers go down
+ *      with their parent rather than being shot individually;
+ *   3. it has reparented to PID 1 — its owning MCP server is dead. A live
+ *      agent's Chrome still has its MCP server as parent and is left alone.
+ */
+import { execSync } from "node:child_process";
+import { existsSync, lstatSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const APPLY = process.argv.includes("--apply");
+const SHARED_PROFILE = path.join(homedir(), ".cache/chrome-devtools-mcp/chrome-profile");
+
+/** Does this ps line look like an agent-launched Chrome profile? */
+const AGENT_PROFILE = /--user-data-dir=[^ ]*(chrome-devtools-mcp|puppeteer_dev_(chrome|firefox)_profile)/;
+
+/**
+ * Pure classifier over `ps -axo pid=,ppid=,command=` rows so the kill logic is
+ * testable without killing anything. Returns { orphans, live }.
+ */
+export function classify(rows) {
+  const orphans = [], live = [];
+  for (const r of rows) {
+    if (!AGENT_PROFILE.test(r.command)) continue;     // fence 1: agent profile only
+    if (/--type=/.test(r.command)) continue;          // fence 2: main process only
+    (r.ppid === 1 ? orphans : live).push(r);          // fence 3: dead parent = orphan
+  }
+  return { orphans, live };
+}
+
+export function parsePs(text) {
+  return text.split("\n").flatMap((line) => {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    return m ? [{ pid: Number(m[1]), ppid: Number(m[2]), command: m[3] }] : [];
+  });
+}
+
+if (import.meta.main) {
+  const rows = parsePs(execSync("ps -axo pid=,ppid=,command=", { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
+  const { orphans, live } = classify(rows);
+
+  if (live.length) console.log(`${live.length} agent Chrome(s) with a living MCP server — left alone`);
+
+  if (!orphans.length) {
+    console.log("no orphaned agent Chromes");
+  } else {
+    for (const o of orphans) {
+      const profile = (o.command.match(/--user-data-dir=([^ ]+)/) ?? [])[1] ?? "?";
+      console.log(`  ${APPLY ? "killing" : "would kill"} pid ${o.pid}  ${profile}`);
+      if (!APPLY) continue;
+      try { process.kill(o.pid, "SIGTERM"); } catch {}
+    }
+    if (APPLY) {
+      // TERM first so Chrome flushes its profile; KILL whatever ignores it.
+      await Bun.sleep(5000);
+      for (const o of orphans) {
+        try { process.kill(o.pid, 0); process.kill(o.pid, "SIGKILL"); console.log(`  SIGKILL pid ${o.pid} (survived TERM)`); }
+        catch { /* already gone — the normal case */ }
+      }
+    }
+  }
+
+  // The legacy shared profile's Singleton* symlinks outlive a killed Chrome and
+  // block the next non-isolated launch. Only removed when NO process — orphan
+  // or live — is still using that profile dir.
+  const sharedInUse = rows.some((r) => r.command.includes(SHARED_PROFILE));
+  if (!sharedInUse && existsSync(SHARED_PROFILE)) {
+    for (const f of ["SingletonLock", "SingletonCookie", "SingletonSocket"]) {
+      const p = path.join(SHARED_PROFILE, f);
+      try {
+        lstatSync(p); // throws when absent — symlinks to dead sockets need lstat
+        console.log(`  ${APPLY ? "removing" : "would remove"} stale ${f}`);
+        if (APPLY) unlinkSync(p);
+      } catch { /* not present */ }
+    }
+  }
+
+  if (!APPLY && orphans.length) console.log("\ndry run — re-run with --apply to kill them");
+}

--- a/orchestrator/chrome-sweep.test.mjs
+++ b/orchestrator/chrome-sweep.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * bun test
+ *
+ * The sweep kills processes, and the one unforgivable failure is killing the
+ * human's actual Chrome. Every fence gets a test proving it holds.
+ */
+import { test, expect } from "bun:test";
+import { classify, parsePs } from "./chrome-sweep.mjs";
+
+const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+test("an orphaned agent Chrome (reparented to launchd) is flagged", () => {
+  const { orphans } = classify([
+    { pid: 500, ppid: 1, command: `${CHROME} --user-data-dir=/Users/x/.cache/chrome-devtools-mcp/chrome-profile --headless` },
+  ]);
+  expect(orphans).toHaveLength(1);
+  expect(orphans[0].pid).toBe(500);
+});
+
+test("an isolated temp profile from a killed run is flagged too", () => {
+  const { orphans } = classify([
+    { pid: 501, ppid: 1, command: `${CHROME} --user-data-dir=/var/folders/pd/T/puppeteer_dev_chrome_profile-Xa1B2c` },
+  ]);
+  expect(orphans).toHaveLength(1);
+});
+
+test("the human's normal Chrome is NEVER touched, even at ppid 1", () => {
+  // Real desktop Chrome is launched by launchd, so ppid 1 is its normal state —
+  // the profile fence is what protects it, not the parent check.
+  const { orphans, live } = classify([
+    { pid: 600, ppid: 1, command: `${CHROME}` },
+    { pid: 601, ppid: 1, command: `${CHROME} --user-data-dir=/Users/x/Library/Application Support/Google/Chrome` },
+  ]);
+  expect(orphans).toHaveLength(0);
+  expect(live).toHaveLength(0);
+});
+
+test("an agent Chrome whose MCP server is alive is left alone", () => {
+  const { orphans, live } = classify([
+    { pid: 700, ppid: 42371, command: `${CHROME} --user-data-dir=/var/folders/T/chrome-devtools-mcp-tmp-abc --headless` },
+  ]);
+  expect(orphans).toHaveLength(0);
+  expect(live).toHaveLength(1);
+});
+
+test("helper processes are skipped — killing the main brings them down", () => {
+  const { orphans } = classify([
+    { pid: 800, ppid: 1, command: `${CHROME} --type=renderer --user-data-dir=/x/chrome-devtools-mcp/chrome-profile` },
+    { pid: 801, ppid: 1, command: `${CHROME} --type=gpu-process --user-data-dir=/x/chrome-devtools-mcp/chrome-profile` },
+  ]);
+  expect(orphans).toHaveLength(0);
+});
+
+test("parsePs handles ps output with leading whitespace and spaces in commands", () => {
+  const rows = parsePs(`  123     1 ${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p\n 45  6789 /usr/bin/tail -f log\n\n`);
+  expect(rows).toHaveLength(2);
+  expect(rows[0]).toEqual({ pid: 123, ppid: 1, command: `${CHROME} --user-data-dir=/x/chrome-devtools-mcp/p` });
+});

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -280,6 +280,12 @@ async function runTicket(t) {
         "--output-format", "stream-json", "--verbose",
         "--max-budget-usd", budget,
         "--fallback-model", "sonnet",
+        // Browser server from git: isolated per-session Chrome (ends the
+        // shared-profile collisions) + webp screenshot caps at the source.
+        // NOT --strict-mcp-config — strict drops the claude.ai connectors,
+        // and losing the Linear MCP severs the control plane (verified
+        // 2026-08-04). Mirrors run-agent.sh.
+        "--mcp-config", path.join(ROOT, "config/mcp/claude.json"),
         ...(COMMAND_MODEL ? ["--model", COMMAND_MODEL] : []),
       ];
     } else if (HARNESS === "codex") {

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -199,12 +199,19 @@ unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
 # still parses the final envelope for the exit code.
 set +e
 if [[ "$HARNESS" == "claude" ]]; then
+  # --mcp-config supplies the browser server from git (config/mcp/claude.json):
+  # isolated per-session Chrome profiles ended the shared-profile collisions
+  # (95 errors across 26 runs), and webp screenshot caps cut the biggest context
+  # cost at the source. Deliberately NOT --strict-mcp-config: strict also drops
+  # the claude.ai connectors, and losing the Linear MCP severs the control
+  # plane (verified empirically 2026-08-04 — 0 Linear tools under strict).
   (
     cd "$REPO_PATH"
     $RUN_CAP $ENV_PREFIX claude -p "$PROMPT" \
       --output-format stream-json --verbose \
       --max-budget-usd "$BUDGET" \
       --fallback-model sonnet \
+      --mcp-config "$ROOT/config/mcp/claude.json" \
       $MODEL_ARGS $READONLY_ARGS
   ) 2>&1 | (cd "$ROOT" && bun runners/report.mjs --log "$LOG" --harness claude)
 else

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -84,9 +84,9 @@ A tool result is not paid for once. It stays in the context window and is re-sen
 
 ### Browsers
 
-The browser profile is **shared between concurrently running agents**. `browser is already running for .../chrome-profile` means another agent has it — that is contention, not a crash, and it was hit 95 times across 26 runs.
+Factory-spawned sessions get their **own isolated headless Chrome** (via `--mcp-config`, `config/mcp/claude.json` in the factory repo) — a temp profile per session, screenshots served as capped webp. There is nothing to share and nothing to fight over.
 
-Do not retry the call and do not kill the other agent's browser. Attach to what is already there (`list_pages` then `select_page`, or open a new tab), or if you need genuine isolation, launch with an isolated profile of your own.
+If a browser tool still errors: report it and continue with non-browser verification — never retry in a loop, and **never kill another process's Chrome**; a killed browser mid-flight destroys another agent's verification run. `browser is already running for .../chrome-profile` means you are running outside the factory config (interactive session, older harness) where the profile IS shared — attach to the running browser (`list_pages`, then work in your own new page) rather than fighting the lock.
 
 ### Shell globs
 


### PR DESCRIPTION
Fixes the browser-contention finding (95 collisions across 26 runs) structurally, and takes the biggest context cost down with it.

## What

- **`config/mcp/claude.json`** — browser server passed to every Claude spawn via `--mcp-config` (wired in `run-agent.sh` + `tick.mjs`): `--isolated` temp profile per session, `--headless`, webp screenshot caps (q70, max-width 1280). Screenshots were 74% of 10.1GB re-sent context; the caps cut them 4–6x at the source while per-call PNG remains available.
- **Deliberately not `--strict-mcp-config`** — verified empirically that strict drops claude.ai connectors (0 Linear tools under strict, 52 without), which would sever the control plane. The unconfigured chrome-devtools *plugin* is disabled in user settings instead; exactly one browser server loads.
- **`orchestrator/chrome-sweep.mjs`** — kills Chromes orphaned by wall-cap kills (three fences: agent profile dir, main process, PPID 1) and clears stale `Singleton*` locks. Dry-run default. The human's own Chrome is protected by a test per fence.
- Floor `Browsers` section rewritten for the isolated world; the old "attach" advice is scoped to non-factory sessions where the profile really is shared.

## Verification

- Two parallel headless sessions each launched their own Chrome and navigated `example.com` — zero contention (this was the exact 10-agents-1-lock failure mode).
- Headless spawn with the config: Linear connector 52 tools ✓, `mcp__chrome-devtools__*` 29 ✓, plugin tools 0 ✓.
- `bun test`: 93 pass. Live sweep dry-run found and (with `--apply`) removed the real stale lock from tonight.

Follow-up: after the next batch, `bun run economics -- --since 1d` should show browser collisions at zero and `take_screenshot` payload down 4–6x.