### PR TITLE
feat(event-runtime): registry-derived inject templates and trigger-again (OPS-214)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -157,10 +157,24 @@ confirmation that states it overrides the attempt budget and is recorded.
 `409` (`IllegalTransition`, `attempts_exhausted`) renders as an inline
 explanation, not a toast that evaporates.
 
-### 4.4 Inject — `POST /replay`
+### 4.4 Inject — `POST /replay` (templates: OPS-214)
 
 Dev parity with `cli.mjs inject`: a dialog with a JSON textarea for an event
 envelope, client-side-validated against the envelope shape before submitting.
+
+**Templates are derived, never hand-maintained (OPS-214).** One chip per
+registered event type; the payload skeleton is built from that event's agent
+*input schema* (required fields only; enums seed their first value, numbers
+their minimum, `minItems` arrays one element, patterned strings a
+recognisable placeholder). A newly registered event type therefore appears
+with no UI change, and a template can never propose a payload the runtime
+would reject for shape. Ids and `occurredAt` are generated per dialog
+opening; the JSON stays fully editable — the template is a starting point,
+not a cage. An unregistered `type` warns once (it is admissible, but parks
+as `human_needed`) and injects on the second click. The Events view offers
+**Trigger again**, which clones an envelope under a *fresh* identity —
+deliberately distinct from Replay, which reuses the delivery id and dedups
+to a no-op.
 The response distinguishes `admitted` from `duplicate` — a duplicate is a
 success ("§5.1 working as designed"), displayed as such, not an error.
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -29,6 +29,7 @@ export function App() {
   const view = route[0];
   const [, cycleTheme] = useTheme();
   const [injectOpen, setInjectOpen] = useState(false);
+  const [injectSeed, setInjectSeed] = useState<Record<string, unknown> | undefined>(undefined);
   const [focusRunId, setFocusRunId] = useState<string | null>(null);
   const [focusProposalId, setFocusProposalId] = useState<string | null>(null);
   const [focusEventStatus, setFocusEventStatus] = useState<string | null>(null);
@@ -222,6 +223,10 @@ export function App() {
             connected={connected}
             focusStatus={focusEventStatus}
             onFocusConsumed={() => setFocusEventStatus(null)}
+            onTriggerAgain={(envelope) => {
+              setInjectSeed(envelope);
+              setInjectOpen(true);
+            }}
           />
         ) : (
           <Overview
@@ -235,7 +240,15 @@ export function App() {
       </main>
 
       <CommandPalette actions={paletteActions} onJumpRun={jumpToRun} onJumpProposal={jumpToProposal} />
-      {injectOpen && <InjectDialog onClose={() => setInjectOpen(false)} />}
+      {injectOpen && (
+        <InjectDialog
+          initialEnvelope={injectSeed}
+          onClose={() => {
+            setInjectOpen(false);
+            setInjectSeed(undefined);
+          }}
+        />
+      )}
       <ToastContainer />
     </div>
   );

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1,35 +1,74 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import { api } from "../api";
+import { buildTemplates, triggerId, type TriggerTemplate } from "../templates";
 import { Button, Dialog, VerbError } from "./ui";
-
-const TEMPLATE = JSON.stringify(
-  {
-    schemaVersion: "factory.event/v1",
-    eventId: "manual-001",
-    type: "factory.status-report.requested",
-    source: "web-inject",
-    subject: "factory",
-    occurredAt: new Date().toISOString(),
-    correlationId: "manual-001",
-    payload: { repos: [] },
-  },
-  null,
-  2,
-);
 
 const REQUIRED = ["schemaVersion", "eventId", "type", "source", "occurredAt"];
 
-/** Inject dialog (webui spec §4.4) — same admission path as `cli.mjs inject`. */
-export function InjectDialog({ onClose }: { onClose: () => void }) {
-  const [text, setText] = useState(TEMPLATE);
-  const [clientError, setClientError] = useState<string | null>(null);
+/** Blank slate for an unregistered/hand-written envelope (the escape hatch). */
+function blankEnvelope(nowMs: number) {
+  const id = triggerId(nowMs);
+  return {
+    schemaVersion: "factory.event/v1",
+    eventId: id,
+    type: "",
+    source: "web-trigger",
+    subject: "factory",
+    occurredAt: new Date(nowMs).toISOString(),
+    correlationId: id,
+    payload: {},
+  };
+}
+
+const pretty = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
+
+/**
+ * Inject dialog (webui spec §4.4, templates per OPS-214).
+ *
+ * Templates are derived from the registry — one per registered event type,
+ * with the payload skeleton built from that event's agent input schema — so
+ * they cannot drift from what the runtime will actually accept, and a newly
+ * registered event type appears here with no UI change. The raw JSON stays
+ * editable underneath: the template is a starting point, never a cage.
+ */
+export function InjectDialog({
+  onClose,
+  initialEnvelope,
+}: {
+  onClose: () => void;
+  initialEnvelope?: Record<string, unknown>;
+}) {
   const queryClient = useQueryClient();
+  const registry = useQuery({ queryKey: ["agents"], queryFn: api.agents });
+
+  // One clock read per dialog opening: stable ids while editing, fresh ones
+  // each time the dialog is opened.
+  const openedAt = useMemo(() => Date.now(), []);
+  const templates = useMemo(
+    () => (registry.data ? buildTemplates(registry.data, openedAt) : []),
+    [registry.data, openedAt],
+  );
+
+  const [selected, setSelected] = useState<string | null>(initialEnvelope ? "__given__" : null);
+  const [text, setText] = useState(() => pretty(initialEnvelope ?? blankEnvelope(openedAt)));
+  const [clientError, setClientError] = useState<string | null>(null);
+  // Unregistered event types are legitimately admissible (they park as
+  // human_needed), so this warns once and then lets the operator through.
+  const [unregisteredAck, setUnregisteredAck] = useState(false);
 
   const inject = useMutation({
     mutationFn: (envelope: unknown) => api.replay(envelope),
     onSuccess: () => queryClient.invalidateQueries(),
   });
+
+  function choose(template: TriggerTemplate) {
+    setSelected(template.eventType);
+    setText(pretty(template.envelope));
+    setClientError(null);
+    setUnregisteredAck(false);
+    inject.reset();
+  }
 
   function submit() {
     setClientError(null);
@@ -45,23 +84,72 @@ export function InjectDialog({ onClose }: { onClose: () => void }) {
       setClientError(`missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`);
       return;
     }
+    const registered = registry.data?.eventTypes.some((r) => r.type === envelope.type) ?? true;
+    if (!registered && !unregisteredAck) {
+      setClientError(
+        `"${envelope.type}" is not a registered event type — it will be admitted, but planning will park it as human_needed. Inject again to confirm.`,
+      );
+      setUnregisteredAck(true);
+      return;
+    }
     inject.mutate(envelope);
   }
 
   const outcome = inject.data;
   return (
     <Dialog title="Inject event" onClose={onClose} wide>
-      <div className="mb-2 text-[12px] text-(--text-dim)">
-        Replays an envelope through the same intake as the webhook. Duplicate delivery is safe —
-        one admission, one proposal, one run.
+      <div className="mb-3 text-[12px] text-(--text-dim)">
+        Templates come from the registry — payload fields are the ones each agent's input schema
+        requires. Edit freely before firing; duplicate delivery is safe.
       </div>
+
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {templates.map((t) => (
+          <button
+            key={t.eventType}
+            type="button"
+            title={`${t.agent} · payload: ${t.summary}`}
+            onClick={() => choose(t)}
+            className={`rounded-md border px-2 py-1 text-left text-[11.5px] ${
+              selected === t.eventType
+                ? "border-(--accent) bg-(--surface-3) text-(--text)"
+                : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
+            }`}
+          >
+            <span className="mono">{t.eventType}</span>
+            <span className="ml-1.5 text-(--text-faint)">{t.summary}</span>
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            setSelected(null);
+            setText(pretty(blankEnvelope(openedAt)));
+            setUnregisteredAck(false);
+            inject.reset();
+          }}
+          className={`rounded-md border px-2 py-1 text-[11.5px] ${
+            selected === null
+              ? "border-(--accent) bg-(--surface-3) text-(--text)"
+              : "border-(--border) text-(--text-faint) hover:bg-(--surface-2)"
+          }`}
+        >
+          blank
+        </button>
+      </div>
+
       <textarea
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => {
+          setText(e.target.value);
+          setClientError(null);
+          setUnregisteredAck(false);
+        }}
         spellCheck={false}
         rows={14}
         className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-(--text) outline-none focus:border-(--border-strong)"
       />
+
       {clientError && <VerbError error={new Error(clientError)} />}
       <VerbError error={inject.error} />
       {outcome && (
@@ -74,9 +162,10 @@ export function InjectDialog({ onClose }: { onClose: () => void }) {
         >
           {outcome.duplicate
             ? `duplicate — event ${outcome.eventId} was already admitted (dedup working as designed)`
-            : `admitted event ${outcome.eventId}`}
+            : `admitted event ${outcome.eventId} — the planner proposes next`}
         </div>
       )}
+
       <div className="mt-3 flex justify-end gap-2">
         <Button onClick={onClose}>Close</Button>
         <Button variant="primary" onClick={submit} disabled={inject.isPending}>

--- a/event-runtime/web/src/templates.test.ts
+++ b/event-runtime/web/src/templates.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { buildSkeleton, buildTemplates, retriggerEnvelope, summarize, triggerId } from "./templates";
+import type { AgentsView } from "./types";
+
+const NOW = Date.parse("2026-08-13T09:15:00.000Z");
+
+const agent = (over: Record<string, unknown> = {}) =>
+  ({
+    ref: "a@1",
+    id: "a",
+    version: 1,
+    outputContract: "c/v1",
+    workspace: { type: "ephemeral" },
+    capabilities: {},
+    limits: {},
+    mutating: false,
+    promptFile: "",
+    prompt: "",
+    inputSchemaFile: "",
+    inputSchema: {},
+    outputSchemaFile: "",
+    outputSchema: {},
+    pins: {},
+    command: null,
+    actionRegistry: null,
+    hosts: null,
+    eventTypes: [],
+    ...over,
+  }) as AgentsView["agents"][number];
+
+describe("buildSkeleton", () => {
+  test("includes required properties only — optional fields stay out of the way", () => {
+    expect(
+      buildSkeleton({
+        required: ["host", "mount"],
+        properties: { host: { type: "string" }, mount: { type: "string" }, note: { type: "string" } },
+      }),
+    ).toEqual({ host: "", mount: "" });
+  });
+
+  test("enums seed their first value, numbers their minimum, booleans false", () => {
+    expect(
+      buildSkeleton({
+        required: ["host", "usedPct", "flag"],
+        properties: {
+          host: { enum: ["lab", "web"] },
+          usedPct: { type: "number", minimum: 0 },
+          flag: { type: "boolean" },
+        },
+      }),
+    ).toEqual({ host: "lab", usedPct: 0, flag: false });
+  });
+
+  test("arrays with minItems seed one element — an empty array would be a guaranteed 422", () => {
+    expect(
+      buildSkeleton({
+        required: ["repos", "tags"],
+        properties: {
+          repos: { type: "array", minItems: 1, items: { type: "string" } },
+          tags: { type: "array", items: { type: "string" } },
+        },
+      }),
+    ).toEqual({ repos: [""], tags: [] });
+  });
+
+  test("pattern hints produce a recognisable placeholder, not invented content", () => {
+    expect(
+      buildSkeleton({
+        required: ["repo", "mount"],
+        properties: {
+          repo: { type: "string", pattern: "^[^/\\s]+/[^/\\s]+$" },
+          mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
+        },
+      }),
+    ).toEqual({ repo: "owner/name", mount: "/" });
+  });
+
+  test("nested objects recurse", () => {
+    expect(
+      buildSkeleton({
+        required: ["outer"],
+        properties: {
+          outer: { type: "object", required: ["inner"], properties: { inner: { type: "integer", minimum: 3 } } },
+        },
+      }),
+    ).toEqual({ outer: { inner: 3 } });
+  });
+});
+
+describe("buildTemplates", () => {
+  const view: AgentsView = {
+    agents: [
+      agent({
+        ref: "disk-diagnose@1",
+        inputSchema: {
+          required: ["host", "mount", "usedPct", "alertId"],
+          properties: {
+            host: { enum: ["lab", "web"] },
+            mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
+            usedPct: { type: "number", minimum: 0 },
+            alertId: { type: "string" },
+          },
+        },
+      }),
+    ],
+    edges: {},
+    eventTypes: [
+      {
+        type: "keephq.disk-alert.raised",
+        agent: "disk-diagnose@1",
+        adapter: "claude",
+        idempotencyScope: ["subject", "correlationId"],
+        proposalTtlSeconds: 1800,
+      },
+    ],
+    contracts: {},
+  };
+
+  test("one template per registered event type, payload derived from the agent's schema", () => {
+    const [t] = buildTemplates(view, NOW);
+    expect(t.eventType).toBe("keephq.disk-alert.raised");
+    expect(t.agent).toBe("disk-diagnose@1");
+    expect(t.summary).toBe("host, mount, usedPct, alertId");
+    expect(t.envelope).toMatchObject({
+      schemaVersion: "factory.event/v1",
+      type: "keephq.disk-alert.raised",
+      source: "web-trigger",
+      occurredAt: "2026-08-13T09:15:00.000Z",
+      payload: { host: "lab", mount: "/", usedPct: 0, alertId: "" },
+    });
+  });
+
+  test("eventId and correlationId match, so the envelope is self-consistent", () => {
+    const [t] = buildTemplates(view, NOW);
+    expect(t.envelope.eventId).toBe(t.envelope.correlationId);
+    expect(t.envelope.eventId).toBe(triggerId(NOW));
+  });
+
+  test("an unknown agent still yields a usable envelope with an empty payload", () => {
+    const [t] = buildTemplates({ ...view, agents: [] }, NOW);
+    expect(t.envelope.payload).toEqual({});
+    expect(t.summary).toBe("no required payload fields");
+  });
+});
+
+describe("retriggerEnvelope", () => {
+  test("fresh identity, same payload — deliberately not a replay", () => {
+    const original = {
+      schemaVersion: "factory.event/v1",
+      eventId: "keep-1",
+      correlationId: "alert-1",
+      type: "keephq.disk-alert.raised",
+      source: "keephq",
+      occurredAt: "2026-08-12T10:00:00Z",
+      payload: { host: "lab", usedPct: 93 },
+    };
+    const again = retriggerEnvelope(original, NOW);
+    expect(again.eventId).not.toBe(original.eventId);
+    expect(again.eventId).toBe(again.correlationId);
+    expect(again.payload).toEqual(original.payload);
+    expect(again.type).toBe(original.type);
+    expect(again.source).toBe("web-trigger");
+  });
+});
+
+describe("summarize", () => {
+  test("lists required fields, or says there are none", () => {
+    expect(summarize({ required: ["a", "b"] })).toBe("a, b");
+    expect(summarize({})).toBe("no required payload fields");
+    expect(summarize(undefined)).toBe("no required payload fields");
+  });
+});

--- a/event-runtime/web/src/templates.ts
+++ b/event-runtime/web/src/templates.ts
@@ -1,0 +1,117 @@
+import type { AgentsView } from "./types";
+
+// Trigger templates (OPS-214): one per registered event type, with the
+// payload skeleton derived from that event's agent input schema. Deriving
+// beats hand-maintaining — a template can never drift from the registry,
+// and a newly registered event type shows up without a UI change.
+
+export interface TriggerTemplate {
+  eventType: string;
+  agent: string;
+  adapter: string;
+  /** Field notes for the picker: what the payload wants, in one line. */
+  summary: string;
+  envelope: Record<string, unknown>;
+}
+
+/** A plausible starting value for one schema property — never a lie, just a seed. */
+function seedFor(name: string, schema: any): unknown {
+  if (!schema || typeof schema !== "object") return "";
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0];
+  if (schema.const !== undefined) return schema.const;
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case "integer":
+    case "number":
+      return schema.minimum ?? 0;
+    case "boolean":
+      return false;
+    case "array": {
+      // minItems > 0 means "empty is invalid" — seed one element so the
+      // template is submittable, not a guaranteed 422.
+      const item = seedFor(name, schema.items);
+      return (schema.minItems ?? 0) > 0 ? [item] : [];
+    }
+    case "object":
+      return buildSkeleton(schema);
+    default:
+      // Pattern-constrained strings get a hint the operator can recognise and
+      // replace; anything else stays empty rather than inventing content.
+      if (typeof schema.pattern === "string") {
+        // Order matters: a path pattern ("^/…") also contains a slash, so the
+        // absolute-path case must be tested before the owner/name case.
+        if (schema.pattern.startsWith("^/")) return "/";
+        if (schema.pattern.includes("/")) return "owner/name";
+      }
+      return "";
+  }
+}
+
+/** Required properties only: the smallest envelope that can pass validation. */
+export function buildSkeleton(schema: any): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const required: string[] = schema?.required ?? [];
+  const props = schema?.properties ?? {};
+  for (const name of required) {
+    out[name] = seedFor(name, props[name]);
+  }
+  return out;
+}
+
+/** One-line description of the payload shape, for the template list. */
+export function summarize(schema: any): string {
+  const required: string[] = schema?.required ?? [];
+  if (required.length === 0) return "no required payload fields";
+  return required.join(", ");
+}
+
+/**
+ * Deterministic-ish id seed. The caller passes the clock so this stays a pure
+ * function (and tests get stable output).
+ */
+export function triggerId(nowMs: number, suffix = ""): string {
+  const stamp = new Date(nowMs).toISOString().replace(/[-:]/g, "").replace(/\..+/, "");
+  return `web-${stamp}${suffix}`;
+}
+
+export function buildTemplates(view: AgentsView, nowMs: number): TriggerTemplate[] {
+  const byRef = new Map(view.agents.map((a) => [a.ref, a]));
+  return (view.eventTypes ?? []).map((route) => {
+    const def = byRef.get(route.agent);
+    const id = triggerId(nowMs);
+    return {
+      eventType: route.type,
+      agent: route.agent,
+      adapter: route.adapter,
+      summary: summarize(def?.inputSchema),
+      envelope: {
+        schemaVersion: "factory.event/v1",
+        eventId: id,
+        type: route.type,
+        source: "web-trigger",
+        subject: "factory",
+        occurredAt: new Date(nowMs).toISOString(),
+        correlationId: id,
+        payload: buildSkeleton(def?.inputSchema),
+      },
+    };
+  });
+}
+
+/**
+ * Clone an existing event's envelope under a fresh identity — "fire this
+ * again", which is deliberately NOT replay: replay reuses the delivery id and
+ * dedups to a no-op, this makes a genuinely new admission.
+ */
+export function retriggerEnvelope(envelope: Record<string, unknown>, nowMs: number): Record<string, unknown> {
+  const id = triggerId(nowMs, "-again");
+  return {
+    ...envelope,
+    eventId: id,
+    correlationId: id,
+    source: "web-trigger",
+    occurredAt: new Date(nowMs).toISOString(),
+    receivedAt: undefined,
+  };
+}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
+import { retriggerEnvelope } from "../templates";
 import { useListKeys, useNow } from "../hooks";
 import { setContextActions } from "../palette";
 import type { AdmittedEvent } from "../types";
@@ -23,10 +24,12 @@ export function Events({
   connected,
   focusStatus,
   onFocusConsumed,
+  onTriggerAgain,
 }: {
   connected: boolean;
   focusStatus: string | null;
   onFocusConsumed: () => void;
+  onTriggerAgain: (envelope: Record<string, unknown>) => void;
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
@@ -100,6 +103,10 @@ export function Events({
           ? [{ label: `Requeue ${sel.eventId}`, hint: "q", run: () => requeue.mutate(sel) }]
           : []),
         { label: `Replay ${sel.eventId} through intake`, run: () => replay.mutate(sel.envelope) },
+        {
+          label: `Trigger ${sel.type} again (new event id)…`,
+          run: () => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now())),
+        },
       ]);
     }
     return () => setContextActions([]);
