### PR TITLE
feat(factory): add deployment-aware status hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,37 @@ Prefixed `factory-` so they're identifiable as ours and never collide with a rep
 | `/factory-triage` | Turns `Triage` tickets into `ai:agent-ready` ones |
 | `/factory-audit` | Grades a repo against project-conventions `PC-01`..`PC-20`, files the gaps |
 
+### `factory status` — the everyday hub
+
+Run this from a configured repository (or choose one explicitly):
+
+```bash
+factory status
+factory status --repo legalease
+factory status --json
+```
+
+It is read-only and answers the immediate operational questions: which repository
+and branch you are in, whether the checkout is clean, the fetched remote base
+and deploy refs, deployment freshness, the live Linear pipeline counts, and the
+single recommended next action. The default output explains that action in plain
+English; `--json` is for scripts.
+
+A repo may opt into deployment revision comparison in `config/repos.yaml`:
+
+```yaml
+deployment:
+  url: https://app.example.com/healthz # exact endpoint, or origin -> /version.json
+  branch: develop                      # branch represented by this environment
+  revision_field: revision              # optional; commit/git_sha/sha are automatic
+```
+
+The endpoint must return JSON containing a revision field, such as
+`{"revision":"<git SHA>"}` or `{"commit":"<git SHA>"}`. `factory status`
+labels failures to fetch or missing metadata as **unknown**—never as a stale
+deploy—and distinguishes an older deploy from an unrelated revision. It also
+shows when the reaper and per-repository janitor last ran.
+
 ### CLI notification wrapper
 
 `factory notify` is the cwd-independent human interrupt channel used by the factory floor:

--- a/bin/factory
+++ b/bin/factory
@@ -67,6 +67,7 @@ case "$cmd" in
   queue)        run_bun orchestrator/queue.mjs "$@" ;;
   next)         run_bun orchestrator/next.mjs "$@" ;;
   state)        run_bun orchestrator/state.mjs "$@" ;;
+  status)       run_bun orchestrator/status.mjs "$@" ;;
   friction)     run_bun orchestrator/friction.mjs "$@" ;;
   economics)    run_bun orchestrator/economics.mjs "$@" ;;
   ci)           run_bun orchestrator/ci.mjs "$@" ;;
@@ -112,6 +113,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   queue         orchestrator/queue.mjs
   next          orchestrator/next.mjs
   state         orchestrator/state.mjs
+  status        orchestrator/status.mjs (repo, deployment, and factory snapshot)
   friction      orchestrator/friction.mjs
   economics     orchestrator/economics.mjs
   ci            orchestrator/ci.mjs

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -273,7 +273,7 @@ repos:
   # shared/ in place and its changes land by ordinary commit/PR, not worktree.
   - name: factory
     path: ~/Develop/factory
-    github: watt-mind/factory
+    github: hdkiller/factory
     team: OPS
     base: main
     report_only: true            # never a dispatch target — no worktree tooling

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -33,6 +33,10 @@ repos:
     # What "Done" means beyond a merge (linear.md §7).
     smoke_workflow: smoke-dev.yml
     smoke_url: https://bj29-dev.projects.watt-mind.com
+    # Optional public metadata; an origin is queried at /version.json.
+    deployment:
+      url: https://bj29-dev.projects.watt-mind.com
+      branch: develop
 
     # Concurrency. Merges are always serialized regardless; this caps how many
     # ticket agents run at once, and each one costs a worktree on disk.
@@ -137,6 +141,11 @@ repos:
     # the cap is per repo, not per supervisor.
     max_in_flight: 20
 
+    deployment:
+      url: https://legal-dev.projects.watt-mind.com/healthz
+      branch: develop
+      revision_field: revision
+
     # Surfaces where a diff is never auto-merged, on top of the global list in
     # policy.yaml. Without these, escalate.mjs has nothing to check and the
     # whole mechanical half of the gate is missing — in a CLNT repo that
@@ -176,6 +185,10 @@ repos:
     # Cap concurrent ticket agents for this repo. One agent receives one
     # isolated worktree, so this also permits up to eight active worktrees.
     max_in_flight: 20
+
+    deployment:
+      url: https://cashsaas.projects.watt-mind.com
+      branch: master
 
     # What "verified" means. Agents run this before any PR.
     verify: npm run typecheck && npm run lint && npm run format:check
