### PR TITLE
Strict MCP: the factory's tool surface is declared in git

### DIFF
--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -96,13 +96,16 @@ Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.
 
 **Use `bun tools/linear.mjs` from the factory checkout — not the Linear MCP.** The MCP is a UI-managed connector that fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback. The tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
 
+You work in a worktree, not in the factory checkout, so **always go through `$FACTORY_ROOT`** — the factory sets it on every run. A bare `bun tools/linear.mjs` resolves to nothing.
+
 ```bash
-bun tools/linear.mjs get CLNT-616                     # ticket, state, labels, criteria
-bun tools/linear.mjs claim CLNT-616 --agent claude    # assign + In Progress + labels + read-back
-bun tools/linear.mjs comment CLNT-616 "..."           # the heartbeat
-bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
-bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
-bun tools/linear.mjs queue --team CLNT                # what is dispatchable
+L="$FACTORY_ROOT/tools/linear.mjs"                 # or ~/Develop/factory/tools/linear.mjs
+bun "$L" get CLNT-616                              # ticket, state, labels, criteria
+bun "$L" claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
+bun "$L" comment CLNT-616 "..."                    # the heartbeat
+bun "$L" state CLNT-616 "In Review" --add ai:needs-review
+bun "$L" file --team CLNT --title "..." --body "..." --type bug
+bun "$L" queue --team CLNT                         # what is dispatchable
 ```
 
 `claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -281,12 +281,12 @@ async function runTicket(t) {
         "--output-format", "stream-json", "--verbose",
         "--max-budget-usd", budget,
         "--fallback-model", "sonnet",
-        // Browser server from git: isolated per-session Chrome (ends the
-        // shared-profile collisions) + webp screenshot caps at the source.
-        // NOT --strict-mcp-config — strict drops the claude.ai connectors,
-        // and losing the Linear MCP severs the control plane (verified
-        // 2026-08-04). Mirrors run-agent.sh.
-        "--mcp-config", path.join(ROOT, "config/mcp/claude.json"),
+        // --strict makes this file the ONLY source of MCP servers: no user
+        // scope, no project .mcp.json, no claude.ai connectors. What an
+        // unattended agent can reach is declared in git and moves by PR.
+        // Drops the Linear MCP too — tools/linear.mjs replaces it, reached via
+        // the FACTORY_ROOT set below. Mirrors run-agent.sh.
+        "--mcp-config", path.join(ROOT, "config/mcp/claude.json"), "--strict-mcp-config",
         ...(COMMAND_MODEL ? ["--model", COMMAND_MODEL] : []),
       ];
     } else if (HARNESS === "codex") {
@@ -329,6 +329,12 @@ async function runTicket(t) {
       "-u", "GROQ_API_KEY",
       "-u", "CLAUDECODE",
       "-u", "CLAUDE_CODE_ENTRYPOINT",
+      // Agents run in a worktree, not in this checkout, so `bun
+      // tools/linear.mjs` does not resolve for them. The floor tells them to
+      // use "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that true.
+      // Without it, --strict-mcp-config removes the Linear MCP and leaves no
+      // replacement — the control plane goes silent.
+      `FACTORY_ROOT=${ROOT}`,
       harnessBin, ...piPreArgs, ...harnessArgs
     ];
     const [bin, args] = TIMEOUT_BIN

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -128,6 +128,12 @@ fi
 # runs draw on subscription allowances instead of API per-token billing.
 UNSET_KEYS=("-u" "ANTHROPIC_API_KEY" "-u" "GEMINI_API_KEY" "-u" "GOOGLE_API_KEY" "-u" "GOOGLE_GENAI_API_KEY" "-u" "OPENAI_API_KEY" "-u" "MISTRAL_API_KEY" "-u" "DEEPSEEK_API_KEY" "-u" "GROQ_API_KEY")
 
+# Stages run inside a repo, not inside this checkout, so `bun tools/linear.mjs`
+# does not resolve for them. The floor tells agents to use
+# "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that path real. Without
+# it, --strict-mcp-config removes the Linear MCP and leaves no replacement.
+export FACTORY_ROOT="$ROOT"
+
 if [[ "$USE_API" == "1" ]]; then
   [[ -n "${ANTHROPIC_API_KEY:-}" ]] || { echo "--use-api given but ANTHROPIC_API_KEY is not set" >&2; exit 2; }
   AUTH_NOTE="ANTHROPIC_API_KEY (billed per token; connectors disabled)"
@@ -138,9 +144,14 @@ else
 fi
 
 if [[ "$DRY" == "1" ]]; then
+  # Must mirror the real invocation below. A --dry that omits flags is worse
+  # than no --dry: it is the thing people check before trusting a run.
+  MCP_NOTE=""
+  [[ "$HARNESS" == "claude" ]] && MCP_NOTE="--mcp-config $ROOT/config/mcp/claude.json --strict-mcp-config"
   echo "would run in $REPO_PATH:"
-  echo "  $HARNESS -p '$PROMPT' --max-budget-usd $BUDGET $MODEL_ARGS $READONLY_ARGS"
-  echo "  auth: $AUTH_NOTE"
+  echo "  $HARNESS -p '$PROMPT' --max-budget-usd $BUDGET $MCP_NOTE $MODEL_ARGS $READONLY_ARGS"
+  echo "  auth: $AUTH_NOTE   FACTORY_ROOT=$ROOT"
+  [[ -n "$MCP_NOTE" ]] && echo "  mcp:  strict — only servers declared in config/mcp/claude.json (no claude.ai connectors)"
   exit 0
 fi
 
