### PR TITLE
feat(event-runtime): graph canvas — capability map (OPS-224 phase 1)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -149,6 +149,7 @@ function eventsView(db, status) {
     occurredAt: row.occurred_at,
     receivedAt: row.received_at,
     correlationId: row.correlation_id,
+    causationId: row.causation_id,
     planFailures: row.plan_failures,
     lastPlanError: row.last_plan_error,
     admittedAt: row.admitted_at,
@@ -248,6 +249,11 @@ function agentsView(registry) {
       outputSchemaFile: def.output_schema,
       outputSchema: def.outputSchema,
       pins: def.pins,
+      // Closed-execution shape (OPS-223/OPS-208): what a mutating definition
+      // is actually allowed to run. Null for LLM agents.
+      command: def.command ?? null,
+      actionRegistry: def.actionRegistry ?? null,
+      hosts: def.hosts ? Object.keys(def.hosts) : null,
       eventTypes: Object.entries(registry.eventTypes)
         .filter(([, mapping]) => mapping.agent === def.ref)
         .map(([type, mapping]) => ({
@@ -256,6 +262,18 @@ function agentsView(registry) {
           idempotencyScope: mapping.idempotencyScope,
           proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
         })),
+    })),
+    // Recommendation edges (OPS-223) — the capability map's defining relation:
+    // which artifact value on which agent routes to which follow-up event type.
+    edges: registry.edges ?? {},
+    // Every registered route, including types whose agent has no edges — the
+    // graph needs the full topology, not just what agents happen to mention.
+    eventTypes: Object.entries(registry.eventTypes).map(([type, mapping]) => ({
+      type,
+      agent: mapping.agent,
+      adapter: mapping.adapter,
+      idempotencyScope: mapping.idempotencyScope,
+      proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
     })),
     contracts: {
       "factory.event/v1": registry.schemas.envelope,

--- a/event-runtime/web/bun.lock
+++ b/event-runtime/web/bun.lock
@@ -7,12 +7,15 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.5",
         "@tanstack/react-query": "^5.62.0",
+        "@xyflow/react": "^12.11.3",
         "cmdk": "^1.0.4",
+        "elkjs": "^0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@types/bun": "^1.3.14",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -253,7 +256,23 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -261,19 +280,45 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@xyflow/react": ["@xyflow/react@12.11.3", "", { "dependencies": { "@xyflow/system": "0.0.80", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "@types/react": ">=17", "@types/react-dom": ">=17", "react": ">=17", "react-dom": ">=17" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.80", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ=="],
 
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
+
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -282,6 +327,8 @@
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.405", "", {}, "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew=="],
+
+    "elkjs": ["elkjs@0.12.0", "", {}, "sha512-YZcKynxVxYoKIOEpywEPwCFdg+BTbxQRNf3pbwdDCvc8O3kQD8bmIwSxKU1eOTVc4Xo+VG9Te+575mlfvOrhEQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
@@ -377,15 +424,21 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
 

--- a/event-runtime/web/package.json
+++ b/event-runtime/web/package.json
@@ -9,12 +9,15 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.5",
     "@tanstack/react-query": "^5.62.0",
+    "@xyflow/react": "^12.11.3",
     "cmdk": "^1.0.4",
+    "elkjs": "^0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@types/bun": "^1.3.14",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -7,6 +7,7 @@ import { InjectDialog } from "./components/InjectDialog";
 import { ToastContainer } from "./components/ui";
 import { Agents } from "./views/Agents";
 import { Events } from "./views/Events";
+import { Graph } from "./views/Graph";
 import { Overview } from "./views/Overview";
 import { Proposals } from "./views/Proposals";
 import { Runs } from "./views/Runs";
@@ -20,6 +21,7 @@ const NAV = [
   { key: "proposals", label: "Proposals", go: "p" },
   { key: "runs", label: "Runs", go: "r" },
   { key: "agents", label: "Agents", go: "t" },
+  { key: "graph", label: "Graph", go: "g" },
 ] as const;
 
 export function App() {
@@ -190,7 +192,7 @@ export function App() {
           </div>
           <div className="mt-1.5 text-(--text-faint)">
             <span className="mono">⌘K</span> commands · <span className="mono">g</span>+
-            <span className="mono">o/e/p/r/t</span> navigate
+            <span className="mono">o/e/p/r/t/g</span> navigate
           </div>
         </div>
       </nav>
@@ -211,6 +213,8 @@ export function App() {
             onFocusConsumed={() => setFocusRunId(null)}
             onJumpAgent={jumpToAgent}
           />
+        ) : view === "graph" ? (
+          <Graph />
         ) : view === "agents" ? (
           <Agents focusAgentRef={focusAgentRef} onFocusConsumed={() => setFocusAgentRef(null)} />
         ) : view === "events" ? (

--- a/event-runtime/web/src/graph/layout.ts
+++ b/event-runtime/web/src/graph/layout.ts
@@ -1,0 +1,34 @@
+import ELK from "elkjs/lib/elk.bundled.js";
+import type { CapabilityGraph } from "./model";
+
+// Layered left-to-right layout via elk. Hand-rolling DAG layout is where
+// these views die; elk does it properly and runs in a worker-free bundle.
+
+const elk = new ELK();
+
+export const NODE_WIDTH = 236;
+export const NODE_HEIGHT = 92;
+
+const OPTIONS = {
+  "elk.algorithm": "layered",
+  "elk.direction": "RIGHT",
+  "elk.layered.spacing.nodeNodeBetweenLayers": "150",
+  "elk.spacing.nodeNode": "44",
+  "elk.spacing.edgeLabel": "8",
+  "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+  "elk.edgeRouting": "SPLINES",
+};
+
+export async function layoutGraph(graph: CapabilityGraph): Promise<Map<string, { x: number; y: number }>> {
+  const result = await elk.layout({
+    id: "root",
+    layoutOptions: OPTIONS,
+    children: graph.nodes.map((n) => ({ id: n.id, width: NODE_WIDTH, height: NODE_HEIGHT })),
+    edges: graph.edges.map((e) => ({ id: e.id, sources: [e.source], targets: [e.target] })),
+  });
+  const positions = new Map<string, { x: number; y: number }>();
+  for (const child of result.children ?? []) {
+    positions.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 });
+  }
+  return positions;
+}

--- a/event-runtime/web/src/graph/model.test.ts
+++ b/event-runtime/web/src/graph/model.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { buildCapabilityGraph } from "./model";
+import type { AgentsView } from "../types";
+
+// The topology rules are pure data — tested without React or a browser.
+
+const agent = (over: Partial<AgentsView["agents"][number]> = {}) =>
+  ({
+    ref: "a@1",
+    id: "a",
+    version: 1,
+    outputContract: "c/v1",
+    workspace: { type: "ephemeral" },
+    capabilities: { services: ["x:read"] },
+    limits: { timeout_seconds: 60, attempts: 1 },
+    mutating: false,
+    promptFile: "p.md",
+    prompt: "",
+    inputSchemaFile: "i.json",
+    inputSchema: {},
+    outputSchemaFile: "o.json",
+    outputSchema: {},
+    pins: {},
+    command: null,
+    actionRegistry: null,
+    hosts: null,
+    eventTypes: [],
+    ...over,
+  }) as AgentsView["agents"][number];
+
+const view = (over: Partial<AgentsView> = {}): AgentsView => ({
+  agents: [],
+  edges: {},
+  eventTypes: [],
+  contracts: {},
+  ...over,
+});
+
+describe("buildCapabilityGraph", () => {
+  test("routes event types to their agents", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [agent({ ref: "doctor@1" })],
+        eventTypes: [
+          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: ["inputHash"], proposalTtlSeconds: 1800 },
+        ],
+      }),
+    );
+    expect(g.nodes.map((n) => n.id)).toEqual(["event:gh.failed", "agent:doctor@1"]);
+    expect(g.edges).toEqual([
+      { id: "routes:gh.failed", source: "event:gh.failed", target: "agent:doctor@1", kind: "routes" },
+    ]);
+  });
+
+  test("draws recommendation edges from an agent to follow-up event types", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [agent({ ref: "doctor@1" }), agent({ ref: "rerun@1", mutating: true, command: ["gh", "run"] })],
+        eventTypes: [
+          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+        ],
+        edges: {
+          "doctor@1": {
+            recommendationField: "verdict",
+            edges: { FLAKE: { eventType: "ci.rerun", input: {} } },
+          },
+        },
+      }),
+    );
+    const rec = g.edges.find((e) => e.kind === "recommends");
+    expect(rec).toMatchObject({ source: "agent:doctor@1", target: "event:ci.rerun", label: "verdict = FLAKE" });
+    const rerun = g.nodes.find((n) => n.id === "agent:rerun@1");
+    expect(rerun).toMatchObject({ kind: "agent", mutating: true, execution: "command" });
+  });
+
+  test("unmapped enum values become one terminal — 'the chain ends here' is topology", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [
+          agent({
+            ref: "doctor@1",
+            outputSchema: { properties: { verdict: { enum: ["TICKET", "ENV", "FLAKE"] } } },
+          }),
+          agent({ ref: "rerun@1" }),
+        ],
+        eventTypes: [
+          { type: "gh.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+          { type: "ci.rerun", agent: "rerun@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+        ],
+        edges: {
+          "doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "ci.rerun", input: {} } } },
+        },
+      }),
+    );
+    const terminal = g.nodes.find((n) => n.kind === "terminal");
+    expect(terminal).toMatchObject({ id: "terminal:doctor@1", reason: "TICKET, ENV" });
+    expect(g.edges.some((e) => e.target === "terminal:doctor@1")).toBe(true);
+  });
+
+  test("fully-mapped enums draw no terminal", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [
+          agent({ ref: "d@1", outputSchema: { properties: { r: { enum: ["GO"] } } } }),
+          agent({ ref: "next@1" }),
+        ],
+        eventTypes: [
+          { type: "t.next", agent: "next@1", adapter: "command", idempotencyScope: [], proposalTtlSeconds: null },
+        ],
+        edges: { "d@1": { recommendationField: "r", edges: { GO: { eventType: "t.next", input: {} } } } },
+      }),
+    );
+    expect(g.nodes.some((n) => n.kind === "terminal")).toBe(false);
+  });
+
+  test("never draws an edge to an unregistered target", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [agent({ ref: "d@1" })],
+        edges: { "d@1": { recommendationField: "r", edges: { GO: { eventType: "nope.missing", input: {} } } } },
+      }),
+    );
+    expect(g.edges).toEqual([]);
+  });
+
+  test("action-registry agents report their execution shape, actions, and hosts", () => {
+    const g = buildCapabilityGraph(
+      view({
+        agents: [
+          agent({
+            ref: "remediate@1",
+            mutating: true,
+            actionRegistry: { "docker-builder-prune": { remote: "sudo docker builder prune -af" } },
+            hosts: ["lab", "web"],
+          }),
+        ],
+      }),
+    );
+    expect(g.nodes[0]).toMatchObject({
+      kind: "agent",
+      execution: "actions",
+      actions: ["docker-builder-prune"],
+      hosts: ["lab", "web"],
+    });
+  });
+});

