### PR TITLE
fix(orchestrator): stop parseOwnedPaths dropping annotated paths (OPS-72)

### DIFF
--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -46,6 +46,12 @@ export function parseOwnedPaths(description = "") {
 
   return out
     .map((s) => s.replace(/`/g, "").replace(/[,;]$/, "").trim())
+    // Tickets routinely annotate a path with its change kind — "(new)",
+    // "(modified)", "(deleted)" — right after the backtick. Left in place that
+    // annotation is prose, not part of the path, and used to sink the whole
+    // line: `foo.ts (new)` has a space, so it read as prose and got dropped,
+    // silently downgrading a perfectly good path to "no Owned Paths".
+    .map((s) => s.replace(/\s*\([^()]*\)\s*$/, "").trim())
     .filter(Boolean)
     .filter((s) => !s.startsWith("#"))
     // A path has no spaces and looks like a path: a separator, a wildcard, or an

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -124,3 +124,11 @@ test("indented code blocks work too", () => {
   const desc = "## Owned Paths\n\n    src/main.ts\n    src/**/*.test.ts\n\n## Next";
   expectEqual(parseOwnedPaths(desc), ["src/main.ts", "src/**/*.test.ts"]);
 });
+
+test("a trailing change-kind annotation doesn't sink the path (CLNT-765/768/764 shape)", () => {
+  const desc = "## Owned Paths\n\n* `src/analytics/kpis/avgBasePriceByProduct.ts` (new)\n* `src/analytics/kpis/existing.ts` (modified)\n";
+  expectEqual(parseOwnedPaths(desc), [
+    "src/analytics/kpis/avgBasePriceByProduct.ts",
+    "src/analytics/kpis/existing.ts",
+  ]);
+});


### PR DESCRIPTION
## Summary
- `parseOwnedPaths` rejected any Owned Paths bullet containing whitespace as prose, which silently dropped paths written with a trailing change-kind annotation like `` `path.ts` (new) ``
- This made dispatch treat those tickets as having zero Owned Paths ("not agent-ready") and skip them — no error surfaced anywhere
- Found live on cashsaas: 3 of 6 ready tickets (CLNT-765, CLNT-768, CLNT-764) were silently excluded from dispatch by this bug

Fixes OPS-72

## Test plan
- [x] `bun test orchestrator/owned-paths.test.mjs` — added regression test for the `(new)`/`(modified)` annotation shape, all 13 tests pass
- [x] `bun test orchestrator/` — full orchestrator suite green (81 pass)
- [x] Verified live: `bun orchestrator/queue.mjs --repo cashsaas` went from 1 startable ticket to 3 (CLNT-765, CLNT-768, CLNT-764) after the fix, and the next dispatch tick picked up CLNT-765 and CLNT-768 immediately