### PR TITLE
feat(event-runtime): discovered chains — ci-doctor, recommendation edges, closed-command adapter

### DIFF
--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -133,7 +133,7 @@ the direction to build toward, ahead of general declared workflows (slice
 **per-edge earned automation** — each recommendation edge (a specific
 `A-recommendation → B` mapping) is watched individually and earns
 auto-approval on its own record; mutating edges may simply never earn it.
-First use case: to be selected before any implementation ticket is cut.
+First use case: **shipped (OPS-223)** — the CI failure doctor: `github.workflow-run.failed` → `ci-doctor@1` verdict → `FLAKE|ENV → ci-rerun@1` / `TICKET → ci-notify@1`, every edge watched; the edge registry (`edges.json`), chain resolver (`lib/chain.mjs`), and closed-template command adapter are the §6 cut-line 6 machinery.
 
 ## 6. Ticket cut-lines (when the operator says go)
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -57,7 +57,7 @@ machinery it earns. Anything no listed event type needs stays unbuilt.
 | :--- | :--- | :--- | :--- |
 | `factory.status-report.requested` | operator webhook / replay CLI | intake, dedup, planner, approval, ephemeral workspace, schema verification, receipts | slice 1 |
 | `keephq.disk-alert.raised` | Keep HQ infra alert webhook | two-node DAG (diagnose → remediate), semantic verification against declared evidence (`evidenceSetHash`), typed remediation plans from a **closed action registry**, first infra-mutating executor behind watched approval (OPS-208) | slice 2 |
-| `github.workflow-run.failed` | GitHub webhook | log-derived evidence, artifact retention, correlation with an external PR | later |
+| `github.workflow-run.failed` | GitHub webhook / replay CLI | first discovered chain (OPS-223): typed `ci-doctor` diagnosis → recommendation edges → watched closed-command follow-ups (`gh run rerun`, notify); command adapter and edge registry | shipped |
 | `sentry.issue.created` | Sentry webhook | *(dropped as a slice — Sentry already feeds Linear directly, so classifying here validates nothing operationally new; revisit only if that intake moves)* | — |
 | `clock.tick.<loop>` | scheduler | admitted, audited timer events; per-loop migration of the standing loops | later, per loop |
 | repository-mutating events | GitHub / Linear | shared claim, capacity, Owned Paths, and approval authority with the ticket dispatcher (§3) | last |

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -53,6 +53,20 @@ Dev loop: `cd event-runtime/web && bunx vite` (proxies /api to the control
 API). Keyboard-first: `⌘K` palette, `g o/p/r` to navigate, `j/k` + `Enter` on
 lists, `a`/`x` to approve/reject the selected proposal.
 
+## Discovered chains (OPS-223)
+
+Agents never spawn agents: a completed run whose artifact carries a typed
+recommendation (per `edges.json`) emits an internal event through the same
+intake — `eventId chain-<runId>` (once per run, ever), `correlationId`
+inherited, `causationId` = the source run — and the planner proposes the
+follow-up, **watched like everything else**. First chain: `ci-doctor@1`
+diagnoses a failed GitHub Actions run (`github.workflow-run.failed`) and
+recommends `FLAKE|ENV → ci-rerun@1` (closed command template
+`gh run rerun … --failed`, once-per-run by idempotency) or
+`TICKET → ci-notify@1` (`factory notify "CI RED …"`). Mutating definitions
+are admitted only as closed command templates (`lib/adapters/command.mjs`) —
+enforceable by construction, no shell, no model (§14).
+
 ## Demo environments and e2e (OPS-217)
 
 `bin/worktree-up.sh` provisions an **isolated, seeded** runtime — the part
@@ -128,6 +142,8 @@ spec (§12).
 | `lib/worker.mjs` | single worker: lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
+| `lib/chain.mjs` `edges.json` | discovered chains: typed recommendation → internal event → watched proposal (OPS-223) |
+| `lib/adapters/command.mjs` | closed-template command executor — the only admissible mutating agent form (§14) |
 | `lib/artifacts.mjs` | content-addressed artifact/transcript store, streamed via `GET /artifacts/:sha256` |
 | `lib/api.mjs` `cli.mjs` | loopback control API + CLI client (§12–§13) |
 | `web/` | web control plane: Vite/React app + `serve.mjs` static/proxy server |

--- a/event-runtime/agents/ci-doctor.json
+++ b/event-runtime/agents/ci-doctor.json
@@ -1,0 +1,28 @@
+{
+  "id": "ci-doctor",
+  "version": 1,
+  "prompt": "agents/ci-doctor.md",
+  "input_schema": "schemas/ci-doctor.input.json",
+  "output_schema": "schemas/ci-doctor.output.json",
+  "output_contract": "factory.ci-doctor/v1",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/ci-doctor.md": "sha256:08ac4640a8a3c51b13731e23398f21cd448d326b03746d7b6ec570835d519469",
+    "schemas/ci-doctor.input.json": "sha256:c2b79435ab29e8a0f08e262b4ae2d5bac86ae335c86b9fd4e8c210b037319113",
+    "schemas/ci-doctor.output.json": "sha256:fa0d9eefc2ed4f68b97d5d7b9ec91f36a233bff945bba71b3d9e6e8343167680"
+  }
+}