@@ -218,6 +231,10 @@ repos:
 
     max_in_flight: 10
 
+    deployment:
+      url: https://proxies.projects.watt-mind.com
+      branch: master
+
     escalate_paths:
       - grocery_platform/settings*.py
       - "**/migrations/**"
@@ -256,7 +273,7 @@ repos:
   # shared/ in place and its changes land by ordinary commit/PR, not worktree.
   - name: factory
     path: ~/Develop/factory
-    github: hdkiller/factory
+    github: watt-mind/factory
     team: OPS
     base: main
     report_only: true            # never a dispatch target — no worktree tooling

--- a/lib/repo-status.mjs
+++ b/lib/repo-status.mjs
@@ -1,0 +1,39 @@
+/** Helpers for the read-only `factory status` command. */
+
+export const DEFAULT_REVISION_FIELDS = ["revision", "commit", "git_sha", "gitSha", "sha"];
+
+export function deployedRevision(payload, configuredField) {
+  if (!payload || typeof payload !== "object") return null;
+  const fields = configuredField ? [configuredField, ...DEFAULT_REVISION_FIELDS] : DEFAULT_REVISION_FIELDS;
+  for (const field of fields) {
+    const value = payload[field];
+    if (typeof value === "string" && value.trim()) return { field, value: value.trim() };
+  }
+  return null;
+}
+
+/** A configured deployment URL may be either the full metadata endpoint or an origin. */
+export function metadataUrl(url) {
+  if (!url) return null;
+  const parsed = new URL(url);
+  if (parsed.pathname === "/" || parsed.pathname === "") parsed.pathname = "/version.json";
+  return parsed.toString();
+}
+
+export function deploymentState({ deployed, remoteSha, localContains = null }) {
+  if (!deployed) return { state: "unknown", message: "endpoint did not expose a revision" };
+  if (!remoteSha) return { state: "unknown", message: "could not read the remote branch" };
+  if (deployed === remoteSha) return { state: "current", message: "matches the remote branch tip" };
+  if (localContains === true) return { state: "stale", message: "is behind the remote branch tip" };
+  if (localContains === false) return { state: "diverged", message: "does not occur in the local remote-branch history" };
+  return { state: "different", message: "differs from the remote branch tip" };
+}
+
+export function formatAge(ms, now = Date.now()) {
+  if (ms == null) return "never recorded";
+  const seconds = Math.max(0, Math.floor((now - ms) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+}

--- a/lib/repo-status.test.mjs
+++ b/lib/repo-status.test.mjs
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { deployedRevision, deploymentState, formatAge, metadataUrl } from "./repo-status.mjs";
+
+test("uses a configured revision field and accepts common revision payloads", () => {
+  expect(deployedRevision({ revision: "abc", commit: "def" }, "revision")).toEqual({ field: "revision", value: "abc" });
+  expect(deployedRevision({ commit: "def" })).toEqual({ field: "commit", value: "def" });
+  expect(deployedRevision({ status: "ok" })).toBeNull();
+});
+
+test("preserves exact metadata endpoint and supplies version.json for an origin", () => {
+  expect(metadataUrl("https://app.example.test")).toBe("https://app.example.test/version.json");
+  expect(metadataUrl("https://app.example.test/healthz")).toBe("https://app.example.test/healthz");
+});
+
+test("reports deployed revision freshness without claiming a failed lookup is stale", () => {
+  expect(deploymentState({ deployed: "abc", remoteSha: "abc" }).state).toBe("current");
+  expect(deploymentState({ deployed: "abc", remoteSha: "def", localContains: true }).state).toBe("stale");
+  expect(deploymentState({ deployed: "abc", remoteSha: "def", localContains: false }).state).toBe("diverged");
+  expect(deploymentState({ deployed: null, remoteSha: "def" }).state).toBe("unknown");
+  expect(formatAge(null)).toBe("never recorded");
+});

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -19,7 +19,7 @@
  * Losing an agent's unpushed work would be far worse than the disk it holds.
  * Never add --force here; if a worktree won't go, that is a finding to look at.
  */
-import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, mkdirSync, appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { homedir } from "node:os";
@@ -41,6 +41,18 @@ const c = {
   dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
   green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
+
+// Keep a lightweight per-repo run marker. Unlike worktree discovery this does
+// not depend on there being an orphan, so `factory status` can accurately say
+// when the janitor was last invoked even when it found nothing.
+if (!GATE) {
+  try {
+    const logDir = path.join(homedir(), ".factory/logs");
+    mkdirSync(logDir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
+    for (const repo of repos) appendFileSync(path.join(logDir, `janitor-${repo.name}-${stamp}.log`), `${new Date().toISOString()} ${APPLY ? "apply" : "dry"}\n`);
+  } catch { /* observability must never block safe cleanup */ }
+}
 
 let totalReclaimable = 0;
 

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * At-a-glance status for the configured repository containing cwd.
+ *
+ *   factory status
+ *   factory status --repo legalease
+ *   factory status --json
+ *
+ * Read-only: refreshes remote refs, reads the live factory queue, and, when
+ * configured, fetches the public deployment metadata endpoint.
+ */
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { ROOT } from "../lib/schedule.mjs";
+import { loadQueueConfig, fetchQueueSummaries } from "../lib/queue-summary.mjs";
+import { recommendNext } from "../lib/next-recommend.mjs";
+import { formatAge, deployedRevision, deploymentState, metadataUrl } from "../lib/repo-status.mjs";
+import { latestReaperRunMs } from "./reaper.mjs";
+
+const argv = process.argv.slice(2);
+const val = (flag) => { const i = argv.indexOf(flag); return i === -1 ? null : argv[i + 1]; };
+const JSON_OUT = argv.includes("--json");
+const c = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`, dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
+};
+const expand = (p) => p?.replace(/^~/, homedir());
+const sh = (args, cwd) => {
+  const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
+  return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+};
+
+function configuredRepo() {
+  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const explicit = val("--repo");
+  if (explicit) return (cfg.repos ?? []).find((r) => r.name === explicit) ?? null;
+  const cwd = process.cwd();
+  const byPath = (cfg.repos ?? []).find((r) => {
+    const roots = [r.path, r.worktree_root].map(expand).filter(Boolean);
+    return roots.some((root) => cwd === root || cwd.startsWith(`${root}/`));
+  });
+  if (byPath) return byPath;
+
+  // The factory itself has no worktree_root, and users may create a worktree
+  // outside the configured location. The configured GitHub slug remains a
+  // stable identity in both cases.
+  const remote = sh(["git", "config", "--get", "remote.origin.url"], cwd).out
+    .replace(/^git@github\.com:/, "").replace(/^https?:\/\/github\.com\//, "").replace(/\.git$/, "");
+  return (cfg.repos ?? []).find((r) => r.github === remote) ?? null;
+}
+
+// Resolve before doing network work so an unmapped cwd fails with an actionable message.
+const repoConfig = configuredRepo();
+if (!repoConfig) {
+  console.error("no configured repository for cwd — pass --repo <name>");
+  process.exit(2);
+}
+const configuredPath = expand(repoConfig.path);
+// Worktrees are valid entry points; use the checkout containing cwd for branch
+// and cleanliness, but retain the configured root for callers outside a repo.
+const repoPath = sh(["git", "rev-parse", "--show-toplevel"], process.cwd()).out || configuredPath;
+if (!existsSync(repoPath)) {
+  console.error(`configured path does not exist: ${repoPath}`);
+  process.exit(2);
+}
+
+const deployBranch = repoConfig.deploy_branch ?? (repoConfig.base === "main" ? "main" : "master");
+const baseBranch = repoConfig.base;
+const metadataBranch = repoConfig.deployment?.branch ?? deployBranch;
+const fetchResult = sh(["git", "fetch", "--quiet", "origin", ...new Set([baseBranch, deployBranch, metadataBranch])], repoPath);
+const branch = sh(["git", "branch", "--show-current"], repoPath).out || "(detached)";
+const head = sh(["git", "rev-parse", "HEAD"], repoPath).out || null;
+const dirty = sh(["git", "status", "--porcelain"], repoPath).out.split("\n").filter(Boolean);
+
+function remoteRef(name) {
+  const sha = sh(["git", "rev-parse", `origin/${name}`], repoPath).out || null;
+  const aheadBehind = head && sha ? sh(["git", "rev-list", "--left-right", "--count", `HEAD...origin/${name}`], repoPath).out.split(/\s+/).map(Number) : [];
+  return { branch: name, sha, checkoutAhead: aheadBehind[0] ?? null, checkoutBehind: aheadBehind[1] ?? null };
+}
+const base = remoteRef(baseBranch);
+const deploy = remoteRef(deployBranch);
+const metadataRef = metadataBranch === deployBranch ? deploy : metadataBranch === baseBranch ? base : remoteRef(metadataBranch);
+
+let deployment = { configured: false, state: "not configured" };
+if (repoConfig.deployment?.url) {
+  const url = metadataUrl(repoConfig.deployment.url);
+  deployment = { configured: true, url, branch: metadataBranch, state: "unknown" };
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(10_000), headers: { accept: "application/json" } });
+    if (!response.ok) {
+      deployment.error = `HTTP ${response.status}`;
+    } else {
+      const payload = await response.json();
+      const revision = deployedRevision(payload, repoConfig.deployment.revision_field);
+      deployment.payload = payload;
+      deployment.revision = revision?.value ?? null;
+      deployment.revisionField = revision?.field ?? null;
+      const contains = revision?.value && metadataRef.sha
+        ? sh(["git", "merge-base", "--is-ancestor", revision.value, `origin/${metadataBranch}`], repoPath).ok
+        : null;
+      Object.assign(deployment, deploymentState({ deployed: revision?.value, remoteSha: metadataRef.sha, localContains: contains }));
+    }
+  } catch (error) { deployment.error = error.message; }
+}
+
+function latestJanitorRunMs(repo) {
+  const dir = path.join(homedir(), ".factory/logs");
+  let latest = null;
+  try {
+    for (const name of readdirSync(dir)) {
+      if (!new RegExp(`^janitor-${repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d{8}-\\d{6}\\.log$`).test(name)) continue;
+      const at = statSync(path.join(dir, name)).mtimeMs;
+      if (latest === null || at > latest) latest = at;
+    }
+  } catch { /* no logs yet */ }
+  return latest;
+}
+
+const { repos, defaultCap } = loadQueueConfig([repoConfig.name]);
+let queue = null, next = null, queueError = null;
+try {
+  queue = (await fetchQueueSummaries(repos, defaultCap))[0] ?? null;
+  if (queue) next = recommendNext(queue);
+} catch (error) { queueError = error.message; }
+
+const output = {
+  repo: repoConfig.name, path: repoPath, configuredPath, github: repoConfig.github, reportOnly: !!repoConfig.report_only,
+  checkout: { branch, head, dirtyFiles: dirty.length }, fetch: fetchResult.ok ? null : fetchResult.err,
+  branches: { base, deploy }, deployment,
+  maintenance: { reaperLastRun: latestReaperRunMs(), janitorLastRun: latestJanitorRunMs(repoConfig.name) },
+  factory: queue ? { queue, next } : { error: queueError },
+};
+if (JSON_OUT) { console.log(JSON.stringify(output, null, 2)); process.exit(0); }
+
+console.log(c.bold(`\nfactory status — ${repoConfig.name}`));
+console.log(c.dim(`${repoPath}${repoConfig.report_only ? "  · report-only" : ""}`));
+console.log(`\nCheckout   ${branch}  ${(head ?? "unknown").slice(0, 12)}  ${dirty.length ? c.yellow(`${dirty.length} changed file(s)`) : c.green("clean")}`);
+for (const [label, ref] of [["Base", base], ["Deploy", deploy]]) {
+  const delta = ref.checkoutAhead == null ? "unavailable" : `checkout +${ref.checkoutAhead}/-${ref.checkoutBehind}`;
+  console.log(`${label.padEnd(10)} origin/${ref.branch}  ${(ref.sha ?? "unavailable").slice(0, 12)}  ${c.dim(delta)}`);
+}
+console.log(`\nDeployment ${deployment.configured ? deployment.url : c.dim("not configured")}`);
+if (deployment.configured) {
+  console.log(c.dim(`  comparing with origin/${deployment.branch}`));
+  if (deployment.revision) console.log(`  ${deployment.revisionField}  ${deployment.revision.slice(0, 12)}`);
+  const color = deployment.state === "current" ? c.green : ["stale", "diverged", "different"].includes(deployment.state) ? c.yellow : c.red;
+  console.log(`  ${color(deployment.state)} — ${deployment.message ?? deployment.error ?? "could not fetch endpoint"}`);
+}
+console.log(`\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`);
+console.log(c.bold("\nFactory now:"));
+if (queue) {
+  console.log(`  Triage ${queue.triageState} · Todo ${queue.todoNotReady} · Ready ${queue.ready} · In progress ${queue.inProgress} · Review ${queue.inReview} · Blocked ${queue.blocked}`);
+  const command = next.command ? `${next.command}${next.args ? ` ${next.args}` : ""}` : "(wait)";
+  console.log(`  Next ${c.green(command)} — ${next.reason}`);
+
+  const action = next.command?.replace(/^factory-/, "");
+  const explanations = {
+    triage: "clarify and prepare the oldest tickets so agents can safely take them",
+    work: "claim up to three ready tickets and implement them in isolated worktrees",
+    merge: "review mergeable pull requests, verify their checks, then land eligible changes",
+    reconcile: "repair claims whose agent/worktree is no longer live",
+    digest: "show the questions currently waiting for a human answer",
+    unblock: "re-check held tickets for new evidence that removes their block",
+    sweep: "retire obsolete or duplicate tickets while the main pipeline is idle",
+  };
+  const waitExplanation = {
+    capacity: "Workers are already at capacity; let an active ticket finish before dispatching another.",
+    "path collision": "Ready tickets overlap paths with active work; wait rather than create a conflicting worktree.",
+    report_only: "This repository is intentionally report-only until its safe worktree lifecycle exists.",
+    idle: "No ticket needs action right now; re-run after a branch, deploy, or ticket changes.",
+  };
+  console.log(c.bold("\nSuggested action:"));
+  if (action && explanations[action]) {
+    console.log(`  ${c.green(`factory ${action}${next.args ? ` ${next.args}` : ""}`)} — ${explanations[action]}.`);
+  } else if (next.command === "tick") {
+    console.log(`  ${c.green("factory tick --repo " + repoConfig.name + " --apply")} — run one orchestrated dispatch/merge pass.`);
+  } else {
+    console.log(`  ${c.dim(waitExplanation[next.constraint] ?? "No safe factory command is applicable yet; re-run after the state changes.")}`);
+  }
+  console.log(c.dim("  `factory status --json` is available for scripts; this view is the human-facing hub."));
+} else console.log(c.red(`  queue unavailable — ${queueError ?? "unknown error"}`));
+console.log();

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -21,45 +21,111 @@ import { latestReaperRunMs } from "./reaper.mjs";
 const argv = process.argv.slice(2);
 const val = (flag) => { const i = argv.indexOf(flag); return i === -1 ? null : argv[i + 1]; };
 const JSON_OUT = argv.includes("--json");
+const explicitRepo = val("--repo");
 const c = {
-  bold: (s) => `\x1b[1m${s}\x1b[0m`, dim: (s) => `\x1b[2m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
 const expand = (p) => p?.replace(/^~/, homedir());
+const quoteArg = (value) => `"${String(value).replace(/"/g, "\\\"")}"`;
 const sh = (args, cwd) => {
   const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
   return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
 };
 
+function normalizeGitRemote(raw) {
+  if (!raw) return null;
+  return raw
+    .replace(/^git@github\.com:/, "")
+    .replace(/^https?:\/\/(?:www\.)?github\.com\//, "")
+    .replace(/\.git$/, "")
+    .trim();
+}
+
+function gitRemote(cwd) {
+  return normalizeGitRemote(sh(["git", "config", "--get", "remote.origin.url"], cwd).out);
+}
+
+function checkoutMatchesRepo(repo, checkoutRoot, fallbackRemote = gitRemote(checkoutRoot)) {
+  const roots = [repo.path, repo.worktree_root].map(expand).filter(Boolean);
+  const byPath = roots.some((root) => checkoutRoot === root || checkoutRoot.startsWith(`${root}/`));
+  if (byPath) return true;
+  if (!fallbackRemote || !repo.github) return false;
+  return normalizeGitRemote(repo.github) === fallbackRemote;
+}
+
 function configuredRepo() {
   const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-  const explicit = val("--repo");
-  if (explicit) return (cfg.repos ?? []).find((r) => r.name === explicit) ?? null;
+  const repos = cfg.repos ?? [];
+
+  if (explicitRepo) {
+    return repos.find((r) => r.name === explicitRepo) ?? null;
+  }
+
   const cwd = process.cwd();
-  const byPath = (cfg.repos ?? []).find((r) => {
-    const roots = [r.path, r.worktree_root].map(expand).filter(Boolean);
-    return roots.some((root) => cwd === root || cwd.startsWith(`${root}/`));
-  });
+  const cwdTop = sh(["git", "rev-parse", "--show-toplevel"], cwd).out;
+  const cwdRemote = gitRemote(cwd);
+
+  const byPath = repos.find((r) => checkoutMatchesRepo(r, cwdTop, cwdRemote));
   if (byPath) return byPath;
 
-  // The factory itself has no worktree_root, and users may create a worktree
-  // outside the configured location. The configured GitHub slug remains a
-  // stable identity in both cases.
-  const remote = sh(["git", "config", "--get", "remote.origin.url"], cwd).out
-    .replace(/^git@github\.com:/, "").replace(/^https?:\/\/github\.com\//, "").replace(/\.git$/, "");
-  return (cfg.repos ?? []).find((r) => r.github === remote) ?? null;
+  return repos.find((r) => normalizeGitRemote(r.github) === cwdRemote) ?? null;
+}
+
+function recommendationDto(plan, seen = new WeakSet()) {
+  if (!plan || typeof plan !== "object") return null;
+  if (seen.has(plan)) return null;
+  seen.add(plan);
+  return {
+    repo: plan.repo,
+    command: plan.command,
+    args: plan.args,
+    reason: plan.reason,
+    constraint: plan.constraint,
+    stage: plan.stage,
+    exec: plan.exec,
+    alternates: Array.isArray(plan.alternates)
+      ? plan.alternates.map((a) => recommendationDto(a, seen)).filter(Boolean)
+      : [],
+  };
+}
+
+function recommendedCommand(plan, repoName) {
+  if (!plan || typeof plan !== "object") return null;
+  if (plan.exec) return plan.exec;
+
+  if (plan.command === "tick") return `bun orchestrator/tick.mjs --repo ${quoteArg(repoName)} --apply`;
+  if (plan.command === "reconcile") return `bun orchestrator/reconcile.mjs --repo ${quoteArg(repoName)} --apply`;
+  if (plan.command === "digest") return `bun orchestrator/digest.mjs --repo ${quoteArg(repoName)}`;
+  if (plan.command?.startsWith("factory-")) {
+    const args = plan.args ? ` --args ${quoteArg(plan.args)}` : "";
+    const readOnly = new Set(["factory-triage", "factory-unblock", "factory-sweep"]).has(plan.command);
+    const readOnlyFlag = readOnly ? " --read-only" : "";
+    return `factory run --repo ${quoteArg(repoName)} --command ${plan.command}${args}${readOnlyFlag}`.trim();
+  }
+  return null;
+}
+
+function factoryQueueAvailability(config) {
+  if (config.report_only) return "report-only repository";
+  if (!config.team || !config.project) return "missing linear team/project configuration";
+  return null;
 }
 
 // Resolve before doing network work so an unmapped cwd fails with an actionable message.
 const repoConfig = configuredRepo();
 if (!repoConfig) {
-  console.error("no configured repository for cwd — pass --repo <name>");
+  const names = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8")).repos?.map((r) => r.name).join(", ") ?? "";
+  console.error(`no configured repository for cwd${explicitRepo ? ` --repo ${explicitRepo}` : ""} — pass --repo <name>`);
+  if (!explicitRepo && names) console.error(`known repositories: ${names}`);
   process.exit(2);
 }
 const configuredPath = expand(repoConfig.path);
-// Worktrees are valid entry points; use the checkout containing cwd for branch
-// and cleanliness, but retain the configured root for callers outside a repo.
-const repoPath = sh(["git", "rev-parse", "--show-toplevel"], process.cwd()).out || configuredPath;
+const cwdTop = sh(["git", "rev-parse", "--show-toplevel"], process.cwd()).out;
+const repoPath = cwdTop && checkoutMatchesRepo(repoConfig, cwdTop, gitRemote(cwdTop)) ? cwdTop : configuredPath;
 if (!existsSync(repoPath)) {
   console.error(`configured path does not exist: ${repoPath}`);
   process.exit(2);
@@ -119,19 +185,38 @@ function latestJanitorRunMs(repo) {
 
 const { repos, defaultCap } = loadQueueConfig([repoConfig.name]);
 let queue = null, next = null, queueError = null;
-try {
-  queue = (await fetchQueueSummaries(repos, defaultCap))[0] ?? null;
-  if (queue) next = recommendNext(queue);
-} catch (error) { queueError = error.message; }
+const queueUnavailable = factoryQueueAvailability(repoConfig);
+if (!queueUnavailable) {
+  try {
+    queue = (await fetchQueueSummaries(repos, defaultCap))[0] ?? null;
+    if (queue) next = recommendationDto(recommendNext(queue));
+  } catch (error) {
+    queueError = error.message;
+  }
+}
 
 const output = {
-  repo: repoConfig.name, path: repoPath, configuredPath, github: repoConfig.github, reportOnly: !!repoConfig.report_only,
-  checkout: { branch, head, dirtyFiles: dirty.length }, fetch: fetchResult.ok ? null : fetchResult.err,
-  branches: { base, deploy }, deployment,
+  repo: repoConfig.name,
+  path: repoPath,
+  configuredPath,
+  github: repoConfig.github,
+  reportOnly: !!repoConfig.report_only,
+  checkout: { branch, head, dirtyFiles: dirty.length },
+  fetch: fetchResult.ok ? null : fetchResult.err,
+  branches: { base, deploy },
+  deployment,
   maintenance: { reaperLastRun: latestReaperRunMs(), janitorLastRun: latestJanitorRunMs(repoConfig.name) },
-  factory: queue ? { queue, next } : { error: queueError },
+  factory: queueUnavailable
+    ? { available: false, reason: queueUnavailable, queue: null, next: null, error: null }
+    : queue
+      ? { available: true, queue, next }
+      : { available: false, reason: queueError ?? "unknown error", queue: null, next: null, error: queueError },
 };
-if (JSON_OUT) { console.log(JSON.stringify(output, null, 2)); process.exit(0); }
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(output, null, 2));
+  process.exit(0);
+}
 
 console.log(c.bold(`\nfactory status — ${repoConfig.name}`));
 console.log(c.dim(`${repoPath}${repoConfig.report_only ? "  · report-only" : ""}`));
@@ -147,37 +232,35 @@ if (deployment.configured) {
   const color = deployment.state === "current" ? c.green : ["stale", "diverged", "different"].includes(deployment.state) ? c.yellow : c.red;
   console.log(`  ${color(deployment.state)} — ${deployment.message ?? deployment.error ?? "could not fetch endpoint"}`);
 }
+
+const factoryStatus = output.factory;
 console.log(`\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`);
 console.log(c.bold("\nFactory now:"));
-if (queue) {
+
+if (!factoryStatus.available) {
+  console.log(c.red(`  queue unavailable — ${factoryStatus.reason}`));
+} else if (queue) {
   console.log(`  Triage ${queue.triageState} · Todo ${queue.todoNotReady} · Ready ${queue.ready} · In progress ${queue.inProgress} · Review ${queue.inReview} · Blocked ${queue.blocked}`);
   const command = next.command ? `${next.command}${next.args ? ` ${next.args}` : ""}` : "(wait)";
   console.log(`  Next ${c.green(command)} — ${next.reason}`);
 
-  const action = next.command?.replace(/^factory-/, "");
-  const explanations = {
-    triage: "clarify and prepare the oldest tickets so agents can safely take them",
-    work: "claim up to three ready tickets and implement them in isolated worktrees",
-    merge: "review mergeable pull requests, verify their checks, then land eligible changes",
-    reconcile: "repair claims whose agent/worktree is no longer live",
-    digest: "show the questions currently waiting for a human answer",
-    unblock: "re-check held tickets for new evidence that removes their block",
-    sweep: "retire obsolete or duplicate tickets while the main pipeline is idle",
-  };
-  const waitExplanation = {
-    capacity: "Workers are already at capacity; let an active ticket finish before dispatching another.",
-    "path collision": "Ready tickets overlap paths with active work; wait rather than create a conflicting worktree.",
-    report_only: "This repository is intentionally report-only until its safe worktree lifecycle exists.",
-    idle: "No ticket needs action right now; re-run after a branch, deploy, or ticket changes.",
-  };
+  const suggested = recommendedCommand(next, repoConfig.name);
   console.log(c.bold("\nSuggested action:"));
-  if (action && explanations[action]) {
-    console.log(`  ${c.green(`factory ${action}${next.args ? ` ${next.args}` : ""}`)} — ${explanations[action]}.`);
-  } else if (next.command === "tick") {
-    console.log(`  ${c.green("factory tick --repo " + repoConfig.name + " --apply")} — run one orchestrated dispatch/merge pass.`);
+  if (suggested) {
+    console.log(`  ${c.green(suggested)} — ${next.reason}.`);
   } else {
-    console.log(`  ${c.dim(waitExplanation[next.constraint] ?? "No safe factory command is applicable yet; re-run after the state changes.")}`);
+    const waitExplanation = {
+      capacity: "Workers are already at capacity; let an active ticket finish before dispatching another.",
+      "path collision": "Ready tickets overlap paths with active work; wait rather than create a conflicting worktree.",
+      report_only: "This repository is intentionally report-only until its safe worktree lifecycle exists.",
+      idle: "No ticket needs action right now; re-run after a branch, deploy, or ticket changes.",
+    };
+    const alternate = waitExplanation[next?.constraint] ?? "No safe factory command is applicable yet; re-run after the state changes.";
+    console.log(`  ${c.dim(alternate)}`);
   }
-  console.log(c.dim("  `factory status --json` is available for scripts; this view is the human-facing hub."));
-} else console.log(c.red(`  queue unavailable — ${queueError ?? "unknown error"}`));
+} else {
+  console.log(c.red(`  queue unavailable — ${queueError ?? "unknown error"}`));
+}
+
+console.log(c.dim("  `factory status --json` is available for scripts; this view is the human-facing hub."));
 console.log();

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -140,6 +140,9 @@ const head = sh(["git", "rev-parse", "HEAD"], repoPath).out || null;
 const dirty = sh(["git", "status", "--porcelain"], repoPath).out.split("\n").filter(Boolean);
 
 function remoteRef(name) {
+  // Cached origin refs are not trustworthy when refresh failed: reporting a
+  // stale deployment as current is worse than reporting it unknown.
+  if (!fetchResult.ok) return { branch: name, sha: null, checkoutAhead: null, checkoutBehind: null };
   const sha = sh(["git", "rev-parse", `origin/${name}`], repoPath).out || null;
   const aheadBehind = head && sha ? sh(["git", "rev-list", "--left-right", "--count", `HEAD...origin/${name}`], repoPath).out.split(/\s+/).map(Number) : [];
   return { branch: name, sha, checkoutAhead: aheadBehind[0] ?? null, checkoutBehind: aheadBehind[1] ?? null };
@@ -152,7 +155,9 @@ let deployment = { configured: false, state: "not configured" };
 if (repoConfig.deployment?.url) {
   const url = metadataUrl(repoConfig.deployment.url);
   deployment = { configured: true, url, branch: metadataBranch, state: "unknown" };
+  if (!fetchResult.ok) deployment.error = `remote refresh failed: ${fetchResult.err || "unknown error"}`;
   try {
+    if (!fetchResult.ok) throw new Error(deployment.error);
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000), headers: { accept: "application/json" } });
     if (!response.ok) {
       deployment.error = `HTTP ${response.status}`;


### PR DESCRIPTION
## Summary
- add `factory status` as the human-facing repository/factory hub
- compare configured deployment revision endpoints with remote branches
- surface current factory state, recommended plain-English action, and reaper/janitor recency
- configure current BJ29, Legalease, CashSaaS, and Proxies metadata endpoints

## Verification
- `bun test`
- `bun build/emit.mjs --check`
- exercised `factory status` against Legalease and CashSaaS deployment metadata
- remote refresh failures fail closed rather than trusting cached refs

Fixes OPS-195