@@ -236,6 +243,14 @@ export function Events({
               onClick={() => replay.mutate(sel.envelope)}
             >
               Replay through intake
+            </Button>
+            {/* Distinct from replay: a fresh delivery identity, so it admits
+                a NEW event instead of deduping to a no-op (OPS-214). */}
+            <Button
+              disabled={!connected}
+              onClick={() => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now()))}
+            >
+              Trigger again…
             </Button>
           </div>
           <VerbError error={requeue.error ?? replay.error} />


### PR DESCRIPTION
Fixes OPS-214

Pre-defined, editable templates in the Inject dialog — one per registered event type, with payload skeletons derived from each agent's input schema, so they cannot drift from the registry and a newly registered event type appears with no UI change.

- Seeds: enum → first value, number → minimum, boolean → false, `minItems` array → one element, patterned string → recognisable placeholder (`owner/name`, `/`); required fields only.
- Ids/`occurredAt` generated per dialog opening; JSON stays editable.
- Unregistered `type` warns once (admissible, parks as human_needed), injects on confirm.
- Events: **Trigger again** clones an envelope under a fresh identity — distinct from Replay, which dedups by design.

Verification: 152 tests green incl. 10 new pure template tests (one caught a real ordering bug: a path pattern also contains `/`, so it was seeding `owner/name` for mounts); web build clean; live browser check — every registered type renders a template, disk-alert template fired and admitted.