### PR TITLE
feat(factory): add cwd-independent notify wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Prefixed `factory-` so they're identifiable as ours and never collide with a rep
 | `/factory-triage` | Turns `Triage` tickets into `ai:agent-ready` ones |
 | `/factory-audit` | Grades a repo against project-conventions `PC-01`..`PC-20`, files the gaps |
 
+### CLI notification wrapper
+
+`factory notify` is the cwd-independent human interrupt channel used by the factory floor:
+
+```bash
+factory notify "BLOCKED LAB-176: need approval"
+echo "CI RED LAB-176: verification failed" | factory notify -
+```
+
+It delegates to `~/Develop/hdkiller/scripts/notify.py` and preserves its exit status, so callers must post the same message to Linear when it fails.
+
 ## Agents
 
 Agents are isolated specialist contexts, not workflow entry points. Their names use `factory-<role>` so ownership is visible without repeating the resource type in every identifier.

--- a/bin/factory
+++ b/bin/factory
@@ -80,6 +80,11 @@ case "$cmd" in
   warm)         run_bun orchestrator/warm.mjs "$@" ;;
   tick)         run_bun orchestrator/tick.mjs "$@" ;;
   run)          run_sh runners/run-agent.sh "$@" ;;
+  notify)
+    # A cwd-independent wrapper for the factory floor's interrupt channel.
+    # FACTORY_NOTIFY_SCRIPT is for tests or a deliberate local override only.
+    exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" "$@"
+    ;;
   ""|help|-h|--help)
     show_banner
     cat <<EOF
@@ -102,8 +107,10 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   warm          orchestrator/warm.mjs
   tick          orchestrator/tick.mjs
   run           runners/run-agent.sh
+  notify        ~/Develop/hdkiller/scripts/notify.py (human interrupt channel)
 
 Works from any cwd (worktrees included). Install: bun build/emit.mjs --link-bin
+  factory notify "BLOCKED LAB-176: need approval"
 EOF
     ;;
   *)

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -1,0 +1,71 @@
+import { test, expect } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const FACTORY = path.resolve(import.meta.dir, "factory");
+
+function makeNotifier(dir) {
+  const notifier = path.join(dir, "notify_stub.py");
+  writeFileSync(
+    notifier,
+    `import os
+import sys
+from pathlib import Path
+
+Path(os.environ["FACTORY_NOTIFY_TEST_ARGS"]).write_text("\\n".join(sys.argv[1:]) + "\\n")
+Path(os.environ["FACTORY_NOTIFY_TEST_STDIN"]).write_text(sys.stdin.read())
+sys.exit(int(os.environ.get("FACTORY_NOTIFY_TEST_EXIT", "0")))
+`,
+  );
+  return notifier;
+}
+
+function runNotify({ args, stdin = "", exitCode = "0" }) {
+  const dir = mkdtempSync(path.join(tmpdir(), "factory-notify-"));
+  const argsFile = path.join(dir, "args");
+  const stdinFile = path.join(dir, "stdin");
+  const notifier = makeNotifier(dir);
+  const result = Bun.spawnSync({
+    cmd: ["bash", FACTORY, "notify", ...args],
+    cwd: dir,
+    stdin: new TextEncoder().encode(stdin),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      FACTORY_NOTIFY_SCRIPT: notifier,
+      FACTORY_NOTIFY_TEST_ARGS: argsFile,
+      FACTORY_NOTIFY_TEST_STDIN: stdinFile,
+      FACTORY_NOTIFY_TEST_EXIT: exitCode,
+    },
+  });
+  return {
+    status: result.exitCode,
+    args: readFileSync(argsFile, "utf8"),
+    stdin: readFileSync(stdinFile, "utf8"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+test("factory notify delegates argv to the notifier from any cwd", () => {
+  const result = runNotify({ args: ["BLOCKED", "LAB-176:", "need approval"] });
+  try {
+    expect(result.status).toBe(0);
+    expect(result.args).toBe("BLOCKED\nLAB-176:\nneed approval\n");
+    expect(result.stdin).toBe("");
+  } finally {
+    result.cleanup();
+  }
+});
+
+test("factory notify preserves stdin mode and the notifier exit code", () => {
+  const result = runNotify({ args: ["-"], stdin: "CI RED LAB-176: test failure\n", exitCode: "7" });
+  try {
+    expect(result.status).toBe(7);
+    expect(result.args).toBe("-\n");
+    expect(result.stdin).toBe("CI RED LAB-176: test failure\n");
+  } finally {
+    result.cleanup();
+  }
+});

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -106,6 +106,16 @@ repos:
     worktree_root: ~/Develop/.worktrees/coach-wattz
     report_only: true            # PC-15 pending — see CW-363
 
+  - name: watts-mobile
+    path: ~/Develop/watts-mobile
+    github: watt-mind/watts-mobile
+    team: CW
+    project: Mobile App
+    base: develop
+    worktree_root: ~/Develop/.worktrees/watts-mobile
+    report_only: true            # No isolated worktree lifecycle yet.
+    verify: pnpm typecheck && pnpm lint && pnpm test
+
   - name: legalease
     path: ~/Develop/legalease
     github: watt-mind/legalease

--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -45,7 +45,7 @@ Move the ticket to `Blocked`, say specifically what you need in one answerable q
 **"Notify" means exactly this command** — a Linear comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
 
 ```bash
-python3 ~/Develop/hdkiller/scripts/notify.py "<EVENT> <TICKET/PR>: <one answerable sentence>"
+factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
 ```
 
 Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a Linear comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to Linear and the run report, never here.
@@ -109,7 +109,7 @@ factory next --repo bj29
 factory label-guard --repo bj29 --apply
 ```
 
-Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). Never `bun orchestrator/...` from a worktree — that path is not there.
+Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). `factory notify` is the cwd-independent wrapper around the human interrupt channel. Never `bun orchestrator/...` from a worktree — that path is not there.
 
 ### Linear
 

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -45,7 +45,7 @@ Move the ticket to `Blocked`, say specifically what you need in one answerable q
 **"Notify" means exactly this command** — a Linear comment, a `Blocked` state change, or a line in your final report does not reach the human in real time:
 
 ```bash
-python3 ~/Develop/hdkiller/scripts/notify.py "<EVENT> <TICKET/PR>: <one answerable sentence>"
+factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
 ```
 
 Event prefix is one of `BLOCKED`, `ESCALATED`, `CI RED`, `SMOKE RED`, `CIRCUIT BREAKER`, `RC READY`. It pushes a Telegram message to the human and exits non-zero on failure — if it fails, post the same text as a Linear comment and flag the failed push in your report. Notify only for those six events; routine progress (claims, PRs opened, clean merges) goes to Linear and the run report, never here.
@@ -109,7 +109,7 @@ factory next --repo bj29
 factory label-guard --repo bj29 --apply
 ```
 
-Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). Never `bun orchestrator/...` from a worktree — that path is not there.
+Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/factory` → `~/.local/bin/factory`). `factory notify` is the cwd-independent wrapper around the human interrupt channel. Never `bun orchestrator/...` from a worktree — that path is not there.
 
 ### Linear
 


### PR DESCRIPTION
Fixes LAB-176

Adds `factory notify` as the factory-floor notification command. It delegates to the restored Apprise-backed notifier, supports stdin, and preserves its exit status.

Verified:
- `bun build/emit.mjs --check`
- `bun test` (144 passing)
- real `factory notify` Apprise delivery

run: