### PR TITLE
tools/linear.mjs — factory Linear verbs as a shell tool

### DIFF
--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -92,9 +92,22 @@ If a browser tool still errors: report it and continue with non-browser verifica
 
 Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.ts`. zsh expands the unquoted form against the current directory and **errors** when nothing matches there, killing the command before grep runs. Seen repeatedly in real transcripts.
 
-### Linear labels
+### Linear
 
-`type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y`. Nothing else resolves — `type:chore` fails the mutation. `area:*` values are per-team; check an existing ticket in the same project rather than inventing one. Every new issue also gets exactly one `source:*` label saying what created it: `source:agent` for work you discover and file yourself, `source:human` for a direct human request, `source:sentry` / `source:client-support` for those intake paths.
+**Use `bun tools/linear.mjs` from the factory checkout — not the Linear MCP.** The MCP is a UI-managed connector that fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback. The tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
+
+```bash
+bun tools/linear.mjs get CLNT-616                     # ticket, state, labels, criteria
+bun tools/linear.mjs claim CLNT-616 --agent claude    # assign + In Progress + labels + read-back
+bun tools/linear.mjs comment CLNT-616 "..."           # the heartbeat
+bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
+bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
+bun tools/linear.mjs queue --team CLNT                # what is dispatchable
+```
+
+`claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.
+
+**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove`; a hand-written mutation that passes only the labels you want added silently strips every other label on the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
 
 ### Secrets
 

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -28,6 +28,7 @@ import { gql } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
 import { parseOwnedPaths, pathsCollide } from "./owned-paths.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
+import { agentLabel } from "../tools/linear.mjs";
 
 const argv = process.argv.slice(2);
 const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -64,7 +65,7 @@ if (!Bun.which(HARNESS)) { console.error(`harness "${HARNESS}" is not on PATH`);
 // linear.md's agent:* taxonomy names the harness that actually holds the
 // claim (agent:claude-code, agent:gemini, ...) — it must track HARNESS, not
 // assume claude, or a ticket run on agy gets labelled as if Claude did it.
-const AGENT_LABEL = `agent:${HARNESS === "claude" ? "claude-code" : HARNESS}`;
+const AGENT_LABEL = agentLabel(HARNESS);
 
 const TIMEOUT_BIN = Bun.which("timeout") ?? Bun.which("gtimeout");
 if (!TIMEOUT_BIN) console.log(c.yellow("  ! no timeout(1)/gtimeout on PATH — a wedged run will not be wall-clock capped"));

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -92,9 +92,22 @@ If a browser tool still errors: report it and continue with non-browser verifica
 
 Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.ts`. zsh expands the unquoted form against the current directory and **errors** when nothing matches there, killing the command before grep runs. Seen repeatedly in real transcripts.
 
-### Linear labels
+### Linear
 
