### PR TITLE
ux-critic: use a dev login, report its absence

### DIFF
--- a/plugins/core/agents/ux-critic.md
+++ b/plugins/core/agents/ux-critic.md
@@ -23,6 +23,12 @@ If acceptance criteria or a persona are missing, derive a sensible persona from 
 
 Experience the app **first**, before reading any diff. You may read code afterwards only to check whether a suggestion is cheap or expensive — never to soften a finding.
 
+### Getting logged in
+
+Most flows worth critiquing are behind a login. Repos following the baseline ship **`bin/dev-login.sh [role]`** (`PC-21`) — a dev-gated command that hands you an authenticated session for a seeded user. Check `AGENTS.md` for it and use it; it exists so your review starts at the feature instead of the login form.
+
+If the repo has no such script: **say so as a finding and review what you can reach unauthenticated.** Do not type credentials into a login form, mint a session by hand, or edit auth settings to get past it. Across 485 measured runs that improvisation burned whole budgets — 64 runs hand-minted session keys — and produced screenshots of login pages instead of the feature under review. A missing `bin/dev-login.sh` is a real gap in the repo, and reporting it fixes the problem permanently; working around it fixes nothing and costs the same again next ticket.
+
 ## What to evaluate
 
 Walk each flow as the persona, narrating friction honestly:

--- a/shared/agents/ux-critic.md
+++ b/shared/agents/ux-critic.md
@@ -23,6 +23,12 @@ If acceptance criteria or a persona are missing, derive a sensible persona from 
 
 Experience the app **first**, before reading any diff. You may read code afterwards only to check whether a suggestion is cheap or expensive — never to soften a finding.
 
+### Getting logged in
+
+Most flows worth critiquing are behind a login. Repos following the baseline ship **`bin/dev-login.sh [role]`** (`PC-21`) — a dev-gated command that hands you an authenticated session for a seeded user. Check `AGENTS.md` for it and use it; it exists so your review starts at the feature instead of the login form.
+
+If the repo has no such script: **say so as a finding and review what you can reach unauthenticated.** Do not type credentials into a login form, mint a session by hand, or edit auth settings to get past it. Across 485 measured runs that improvisation burned whole budgets — 64 runs hand-minted session keys — and produced screenshots of login pages instead of the feature under review. A missing `bin/dev-login.sh` is a real gap in the repo, and reporting it fixes the problem permanently; working around it fixes nothing and costs the same again next ticket.
+
 ## What to evaluate
 
 Walk each flow as the persona, narrating friction honestly:


### PR DESCRIPTION
Addresses the auth friction that makes screenshot-based review expensive.

## The measured problem

Across 485 runs, agents reinvented an auth workaround per ticket:

| signal | count |
| :--- | ---: |
| runs that hand-minted a Django session key | **64** |
| `SKIP_EMAIL_VERIFICATION_IN_DEV` references | 437 |
| `SessionStore` / `session_key` | 802 |

No two agents solved it the same way, and the ux-critic's screenshots were as likely to show a login page as the feature under review.

## What changed

`ux-critic` now checks `AGENTS.md` for **`bin/dev-login.sh [role]`** and uses it. When it's missing, it **reports that as a finding** and reviews what it can reach unauthenticated — explicitly forbidden from typing credentials, minting sessions, or editing auth settings to get past the wall. Reporting the gap fixes it permanently; improvising fixes nothing and costs the same again next ticket.

The requirement itself lands as **`PC-21`** in `hdkiller/docs/guides/project-conventions.md` §3G, so `/factory-audit` grades every repo against it and files the gaps — that's the mechanism that gets these actually built.

## Deliberately *not* a "no-auth version"

A build or flag that disables authentication is one misconfiguration away from a production auth bypass, and in a `CLNT` repo that's a client incident. `PC-21` keeps auth fully enforced and removes only the *cost of logging in*:

- dev-gated script yielding a **seeded** user's session (never invents or mutates a real user)
- **fails closed** — refuses to run unless it can prove DEBUG + local DB + loopback bind; unprovable means exit non-zero, never "assume dev"
- **not deployable** — guarded so a grep for its entrypoint in production settings/build comes back empty

`N/A` for repos with no authenticated UI.

Verified: 104 tests pass, `--check` green.