### PR TITLE
Register proxies for factory command distribution

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -196,9 +196,12 @@ repos:
       - src/auth/**
       - src/server/serverMiddleware.ts
 
+  # Command distribution only. Its worktree scripts exist, but this entry has
+  # not yet authorized factory dispatch; retain the report-only guard (OPS-115).
   - name: proxies
     path: ~/Develop/pets/proxies
     github: watt-mind/proxies
+    report_only: true
 
     # Linear routing (AGENTS.md + linear.md §1)
     team: LAB


### PR DESCRIPTION
## Summary
- add the proxies checkout to factory repository inventory
- retain `report_only` so this registration cannot enable dispatch

## Verification
- `bun run link-repos` (10 command symlinks created; existing `opsx/` commands retained)
- `bun test`
- `bun build/emit.mjs --check`

Fixes OPS-115