### PR TITLE
feat(event-runtime): slice 2 — disk alert diagnose → approved remediation, evidence-verified

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -56,7 +56,7 @@ machinery it earns. Anything no listed event type needs stays unbuilt.
 | Event type | Source | Machinery it earns | When |
 | :--- | :--- | :--- | :--- |
 | `factory.status-report.requested` | operator webhook / replay CLI | intake, dedup, planner, approval, ephemeral workspace, schema verification, receipts | slice 1 |
-| `keephq.disk-alert.raised` | Keep HQ infra alert webhook | two-node DAG (diagnose → remediate), semantic verification against declared evidence (`evidenceSetHash`), typed remediation plans from a **closed action registry**, first infra-mutating executor behind watched approval (OPS-208) | slice 2 |
+| `keephq.disk-alert.raised` | Keep HQ infra alert webhook / replay CLI | two-node chain (diagnose → remediate) via the discovered-chain machinery, semantic verification recomputing reclaimed bytes from before/after probe evidence, typed remediation plans from a **closed action registry** (`lib/adapters/actions.mjs`), first infra-mutating executor behind watched approval (OPS-208) | shipped (watched) |
 | `github.workflow-run.failed` | GitHub webhook / replay CLI | first discovered chain (OPS-223): typed `ci-doctor` diagnosis → recommendation edges → watched closed-command follow-ups (`gh run rerun`, notify); command adapter and edge registry | shipped |
 | `sentry.issue.created` | Sentry webhook | *(dropped as a slice — Sentry already feeds Linear directly, so classifying here validates nothing operationally new; revisit only if that intake moves)* | — |
 | `clock.tick.<loop>` | scheduler | admitted, audited timer events; per-loop migration of the standing loops | later, per loop |

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -67,6 +67,21 @@ recommends `FLAKE|ENV → ci-rerun@1` (closed command template
 are admitted only as closed command templates (`lib/adapters/command.mjs`) —
 enforceable by construction, no shell, no model (§14).
 
+## Slice 2: disk alert → diagnose → approved remediation (OPS-208)
+
+`keephq.disk-alert.raised` (payload `{host, mount, usedPct, alertId}`; dedup
+on host+alertId via subject+correlationId) → `disk-diagnose@1` re-measures
+the disk over read-only SSH — a webhook is a hint, not truth — and produces a
+typed plan: `NOOP` (stale alert, chain ends) or `REMEDIATE` with action IDs
+from the closed registry. The REMEDIATE edge chains to `disk-remediate@1`
+(actions adapter): the operator approves the **concrete action list**, the
+executor resolves IDs to fixed remote commands (`docker builder prune`,
+`docker system prune`, `journalctl --vacuum-time=3d`) over SSH to the host
+allowlist (`lab`, `web`), probes `df` before/after, and the verifier
+**recomputes reclaimed bytes from the probe evidence** — a claim that does
+not match is a ContractViolation, not a success. An unregistered action ID
+refuses before executing anything.
+
 ## Demo environments and e2e (OPS-217)
 
 `bin/worktree-up.sh` provisions an **isolated, seeded** runtime — the part
@@ -142,6 +157,7 @@ spec (§12).
 | `lib/worker.mjs` | single worker: lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
+| `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |
 | `lib/chain.mjs` `edges.json` | discovered chains: typed recommendation → internal event → watched proposal (OPS-223) |
 | `lib/adapters/command.mjs` | closed-template command executor — the only admissible mutating agent form (§14) |
 | `lib/artifacts.mjs` | content-addressed artifact/transcript store, streamed via `GET /artifacts/:sha256` |

--- a/event-runtime/agents/disk-diagnose.json
+++ b/event-runtime/agents/disk-diagnose.json
@@ -1,0 +1,29 @@
+{
+  "id": "disk-diagnose",
+  "version": 1,
+  "prompt": "agents/disk-diagnose.md",
+  "input_schema": "schemas/disk-diagnose.input.json",
+  "output_schema": "schemas/disk-diagnose.output.json",
+  "output_contract": "factory.disk-diagnosis/v1",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "ssh:read:lab",
+      "ssh:read:web"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/disk-diagnose.md": "sha256:606e047275affafd71a93fd167348836e6c76a5fa16982ac8d07b0c2b2e63098",
+    "schemas/disk-diagnose.input.json": "sha256:e97b9b0bf65fdc4ae621cf23acf1b83710f9c2e74d2c8955f4ac532a67146f64",
+    "schemas/disk-diagnose.output.json": "sha256:934dfbd1a4e72ec1de1d1d1f85cfcbdd8a5dbbb3a779e8df1c70d9d68bd77ce7"
+  }
+}

--- a/event-runtime/agents/disk-diagnose.md
+++ b/event-runtime/agents/disk-diagnose.md
@@ -1,0 +1,61 @@
+# disk-diagnose — verify a disk alert and propose a typed remediation plan
+
+You are an infrastructure diagnostician. `./input.json` describes a Keep HQ
+disk alert: `{ "host": "<name>", "mount": "<path>", "usedPct": <n>, "alertId": "<id>" }`.
+A webhook is a hint, not truth: your first job is to measure the actual disk
+state now. Write `./result.json`. You are strictly read-only — you never
+delete, prune, vacuum, restart, or modify anything. Work only inside this
+directory.
+
+## Host access (allowlist — nothing else)
+
+| host | ssh target |
+| :--- | :--- |
+| lab | `root@100.110.36.96` |
+| web | `hdkiller@100.93.81.56` |
+
+## Method — read-only commands only
+
+1. `ssh <target> "df --output=used,size,pcent -B1 <mount>"` — current truth.
+2. If genuinely full (≥ 85% measured now), find where the bytes are:
+   `ssh <target> "docker system df"`, `ssh <target> "journalctl --disk-usage"`,
+   `ssh <target> "du -x -d1 -B1 /var/lib/docker 2>/dev/null | sort -n | tail -5"`.
+3. Build the plan **only** from these registered action IDs:
+   - `docker-builder-prune` — build cache (usually the big one on CI runners)
+   - `docker-system-prune` — dangling images/containers/networks
+   - `journal-vacuum-3d` — journald logs beyond 3 days
+
+## Output
+
+Measured usage below 85% → the alert is stale; recommend NOOP:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": { "recommendation": "NOOP", "mount": "/", "usedPct": 62, "plan": [], "analysis": "disk healthy at diagnose time — stale alert" },
+  "evidence": { "commands": ["..."], "outputs": { "df": "..." } }
+}
+```
+
+Genuinely full → recommend REMEDIATE with the concrete plan (largest expected
+reclaim first, `expectedReclaimBytes` from the evidence you gathered):
+
+```json
+{
+  "artifact": {
+    "recommendation": "REMEDIATE",
+    "mount": "/",
+    "usedPct": 93,
+    "plan": [{ "action": "docker-builder-prune", "expectedReclaimBytes": 12000000000 }],
+    "analysis": "one sentence: what is eating the disk"
+  },
+  "evidence": { "commands": ["every ssh command you ran"], "outputs": { "df": "...", "dockerDf": "..." } }
+}
+```
+
+Unknown host, unreachable host, or disk full of something no registered
+action addresses → refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.
+Never invent action IDs; never propose free-form commands.

--- a/event-runtime/agents/disk-remediate.json
+++ b/event-runtime/agents/disk-remediate.json
@@ -1,0 +1,54 @@
+{
+  "id": "disk-remediate",
+  "version": 1,
+  "prompt": "agents/disk-remediate.md",
+  "input_schema": "schemas/disk-remediate.input.json",
+  "output_schema": "schemas/disk-remediation.output.json",
+  "output_contract": "factory.disk-remediation/v1",
+  "exec": [
+    "ssh",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=10",
+    "{target}",
+    "{remote}"
+  ],
+  "hosts": {
+    "lab": "root@100.110.36.96",
+    "web": "hdkiller@100.93.81.56"
+  },
+  "probeRemote": "df --output=used -B1 {mount} | tail -1",
+  "actionRegistry": {
+    "docker-builder-prune": {
+      "remote": "sudo docker builder prune -af"
+    },
+    "docker-system-prune": {
+      "remote": "sudo docker system prune -af"
+    },
+    "journal-vacuum-3d": {
+      "remote": "sudo journalctl --vacuum-time=3d"
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "infra:exec:lab",
+      "infra:exec:web"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/disk-remediate.md": "sha256:f886a34a264a2c83356b9e5cc5a96df7e994dbbbebd278afa5b4564c4b99c1e8",
+    "schemas/disk-remediate.input.json": "sha256:35468a6619856bdb6b751260f941c770b9dab144a0881cf4cdd3eac0a759966f",
+    "schemas/disk-remediation.output.json": "sha256:2ead535aeab711c998a5f074ff0408acd9799ff18d95635f66bbde6116efb806"
+  }
+}

--- a/event-runtime/agents/disk-remediate.md
+++ b/event-runtime/agents/disk-remediate.md
@@ -1,0 +1,20 @@
+# disk-remediate — closed action-list executor
+
+Not a prompt: this definition executes an **approved action list** via the
+deterministic actions adapter (`lib/adapters/actions.mjs`). No model runs.
+
+Registered actions (the closed registry — nothing else can execute):
+
+| action id | remote command |
+| :--- | :--- |
+| `docker-builder-prune` | `sudo docker builder prune -af` |
+| `docker-system-prune` | `sudo docker system prune -af` |
+| `journal-vacuum-3d` | `sudo journalctl --vacuum-time=3d` |
+
+Host allowlist: `lab` (`root@100.110.36.96`), `web` (`hdkiller@100.93.81.56`).
+
+The adapter probes `df --output=used -B1 <mount>` before and after, records
+raw probe output as evidence, and the verifier **recomputes** reclaimed bytes
+from that evidence (§9 semantic verification) — a claim that does not match
+the probes is a ContractViolation, not a success. An action ID outside the
+table above refuses before executing anything.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -14,6 +14,7 @@
  * runtime state.
  */
 import { readFileSync } from "node:fs";
+import * as actions from "./lib/adapters/actions.mjs";
 import * as claude from "./lib/adapters/claude.mjs";
 import * as command from "./lib/adapters/command.mjs";
 import * as fake from "./lib/adapters/fake.mjs";
@@ -88,7 +89,7 @@ async function serve(args) {
   const port = flagValue(args, "--port") ? Number(flagValue(args, "--port")) : DEFAULT_PORT;
   if (!Number.isInteger(port) || port < 0) fail(`serve: invalid --port ${flagValue(args, "--port")}`);
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  const adapters = { claude, command, fake };
+  const adapters = { actions, claude, command, fake };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`serve: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -4,15 +4,38 @@
     "edges": {
       "FLAKE": {
         "eventType": "factory.ci-rerun.requested",
-        "input": { "repo": "$.input.repo", "runId": "$.input.runId" }
+        "input": {
+          "repo": "$.input.repo",
+          "runId": "$.input.runId"
+        }
       },
       "ENV": {
         "eventType": "factory.ci-rerun.requested",
-        "input": { "repo": "$.input.repo", "runId": "$.input.runId" }
+        "input": {
+          "repo": "$.input.repo",
+          "runId": "$.input.runId"
+        }
       },
       "TICKET": {
         "eventType": "factory.ci-escalate.requested",
-        "input": { "repo": "$.input.repo", "runId": "$.input.runId", "summary": "$.artifact.summary" }
+        "input": {
+          "repo": "$.input.repo",
+          "runId": "$.input.runId",
+          "summary": "$.artifact.summary"
+        }
+      }
+    }
+  },
+  "disk-diagnose@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "REMEDIATE": {
+        "eventType": "keephq.disk-remediate.requested",
+        "input": {
+          "host": "$.input.host",
+          "mount": "$.artifact.mount",
+          "actions": "$.artifact.plan"
+        }
       }
     }
   }

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -2,25 +2,51 @@
   "factory.status-report.requested": {
     "agent": "factory-status-report@1",
     "adapter": "claude",
-    "idempotencyScope": ["correlationId", "inputHash"],
+    "idempotencyScope": [
+      "correlationId",
+      "inputHash"
+    ],
     "proposalTtlSeconds": 1800
   },
   "github.workflow-run.failed": {
     "agent": "ci-doctor@1",
     "adapter": "claude",
-    "idempotencyScope": ["inputHash"],
+    "idempotencyScope": [
+      "inputHash"
+    ],
     "proposalTtlSeconds": 1800
   },
   "factory.ci-rerun.requested": {
     "agent": "ci-rerun@1",
     "adapter": "command",
-    "idempotencyScope": ["inputHash"],
+    "idempotencyScope": [
+      "inputHash"
+    ],
     "proposalTtlSeconds": 1800
   },
   "factory.ci-escalate.requested": {
     "agent": "ci-notify@1",
     "adapter": "command",
-    "idempotencyScope": ["inputHash"],
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "keephq.disk-alert.raised": {
+    "agent": "disk-diagnose@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "subject",
+      "correlationId"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "keephq.disk-remediate.requested": {
+    "agent": "disk-remediate@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
     "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -1,0 +1,137 @@
+/**
+ * Closed action-list executor (docs/event-runtime.md §11, §14; OPS-208).
+ *
+ * Slice 2's remediation node: executes an *approved list of action IDs*, each
+ * resolved to a fixed remote command from the definition's action registry —
+ * the model proposed the plan, the operator approved the concrete list, and
+ * this code executes exactly the registered templates, nothing else. An
+ * unregistered action ID, unknown host, or missing probe fails the attempt
+ * before any action runs.
+ *
+ * The definition declares:
+ *   exec           argv template reaching the host: ["ssh","-o","BatchMode=yes","{target}","{remote}"]
+ *   hosts          { hostName: sshTarget } — the host allowlist, closed
+ *   probeRemote    fixed remote command measuring used bytes ({mount} substitutable)
+ *   actionRegistry { actionId: { remote: "<fixed remote command>" } }
+ *
+ * Evidence discipline (§9): the probe runs before and after; raw outputs go
+ * into evidence, derived numbers into the artifact, and the verifier
+ * recomputes reclaimedBytes from the evidence — a wrong claim fails closed.
+ */
+import { spawnSync } from "node:child_process";
+import { appendFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const OUTPUT_TAIL_CHARS = 2_000;
+
+/** {mount}-style substitution in a remote command string; fields are schema-validated at plan time. */
+function substituteRemote(remote, input) {
+  return remote.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
+    const value = input?.[field];
+    if (value === undefined || value === null || !["string", "number"].includes(typeof value)) {
+      throw new Error(`remote template references missing/non-primitive input field "${field}"`);
+    }
+    return String(value);
+  });
+}
+
+function buildArgv(exec, target, remote) {
+  return exec.map((element) => element.replace("{target}", target).replace("{remote}", remote));
+}
+
+/** Last integer in probe output — `df --output=used -B1 <mount> | tail -1`. */
+function probeBytes(raw) {
+  const match = String(raw ?? "").trim().match(/(\d+)\s*$/);
+  if (!match) throw new Error(`probe output has no byte count: "${String(raw).slice(0, 120)}"`);
+  return Number(match[1]);
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
+ */
+export async function execute({ spec, def, workspaceDir, timeoutMs }) {
+  const log = path.join(workspaceDir, ".actions.log");
+  const fail = (message) => {
+    appendFileSync(log, `REFUSED before execution: ${message}\n`, "utf8");
+    return { exitCode: 1, timedOut: false };
+  };
+
+  const input = spec.input ?? {};
+  const exec = def.exec;
+  if (!Array.isArray(exec) || exec.length === 0) return fail(`definition ${def.ref} has no exec template`);
+  const target = def.hosts?.[input.host];
+  if (!target) return fail(`host "${input.host}" is not in the definition's host allowlist`);
+
+  // Resolve EVERYTHING before executing ANYTHING — an unregistered action ID
+  // in the approved plan is a refusal, not a partial execution (OPS-208 AC).
+  let probeRemote;
+  const actionCommands = [];
+  try {
+    probeRemote = substituteRemote(def.probeRemote, input);
+    for (const entry of input.actions ?? []) {
+      const registered = def.actionRegistry?.[entry.action];
+      if (!registered) throw new Error(`action "${entry.action}" is not in the closed action registry`);
+      actionCommands.push({ id: entry.action, remote: substituteRemote(registered.remote, input) });
+    }
+    if (actionCommands.length === 0) throw new Error("empty action list");
+  } catch (err) {
+    return fail(err.message);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  const outputs = {};
+  const run = (label, remote) => {
+    const budget = Math.max(1000, deadline - Date.now());
+    const proc = spawnSync(buildArgv(exec, target, remote)[0], buildArgv(exec, target, remote).slice(1), {
+      encoding: "utf8",
+      timeout: budget,
+    });
+    const raw = `${proc.stdout ?? ""}${proc.stderr ?? ""}`;
+    outputs[label] = raw.slice(-OUTPUT_TAIL_CHARS);
+    appendFileSync(log, `$ ${label}: ${remote}\n${outputs[label]}\n`, "utf8");
+    if (proc.error?.code === "ETIMEDOUT") throw Object.assign(new Error(`${label} timed out`), { timedOut: true });
+    if (proc.status !== 0) throw new Error(`${label} exited ${proc.status}`);
+    return proc.stdout ?? "";
+  };
+
+  try {
+    const probeBefore = run("probe-before", probeRemote);
+    for (const action of actionCommands) run(action.id, action.remote);
+    const probeAfter = run("probe-after", probeRemote);
+
+    const beforeUsedBytes = probeBytes(probeBefore);
+    const afterUsedBytes = probeBytes(probeAfter);
+    writeFileSync(
+      path.join(workspaceDir, "result.json"),
+      `${JSON.stringify(
+        {
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "completed",
+          reasonCode: "ok",
+          artifact: {
+            host: input.host,
+            mount: input.mount,
+            actions: actionCommands.map((a) => a.id),
+            beforeUsedBytes,
+            afterUsedBytes,
+            reclaimedBytes: beforeUsedBytes - afterUsedBytes,
+          },
+          evidence: {
+            probeBefore,
+            probeAfter,
+            commands: [probeRemote, ...actionCommands.map((a) => a.remote)],
+            outputs,
+          },
+          artifacts: [{ kind: "log", path: ".actions.log" }],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    return { exitCode: 0, timedOut: false };
+  } catch (err) {
+    appendFileSync(log, `FAILED: ${err.message}\n`, "utf8");
+    return { exitCode: 1, timedOut: err.timedOut === true };
+  }
+}

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -53,6 +53,45 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env }) {
     });
     return { exitCode: 0, timedOut: false };
   }
+  if (spec.outputContract === "factory.disk-diagnosis/v1") {
+    // Stale-alert semantics ride on the alert's own number: < 85% → NOOP.
+    const stale = (spec.input?.usedPct ?? 100) < 85;
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: stale
+        ? { recommendation: "NOOP", mount: spec.input.mount, usedPct: spec.input.usedPct, plan: [], analysis: "fake: disk healthy at diagnose time" }
+        : {
+            recommendation: "REMEDIATE",
+            mount: spec.input.mount,
+            usedPct: spec.input.usedPct,
+            plan: [{ action: "docker-builder-prune", expectedReclaimBytes: 1_000_000 }],
+            analysis: "fake: docker build cache is eating the disk",
+          },
+      evidence: { commands: ["fake df"], outputs: { df: "fake" } },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.disk-remediation/v1") {
+    // mount "/bad" → a lying artifact, so tests can prove the verifier fails closed.
+    const lying = spec.input?.mount === "/bad";
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        host: spec.input.host,
+        mount: spec.input.mount,
+        actions: (spec.input.actions ?? []).map((a) => a.action),
+        beforeUsedBytes: 5_000_000,
+        afterUsedBytes: 4_000_000,
+        reclaimedBytes: lying ? 9_999_999 : 1_000_000,
+      },
+      evidence: { probeBefore: "5000000", probeAfter: "4000000", commands: ["fake"], outputs: {} },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
   if (spec.outputContract === "factory.command-result/v1") {
     writeResult(workspaceDir, {
       schemaVersion: "factory.agent-result/v1",

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -31,11 +31,17 @@ function loadAgentDef(root, file) {
   // enforceable by construction — a fixed argv template (the closed action
   // registry), never a model. LLM agents stay read-only in the MVP (§3).
   if (def.mutating !== false) {
-    const closedTemplate =
+    const closedArgv =
       Array.isArray(def.command) && def.command.length > 0 && def.command.every((e) => typeof e === "string");
-    if (!closedTemplate) {
+    const closedActionRegistry =
+      def.actionRegistry !== undefined &&
+      def.hosts !== undefined &&
+      Array.isArray(def.exec) &&
+      Object.values(def.actionRegistry).every((a) => typeof a?.remote === "string") &&
+      Object.values(def.hosts).every((t) => typeof t === "string");
+    if (!closedArgv && !closedActionRegistry) {
       throw new RegistryError(
-        `${file}: mutating agents are admitted only as closed command templates (docs/event-runtime.md §14; OPS-223)`,
+        `${file}: mutating agents are admitted only as closed command templates or closed action registries (docs/event-runtime.md §14; OPS-223/OPS-208)`,
       );
     }
   }

--- a/event-runtime/lib/slice2.test.mjs
+++ b/event-runtime/lib/slice2.test.mjs
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as actions from "./adapters/actions.mjs";
+import * as fake from "./adapters/fake.mjs";
+import { resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+
+function alertEnvelope(overrides = {}) {
+  const id = overrides.alertId ?? `alert-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    schemaVersion: "factory.event/v1",
+    eventId: `keep-${id}`,
+    type: "keephq.disk-alert.raised",
+    source: "keephq",
+    subject: overrides.host ?? "lab",
+    occurredAt: "2026-08-12T22:00:00Z",
+    correlationId: id,
+    causationId: null,
+    payload: {
+      host: overrides.host ?? "lab",
+      mount: overrides.mount ?? "/",
+      usedPct: overrides.usedPct ?? 93,
+      alertId: id,
+    },
+  };
+}
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-ws-"));
+  const adapters = { claude: fake, actions: fake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    expect(approved.approved).toBe(true);
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+describe("slice 2: disk alert → diagnose → approved remediation (OPS-208)", () => {
+  test("full two-node chain, evidence-verified reclaim", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, alertEnvelope({ alertId: "a1", usedPct: 93 }));
+
+    const diagnose = await approveNext("disk-diagnose@1");
+    expect(diagnose.summary.terminalState).toBe("COMPLETED");
+
+    // REMEDIATE recommendation → chain event → watched remediation proposal.
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const remedProposal = openProposals(db, {}).find((p) => p.spec?.agent === "disk-remediate@1");
+    expect(remedProposal.status).toBe("open"); // AC: no node B without approval
+    expect(remedProposal.spec.input).toEqual({
+      host: "lab",
+      mount: "/",
+      actions: [{ action: "docker-builder-prune", expectedReclaimBytes: 1_000_000 }],
+    });
+
+    const remediate = await approveNext("disk-remediate@1");
+    expect(remediate.summary.terminalState).toBe("COMPLETED");
+
+    const result = db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(remediate.runId);
+    const parsed = JSON.parse(result.result_json);
+    expect(parsed.artifact.reclaimedBytes).toBe(1_000_000);
+    expect(parsed.verification.checks).toContain("evidence_recomputed");
+    expect(parsed.evidenceSetHash).toMatch(/^sha256:/);
+
+    // Remediation result has no registered edges — the chain terminates.
+    expect(resolveChains(db, registry).emitted).toBe(0);
+  });
+
+  test("stale alert (healthy at diagnose time) → NOOP, no remediation proposed", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, alertEnvelope({ alertId: "a2", usedPct: 41 }));
+    const diagnose = await approveNext("disk-diagnose@1");
+    expect(diagnose.summary.terminalState).toBe("COMPLETED");
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "disk-remediate@1")).toBeUndefined();
+  });
+
+  test("duplicate alert (same host+alertId) → one run", async () => {
+    const { db } = harness();
+    admitEvent(db, registry, alertEnvelope({ alertId: "a3", usedPct: 93 }));
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    // Re-fired alert: same alertId/host, different usedPct — must converge.
+    admitEvent(db, registry, { ...alertEnvelope({ alertId: "a3", usedPct: 97 }), eventId: "keep-a3-refire" });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("a lying artifact fails closed: verifier recomputes reclaim from evidence", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, alertEnvelope({ alertId: "a4", mount: "/bad", usedPct: 95 }));
+    await approveNext("disk-diagnose@1");
+    resolveChains(db, registry);
+    const remediate = await approveNext("disk-remediate@1");
+    expect(remediate.summary.terminalState).toBe("FAILED");
+    expect(remediate.summary.reasonCode).toBe("contract_violation");
+    // The journal carries the recomputation detail.
+    const journal = db
+      .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
+      .get(remediate.runId);
+    expect(journal.reason).toContain("evidence_mismatch: reclaimedBytes 9999999 != recomputed 1000000");
+  });
+});
+
+describe("actions adapter (OPS-208)", () => {
+  // A local stand-in for ssh: exec = ["sh", "-c", "{remote}"] runs the remote
+  // string in a local shell, so probes and actions are real but harmless.
+  function localDef(dir) {
+    return {
+      ref: "test-actions@1",
+      exec: ["sh", "-c", "{remote}"],
+      hosts: { testhost: "unused-target" },
+      probeRemote: `wc -c < ${dir}/blob | tr -d ' '`,
+      actionRegistry: {
+        shrink: { remote: `truncate -s 400 ${dir}/blob` },
+      },
+    };
+  }
+
+  test("probes before/after, executes registered actions, artifact matches evidence", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+
+    const outcome = await actions.execute({
+      spec: { input: { host: "testhost", mount: "/", actions: [{ action: "shrink" }] } },
+      def: localDef(dir),
+      workspaceDir,
+      timeoutMs: 10_000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact.beforeUsedBytes).toBe(1000);
+    expect(result.artifact.afterUsedBytes).toBe(400);
+    expect(result.artifact.reclaimedBytes).toBe(600);
+    expect(result.evidence.probeBefore.trim()).toBe("1000");
+  });
+
+  test("unregistered action ID refuses before executing anything", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+
+    const outcome = await actions.execute({
+      spec: { input: { host: "testhost", mount: "/", actions: [{ action: "shrink" }, { action: "rm-rf-everything" }] } },
+      def: localDef(dir),
+      workspaceDir,
+      timeoutMs: 10_000,
+    });
+    expect(outcome.exitCode).toBe(1);
+    // The registered action in the same list did NOT run either.
+    expect(readFileSync(path.join(dir, "blob")).length).toBe(1000);
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("not in the closed action registry");
+  });
+
+  test("unknown host refuses before executing", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-"));
+    writeFileSync(path.join(dir, "blob"), Buffer.alloc(1000));
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-act-ws-"));
+    const outcome = await actions.execute({
+      spec: { input: { host: "prod-db", mount: "/", actions: [{ action: "shrink" }] } },
+      def: localDef(dir),
+      workspaceDir,
+      timeoutMs: 10_000,
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("host allowlist");
+  });
+});

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -93,11 +93,52 @@ function verifyRefused({ spec, candidate, attempt }) {
   return { kind: "refused", reasonCode: candidate.reasonCode, result };
 }
 