@@ -199,19 +210,22 @@ unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
 # still parses the final envelope for the exit code.
 set +e
 if [[ "$HARNESS" == "claude" ]]; then
-  # --mcp-config supplies the browser server from git (config/mcp/claude.json):
-  # isolated per-session Chrome profiles ended the shared-profile collisions
-  # (95 errors across 26 runs), and webp screenshot caps cut the biggest context
-  # cost at the source. Deliberately NOT --strict-mcp-config: strict also drops
-  # the claude.ai connectors, and losing the Linear MCP severs the control
-  # plane (verified empirically 2026-08-04 — 0 Linear tools under strict).
+  # --strict-mcp-config makes config/mcp/claude.json the ONLY source of MCP
+  # servers: no user scope, no project .mcp.json, no claude.ai connectors. What
+  # an unattended agent can reach is now declared in git and moves by PR.
+  #
+  # That deliberately drops the Linear MCP too — tools/linear.mjs replaces it,
+  # which is why FACTORY_ROOT above is load-bearing rather than a convenience.
+  # It also drops what nobody chose to grant: sessions were loading a client law
+  # firm's connector (51 tools) and Gmail (16) into agents running unattended
+  # under bypassPermissions.
   (
     cd "$REPO_PATH"
     $RUN_CAP $ENV_PREFIX claude -p "$PROMPT" \
       --output-format stream-json --verbose \
       --max-budget-usd "$BUDGET" \
       --fallback-model sonnet \
-      --mcp-config "$ROOT/config/mcp/claude.json" \
+      --mcp-config "$ROOT/config/mcp/claude.json" --strict-mcp-config \
       $MODEL_ARGS $READONLY_ARGS
   ) 2>&1 | (cd "$ROOT" && bun runners/report.mjs --log "$LOG" --harness claude)
 else

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -96,13 +96,16 @@ Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.
 
 **Use `bun tools/linear.mjs` from the factory checkout — not the Linear MCP.** The MCP is a UI-managed connector that fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback. The tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
 
+You work in a worktree, not in the factory checkout, so **always go through `$FACTORY_ROOT`** — the factory sets it on every run. A bare `bun tools/linear.mjs` resolves to nothing.
+
 ```bash
-bun tools/linear.mjs get CLNT-616                     # ticket, state, labels, criteria
-bun tools/linear.mjs claim CLNT-616 --agent claude    # assign + In Progress + labels + read-back
-bun tools/linear.mjs comment CLNT-616 "..."           # the heartbeat
-bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
-bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
-bun tools/linear.mjs queue --team CLNT                # what is dispatchable
+L="$FACTORY_ROOT/tools/linear.mjs"                 # or ~/Develop/factory/tools/linear.mjs
+bun "$L" get CLNT-616                              # ticket, state, labels, criteria
+bun "$L" claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
+bun "$L" comment CLNT-616 "..."                    # the heartbeat
+bun "$L" state CLNT-616 "In Review" --add ai:needs-review
+bun "$L" file --team CLNT --title "..." --body "..." --type bug
+bun "$L" queue --team CLNT                         # what is dispatchable
 ```
 
 `claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.


### PR DESCRIPTION
Completes OPS-68. The flip held back in #25 is now safe, because #25 shipped the replacement.

## Before → after

Tools reachable by an agent running unattended under `bypassPermissions`:

| | before | after |
| :--- | ---: | ---: |
| chrome-devtools | 29 | **29** |
| claude_ai_Linear | 52 | 0 → `tools/linear.mjs` |
| **a client law firm's connector** | **51** | **0** |
| **claude_ai_Gmail** | **16** | **0** |
| Drive · Calendar · Sentry | 26 | 0 |
| **total** | **174** | **29** |

Nothing in the factory ever needed the client connector or Gmail. They were there because connectors arrive as a bundle, configured in a UI, changing whenever a checkbox moves.

## The blocker I found before flipping

`bun tools/linear.mjs` **does not resolve for agents** — they run in a worktree, not in the factory checkout:

```
$ cd ~/Develop/pets/bj29 && bun tools/linear.mjs get OPS-68
error: Module not found "tools/linear.mjs"
```

Flipping strict without fixing that would have removed the Linear MCP *and* left no replacement — the control plane goes silent, which is the precise failure this whole thread has been about. So `tick.mjs` and `run-agent.sh` now export `FACTORY_ROOT`, and the floor uses `"$FACTORY_ROOT/tools/linear.mjs"`.

## Verification — in a repo checkout, under strict

- Agent **read** a ticket through the tool → replied `In Review` ✓
- Agent **wrote** a comment that landed on OPS-68 at 21:03:21 ✓ (verified server-side)
- Census: `29 chrome-devtools`; Gmail / Hercsik / Drive / Calendar / Sentry / Linear all `gone` ✓
- `bun test` 104 pass · `--check` green · codex/agy dry runs unaffected ✓

## Also

`--dry` printed a hardcoded command line that no longer matched the real invocation. Fixed, and it now names the MCP mode explicitly — a dry run that omits flags is worse than no dry run, since it's what you check before trusting a run.

Interactive sessions keep every connector; this changes factory spawns only.