--- a/event-runtime/agents/ci-doctor.md
+++ b/event-runtime/agents/ci-doctor.md
@@ -1,0 +1,50 @@
+# ci-doctor — diagnose one failed GitHub Actions run
+
+You are a CI diagnostician. `./input.json` names one failed GitHub Actions
+run: `{ "repo": "<owner>/<name>", "runId": <id> }`. Diagnose it and write
+`./result.json`. You are read-only: you never re-run workflows, never push,
+never edit anything. Work only inside this directory.
+
+## Method
+
+1. `gh run view <runId> --repo <repo>` — identify the failed job(s).
+2. `gh run view <runId> --repo <repo> --log-failed` — find the first real
+   error (not the cascade after it). Quote the smallest set of log lines that
+   prove the diagnosis.
+3. `gh run list --repo <repo> --limit 10 --json conclusion,headSha` — check
+   history: is this failure novel, repeated, or intermittent?
+
+## Verdict — exactly one
+
+- **TICKET** — the code or configuration in the commit is at fault; a change
+  is required and someone should file/fix it.
+- **ENV** — the environment failed before or around the code: runner setup,
+  network, disk, credentials, external service. The diff is innocent.
+- **FLAKE** — an intermittent failure with green history around it: timing,
+  race, flaky test, transient dependency.
+
+If torn between TICKET and FLAKE, prefer TICKET — a wrongly-rerun real bug
+hides longer than a wrongly-ticketed flake.
+
+## Output
+
+Write `./result.json`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "verdict": "ENV",
+    "culprit": "job Verify, step Setup bun",
+    "summary": "one plain sentence an operator can act on",
+    "evidenceLines": ["the exact log lines the verdict rests on"]
+  },
+  "evidence": { "commands": ["the gh commands you ran"] }
+}
+```
+
+`verdict` must be exactly `TICKET`, `ENV`, or `FLAKE`. If the run cannot be
+inspected at all (gh errors, run not found), refuse instead:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "missing_input"}`.

--- a/event-runtime/agents/ci-notify.json
+++ b/event-runtime/agents/ci-notify.json
@@ -1,0 +1,33 @@
+{
+  "id": "ci-notify",
+  "version": 1,
+  "prompt": "agents/ci-notify.md",
+  "input_schema": "schemas/ci-notify.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "factory",
+    "notify",
+    "CI RED {repo} run {runId}: {summary}"
+  ],
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "notify:telegram"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 60,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/ci-notify.md": "sha256:c12a7d0613ed8fc030f29447f495fd0d70c55ec099f42ac9c08e07629283510d",
+    "schemas/ci-notify.input.json": "sha256:56dce2eea1f7c4b8e18fc1b2cbdfd6f121d4f8115c6218fcc60817e810d425f2",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/ci-notify.md
+++ b/event-runtime/agents/ci-notify.md
@@ -1,0 +1,12 @@
+# ci-notify — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+factory notify "CI RED {repo} run {runId}: {summary}"
+```
+
+Pushes the operator notification for a `TICKET` verdict from `ci-doctor@1` —
+a real failure needing a human decision, per the notification protocol
+(escalations only, never routine progress).

--- a/event-runtime/agents/ci-rerun.json
+++ b/event-runtime/agents/ci-rerun.json
@@ -1,0 +1,37 @@
+{
+  "id": "ci-rerun",
+  "version": 1,
+  "prompt": "agents/ci-rerun.md",
+  "input_schema": "schemas/ci-rerun.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "gh",
+    "run",
+    "rerun",
+    "{runId}",
+    "--failed",
+    "--repo",
+    "{repo}"
+  ],
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 120,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/ci-rerun.md": "sha256:1e357287cb35d28f110040f665733cb6db76d8fcc2c2bd43d412148ed3d27ad6",
+    "schemas/ci-rerun.input.json": "sha256:5a310db030e328bef28f48a403e00f00bc3f61c5ce9d3c963e3ea72afd1b42b7",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/ci-rerun.md
+++ b/event-runtime/agents/ci-rerun.md
@@ -1,0 +1,13 @@
+# ci-rerun — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+gh run rerun {runId} --failed --repo {repo}
+```
+
+Re-runs only the failed jobs of one GitHub Actions run. Recommended by
+`ci-doctor@1` on a `FLAKE` or `ENV` verdict; the idempotency scope
+(`inputHash` over `{repo, runId}`) makes it structurally once-per-run — the
+"don't keep re-running an ENV failure" rule as dedup, not discipline.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -15,6 +15,7 @@
  */
 import { readFileSync } from "node:fs";
 import * as claude from "./lib/adapters/claude.mjs";