+/** Last integer in a raw probe output — `df --output=used -B1` style. */
+function parseProbeBytes(raw) {
+  const match = String(raw ?? "").trim().match(/(\d+)\s*$/);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Semantic verification (§9, slice 2 / OPS-208): closed, data-only predicates
+ * keyed by output contract. These check *truth*, not form — the claimed
+ * numbers must be recomputable from the declared evidence, and a mismatch is
+ * a ContractViolation, never a warning.
+ */
+const SEMANTIC_CHECKS = {
+  "factory.disk-remediation/v1": (candidate) => {
+    const violations = [];
+    const { artifact, evidence } = candidate;
+    if (evidence === undefined) return ["evidence_required: factory.disk-remediation/v1 claims are recomputed from probes"];
+    const before = parseProbeBytes(evidence.probeBefore);
+    const after = parseProbeBytes(evidence.probeAfter);
+    if (before === null) violations.push("evidence_unparseable: probeBefore has no byte count");
+    if (after === null) violations.push("evidence_unparseable: probeAfter has no byte count");
+    if (violations.length > 0) return violations;
+    if (artifact.beforeUsedBytes !== before) {
+      violations.push(`evidence_mismatch: beforeUsedBytes ${artifact.beforeUsedBytes} != probed ${before}`);
+    }
+    if (artifact.afterUsedBytes !== after) {
+      violations.push(`evidence_mismatch: afterUsedBytes ${artifact.afterUsedBytes} != probed ${after}`);
+    }
+    if (artifact.reclaimedBytes !== before - after) {
+      violations.push(`evidence_mismatch: reclaimedBytes ${artifact.reclaimedBytes} != recomputed ${before - after}`);
+    }
+    return violations;
+  },
+};
+
 function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts = [] }) {
   if (candidate.artifact === undefined) throw new ContractViolation(["missing_artifact"]);
 
   const artifactCheck = validate(def.outputSchema, candidate.artifact);
   if (!artifactCheck.valid) throw new ContractViolation(artifactCheck.errors);
+
+  const semantic = SEMANTIC_CHECKS[spec.outputContract];
+  if (semantic) {
+    const semanticViolations = semantic(candidate);
+    if (semanticViolations.length > 0) throw new ContractViolation(semanticViolations);
+  }
 
   // Runtime-injected artifacts (e.g. the adapter's transcript): best-effort —
   // included when present, never a violation when absent, and never allowed
@@ -157,6 +198,7 @@ function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalH
       checks: [
         "schema_valid", "hash_recomputed", "paths_confined", "artifacts_exist",
         ...(evidence !== undefined ? ["evidence_retained"] : []),
+        ...(SEMANTIC_CHECKS[spec.outputContract] ? ["evidence_recomputed"] : []),
       ],
     },
     artifacts: collected,

