### PR TITLE
fix(build): wire up --link-repos so repo command symlinks stop going stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ The **content** is portable; only the **packaging** isn't. `SKILL.md` is a forma
 bun build/emit.mjs           # regenerate everything
 bun build/emit.mjs --check   # CI: fail if the tree drifted from shared/
 bun build/emit.mjs --link    # symlink this machine's harnesses at shared/
+bun run link-repos           # symlink plugins/core/commands/ into every repo in config/repos.yaml
 ```
 
-`--link` symlinks rather than copies, so a `git pull` updates every harness at once and there is no copy to go stale. It refuses to overwrite a real file.
+`--link`/`--link-repos` symlink rather than copy, so a `git pull` updates every harness (or repo) at once and there is no copy to go stale. Both refuse to overwrite a real file. `link-repos` matters specifically for headless dispatch — `runners/run-agent.sh` reads commands straight from `<repo>/.claude/commands/`, not the marketplace plugin — so re-run it whenever a `/factory-*` command changes (see SETUP.md §2).
 
 > [!IMPORTANT]
 > **The plugin is a convenience layer, not the safety floor.** It reaches Claude Code only, and a cloud sandbox without GitHub auth for this private repo gets nothing — failing closed without knowing it.

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,9 +13,12 @@ Do this **before** loading any launchd job. A launchd process inherits no intera
 ```bash
 bun build/emit.mjs           # regenerate plugins/ and dist/
 bun build/emit.mjs --link    # symlink ~/.codex, ~/.gemini, ~/.cursor at shared/
+bun run link-repos           # symlink plugins/core/commands/ into every repo in config/repos.yaml
 ```
 
-Symlinks rather than copies: `git pull` then updates every harness at once, and there's no copy to drift. `--link` refuses to overwrite a real file, so it won't clobber anything you wrote by hand.
+Symlinks rather than copies: `git pull` then updates every harness at once, and there's no copy to drift. `--link`/`--link-repos` refuse to overwrite a real file, so neither will clobber anything you wrote by hand.
+
+**`bun run link-repos` is not optional for headless dispatch.** `runners/run-agent.sh` invokes `claude -p`, which reads project commands from `<repo>/.claude/commands/` directly — it does not go through the marketplace plugin in step 4 below (that route needs an interactive session; see the comment above `--link-repos` in `build/emit.mjs`). Skip this and a repo's headless commands silently run against whatever command set was symlinked in last, however old. **Re-run it every time a `/factory-*` command is added, renamed, or removed** — nothing else notices the drift; OPS-69 is exactly this bug (`factory-unblock` merged, never linked into cashsaas/bj29/legalease, first headless run failed with `Unknown command: /factory-unblock`).
 
 ## 3. Scheduling — deliberately empty
 

--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -5,6 +5,11 @@
  *   bun build/emit.mjs           # regenerate plugins/ and dist/
  *   bun build/emit.mjs --check   # CI: fail if the tree isn't reproducible
  *   bun build/emit.mjs --link    # symlink this machine's harnesses at shared/
+ *   bun run link-repos           # symlink plugins/core/commands/ into every
+ *                                 # configured repo's .claude/commands/ — run
+ *                                 # this whenever a /factory-* command is
+ *                                 # added or removed, or product repos keep
+ *                                 # running against a stale command set
  *
  * Why a build step at all: the CONTENT is harness-neutral (SKILL.md is a shared
  * format; command bodies are markdown) but the PACKAGING is not. Claude wants a

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "emit": "bun build/emit.mjs",
     "check": "bun build/emit.mjs --check",
     "link": "bun build/emit.mjs --link",
+    "link-repos": "bun build/emit.mjs --link-repos",
     "sync-floor": "bun build/emit.mjs --sync-floor",
     "economics": "bun orchestrator/economics.mjs",
     "schedule": "bun deploy/gen.mjs",


### PR DESCRIPTION
Fixes OPS-69

`build/emit.mjs --link-repos` already existed and does the right thing (per-command symlinks into every repo in `config/repos.yaml`, idempotent, never overwrites a real file) but had no package.json script, no docs, and wasn't part of the normal setup flow — so it was never run after being written. cashsaas/bj29/legalease's `.claude/commands/` were hand-symlinked once on 2026-08-03 and went stale: `factory-unblock.md` (OPS-67, merged 2026-08-04) had no symlink anywhere, so `runners/run-agent.sh --command factory-unblock` failed with `Unknown command: /factory-unblock` on first use from the watch TUI.

Considered a single directory-level symlink instead of per-file — empirically ruled out: `claude -p` against a scratch `.claude/commands/sub/testcmd.md` namespaces it as `/sub:testcmd`, not `/testcmd`. Adopting that would rename every `/factory-*` command and break `run-agent.sh`'s `PROMPT="/${COMMAND}"` plus every doc/script referencing the bare name.

## What changed

- `package.json` — new `link-repos` script.
- `SETUP.md` / `README.md` — document `bun run link-repos`, explicitly calling out that `run-agent.sh`'s headless `claude -p` reads `<repo>/.claude/commands/` directly (not the marketplace plugin from SETUP.md §4, which only works interactively) — so this step isn't optional, and needs a re-run whenever a `/factory-*` command changes.
- `build/emit.mjs` header comment — added to the usage list.
- Ran `bun run link-repos` to reconcile all four repos now (will re-run once more after merge, from the main checkout — running it from a worktree points the symlinks at the worktree's own path, which disappears when the worktree is torn down).

## Verification

- `bun run check` — 34 emitted files in sync (pre-existing, unrelated `AGENTS.md` floor-staleness warning across all 4 repos — separate maintenance item, not touched here)
- `bun test` — 104 pass, 0 fail
- `bun run link-repos` — linked 7 commands into each of bj29/coach-wattz/legalease/cashsaas