+import * as command from "./lib/adapters/command.mjs";
 import * as fake from "./lib/adapters/fake.mjs";
 import { apiClient } from "./lib/client.mjs";
 import {
@@ -23,6 +24,7 @@ import {
 import { openDb } from "./lib/db.mjs";
 import { newWorkerId } from "./lib/ids.mjs";
 import { publishOutbox } from "./lib/outbox.mjs";
+import { resolveChains } from "./lib/chain.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
 import { startApi } from "./lib/api.mjs";
@@ -86,7 +88,7 @@ async function serve(args) {
   const port = flagValue(args, "--port") ? Number(flagValue(args, "--port")) : DEFAULT_PORT;
   if (!Number.isInteger(port) || port < 0) fail(`serve: invalid --port ${flagValue(args, "--port")}`);
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  const adapters = { claude, fake };
+  const adapters = { claude, command, fake };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`serve: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }
@@ -145,6 +147,12 @@ async function serve(args) {
         sink: (e) => log(`result event ${e.type} (${e.eventId}) artifact ${e.payload?.artifactHash ?? "-"}`),
         now: Date.now(),
       });
+      // Discovered chains (OPS-223): a completed run with a registered
+      // recommendation edge emits an internal event through the same intake;
+      // the next planning pass proposes the follow-up, watched like anything.
+      const chains = resolveChains(db, registry, { now: Date.now() });
+      if (chains.emitted > 0) log(`chain: emitted ${chains.emitted} follow-up event(s) — planning`);
+      for (const err of chains.errors) log(`chain error: ${err}`);
     } catch (err) {
       log(`tick error: ${err.message}`);
     } finally {

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -1,0 +1,19 @@
+{
+  "ci-doctor@1": {
+    "recommendationField": "verdict",
+    "edges": {
+      "FLAKE": {
+        "eventType": "factory.ci-rerun.requested",
+        "input": { "repo": "$.input.repo", "runId": "$.input.runId" }
+      },
+      "ENV": {
+        "eventType": "factory.ci-rerun.requested",
+        "input": { "repo": "$.input.repo", "runId": "$.input.runId" }
+      },
+      "TICKET": {
+        "eventType": "factory.ci-escalate.requested",
+        "input": { "repo": "$.input.repo", "runId": "$.input.runId", "summary": "$.artifact.summary" }
+      }
+    }
+  }
+}

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -4,5 +4,23 @@
     "adapter": "claude",
     "idempotencyScope": ["correlationId", "inputHash"],
     "proposalTtlSeconds": 1800
+  },
+  "github.workflow-run.failed": {
+    "agent": "ci-doctor@1",
+    "adapter": "claude",
+    "idempotencyScope": ["inputHash"],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.ci-rerun.requested": {
+    "agent": "ci-rerun@1",
+    "adapter": "command",
+    "idempotencyScope": ["inputHash"],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.ci-escalate.requested": {
+    "agent": "ci-notify@1",
+    "adapter": "command",
+    "idempotencyScope": ["inputHash"],
+    "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -1,0 +1,99 @@
+/**
+ * Deterministic-command adapter (docs/event-runtime.md §11, §14; OPS-223).
+ *
+ * The §14 "closed action registry" made concrete: a registered definition
+ * declares a fixed argv template, and the only thing an event can influence
+ * is the declared placeholder values — substituted per argv element, spawned
+ * directly with no shell, so an input like `"; rm -rf /"` is just an inert
+ * argument. This is the enforcement-by-construction that lets a `mutating:
+ * true` definition into the registry at all (lib/registry.mjs).
+ *
+ * Exit 0 → writes result.json (factory.agent-result/v1) with the resolved
+ * command and captured output as the artifact. Nonzero/timeout → no result;
+ * the worker records FAILED with `agent_exit_<code>` as usual.
+ */
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+const KILL_GRACE_MS = 10_000;
+const OUTPUT_TAIL_CHARS = 2_000;
+
+/** Substitute `{field}` placeholders in one argv element from spec.input. */
+export function resolveTemplate(template, input) {
+  return template.map((element) =>
+    element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
+      const value = input?.[field];
+      if (value === undefined || value === null) {
+        throw new Error(`command template references missing input field "${field}"`);
+      }
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw new Error(`command template field "${field}" must be a primitive, got ${typeof value}`);
+      }
+      return String(value);
+    }),
+  );
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
+ */
+export async function execute({ spec, def, workspaceDir, timeoutMs }) {
+  if (!Array.isArray(def.command) || def.command.length === 0) {
+    throw new Error(`definition ${def.ref} has no command template — not a command-adapter agent`);
+  }
+  const argv = resolveTemplate(def.command, spec.input);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd: workspaceDir,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+    const collect = (chunk) => {
+      output = (output + chunk.toString()).slice(-OUTPUT_TAIL_CHARS);
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+
+    let timedOut = false;
+    let killTimer;
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS);
+      killTimer.unref?.();
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(termTimer);
+      clearTimeout(killTimer);
+      reject(err);
+    });
+
+    child.on("close", (exitCode) => {
+      clearTimeout(termTimer);
+      clearTimeout(killTimer);
+      if (exitCode === 0 && !timedOut) {
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          `${JSON.stringify(
+            {
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              reasonCode: "ok",
+              artifact: { command: argv, exitCode: 0, outputTail: output },
+              evidence: { command: argv, outputTail: output },
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
+      }
+      resolve({ exitCode, timedOut });
+    });
+  });
+}

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execute, resolveTemplate } from "./command.mjs";
+
+const def = (command) => ({ ref: "test-cmd@1", command });
+const spec = (input) => ({ input });
+const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-cmd-"));
+
+describe("resolveTemplate", () => {
+  test("substitutes placeholders inside argv elements", () => {
+    expect(resolveTemplate(["gh", "run", "rerun", "{runId}", "--repo", "{repo}"], { runId: 42, repo: "wm/x" }))
+      .toEqual(["gh", "run", "rerun", "42", "--repo", "wm/x"]);
+    expect(resolveTemplate(["notify", "CI RED {repo}: {summary}"], { repo: "wm/x", summary: "boom" }))
+      .toEqual(["notify", "CI RED wm/x: boom"]);
+  });
+
+  test("missing or non-primitive fields fail closed", () => {
+    expect(() => resolveTemplate(["x", "{gone}"], {})).toThrow('missing input field "gone"');
+    expect(() => resolveTemplate(["x", "{obj}"], { obj: { a: 1 } })).toThrow("must be a primitive");
+  });
+
+  test("hostile input stays a single inert argument — no shell exists", () => {
+    const argv = resolveTemplate(["echo", "{msg}"], { msg: "; rm -rf / && echo pwned" });
+    expect(argv).toEqual(["echo", "; rm -rf / && echo pwned"]);
+  });
+});
+
+describe("execute", () => {
+  test("exit 0 writes a factory.agent-result/v1 with the resolved command", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: spec({ msg: "hello" }),
+      def: def(["echo", "{msg}"]),
+      workspaceDir,
+      timeoutMs: 5000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.terminalState).toBe("completed");
+    expect(result.artifact.command).toEqual(["echo", "hello"]);
+    expect(result.artifact.exitCode).toBe(0);
+    expect(result.artifact.outputTail).toContain("hello");
+  });
+
+  test("nonzero exit writes no result — the worker records the failure", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: spec({}),
+      def: def(["false"]),
+      workspaceDir,
+      timeoutMs: 5000,
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(() => readFileSync(path.join(workspaceDir, "result.json"))).toThrow();
+  });
+
+  test("timeout TERMs the child and reports timedOut", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: spec({}),
+      def: def(["sleep", "30"]),
+      workspaceDir,
+      timeoutMs: 300,
+    });
+    expect(outcome.timedOut).toBe(true);
+  }, 10_000);
+
+  test("a definition without a command template is refused", async () => {
+    await expect(
+      execute({ spec: spec({}), def: { ref: "x@1" }, workspaceDir: ws(), timeoutMs: 1000 }),
+    ).rejects.toThrow("no command template");
+  });
+});

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -23,9 +23,47 @@ function repoRow(name, overrides = {}) {
 }
 
 /**
+ * ci-doctor artifacts for chain tests/demos: the verdict rides in on the repo
+ * name's suffix — `wm/x-ticket` → TICKET, `wm/x-env` → ENV, else FLAKE.
+ */
+function ciDoctorArtifact(input) {
+  const repo = String(input?.repo ?? "");
+  const verdict = repo.endsWith("-ticket") ? "TICKET" : repo.endsWith("-env") ? "ENV" : "FLAKE";
+  return {
+    verdict,
+    culprit: "job Verify, step Setup bun",
+    summary: `fake diagnosis of ${repo} run ${input?.runId}`,
+    evidenceLines: ["socket hang up", "##[error]Error: socket hang up"],
+  };
+}
+
+/**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs, env }) {
+  // Contract-shaped fakes for the chain slice (OPS-223) — behavior keyed on
+  // the spec's output contract so planner/verifier/chain run unmodified.
+  if (spec.outputContract === "factory.ci-doctor/v1") {
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: ciDoctorArtifact(spec.input),
+      evidence: { commands: ["fake"] },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.command-result/v1") {
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: { command: ["fake"], exitCode: 0, outputTail: "" },
+      evidence: { command: ["fake"] },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+
   const mode = spec.input?.repos?.[0];
 
   switch (mode) {

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -1,0 +1,113 @@
+/**
+ * Discovered chains (docs/event-runtime-workers.md §5; OPS-223).
+ *
+ * Agents never spawn agents. When a run completes, its accepted artifact may
+ * carry a typed recommendation; a registered edge (edges.json) maps that
+ * value to a follow-up event type and an input built from declared paths.
+ * The chain emits an **internal event through the same intake as a webhook**
+ * — same dedup, same planner, same watched approval — with:
+ *
+ *   eventId       chain-<runId>            (one chain event per run, ever)
+ *   correlationId inherited from the originating event
+ *   causationId   the source runId
+ *
+ * Everything here is code: an unregistered recommendation value simply does
+ * not chain, and a hallucinated one costs a rejected proposal, not a run.
+ * Per-edge earned automation layers on later; today every chain proposal is
+ * watched like any other.
+ */
+import { admitEvent } from "./intake.mjs";
+
+export const CHAIN_SOURCE = "chain";
+
+/** Resolve a "$.input.x" / "$.artifact.x.y" path against the chain context. */
+function resolvePath(expr, context) {
+  if (typeof expr !== "string" || !expr.startsWith("$.")) return expr; // literal
+  const [root, ...segments] = expr.slice(2).split(".");
+  if (!(root in context)) throw new Error(`chain input path "${expr}": unknown root "${root}"`);
+  let value = context[root];
+  for (const segment of segments) {
+    if (value === null || typeof value !== "object" || !(segment in value)) {
+      throw new Error(`chain input path "${expr}" resolves to nothing`);
+    }
+    value = value[segment];
+  }
+  if (value === undefined) throw new Error(`chain input path "${expr}" resolves to nothing`);
+  return value;
+}
+
+export function buildChainInput(mapping, context) {
+  const input = {};
+  for (const [field, expr] of Object.entries(mapping)) {
+    input[field] = resolvePath(expr, context);
+  }
+  return input;
+}
+
+/** Completed runs whose agent has registered edges and no chain event yet. */
+function chainCandidates(db, edges) {
+  const agents = Object.keys(edges);
+  if (agents.length === 0) return [];
+  const placeholders = agents.map(() => "?").join(", ");
+  return db
+    .query(
+      `SELECT r.run_id, r.spec_json, res.result_json,
+              e.correlation_id, e.event_id AS origin_event_id, e.source AS origin_source
+       FROM runs r
+       JOIN results res ON res.run_id = r.run_id AND res.attempt = r.attempts
+       JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
+       JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+       WHERE r.state = 'COMPLETED'
+         AND json_extract(r.spec_json, '$.agent') IN (${placeholders})
+         AND NOT EXISTS (
+           SELECT 1 FROM events ce
+           WHERE ce.source = '${CHAIN_SOURCE}' AND ce.event_id = 'chain-' || r.run_id
+         )`,
+    )
+    .all(...agents);
+}
+
+/**
+ * One deterministic pass: emit the chain event for every eligible completed
+ * run. Idempotent — the derived eventId dedups at intake, and candidates
+ * with an existing chain event are excluded up front.
+ *
+ * @returns {{ emitted: number, skipped: number, errors: string[] }}
+ */
+export function resolveChains(db, registry, { now = Date.now() } = {}) {
+  const edges = registry.edges ?? {};
+  const outcome = { emitted: 0, skipped: 0, errors: [] };
+
+  for (const row of chainCandidates(db, edges)) {
+    const spec = JSON.parse(row.spec_json);
+    const result = JSON.parse(row.result_json);
+    const rule = edges[spec.agent];
+    try {
+      const recommendation = result.artifact?.[rule.recommendationField];
+      const edge = rule.edges[recommendation];
+      if (edge === undefined) {
+        // An unmapped value is a legitimate terminal — record nothing, chain nothing.
+        outcome.skipped += 1;
+        continue;
+      }
+      const envelope = {
+        schemaVersion: "factory.event/v1",
+        eventId: `chain-${row.run_id}`,
+        type: edge.eventType,
+        source: CHAIN_SOURCE,
+        subject: spec.agent,
+        occurredAt: new Date(now).toISOString(),
+        correlationId: row.correlation_id ?? row.origin_event_id,
+        causationId: row.run_id,
+        payload: buildChainInput(edge.input, { input: spec.input, artifact: result.artifact ?? {} }),
+      };
+      const admitted = admitEvent(db, registry, envelope, { now });
+      if (admitted.admitted) outcome.emitted += 1;
+      else if (admitted.duplicate) outcome.skipped += 1;
+      else outcome.errors.push(`chain-${row.run_id}: ${admitted.errors.join("; ")}`);
+    } catch (err) {
+      outcome.errors.push(`chain-${row.run_id}: ${err.message}`);
+    }
+  }
+  return outcome;
+}

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { cpSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./adapters/fake.mjs";
+import { buildChainInput, resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry, RegistryError } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+
+function failedRunEnvelope(overrides = {}) {
+  const id = overrides.eventId ?? `gh-${Math.random().toString(36).slice(2, 10)}`;
+  return {
+    schemaVersion: "factory.event/v1",
+    eventId: id,
+    type: "github.workflow-run.failed",
+    source: "github",
+    subject: "ci",
+    occurredAt: "2026-08-12T10:00:00Z",
+    correlationId: id,
+    causationId: null,
+    payload: { repo: "wm/factory", runId: 12345 },
+    ...overrides,
+  };
+}
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-ws-"));
+  // Chain flow under test never spawns real processes: claude AND command
+  // both back onto the contract-shaped fake.
+  const adapters = { claude: fake, command: fake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function runToCompletion(eventId) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find(
+      (p) => p.decision === "run" && (p.event_id === eventId || p.spec?.idempotencyKey),
+    );
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    expect(approved.approved).toBe(true);
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    expect(summary.terminalState).toBe("COMPLETED");
+    return { proposal, runId: approved.runId };
+  }
+
+  return { db, adapters, workerOpts, runToCompletion };
+}
+
+describe("buildChainInput", () => {
+  const context = { input: { repo: "wm/x", runId: 7 }, artifact: { verdict: "FLAKE", nested: { a: 1 } } };
+
+  test("resolves $.input.* and $.artifact.* paths and passes literals through", () => {
+    expect(
+      buildChainInput({ repo: "$.input.repo", v: "$.artifact.verdict", deep: "$.artifact.nested.a", lit: "x" }, context),
+    ).toEqual({ repo: "wm/x", v: "FLAKE", deep: 1, lit: "x" });
+  });
+
+  test("missing path fails loudly", () => {
+    expect(() => buildChainInput({ nope: "$.artifact.absent" }, context)).toThrow("resolves to nothing");
+  });
+});
+
+describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
+  test("FLAKE verdict chains to a watched ci-rerun proposal with inherited correlation", async () => {
+    const { db, runToCompletion } = harness();
+    const envelope = failedRunEnvelope({ eventId: "gh-flake-1" });
+    expect(admitEvent(db, registry, envelope).admitted).toBe(true);
+    const { runId } = await runToCompletion("gh-flake-1");
+
+    const outcome = resolveChains(db, registry);
+    expect(outcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
+
+    // The chain event went through the same intake, with provenance.
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${runId}`);
+    expect(chainEvent.type).toBe("factory.ci-rerun.requested");
+    expect(chainEvent.correlation_id).toBe("gh-flake-1");
+    expect(chainEvent.causation_id).toBe(runId);
+
+    // The planner proposes the follow-up — open and watched, not auto-run.
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-rerun@1");
+    expect(followUp).toBeTruthy();
+    expect(followUp.status).toBe("open");
+    expect(followUp.spec.adapter).toBe("command");
+    expect(followUp.spec.input).toEqual({ repo: "wm/factory", runId: 12345 });
+
+    // Re-resolving chains emits nothing new: the already-chained run is
+    // excluded up front (NOT EXISTS on its chain event) — one event per run, ever.
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+  });
+
+  test("TICKET verdict chains to ci-notify with the diagnosis summary mapped in", async () => {
+    const { db, runToCompletion } = harness();
+    admitEvent(db, registry, failedRunEnvelope({
+      eventId: "gh-ticket-1",
+      payload: { repo: "wm/factory-ticket", runId: 777 },
+    }));
+    await runToCompletion("gh-ticket-1");
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-notify@1");
+    expect(followUp).toBeTruthy();
+    expect(followUp.spec.input.summary).toContain("wm/factory-ticket");
+  });
+
+  test("full chain executes after approval: rerun completes under the command contract", async () => {
+    const { db, runToCompletion, adapters, workerOpts } = harness();
+    admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-flake-2", payload: { repo: "wm/f2", runId: 2 } }));
+    await runToCompletion("gh-flake-2");
+    resolveChains(db, registry);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+
+    const followUp = openProposals(db, {}).find((p) => p.spec?.agent === "ci-rerun@1");
+    const approved = approveProposal(db, registry, followUp.id, { actor: "operator", policyVersion: PV });
+    expect(approved.approved).toBe(true);
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    expect(summary.terminalState).toBe("COMPLETED");
+
+    // The command result has no registered edges — the chain terminates.
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+  });
+
+  test("duplicate failed-run delivery converges: one doctor run, one chain event", async () => {
+    const { db, runToCompletion } = harness();
+    admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
+    const dup = admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
+    expect(dup.duplicate).toBe(true);
+    await runToCompletion("gh-dup-1");
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    expect(resolveChains(db, registry).emitted).toBe(0);
+  });
+});
+
+describe("registry gates (OPS-223)", () => {
+  test("command definitions with mutating: true are admitted; the loaded registry proves it", () => {
+    expect(registry.agents.get("ci-rerun@1").mutating).toBe(true);
+    expect(registry.agents.get("ci-rerun@1").command[0]).toBe("gh");
+  });
+
+  test("edges validation fails closed: unregistered targets and stray input roots", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-reg-"));
+    cpSync(path.join(registry.root, "agents"), path.join(root, "agents"), { recursive: true });
+    cpSync(path.join(registry.root, "schemas"), path.join(root, "schemas"), { recursive: true });
+    cpSync(path.join(registry.root, "event-types.json"), path.join(root, "event-types.json"));
+
+    writeFileSync(
+      path.join(root, "edges.json"),
+      JSON.stringify({ "ci-doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "not.registered", input: {} } } } }),
+    );
+    expect(() => loadRegistry({ root })).toThrow(RegistryError);
+
+    writeFileSync(
+      path.join(root, "edges.json"),
+      JSON.stringify({ "ci-doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "factory.ci-rerun.requested", input: { x: "$.secrets.key" } } } } }),
+    );
+    expect(() => loadRegistry({ root })).toThrow("only $.input.* and $.artifact.*");
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -8,7 +8,7 @@
  * promptVersion is provenance recorded at planning time, not a second
  * identity.
  */
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { hashBytes } from "./canonical.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
@@ -27,8 +27,17 @@ function loadAgentDef(root, file) {
   for (const field of ["id", "version", ...PINNED_FIELDS, "workspace", "capabilities", "limits"]) {
     if (def[field] === undefined) throw new RegistryError(`${file}: missing "${field}"`);
   }
+  // §14 enforcement path: a mutating definition is admitted only when it is
+  // enforceable by construction — a fixed argv template (the closed action
+  // registry), never a model. LLM agents stay read-only in the MVP (§3).
   if (def.mutating !== false) {
-    throw new RegistryError(`${file}: mutating agents are not admitted in the MVP (docs/event-runtime.md §3)`);
+    const closedTemplate =
+      Array.isArray(def.command) && def.command.length > 0 && def.command.every((e) => typeof e === "string");
+    if (!closedTemplate) {
+      throw new RegistryError(
+        `${file}: mutating agents are admitted only as closed command templates (docs/event-runtime.md §14; OPS-223)`,
+      );
+    }
   }
   const pins = def.pins ?? {};
   for (const field of PINNED_FIELDS) {
@@ -78,7 +87,32 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
     agentResult: JSON.parse(readFileSync(path.join(root, "schemas", "factory.agent-result.v1.json"), "utf8")),
   };
 
-  return { root, agents, eventTypes, schemas };
+  // Recommendation edges (OPS-223): validated fail-closed at load — a chain
+  // may only connect registered agents through registered event types, and
+  // input mappings may only draw from the source run's input or artifact.
+  let edges = {};
+  const edgesFile = path.join(root, "edges.json");
+  if (existsSync(edgesFile)) {
+    edges = JSON.parse(readFileSync(edgesFile, "utf8"));
+    for (const [agentRef, rule] of Object.entries(edges)) {
+      if (!agents.has(agentRef)) throw new RegistryError(`edges.json: unregistered source agent ${agentRef}`);
+      if (typeof rule.recommendationField !== "string" || !rule.recommendationField) {
+        throw new RegistryError(`edges.json: ${agentRef} has no recommendationField`);
+      }
+      for (const [value, edge] of Object.entries(rule.edges ?? {})) {
+        if (!eventTypes[edge.eventType]) {
+          throw new RegistryError(`edges.json: ${agentRef}.${value} targets unregistered event type ${edge.eventType}`);
+        }
+        for (const expr of Object.values(edge.input ?? {})) {
+          if (typeof expr === "string" && expr.startsWith("$.") && !/^\$\.(input|artifact)(\.|$)/.test(expr)) {
+            throw new RegistryError(`edges.json: ${agentRef}.${value} input path "${expr}" — only $.input.* and $.artifact.* are allowed`);
+          }
+        }
+      }
+    }
+  }
+
+  return { root, agents, eventTypes, schemas, edges };
 }
 
 export function getAgent(registry, ref) {

--- a/event-runtime/schemas/ci-doctor.input.json
+++ b/event-runtime/schemas/ci-doctor.input.json
@@ -1,0 +1,12 @@
+{
+  "title": "ci-doctor input — one failed GitHub Actions run",
+  "type": "object",
+  "required": ["repo", "runId"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
+    "runId": { "type": ["string", "integer"] },
+    "headSha": { "type": "string" },
+    "workflowName": { "type": "string" }
+  }
+}

--- a/event-runtime/schemas/ci-doctor.output.json
+++ b/event-runtime/schemas/ci-doctor.output.json
@@ -1,0 +1,17 @@
+{
+  "title": "factory.ci-doctor/v1 output artifact — typed CI failure diagnosis",
+  "type": "object",
+  "required": ["verdict", "culprit", "summary", "evidenceLines"],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": { "enum": ["TICKET", "ENV", "FLAKE"] },
+    "culprit": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "evidenceLines": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "suggestedFix": { "type": "string" }
+  }
+}

--- a/event-runtime/schemas/ci-notify.input.json
+++ b/event-runtime/schemas/ci-notify.input.json
@@ -1,0 +1,11 @@
+{
+  "title": "ci-notify input — the diagnosis to escalate",
+  "type": "object",
+  "required": ["repo", "runId", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
+    "runId": { "type": ["string", "integer"] },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}

--- a/event-runtime/schemas/ci-rerun.input.json
+++ b/event-runtime/schemas/ci-rerun.input.json
@@ -1,0 +1,10 @@
+{
+  "title": "ci-rerun input — the run to re-run",
+  "type": "object",
+  "required": ["repo", "runId"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
+    "runId": { "type": ["string", "integer"] }
+  }
+}

--- a/event-runtime/schemas/command-result.output.json
+++ b/event-runtime/schemas/command-result.output.json
@@ -1,0 +1,15 @@
+{
+  "title": "factory.command-result/v1 output artifact — one executed closed-registry command",
+  "type": "object",
+  "required": ["command", "exitCode"],
+  "additionalProperties": false,
+  "properties": {
+    "command": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "exitCode": { "const": 0 },
+    "outputTail": { "type": "string" }
+  }
+}


### PR DESCRIPTION
Fixes OPS-223

First discovered chain per docs/event-runtime-workers.md §5: completed runs with registered recommendation edges emit internal events through the same intake (`chain-<runId>`, once per run ever, correlation inherited, causation = source run); the planner proposes follow-ups, watched. Mutating definitions are admitted only as closed argv templates (command adapter — §14 enforcement by construction). Chain: `github.workflow-run.failed` → ci-doctor verdict → FLAKE|ENV → ci-rerun / TICKET → ci-notify.

Verification: 129 tests green (`bun test event-runtime/`); live end-to-end in an isolated worktree runtime — inject failed-run event → doctor COMPLETED → chain event → watched ci-rerun proposal → approved → COMPLETED.