### PR TITLE
feat(security): add 'factory security' local harness subcommand

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -85,6 +85,16 @@ case "$cmd" in
     # FACTORY_NOTIFY_SCRIPT is for tests or a deliberate local override only.
     exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" "$@"
     ;;
+  security)
+    # Local security harness (OPS-165): Gitleaks + Semgrep + Actionlint on the
+    # repo containing cwd (or the given path). Per-repo scan tuning comes from
+    # config/repos.yaml `security:` blocks, resolved here so the check script
+    # stays a plain env-driven tool.
+    _target="$PWD"
+    for _a in "$@"; do case "$_a" in -*) ;; *) _target="$_a"; break ;; esac; done
+    eval "$(bun "$ROOT/tools/security-env.mjs" "$_target" 2>/dev/null || true)"
+    exec bash "$ROOT/lib/security-check.sh" "$@"
+    ;;
   emit)
     # Swift default: regenerate dist/plugins and link every harness + repos.
     if [[ $# -eq 0 ]]; then
@@ -116,6 +126,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   tick          orchestrator/tick.mjs
   run           runners/run-agent.sh
   notify        ~/Develop/hdkiller/scripts/notify.py (human interrupt channel)
+  security      lib/security-check.sh (gitleaks + semgrep + actionlint on cwd repo)
   emit          build/emit.mjs (--link --link-bin --link-repos when called bare)
 
 Works from any cwd (worktrees included).

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -217,6 +217,21 @@ repos:
       - "**/migrations/**"
       - .github/workflows/**
 
+  # Infra docs source of truth. report_only: docs repo, no worktree tooling.
+  # The security block tunes `factory security` (OPS-165): this PRIVATE repo
+  # intentionally stores operational credentials in docs/ (allowlisted in its
+  # in-repo .gitleaks.toml — CI and the pre-commit hook need that file, so it
+  # stays in-repo), and its scripts/ call fixed API endpoints via urllib,
+  # which the dynamic-urllib audit rule false-positives on.
+  - name: hdkiller
+    path: ~/Develop/hdkiller
+    github: hdkiller/hdkiller
+    team: OPS
+    base: master
+    report_only: true
+    security:
+      semgrep_args: "--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"
+
   # Shared ESLint presets (@watt-mind/eslint-config) — tier 2 of the
   # code-security baseline (OPS-164). Stub until the package lands; report_only
   # because a single-package repo needs no worktree isolation, and verify

--- a/lib/security-check.sh
+++ b/lib/security-check.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Local security harness (OPS-165) — invoked as `factory security`.
+#
+# Runs Gitleaks, Semgrep, and Actionlint against a repo before pushing.
+# Fast local complement to the CI security scan
+# (see hdkiller docs/guides/code-security.md).
+#
+# Usage:
+#   factory security [options] [path]
+#
+# Options:
+#   --history        Gitleaks scans full git history instead of the working tree (slow)
+#   --skip-semgrep   Skip the Semgrep scan (the slowest tool)
+#   -h, --help       Show this help
+#
+# Runs from any git repo/worktree; [path] defaults to the repo containing $PWD.
+#
+# Per-repo tuning comes from config/repos.yaml `security:` blocks — the factory
+# dispatcher resolves the repo and exports SEMGREP_ARGS / GITLEAKS_ARGS before
+# exec'ing this script (tools/security-env.mjs). A repo-root `.gitleaks.toml`
+# is picked up by gitleaks automatically and is the right home for allowlists,
+# because CI and the pre-commit hook need it too.
+set -uo pipefail
+
+HISTORY=0
+SKIP_SEMGREP=0
+TARGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --history) HISTORY=1 ;;
+    --skip-semgrep) SKIP_SEMGREP=1 ;;
+    -h|--help) sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "unknown option: $1" >&2; exit 2 ;;
+    *) TARGET="$1" ;;
+  esac
+  shift
+done
+
+if [ -n "$TARGET" ]; then
+  ROOT=$(git -C "$TARGET" rev-parse --show-toplevel 2>/dev/null)
+else
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
+if [ -z "${ROOT:-}" ]; then
+  echo "error: not inside a git repository (or path is not one)" >&2
+  exit 2
+fi
+
+BOLD=$(tput bold 2>/dev/null || true); RESET=$(tput sgr0 2>/dev/null || true)
+GREEN=$(tput setaf 2 2>/dev/null || true); RED=$(tput setaf 1 2>/dev/null || true)
+YELLOW=$(tput setaf 3 2>/dev/null || true)
+
+echo "${BOLD}factory security${RESET} → $ROOT"
+[ -n "${SEMGREP_ARGS:-}${GITLEAKS_ARGS:-}" ] && echo "  (repo config from config/repos.yaml)"
+
+RESULTS=()
+FAILED=0
+
+run_tool() {
+  local name="$1"; shift
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo; echo "${YELLOW}● $name: SKIPPED (not installed — brew install $1)${RESET}"
+    RESULTS+=("${YELLOW}SKIP${RESET}  $name (not installed)")
+    return
+  fi
+  echo; echo "${BOLD}● $name${RESET}"
+  local start=$SECONDS
+  if "$@"; then
+    RESULTS+=("${GREEN}PASS${RESET}  $name ($((SECONDS - start))s)")
+  else
+    RESULTS+=("${RED}FAIL${RESET}  $name ($((SECONDS - start))s)")
+    FAILED=1
+  fi
+}
+
+# 1. Gitleaks — secrets in the working tree (or full history with --history)
+# shellcheck disable=SC2086
+if [ "$HISTORY" = 1 ]; then
+  run_tool "gitleaks (git history)" gitleaks git "$ROOT" --no-banner --redact ${GITLEAKS_ARGS:-}
+else
+  run_tool "gitleaks (working tree)" gitleaks dir "$ROOT" --no-banner --redact ${GITLEAKS_ARGS:-}
+fi
+
+# 2. Semgrep — SAST, security ruleset only (respects .gitignore)
+if [ "$SKIP_SEMGREP" = 1 ]; then
+  RESULTS+=("${YELLOW}SKIP${RESET}  semgrep (--skip-semgrep)")
+else
+  # shellcheck disable=SC2086
+  run_tool "semgrep (p/security-audit)" semgrep scan --config p/security-audit \
+    --metrics=off --quiet --error ${SEMGREP_ARGS:-} "$ROOT"
+fi
+
+# 3. Actionlint — only when the repo has GitHub workflows
+if [ -d "$ROOT/.github/workflows" ]; then
+  cd "$ROOT" && run_tool "actionlint" actionlint -color
+else
+  RESULTS+=("${YELLOW}SKIP${RESET}  actionlint (no .github/workflows)")
+fi
+
+echo; echo "${BOLD}Summary${RESET}"
+for r in "${RESULTS[@]}"; do echo "  $r"; done
+
+if [ "$FAILED" = 1 ]; then
+  echo; echo "${RED}${BOLD}Security check FAILED${RESET} — fix findings before pushing."
+  exit 1
+fi
+echo; echo "${GREEN}${BOLD}Security check passed.${RESET}"

--- a/tools/security-env.mjs
+++ b/tools/security-env.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env bun
+/**
+ * Resolve a repo's `security:` block from config/repos.yaml into shell exports.
+ *
+ *   eval "$(bun tools/security-env.mjs /path/inside/repo)"
+ *
+ * Prints `export SEMGREP_ARGS=...` / `export GITLEAKS_ARGS=...` lines for the
+ * configured repo containing the given path (match by realpath prefix), or
+ * nothing when the repo has no entry or no security block — the check then
+ * runs with defaults. Central config replaces per-repo dotfiles so scan
+ * tuning lives next to schedule/policy and applies on every machine with a
+ * factory checkout. (.gitleaks.toml stays in-repo: CI and git hooks need it.)
+ */
+import { readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+
+const target = realpathSync(process.argv[2] || process.cwd());
+const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
+
+// Worktrees live outside the configured path, so also match by origin remote
+// (normalized to owner/repo).
+const remote = (() => {
+  const r = Bun.spawnSync(["git", "-C", target, "remote", "get-url", "origin"]);
+  if (r.exitCode !== 0) return null;
+  const m = r.stdout.toString().trim().match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?$/);
+  return m ? m[1] : null;
+})();
+
+for (const repo of cfg.repos || []) {
+  let byPath = false;
+  try {
+    const repoPath = expand(repo.path);
+    byPath = target === repoPath || target.startsWith(repoPath + path.sep);
+  } catch {}
+  if (!byPath && !(remote && repo.github === remote)) continue;
+  const sec = repo.security || {};
+  if (sec.semgrep_args) console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
+  if (sec.gitleaks_args) console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
+  break;
+}


### PR DESCRIPTION
Fixes OPS-165

Adds the tier-3 local security harness from the code-security baseline (hdkiller docs/guides/code-security.md, OPS-162) as a **`factory security` subcommand** (redesigned from a standalone `wm-security-check` binary per user direction — one consistent CLI surface).

- `lib/security-check.sh` — env-driven check: Gitleaks (working tree or `--history`), Semgrep (`p/security-audit`), Actionlint; per-tool summary, non-zero exit on findings
- `tools/security-env.mjs` — resolves the target repo's `security:` block from `config/repos.yaml` (path-prefix match, git-remote fallback for worktrees) into `SEMGREP_ARGS`/`GITLEAKS_ARGS`
- `bin/factory` — `security` case + help entry
- `config/repos.yaml` — `security:` block schema; hdkiller entry (report_only) with its semgrep exclude. Repo-root `.gitleaks.toml` stays in-repo by design: CI and pre-commit hooks need it.

Verification: `bun test` 148 pass; `emit --check` clean, floor 9/9 repos; `factory security` validated against hdkiller from both the main checkout and a worktree (remote-match path) — gitleaks PASS, semgrep PASS with central config applied, exit codes correct.