### PR TITLE
fix: enable safe coach-wattz janitor teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Secrets (injected via launchd env or `op run`), worktrees, agent session logs, a
 
 ## Where things stand (2026-08-03)
 
-**Wired and working for `bj29` only.** coach-wattz, legalease and cashsaas are `report_only` — the janitor sees their orphaned worktrees but dispatch refuses them until [CW-363](https://linear.app/watt-mind/issue/CW-363) and [CLNT-609](https://linear.app/watt-mind/issue/CLNT-609) land worktree scripts.
+**Automated dispatch is authorized for `bj29` only.** coach-wattz's lifecycle scripts landed in [CW-363](https://linear.app/watt-mind/issue/CW-363), so the janitor can safely reclaim its finished worktrees through the repo-owned teardown script. coach-wattz remains `report_only` for dispatch; legalease and cashsaas carry full lifecycle configuration.
 
 | Stage | State |
 | :--- | :--- |

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -1,11 +1,8 @@
 # Per-repo facts the loop needs. One entry only, on purpose.
 #
-# BJ29 is the only repo that currently satisfies PC-15 (industrialized
-# worktrees), which is the precondition for dispatching concurrent agents into
-# it. coach-wattz and legalease get entries when CW-363 and CLNT-609 land —
-# adding them now would mean inventing ports and test commands for tooling that
-# doesn't exist yet, and an agent that trusts an invented port collides with
-# another agent's dev server.
+# BJ29 is currently the only repo authorized for automated dispatch. Repos
+# need industrialized worktrees before dispatch can be enabled; a repo may still
+# configure its teardown script while remaining `report_only` for dispatch.
 
 repos:
   - name: bj29
@@ -96,9 +93,10 @@ repos:
   #   - dispatch must never target them; concurrent agents there share ports and
   #     databases
   #
-  # coach-wattz graduates when CW-363 lands its worktree scripts. legalease
-  # (CLNT-609) and cashsaas (CLNT-791) already have — their entries below carry
-  # worktree_up/down/warm like bj29's, and are no longer report_only.
+  # A report-only repo may configure `worktree_down` for safe janitor cleanup.
+  # The janitor calls that repo-owned script; it never removes a worktree by
+  # hand. coach-wattz's scripts landed in CW-363. legalease (CLNT-609) and
+  # cashsaas (CLNT-791) have graduated to full lifecycle configuration.
   # --------------------------------------------------------------------------
 
   - name: wm-home
@@ -119,8 +117,11 @@ repos:
     team: CW
     project: Coach Watts - Web & AI Core Platform
     base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
     worktree_root: ~/Develop/.worktrees/coach-wattz
-    report_only: true            # PC-15 pending — see CW-363
+    report_only: true            # Dispatch remains disabled; janitor may use the teardown script.
 
   - name: watts-mobile
     path: ~/Develop/watts-mobile

--- a/config/schedule.yaml
+++ b/config/schedule.yaml
@@ -65,9 +65,9 @@ jobs:
   #
   #   triage  ->  dispatch  ->  merge
   #
-  # Only bj29 is targeted today: it is the one repo satisfying PC-15
-  # (industrialized worktrees), which is what makes concurrent agents safe.
-  # coach-wattz and legalease join the --repo list when CW-363/CLNT-609 land.
+  # Only bj29 is targeted today: it is the only repo authorized for automated
+  # dispatch. coach-wattz has lifecycle scripts (CW-363) and can be janitored
+  # safely, but remains report-only until dispatch is explicitly authorized.
   #
   # WHY THE SHORT CADENCES: every stage has a `gate_command` — one cheap Linear
   # query that exits 0 when there is work and 1 when there isn't. Polling is

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -100,17 +100,17 @@ for (const repo of repos) {
     continue;
   }
 
-  // report_only repos are surveyed, never modified. Removing a worktree without
-  // the repo's own down script leaves its database behind — that is how a
-  // Postgres fills up with dev databases nobody can attribute.
-  if (repo.report_only) {
+  // `report_only` disables dispatch, not safe cleanup. A repo with its own
+  // configured teardown script can be reclaimed; one without it is surveyed
+  // only, because removing a worktree by hand leaves its database behind.
+  const down = repo.worktree_down;
+  if (repo.report_only && !down) {
     console.log(c.yellow(`\n  report-only: ${repo.name} has no worktree teardown script (PC-15 pending).`));
     console.log(c.dim(`  Not removing anything. These need the repo's own worktree-down.sh so the`));
     console.log(c.dim(`  per-ticket database goes with the checkout.`));
     continue;
   }
 
-  const down = repo.worktree_down;
   if (!down || !existsSync(path.join(repoPath, down))) {
     console.log(c.red(`  ! ${repo.name} has no worktree_down script (${down}) — refusing to remove by hand`));
     continue;


### PR DESCRIPTION
## Summary
- configure coach-wattz’s shipped worktree lifecycle scripts
- allow janitor cleanup for report-only repos only when they provide a repo-owned teardown script
- keep coach-wattz dispatch disabled and update stale documentation

## Verification
- `bun test` (185 pass)
- `bun orchestrator/janitor.mjs --repo coach-wattz` identifies finished worktrees
- `bun orchestrator/janitor.mjs --repo coach-wattz --apply` successfully removed six finished worktrees before the 10-minute runner ceiling; it never uses `--force`

Fixes OPS-205