--- a/event-runtime/web/src/graph/model.ts
+++ b/event-runtime/web/src/graph/model.ts
@@ -1,0 +1,141 @@
+import type { AgentsView } from "../types";
+
+// The capability map: what this runtime can do, derived purely from the
+// registry (OPS-224 phase 1). No runtime state here — phase 2 overlays that.
+// Kept as plain data, separate from React Flow, so it stays testable and the
+// rendering layer can be swapped without touching the topology rules.
+
+export type GraphNode =
+  | { id: string; kind: "eventType"; label: string; adapter: string; scope: string[]; ttl: number | null }
+  | {
+      id: string;
+      kind: "agent";
+      label: string;
+      adapter: string;
+      mutating: boolean;
+      execution: "model" | "command" | "actions";
+      contract: string;
+      capabilities: string[];
+      actions: string[];
+      hosts: string[];
+    }
+  | { id: string; kind: "terminal"; label: string; reason: string };
+
+export type GraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  kind: "routes" | "recommends";
+  label?: string;
+};
+
+export interface CapabilityGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export const eventNodeId = (type: string) => `event:${type}`;
+export const agentNodeId = (ref: string) => `agent:${ref}`;
+
+/** How an agent actually executes — the honest distinction for the map. */
+function executionOf(def: AgentsView["agents"][number]): "model" | "command" | "actions" {
+  if (def.actionRegistry) return "actions";
+  if (def.command) return "command";
+  return "model";
+}
+
+/**
+ * Build the capability map. Nodes: registered event types, registered agents,
+ * and one terminal per agent that produces recommendations but has values
+ * leading nowhere — "the chain ends here" is topology worth drawing, not an
+ * omission.
+ */
+export function buildCapabilityGraph(view: AgentsView): CapabilityGraph {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  const routes = view.eventTypes ?? [];
+  const byRef = new Map(view.agents.map((a) => [a.ref, a]));
+
+  for (const route of routes) {
+    nodes.push({
+      id: eventNodeId(route.type),
+      kind: "eventType",
+      label: route.type,
+      adapter: route.adapter,
+      scope: route.idempotencyScope ?? [],
+      ttl: route.proposalTtlSeconds,
+    });
+  }
+
+  for (const def of view.agents) {
+    nodes.push({
+      id: agentNodeId(def.ref),
+      kind: "agent",
+      label: def.ref,
+      adapter: def.eventTypes[0]?.adapter ?? "—",
+      mutating: def.mutating,
+      execution: executionOf(def),
+      contract: def.outputContract,
+      capabilities: def.capabilities?.services ?? [],
+      actions: def.actionRegistry ? Object.keys(def.actionRegistry) : [],
+      hosts: def.hosts ?? [],
+    });
+  }
+
+  // event type → agent (the planner's registered mapping)
+  for (const route of routes) {
+    if (!byRef.has(route.agent)) continue; // registry guarantees this, but never draw a dangling edge
+    edges.push({
+      id: `routes:${route.type}`,
+      source: eventNodeId(route.type),
+      target: agentNodeId(route.agent),
+      kind: "routes",
+    });
+  }
+
+  // agent --recommendation--> follow-up event type (the chain edges)
+  for (const [agentRef, rule] of Object.entries(view.edges ?? {})) {
+    const source = agentNodeId(agentRef);
+    if (!byRef.has(agentRef)) continue;
+    for (const [value, edge] of Object.entries(rule.edges ?? {})) {
+      const target = eventNodeId(edge.eventType);
+      if (!nodes.some((n) => n.id === target)) continue;
+      edges.push({
+        id: `rec:${agentRef}:${value}`,
+        source,
+        target,
+        kind: "recommends",
+        label: `${rule.recommendationField} = ${value}`,
+      });
+    }
+  }
+
+  // Terminals: an agent whose output enum has values with no edge ends there.
+  for (const def of view.agents) {
+    const rule = view.edges?.[def.ref];
+    if (!rule) continue;
+    const schema = def.outputSchema as
+      | { properties?: Record<string, { enum?: string[] }> }
+      | undefined;
+    const declared = schema?.properties?.[rule.recommendationField]?.enum ?? [];
+    const unmapped = declared.filter((value) => !(value in (rule.edges ?? {})));
+    if (unmapped.length === 0) continue;
+    const id = `terminal:${def.ref}`;
+    nodes.push({
+      id,
+      kind: "terminal",
+      label: "chain ends",
+      reason: unmapped.join(", "),
+    });
+    edges.push({
+      id: `rec:${def.ref}:terminal`,
+      source: agentNodeId(def.ref),
+      target: id,
+      kind: "recommends",
+      label: `${rule.recommendationField} = ${unmapped.join(" | ")}`,
+    });
+  }
+
+  return { nodes, edges };
+}

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -1,0 +1,119 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { GraphNode } from "./model";
+
+// Custom nodes: plain components on the app's OKLCH tokens, so the canvas
+// reads as part of the tool rather than an embedded diagram widget.
+
+const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
+
+function Shell({
+  children,
+  accent,
+  selected,
+  dashed,
+}: {
+  children: React.ReactNode;
+  accent: string;
+  selected?: boolean;
+  dashed?: boolean;
+}) {
+  return (
+    <div
+      className="rounded-md px-3 py-2 text-left"
+      style={{
+        width: 236,
+        height: 92,
+        background: "var(--surface-1)",
+        border: `1px ${dashed ? "dashed" : "solid"} ${selected ? accent : "var(--border)"}`,
+        boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
+        borderLeft: `3px solid ${accent}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
+  return (
+    <div
+      className="mono truncate text-[10.5px]"
+      style={{ color: dim ? "var(--text-faint)" : "var(--text-dim)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function EventTypeNode({ data, selected }: NodeProps) {
+  const node = data.node as Extract<GraphNode, { kind: "eventType" }>;
+  return (
+    <Shell accent="var(--hue-info)" selected={selected}>
+      <Handle type="target" position={Position.Left} style={handleStyle} />
+      <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--hue-info)" }}>
+        event type
+      </div>
+      <div className="mono truncate text-[12px]" title={node.label}>
+        {node.label}
+      </div>
+      <Line dim>dedup: {node.scope.join(" + ") || "—"}</Line>
+      <Line dim>ttl: {node.ttl ? `${node.ttl / 60}m` : "—"}</Line>
+      <Handle type="source" position={Position.Right} style={handleStyle} />
+    </Shell>
+  );
+}
+
+export function AgentNode({ data, selected }: NodeProps) {
+  const node = data.node as Extract<GraphNode, { kind: "agent" }>;
+  const accent = node.mutating ? "var(--hue-warn)" : "var(--hue-ok)";
+  return (
+    <Shell accent={accent} selected={selected}>
+      <Handle type="target" position={Position.Left} style={handleStyle} />
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
+          {node.execution === "model" ? "agent · model" : `agent · ${node.execution}`}
+        </span>
+        {node.mutating && (
+          <span
+            className="rounded px-1 text-[9.5px] font-semibold tracking-wide uppercase"
+            style={{ color: "var(--hue-warn)", background: "color-mix(in oklch, var(--hue-warn) 15%, transparent)" }}
+          >
+            mutating
+          </span>
+        )}
+      </div>
+      <div className="mono truncate text-[12px]" title={node.label}>
+        {node.label}
+      </div>
+      <Line dim>{node.contract}</Line>
+      <Line dim>
+        {node.execution === "actions"
+          ? `${node.actions.length} actions · ${node.hosts.join(", ")}`
+          : (node.capabilities.join(", ") || "no declared services")}
+      </Line>
+      <Handle type="source" position={Position.Right} style={handleStyle} />
+    </Shell>
+  );
+}
+
+export function TerminalNode({ data, selected }: NodeProps) {
+  const node = data.node as Extract<GraphNode, { kind: "terminal" }>;
+  return (
+    <Shell accent="var(--hue-idle)" selected={selected} dashed>
+      <Handle type="target" position={Position.Left} style={handleStyle} />
+      <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--text-faint)" }}>
+        terminal
+      </div>
+      <div className="text-[12px]" style={{ color: "var(--text-dim)" }}>
+        {node.label}
+      </div>
+      <Line dim>{node.reason}</Line>
+    </Shell>
+  );
+}
+
+export const nodeTypes = {
+  eventType: EventTypeNode,
+  agent: AgentNode,
+  terminal: TerminalNode,
+};

--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -88,3 +88,19 @@ body {
 *::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* React Flow minimap: SVG fills cannot use var()/color-mix, so the node
+   colors live here as classes (Graph view, OPS-224). */
+.react-flow__minimap-node.minimap-node { fill: var(--hue-info); stroke: none; }
+.react-flow__minimap-node.minimap-agent { fill: var(--hue-ok); }
+.react-flow__minimap-node.minimap-terminal { fill: var(--text-faint); }
+
+/* Canvas controls inherit the app's surfaces rather than React Flow's default white. */
+.react-flow__controls-button {
+  background: var(--surface-1);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  fill: var(--text-dim);
+}
+.react-flow__controls-button:hover { background: var(--surface-3); }
+.react-flow__edge-text { fill: var(--text-faint); }

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -183,11 +183,32 @@ export interface AgentDef {
   outputSchemaFile: string;
   outputSchema: unknown;
   pins: Record<string, string>;
+  /** Closed-execution shape: fixed argv (command adapter) or action registry. */
+  command: string[] | null;
+  actionRegistry: Record<string, { remote: string }> | null;
+  hosts: string[] | null;
   eventTypes: AgentEventRoute[];
+}
+
+/** One recommendation edge: an artifact value routing to a follow-up event type. */
+export interface RecommendationRule {
+  recommendationField: string;
+  edges: Record<string, { eventType: string; input: Record<string, string> }>;
+}
+
+/** Every registered route, independent of which agent mentions it. */
+export interface EventRoute {
+  type: string;
+  agent: string;
+  adapter: string;
+  idempotencyScope: string[];
+  proposalTtlSeconds: number | null;
 }
 
 export interface AgentsView {
   agents: AgentDef[];
+  edges: Record<string, RecommendationRule>;
+  eventTypes: EventRoute[];
   contracts: Record<string, unknown>;
 }
 

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -1,0 +1,179 @@
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api";
+import { buildCapabilityGraph, type GraphNode } from "../graph/model";
+import { layoutGraph, NODE_HEIGHT, NODE_WIDTH } from "../graph/layout";
+import { nodeTypes } from "../graph/nodes";
+import { JsonBlock, KV, Section, Button } from "../components/ui";
+
+/**
+ * Graph (webui roadmap / OPS-224 phase 1): the capability map — what this
+ * runtime *can* do, drawn from the registry alone. Event types route to
+ * agents; agents recommend follow-up event types; unmapped recommendation
+ * values are drawn as terminals, because "the chain ends here" is topology.
+ * Phase 2 overlays live run state onto these same nodes.
+ */
+export function Graph() {
+  const registry = useQuery({ queryKey: ["agents"], queryFn: api.agents, refetchInterval: 10_000 });
+  const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const graph = useMemo(
+    () => (registry.data ? buildCapabilityGraph(registry.data) : null),
+    [registry.data],
+  );
+
+  useEffect(() => {
+    if (!graph) return;
+    let cancelled = false;
+    layoutGraph(graph).then((positions) => {
+      if (cancelled) return;
+      setPositioned({
+        nodes: graph.nodes.map((node) => ({
+          id: node.id,
+          type: node.kind,
+          position: positions.get(node.id) ?? { x: 0, y: 0 },
+          data: { node },
+          draggable: true,
+          // Explicit dimensions: the minimap draws from these, and elk was
+          // laid out against the same constants.
+          width: NODE_WIDTH,
+          height: NODE_HEIGHT,
+        })),
+        edges: graph.edges.map((edge) => ({
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          label: edge.label,
+          animated: false,
+          style: {
+            stroke: edge.kind === "recommends" ? "var(--accent)" : "var(--border-strong)",
+            strokeWidth: 1.5,
+            strokeDasharray: edge.kind === "recommends" ? "4 3" : undefined,
+          },
+          labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
+          labelBgStyle: { fill: "var(--surface-0)" },
+        })),
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [graph]);
+
+  const selected: GraphNode | undefined = graph?.nodes.find((n) => n.id === selectedId);
+  const agentDef =
+    selected?.kind === "agent"
+      ? registry.data?.agents.find((a) => a.ref === selected.label)
+      : undefined;
+
+  return (
+    <div className="flex h-full min-w-0">
+      <div className="relative min-w-0 flex-1">
+        <div className="absolute top-4 left-5 z-10">
+          <h1 className="display text-lg font-semibold">Graph</h1>
+          <div className="text-[11px] text-(--text-faint)">
+            what this runtime can do — registered routes and recommendation edges
+          </div>
+        </div>
+        {positioned ? (
+          <ReactFlow
+            nodes={positioned.nodes}
+            edges={positioned.edges}
+            nodeTypes={nodeTypes}
+            onNodeClick={(_, node) => setSelectedId(node.id)}
+            onPaneClick={() => setSelectedId(null)}
+            fitView
+            fitViewOptions={{ padding: 0.25 }}
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.2}
+          >
+            <Background color="var(--border)" gap={20} size={1} />
+            <Controls
+              showInteractive={false}
+              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+            />
+            {/* Minimap paints into SVG where var()/color-mix do not resolve —
+                style its nodes by class instead (see theme.css). */}
+            <MiniMap
+              pannable
+              zoomable
+              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+              maskColor="rgba(0, 0, 0, 0.55)"
+              nodeClassName={(n) => `minimap-node minimap-${n.type}`}
+            />
+          </ReactFlow>
+        ) : (
+          <div className="flex h-full items-center justify-center text-(--text-faint)">
+            {registry.isError ? "runtime unreachable" : "laying out the capability map…"}
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <div className="w-[420px] shrink-0 overflow-auto border-l border-(--border) bg-(--surface-1) p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <div className="display truncate text-[14px] font-semibold">{selected.label}</div>
+            <Button onClick={() => setSelectedId(null)}>Close</Button>
+          </div>
+
+          {selected.kind === "eventType" && (
+            <Section title="Event type">
+              <KV k="type" v={selected.label} />
+              <KV k="adapter" v={selected.adapter} />
+              <KV k="idempotency scope" v={selected.scope.join(" + ") || "—"} />
+              <KV k="proposal ttl" v={selected.ttl ? `${selected.ttl}s` : "—"} />
+            </Section>
+          )}
+
+          {selected.kind === "terminal" && (
+            <Section title="Terminal">
+              <div className="text-[12px] text-(--text-dim)">
+                Recommendation values with no registered edge: <span className="mono">{selected.reason}</span>. A
+                run that returns one of these completes and chains no further.
+              </div>
+            </Section>
+          )}
+
+          {selected.kind === "agent" && agentDef && (
+            <>
+              <Section title="Agent">
+                <KV k="ref" v={agentDef.ref} />
+                <KV k="execution" v={selected.execution} />
+                <KV k="output contract" v={agentDef.outputContract} />
+                <KV k="mutating" v={String(agentDef.mutating)} />
+                <KV k="capabilities" v={agentDef.capabilities?.services?.join(", ") ?? "—"} />
+                <KV k="timeout" v={`${agentDef.limits?.timeout_seconds ?? "—"}s`} />
+                <KV k="attempts" v={String(agentDef.limits?.attempts ?? "—")} />
+              </Section>
+              {agentDef.command && (
+                <Section title="Closed command template">
+                  <JsonBlock value={agentDef.command} />
+                </Section>
+              )}
+              {agentDef.actionRegistry && (
+                <Section title={`Closed action registry · hosts ${agentDef.hosts?.join(", ")}`}>
+                  <JsonBlock value={agentDef.actionRegistry} />
+                </Section>
+              )}
+              <Section title="Prompt">
+                <pre className="mono max-h-64 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-3 whitespace-pre-wrap">
+                  {agentDef.prompt}
+                </pre>
+              </Section>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes OPS-224

The capability map: what this runtime can do, drawn from the registry. React Flow (`@xyflow/react`) + elkjs layered layout, themed from the existing OKLCH tokens.

- Nodes: event types (dedup scope, TTL), agents (model / command / actions execution, mutating badge, contract, capabilities), and terminals for recommendation values with no edge.
- Edges: event type → agent (registered route) and agent → event type (recommendation, labelled with the artifact value).
- Detail panel: for a mutating agent, the literal closed command template or action registry — you can read exactly what it may execute.
- API: `GET /agents` exposes the edge map + full route list; `GET /events` projects `causationId` (needed by phase 2).

Phase 2 (separate ticket) overlays live run state, edge fire counts, and pending proposals as ghost nodes.

Verification: 142 tests green incl. 6 new pure topology tests; web `bun run build` clean; live check against a seeded worktree runtime in dark and light themes.