-`type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y`. Nothing else resolves — `type:chore` fails the mutation. `area:*` values are per-team; check an existing ticket in the same project rather than inventing one. Every new issue also gets exactly one `source:*` label saying what created it: `source:agent` for work you discover and file yourself, `source:human` for a direct human request, `source:sentry` / `source:client-support` for those intake paths.
+**Use `bun tools/linear.mjs` from the factory checkout — not the Linear MCP.** The MCP is a UI-managed connector that fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback. The tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
+
+```bash
+bun tools/linear.mjs get CLNT-616                     # ticket, state, labels, criteria
+bun tools/linear.mjs claim CLNT-616 --agent claude    # assign + In Progress + labels + read-back
+bun tools/linear.mjs comment CLNT-616 "..."           # the heartbeat
+bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
+bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
+bun tools/linear.mjs queue --team CLNT                # what is dispatchable
+```
+
+`claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.
+
+**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove`; a hand-written mutation that passes only the labels you want added silently strips every other label on the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
 
 ### Secrets
 

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env bun
+/**
+ * The factory's Linear surface, as a shell command.
+ *
+ *   bun tools/linear.mjs get CLNT-616
+ *   bun tools/linear.mjs claim CLNT-616 --agent claude
+ *   bun tools/linear.mjs comment CLNT-616 "verified: 42 tests pass"
+ *   bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
+ *   bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
+ *   bun tools/linear.mjs queue --repo bj29
+ *   bun tools/linear.mjs raw '<graphql>' --var key=value
+ *
+ * WHY THIS EXISTS, given a perfectly good Linear MCP.
+ *
+ * Three reasons, in ascending order of importance.
+ *
+ *  1. The MCP is flaky in practice. Across 485 measured runs `list_issues`
+ *     failed input validation 18 times in 12 runs and `save_issue` 10 times,
+ *     and 96 runs fell through to a hand-rolled GraphQL fallback. Agents were
+ *     already routing around it; this makes the route the road.
+ *
+ *  2. It is not declared anywhere. The MCP arrives as a claude.ai connector
+ *     configured in a UI, so what the factory can reach changes when someone
+ *     toggles a checkbox. Everything else the factory depends on is in git and
+ *     moves by PR.
+ *
+ *  3. Connectors come as a bundle, and the bundle is the problem. An unattended
+ *     factory session was loading 174 MCP tools: Linear (52), but also a client
+ *     law firm's connector (51), Gmail (16), Drive, Calendar. Every ticket
+ *     agent running unattended under bypassPermissions had personal mail and
+ *     client data one tool call away, for no reason. Replacing the one
+ *     connector the factory actually needs is what makes it possible to turn
+ *     the rest off (--strict-mcp-config in config/mcp/claude.json).
+ *
+ * NOT A GENERAL LINEAR CLIENT. It covers the verbs the floor's protocol
+ * actually names; anything rarer goes through `raw` with explicit GraphQL
+ * rather than growing an API surface nobody maintains. It reuses gql() from
+ * orchestrator/reaper.mjs — retries, backoff and key loading are solved there,
+ * and a second client would be a second set of bugs.
+ */
+import { gql } from "../orchestrator/reaper.mjs";
+
+// The eight values that resolve; `type:chore` fails the mutation. Kept here as
+// well as in the floor because a typo should fail locally with a list of the
+// valid options, not as an opaque API error three seconds later.
+export const TYPE_LABELS = ["bug", "feature", "ui-ux", "security", "performance", "maintenance", "docs", "a11y"];
+export const SOURCE_LABELS = ["agent", "human", "sentry", "client-support"];
+
+/** Reject label typos before the API does, with a useful message. */
+export function validateLabels(names) {
+  const bad = [];
+  for (const n of names) {
+    if (n.startsWith("type:") && !TYPE_LABELS.includes(n.slice(5))) {
+      bad.push(`${n} — type:* must be one of ${TYPE_LABELS.join(" ")}`);
+    }
+    if (n.startsWith("source:") && !SOURCE_LABELS.includes(n.slice(7))) {
+      bad.push(`${n} — source:* must be one of ${SOURCE_LABELS.join(" ")}`);
+    }
+  }
+  return bad;
+}
+
+/**
+ * The label set after an add/remove, as ids.
+ *
+ * Linear's issueUpdate takes the COMPLETE label set, not a delta — passing only
+ * the labels you want added silently removes every other label on the ticket.
+ * That is the sharp edge this function exists to blunt.
+ */
+export function resolveLabelIds(currentNames, { add = [], remove = [] }, allLabels) {
+  const idOf = (n) => allLabels.find((l) => l.name === n)?.id;
+  const dropped = new Set(remove);
+  const kept = currentNames.filter((n) => !dropped.has(n));
+  return [...new Set([...kept, ...add].map(idOf).filter(Boolean))];
+}
+
+/**
+ * Harness name -> the `agent:*` label that exists in the workspace.
+ *
+ * The Claude harness is `claude` on the command line but `agent:claude-code` in
+ * Linear, and nothing enforces that they agree. tick.mjs imports this rather
+ * than carrying its own copy: two spellings of the same mapping is precisely
+ * the drift this repo exists to prevent, and the failure is silent — tick.mjs
+ * filters unresolved label ids out, so a wrong name just means the ticket never
+ * says which harness holds it.
+ */
+export const agentLabel = (harness) => `agent:${harness === "claude" ? "claude-code" : harness}`;
+
+/**
+ * Claiming drops `ai:agent-ready` and adds `ai:in-progress` + the agent label.
+ * agent-ready means "waiting to be picked up" — keeping it alongside
+ * ai:in-progress leaves the ticket asserting two lifecycle states at once, and
+ * it then survives all the way to Done. One flag, one value.
+ */
+export function claimLabels(currentNames, harness) {
+  const mine = agentLabel(harness);
+  return {
+    add: ["ai:in-progress", mine],
+    remove: ["ai:agent-ready", ...currentNames.filter((n) => n.startsWith("agent:") && n !== mine)],
+  };
+}
+
+/** Compact ticket rendering — the fields the protocol actually acts on. */
+export function formatTicket(i) {
+  const labels = (i.labels?.nodes ?? []).map((l) => l.name);
+  const lines = [
+    `${i.identifier}  ${i.title}`,
+    `  state     ${i.state?.name ?? "?"}`,
+    `  assignee  ${i.assignee?.name ?? "(unassigned)"}`,
+    `  labels    ${labels.join(" ") || "(none)"}`,
+    `  url       ${i.url ?? ""}`,
+  ];
+  if (i.description) lines.push("", i.description);
+  return lines.join("\n");
+}
+
+// --------------------------------------------------------------- helpers ---
+const ISSUE_FIELDS = `id identifier title url description
+  state{ id name type } assignee{ id name }
+  labels(first:30){ nodes{ id name } }`;
+
+async function issueByKey(key) {
+  const d = await gql(`query($k:String!){ issue(id:$k){ ${ISSUE_FIELDS} } }`, { k: key });
+  if (!d?.issue) throw new Error(`no such issue: ${key}`);
+  return d.issue;
+}
+
+const teamOf = (key) => key.split("-")[0];
+
+async function statesFor(teamKey) {
+  const d = await gql(`query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } } } } }`, { t: teamKey });
+  const team = d?.teams?.nodes?.[0];
+  if (!team) throw new Error(`no such team: ${teamKey}`);
+  return { teamId: team.id, states: team.states?.nodes ?? [] };
+}
+
+const allLabelsCache = { v: null };
+async function allLabels() {
+  if (!allLabelsCache.v) {
+    allLabelsCache.v = (await gql(`query{ issueLabels(first:250){ nodes{ id name } } }`))?.issueLabels?.nodes ?? [];
+  }
+  return allLabelsCache.v;
+}
+
+async function applyLabels(issue, add, remove) {
+  const bad = validateLabels(add);
+  if (bad.length) throw new Error("invalid label(s):\n  " + bad.join("\n  "));
+  const all = await allLabels();
+  const missing = add.filter((n) => !all.some((l) => l.name === n));
+  if (missing.length) throw new Error(`label(s) do not exist in this workspace: ${missing.join(", ")}`);
+  const current = (issue.labels?.nodes ?? []).map((l) => l.name);
+  return resolveLabelIds(current, { add, remove }, all);
+}
+
+// ------------------------------------------------------------------ verbs ---
+const argv = process.argv.slice(2);
+const verb = argv[0];
+const positional = argv.slice(1).filter((a) => !a.startsWith("--"));
+const flag = (name, dflt = null) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? dflt : argv[i + 1];
+};
+const flagAll = (name) => argv.flatMap((a, i) => (a === `--${name}` ? [argv[i + 1]] : [])).filter(Boolean);
+const has = (name) => argv.includes(`--${name}`);
+const JSON_OUT = has("json");
+const out = (obj, text) => console.log(JSON_OUT ? JSON.stringify(obj, null, 2) : text);
+
+const VERBS = {
+  async get() {
+    const issue = await issueByKey(positional[0]);
+    out(issue, formatTicket(issue));
+  },
+
+  async claim() {
+    const key = positional[0];
+    const harness = flag("agent", "claude");
+    const issue = await issueByKey(key);
+    const { states } = await statesFor(teamOf(key));
+    const inProgress = states.find((s) => s.name.toLowerCase() === "in progress");
+    if (!inProgress) throw new Error(`team ${teamOf(key)} has no "In Progress" state`);
+
+    const me = (await gql(`query{ viewer{ id name } }`))?.viewer;
+    const { add, remove } = claimLabels((issue.labels?.nodes ?? []).map((l) => l.name), harness);
+    const labelIds = await applyLabels(issue, add, remove);
+
+    await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: { stateId: inProgress.id, assigneeId: me.id, labelIds } });
+
+    // Linear has no compare-and-swap, so this read-back IS the concurrency
+    // control. Enforced here rather than asked of the agent in prose: a claim
+    // that skips it is how two agents end up in one worktree.
+    const back = (await gql(`query($id:String!){ issue(id:$id){ assignee{ id name } } }`, { id: issue.id }))?.issue;
+    const won = back?.assignee?.id === me.id;
+    out({ ok: won, identifier: key, assignee: back?.assignee?.name ?? null },
+      won ? `claimed ${key} as ${me.name}` : `LOST RACE on ${key} — now assigned to ${back?.assignee?.name ?? "someone else"}; take the next ticket`);
+    if (!won) process.exit(1);
+  },
+
+  async comment() {
+    const key = positional[0];
+    const body = positional[1];
+    if (!body) throw new Error(`usage: comment <ISSUE-ID> "<text>"`);
+    const issue = await issueByKey(key);
+    await gql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
+      { in: { issueId: issue.id, body } });
+    out({ ok: true, identifier: key }, `commented on ${key}`);
+  },
+
+  async state() {
+    const key = positional[0];
+    const wanted = positional[1];
+    if (!wanted) throw new Error(`usage: state <ISSUE-ID> "<State Name>" [--add label] [--remove label]`);
+    const issue = await issueByKey(key);
+    const { states } = await statesFor(teamOf(key));
+    const target = states.find((s) => s.name.toLowerCase() === wanted.toLowerCase());
+    if (!target) throw new Error(`no state "${wanted}" on team ${teamOf(key)} — have: ${states.map((s) => s.name).join(", ")}`);
+
+    const add = flagAll("add"), remove = flagAll("remove");
+    const input = { stateId: target.id };
+    if (add.length || remove.length) input.labelIds = await applyLabels(issue, add, remove);
+    if (has("unassign")) input.assigneeId = null;
+
+    await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: input });
+    out({ ok: true, identifier: key, state: target.name }, `${key} -> ${target.name}`);
+  },
+
+  async file() {
+    const team = flag("team");
+    const title = flag("title");
+    if (!team || !title) throw new Error(`usage: file --team CLNT --title "..." [--body "..."] [--type bug] [--area x] [--source agent] [--todo]`);
+
+    const { teamId, states } = await statesFor(team);
+    // New findings land in Triage unless they already meet the agent-ready bar.
+    const stateName = has("todo") ? "Todo" : "Triage";
+    const target = states.find((s) => s.name.toLowerCase() === stateName.toLowerCase());
+
+    const wanted = [
+      ...(flag("type") ? [`type:${flag("type")}`] : []),
+      ...flagAll("area").map((a) => `area:${a}`),
+      `source:${flag("source", "agent")}`,
+      ...(has("todo") ? ["ai:agent-ready"] : []),
+      ...flagAll("label"),
+    ];
+    const bad = validateLabels(wanted);
+    if (bad.length) throw new Error("invalid label(s):\n  " + bad.join("\n  "));
+    const all = await allLabels();
+    const missing = wanted.filter((n) => !all.some((l) => l.name === n));
+    if (missing.length) throw new Error(`label(s) do not exist in this workspace: ${missing.join(", ")}`);
+
+    const d = await gql(
+      `mutation($in:IssueCreateInput!){ issueCreate(input:$in){ success issue{ identifier url } } }`,
+      { in: {
+        teamId, title,
+        description: flag("body", ""),
+        stateId: target?.id,
+        labelIds: resolveLabelIds([], { add: wanted }, all),
+        ...(flag("project") ? { projectId: flag("project") } : {}),
+      } });
+    const created = d?.issueCreate?.issue;
+    if (!created) throw new Error("issueCreate returned no issue");
+    out({ ok: true, ...created }, `filed ${created.identifier} in ${stateName}  ${created.url}`);
+  },
+
+  async queue() {
+    const team = flag("team") ?? teamOf(positional[0] ?? "");
+    if (!team) throw new Error(`usage: queue --team CLNT`);
+    // Dispatchable == Todo + ai:agent-ready + unassigned. The same predicate
+    // the dispatcher uses; agents must not invent their own.
+    const d = await gql(
+      `query($t:String!){ issues(first:100, filter:{ team:{key:{eq:$t}}, state:{name:{eq:"Todo"}}, assignee:{null:true} }){ nodes{ ${ISSUE_FIELDS} } } }`,
+      { t: team });
+    const ready = (d?.issues?.nodes ?? []).filter((i) =>
+      (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"));
+    out(ready, ready.length
+      ? ready.map((i) => `${i.identifier}  ${i.title}`).join("\n")
+      : "no agent-ready tickets");
+  },
+
+  async raw() {
+    const vars = Object.fromEntries(flagAll("var").map((kv) => {
+      const i = kv.indexOf("=");
+      return [kv.slice(0, i), kv.slice(i + 1)];
+    }));
+    console.log(JSON.stringify(await gql(positional[0], vars), null, 2));
+  },
+};
+
+if (import.meta.main) {
+  if (!verb || has("help") || !VERBS[verb]) {
+    console.log(`verbs: ${Object.keys(VERBS).join(", ")}\n`);
+    console.log(import.meta.file ? "see the header of tools/linear.mjs for usage" : "");
+    process.exit(verb && !VERBS[verb] ? 2 : 0);
+  }
+  try {
+    await VERBS[verb]();
+  } catch (e) {
+    console.error(`linear ${verb}: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * bun test
+ *
+ * The label logic is the dangerous part. Linear's issueUpdate takes the
+ * COMPLETE label set rather than a delta, so a function that returns "the
+ * labels to add" instead of "the labels the ticket should end up with" silently
+ * strips every other label on the ticket. That is data loss with no error, on
+ * tickets a human curated — so it gets real tests.
+ */
+import { test, expect } from "bun:test";
+import { resolveLabelIds, claimLabels, validateLabels, formatTicket, agentLabel, TYPE_LABELS } from "./linear.mjs";
+
+const LABELS = [
+  { id: "l-ready", name: "ai:agent-ready" },
+  { id: "l-prog", name: "ai:in-progress" },
+  { id: "l-claude", name: "agent:claude-code" },
+  { id: "l-codex", name: "agent:codex" },
+  { id: "l-bug", name: "type:bug" },
+  { id: "l-area", name: "area:api" },
+  { id: "l-review", name: "ai:needs-review" },
+];
+
+// ------------------------------------------------------------ label math ---
+test("adding a label KEEPS the labels already on the ticket", () => {
+  const ids = resolveLabelIds(["type:bug", "area:api"], { add: ["ai:needs-review"] }, LABELS);
+  expect(ids).toContain("l-bug");
+  expect(ids).toContain("l-area");
+  expect(ids).toContain("l-review");
+  expect(ids).toHaveLength(3);
+});
+
+test("removing takes out only the named label", () => {
+  const ids = resolveLabelIds(["type:bug", "ai:agent-ready"], { remove: ["ai:agent-ready"] }, LABELS);
+  expect(ids).toEqual(["l-bug"]);
+});
+
+test("unknown label names are dropped rather than sent as undefined ids", () => {
+  // A stale label removed from the workspace must not become `undefined` in the
+  // mutation array — Linear rejects the whole update, losing the state change.
+  const ids = resolveLabelIds(["type:bug", "area:deleted-label"], { add: [] }, LABELS);
+  expect(ids).toEqual(["l-bug"]);
+});
+
+test("the result never contains duplicates", () => {
+  const ids = resolveLabelIds(["type:bug"], { add: ["type:bug"] }, LABELS);
+  expect(ids).toEqual(["l-bug"]);
+});
+
+// ----------------------------------------------------------------- claim ---
+test("the claude harness maps to the label that actually exists in Linear", () => {
+  // `claude` on the CLI is `agent:claude-code` in the workspace. Getting this
+  // wrong fails silently: unresolved ids are filtered out, so the ticket simply
+  // never records which harness holds it.
+  expect(agentLabel("claude")).toBe("agent:claude-code");
+  expect(agentLabel("codex")).toBe("agent:codex");
+  expect(agentLabel("gemini")).toBe("agent:gemini");
+});
+
+test("claiming drops agent-ready and adds in-progress plus the harness label", () => {
+  const { add, remove } = claimLabels(["ai:agent-ready", "type:bug"], "claude");
+  expect(add).toEqual(["ai:in-progress", "agent:claude-code"]);
+  expect(remove).toContain("ai:agent-ready");
+
+  const ids = resolveLabelIds(["ai:agent-ready", "type:bug"], { add, remove }, LABELS);
+  expect(ids).toContain("l-prog");
+  expect(ids).toContain("l-claude");
+  expect(ids).toContain("l-bug");           // curated label survives
+  expect(ids).not.toContain("l-ready");     // lifecycle flag replaced
+});
+
+test("re-claiming on a different harness does not leave two agent:* labels", () => {
+  const { add, remove } = claimLabels(["agent:codex", "ai:in-progress"], "claude");
+  expect(remove).toContain("agent:codex");
+  const ids = resolveLabelIds(["agent:codex", "ai:in-progress"], { add, remove }, LABELS);
+  expect(ids).toContain("l-claude");
+  expect(ids).not.toContain("l-codex");
+});
+
+// ------------------------------------------------------------ validation ---
+test("type:chore is rejected with the list of values that work", () => {
+  const bad = validateLabels(["type:chore"]);
+  expect(bad).toHaveLength(1);
+  expect(bad[0]).toContain("maintenance");
+});
+
+test("every documented type:* value passes", () => {
+  expect(validateLabels(TYPE_LABELS.map((t) => `type:${t}`))).toEqual([]);
+});
+
+test("an unknown source:* is rejected; area:* is free-form and is not", () => {
+  expect(validateLabels(["source:invented"])).toHaveLength(1);
+  expect(validateLabels(["source:agent", "area:anything-goes"])).toEqual([]);
+});
+
+// -------------------------------------------------------------- rendering ---
+test("formatTicket shows the fields the protocol acts on", () => {
+  const text = formatTicket({
+    identifier: "CLNT-616", title: "Fix login", url: "https://linear.app/x/CLNT-616",
+    state: { name: "Todo" }, assignee: null,
+    labels: { nodes: [{ name: "ai:agent-ready" }] },
+  });
+  expect(text).toContain("CLNT-616");
+  expect(text).toContain("Todo");
+  expect(text).toContain("(unassigned)");
+  expect(text).toContain("ai:agent-ready");
+});


### PR DESCRIPTION
Fixes OPS-68 (partially — the `--strict-mcp-config` flip is deliberately held back).

## Why replace a working MCP

Three reasons, ascending:

1. **It's flaky.** Over 485 measured runs `list_issues` failed input validation 18x across 12 runs, `save_issue` 10x, and **96 runs fell through to a hand-rolled GraphQL fallback**. Agents were already routing around it while it remained the most-called surface in the factory (2,587 `save_issue`, 2,080 `get_issue`). The fallback was doing real work while the primary was flaky — backwards.
2. **It isn't declared anywhere.** It arrives as a claude.ai connector configured in a UI, so what the factory can reach changes when a checkbox moves. Everything else the factory depends on is in git and moves by PR.
3. **Connectors come as a bundle, and the bundle is the problem.** An unattended session loads **174 MCP tools**:

| tools | server |
| ---: | :--- |
| 52 | claude_ai_Linear |
| **51** | **a client law firm's connector** |
| 29 | chrome-devtools |
| **16** | **claude_ai_Gmail** |
| 26 | Drive · Calendar · Sentry |

Every ticket agent running unattended under `bypassPermissions` had personal mail and client data one tool call away. Replacing the one connector the factory actually needs is what makes turning the rest off possible.

Note: token cost is **not** a reason. I predicted a large saving and measured 30,782 → 27,897 (~2.9k) — tool schemas are deferred, so 174 tools don't sit in context.

## Design

Reuses `gql()` from `orchestrator/reaper.mjs` — retries, backoff and key loading are solved there, and a second client would be a second set of bugs. Not a general Linear client: it covers the verbs the floor's protocol names, and anything rarer goes through `raw '<graphql>' --var k=v` rather than growing an API surface nobody maintains.

**Guardrails are code, not prose:**

- `claim` performs the read-back that *is* the concurrency control (Linear has no compare-and-swap) and **exits non-zero on a lost race** — so "take the next ticket" is enforced rather than requested.
- Label ops go through `--add`/`--remove` because `issueUpdate` **replaces the label set wholesale**. Passing only the labels you want added silently strips every other label — data loss, no error, on tickets a human curated. That trap has four tests.
- `type:chore` fails locally with the list of eight values that work, instead of an opaque API error three seconds later.
- `agentLabel()` is now **shared with `tick.mjs`**. `claude` on the CLI is `agent:claude-code` in Linear; two copies of that mapping is the exact drift this repo exists to prevent, and it fails silently since unresolved ids get filtered out. This bug was found by the tool's own guard during live testing.

## Verification

Live against the workspace, end to end: filed **OPS-68**, commented, transitioned Triage → Todo → In Progress, claimed with read-back returning `claimed OPS-68`. All four curated labels (`type:maintenance area:infra source:agent`) survived every write.

```
bun test                      104 pass, 0 fail
bun build/emit.mjs --check    ok — 34 generated files match shared/
                              floor delivery: 4 repo(s) carrying the current floor
bun orchestrator/tick.mjs     dispatcher unaffected by the shared import
```

## Held back

`--strict-mcp-config` is **not** flipped. The connector stays as a safety net until real tickets have run through the tool — flipping it is a one-line follow-up once that's proven.