--- a/event-runtime/schemas/disk-diagnose.input.json
+++ b/event-runtime/schemas/disk-diagnose.input.json
@@ -1,0 +1,12 @@
+{
+  "title": "disk-diagnose input — one Keep HQ disk alert (host allowlist is the enum)",
+  "type": "object",
+  "required": ["host", "mount", "usedPct", "alertId"],
+  "additionalProperties": false,
+  "properties": {
+    "host": { "enum": ["lab", "web"] },
+    "mount": { "type": "string", "pattern": "^/[A-Za-z0-9/._-]*$" },
+    "usedPct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "alertId": { "type": "string", "minLength": 1 }
+  }
+}

--- a/event-runtime/schemas/disk-diagnose.output.json
+++ b/event-runtime/schemas/disk-diagnose.output.json
@@ -1,0 +1,24 @@
+{
+  "title": "factory.disk-diagnosis/v1 output artifact — typed verdict + remediation plan",
+  "type": "object",
+  "required": ["recommendation", "mount", "usedPct", "plan", "analysis"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": { "enum": ["NOOP", "REMEDIATE"] },
+    "mount": { "type": "string", "pattern": "^/[A-Za-z0-9/._-]*$" },
+    "usedPct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "additionalProperties": false,
+        "properties": {
+          "action": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] },
+          "expectedReclaimBytes": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "analysis": { "type": "string", "minLength": 1 }
+  }
+}

--- a/event-runtime/schemas/disk-remediate.input.json
+++ b/event-runtime/schemas/disk-remediate.input.json
@@ -1,0 +1,23 @@
+{
+  "title": "disk-remediate input — the approved action list",
+  "type": "object",
+  "required": ["host", "mount", "actions"],
+  "additionalProperties": false,
+  "properties": {
+    "host": { "enum": ["lab", "web"] },
+    "mount": { "type": "string", "pattern": "^/[A-Za-z0-9/._-]*$" },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "additionalProperties": false,
+        "properties": {
+          "action": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] },
+          "expectedReclaimBytes": { "type": "integer", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/disk-remediation.output.json
+++ b/event-runtime/schemas/disk-remediation.output.json
@@ -1,0 +1,18 @@
+{
+  "title": "factory.disk-remediation/v1 output artifact — evidence-verified reclaim",
+  "type": "object",
+  "required": ["host", "mount", "actions", "beforeUsedBytes", "afterUsedBytes", "reclaimedBytes"],
+  "additionalProperties": false,
+  "properties": {
+    "host": { "enum": ["lab", "web"] },
+    "mount": { "type": "string" },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] }
+    },
+    "beforeUsedBytes": { "type": "integer", "minimum": 0 },
+    "afterUsedBytes": { "type": "integer", "minimum": 0 },
+    "reclaimedBytes": { "type": "integer" }
+  }
+}


### PR DESCRIPTION
Fixes OPS-208

Two-node watched chain on the OPS-223 machinery: diagnose (LLM, read-only SSH, typed plan) → operator approves the concrete action list → actions adapter executes closed-registry templates with before/after df probes → verifier recomputes reclaimed bytes from evidence, fails closed on mismatch. Stale alerts → typed NOOP, no approval requested. Unregistered action IDs refuse before execution. Host allowlist: lab, web.

Verification: 136 tests green; live watched flow in isolated worktree runtime (alert → diagnose COMPLETED → watched remediate proposal → approved → COMPLETED with evidence_recomputed check and consistent artifact/evidence).