### PR TITLE
feat(event-runtime): tier-1 repository workspace + triage chain (OPS-228, OPS-229)

### DIFF
--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -135,6 +135,38 @@ the direction to build toward, ahead of general declared workflows (slice
 auto-approval on its own record; mutating edges may simply never earn it.
 First use case: **shipped (OPS-223)** — the CI failure doctor: `github.workflow-run.failed` → `ci-doctor@1` verdict → `FLAKE|ENV → ci-rerun@1` / `TICKET → ci-notify@1`, every edge watched; the edge registry (`edges.json`), chain resolver (`lib/chain.mjs`), and closed-template command adapter are the §6 cut-line 6 machinery.
 
+## 5a. Repository access: tier 1 shipped, tier 2 held (OPS-228/OPS-229)
+
+Agents that need a repo split cleanly by whether they *read* code or *build*
+it, and only the second half is expensive.
+
+**Tier 1 — read-only pinned checkout (shipped).** A bare mirror per repo under
+the runtime home, fetched at plan time; each run gets its own detached
+worktree of that mirror at a **SHA resolved at plan time and pinned into the
+run's input** (`repoPin`), so the run names the exact tree it read and dedup
+distinguishes "same repo, new commit". No dependency install, no ports, no
+database — reading code does not need `node_modules`. Repo facts come from
+the factory's existing `config/repos.yaml` (`FACTORY_REPOS_ROOT` overrides
+the checkout it is read from); the runtime is a reader, never a second
+registry. The operator's live checkout is never used: it holds uncommitted
+work an agent would read as truth, concurrent runs would race in it, and even
+a read-only run wants `git fetch`, which writes to `.git`.
+
+**Tier 2 — full worktree (held, deliberately).** Branch, install, ports,
+per-ticket database. Two rules when it is built:
+
+1. **Delegate, never reimplement.** `config/repos.yaml` already declares
+   `worktree_up`/`worktree_down`/`verify` per repo; the provider shells out to
+   them. Git isolates branches, not ports or databases — a second worktree
+   implementation inside the runtime would drift and eventually collide with a
+   dev server.
+2. **The blocker is coordination, not workspaces.** Per event-runtime.md §3,
+   before an event run may claim a ticket or mutate code, both paths must
+   share one claim, capacity, Owned Paths, and approval authority with the
+   ticket dispatcher. Two independent mutation coordinators race even with
+   separate source trees, and both draw on the same unobservable subscription
+   usage window. That is the work to do first — not a workspace provider.
+
 ## 6. Ticket cut-lines (when the operator says go)
 
 1. **Postgres substrate** — port `db.mjs`; same schema; `SKIP LOCKED` in

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -85,6 +85,25 @@ allowlist (`lab`, `web`), probes `df` before/after, and the verifier
 not match is a ContractViolation, not a success. An unregistered action ID
 refuses before executing anything.
 
+## Repository workspaces and the triage chain (OPS-228/OPS-229)
+
+`workspace.type: "repository"` gives an agent a **read-only** source tree:
+a bare mirror per repo (`<home>/mirrors/<repo>.git`, fetched at plan time),
+and per run a detached worktree at the SHA the planner pinned into
+`input.repoPin`. No install, no ports — reading code needs neither. Repo
+facts come from the factory's own `config/repos.yaml`
+(`FACTORY_REPOS_ROOT` to point elsewhere); the operator's live checkout is
+never touched. Full worktrees for *coding* tasks are deliberately not built —
+see [workers doc §5a](../docs/event-runtime-workers.md).
+
+First consumer: `factory.triage.requested` → `triage-scan@1` reads the pinned
+tree plus Linear and emits a typed plan (`TRIAGE` with per-issue actions from
+a closed set, or `NOOP`) → the chain proposes `triage-apply@1` → the operator
+approves the **concrete per-issue action list** → the actions adapter's
+item-list mode resolves each action id to one fixed `tools/linear.mjs`
+invocation. An unregistered action id refuses before applying anything,
+including the valid items beside it.
+
 ## Demo environments and e2e (OPS-217)
 
 `bin/worktree-up.sh` provisions an **isolated, seeded** runtime — the part
@@ -160,6 +179,7 @@ spec (§12).
 | `lib/worker.mjs` | single worker: lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
+| `lib/repos.mjs` `lib/repository.mjs` | repos.yaml reader; mirror + pinned read-only checkout (OPS-228) |
 | `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |
 | `lib/chain.mjs` `edges.json` | discovered chains: typed recommendation → internal event → watched proposal (OPS-223) |
 | `lib/adapters/command.mjs` | closed-template command executor — the only admissible mutating agent form (§14) |

--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -1,0 +1,79 @@
+{
+  "id": "triage-apply",
+  "version": 1,
+  "prompt": "agents/triage-apply.md",
+  "input_schema": "schemas/triage-apply.input.json",
+  "output_schema": "schemas/triage-applied.output.json",
+  "output_contract": "factory.triage-applied/v1",
+  "itemsField": "plan",
+  "itemKey": "issueId",
+  "actionRegistry": {
+    "label-agent-ready": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Todo",
+        "--add",
+        "ai:agent-ready"
+      ]
+    },
+    "move-to-todo": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Todo"
+      ]
+    },
+    "needs-detail": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "comment",
+        "{issueId}",
+        "triage: {reason}"
+      ]
+    },
+    "mark-duplicate": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "comment",
+        "{issueId}",
+        "triage: possible duplicate — {reason}"
+      ]
+    },
+    "needs-human": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "comment",
+        "{issueId}",
+        "triage: needs a human decision — {reason}"
+      ]
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/triage-apply.md": "sha256:4ff7a95e86abb5bbc82bdff3202090673a87347e256e40c03bd1d963b2499992",
+    "schemas/triage-apply.input.json": "sha256:9f62f3ba601e031e96a26d4c9ee42f3008b6f12fe3d7c832d63ffa42474688ad",
+    "schemas/triage-applied.output.json": "sha256:5e4d4a2e59423a2aab88357521ff1e37889d50d658bee7278d599400f5dc3365"
+  }
+}

--- a/event-runtime/agents/triage-apply.md
+++ b/event-runtime/agents/triage-apply.md
@@ -1,0 +1,19 @@
+# triage-apply — closed action-list executor for Linear triage
+
+Not a prompt: this definition applies an **approved per-issue action list**
+via the deterministic actions adapter in item-list mode
+(`lib/adapters/actions.mjs`). No model runs.
+
+Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+
+| action id | effect |
+| :--- | :--- |
+| `label-agent-ready` | `state {issueId} "Todo" --add ai:agent-ready` — the full make-dispatchable transition (the protocol's `Todo` + `ai:agent-ready`) |
+| `move-to-todo` | `state {issueId} "Todo"` |
+| `needs-detail` | `comment {issueId} "<reason>"` — tells the human exactly what is missing |
+| `mark-duplicate` | `comment {issueId} "<reason>"` — names the covering issue; the relation stays a human call |
+| `needs-human` | `comment {issueId} "<reason>"` |
+
+Every action is additive or a forward state move; nothing here closes,
+deletes, or reassigns an issue. An action ID outside this table refuses
+before applying anything — including the legitimate items alongside it.

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -1,0 +1,30 @@
+{
+  "id": "triage-scan",
+  "version": 1,
+  "prompt": "agents/triage-scan.md",
+  "input_schema": "schemas/triage-scan.input.json",
+  "output_schema": "schemas/triage-scan.output.json",
+  "output_contract": "factory.triage-plan/v1",
+  "workspace": {
+    "type": "repository",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:read",
+      "repo:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/triage-scan.md": "sha256:f78451d1e543ee57bc18c514770a9082af58052a27b0bcf5ee78409a3a67fa89",
+    "schemas/triage-scan.input.json": "sha256:9ba24feb44d0b20da3529d978a286d9173ecc5dbd9559da29fc8f98461ec6724",
+    "schemas/triage-scan.output.json": "sha256:27f7e5bbe5e109561f2a3f055dd7801ef263f6750b84936105e6d54070efba97"
+  }
+}

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -1,0 +1,63 @@
+# triage-scan — assess a repo's open Linear issues, propose a typed triage plan
+
+You are a triage analyst. `./input.json` names one repo and the exact source
+tree to read it against:
+
+```json
+{
+  "repo": "bj29",
+  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+}
+```
+
+`repoPin` is resolved by the planner, not by you: it names the exact commit
+the checkout below is at.
+
+The repo's source is checked out **read-only** at `./repo` (that exact SHA).
+You never modify it, never run its build, never install anything. Write
+`./result.json`. Work only inside this directory.
+
+## Method
+
+1. List the repo's open issues in `Triage` and `Todo`:
+   `factory linear issues --repo <name>` (or `bun "$FACTORY_ROOT/tools/linear.mjs"`).
+2. For each, judge whether an agent could pick it up **unambiguously**, using
+   `./repo` to check the claims: do the named files exist, is the described
+   behaviour actually still there, has it already been fixed on this SHA?
+3. Propose exactly one action per issue you touch — leave the rest alone.
+
+## Actions — the closed set
+
+| action | when |
+| :--- | :--- |
+| `label-agent-ready` | fully specified: acceptance criteria, owned paths, verification command |
+| `move-to-todo` | specified and ready to queue (usually alongside agent-ready) |
+| `needs-detail` | real work, but an agent would have to guess — say what is missing |
+| `mark-duplicate` | another open issue covers it; name that issue in `reason` |
+| `needs-human` | a decision only the operator can make |
+
+Never invent an action id. Never propose changes to issues outside this repo.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "TRIAGE",
+    "repo": "bj29",
+    "plan": [
+      { "issueId": "CLNT-123", "action": "label-agent-ready", "reason": "one sentence of why" }
+    ],
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the reads this rests on"], "issuesSeen": 7 }
+}
+```
+
+Queue already clean, or nothing you can judge confidently → `recommendation:
+"NOOP"` with an empty `plan` and a summary saying so. That is a good outcome,
+not a failure. If Linear is unreachable, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -38,5 +38,17 @@
         }
       }
     }
+  },
+  "triage-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "TRIAGE": {
+        "eventType": "factory.triage-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "plan": "$.artifact.plan"
+        }
+      }
+    }
   }
 }

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -48,5 +48,21 @@
       "inputHash"
     ],
     "proposalTtlSeconds": 1800
+  },
+  "factory.triage.requested": {
+    "agent": "triage-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.triage-apply.requested": {
+    "agent": "triage-apply@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -21,6 +21,7 @@
 import { spawnSync } from "node:child_process";
 import { appendFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
 
 const OUTPUT_TAIL_CHARS = 2_000;
 
@@ -46,10 +47,101 @@ function probeBytes(raw) {
   return Number(match[1]);
 }
 
+/** Substitute {field} placeholders across an argv template (item-list mode). */
+function substituteArgv(argv, context) {
+  return argv.map((element) =>
+    element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
+      const value = context?.[field];
+      if (value === undefined || value === null || !["string", "number"].includes(typeof value)) {
+        throw new Error(`argv template references missing/non-primitive field "${field}"`);
+      }
+      return String(value);
+    }),
+  );
+}
+
+/**
+ * Item-list mode (OPS-229): the approved plan is a *list*, each item resolved
+ * to a fixed local argv from the closed registry — one registered action per
+ * item, nothing else executable. Used by triage-apply, where each item is a
+ * Linear transition rather than a remote shell command.
+ */
+async function executeItemList({ spec, def, workspaceDir, timeoutMs }) {
+  const log = path.join(workspaceDir, ".actions.log");
+  const fail = (message) => {
+    appendFileSync(log, `REFUSED before execution: ${message}\n`, "utf8");
+    return { exitCode: 1, timedOut: false };
+  };
+
+  const items = spec.input?.[def.itemsField];
+  if (!Array.isArray(items) || items.length === 0) return fail(`no items in input.${def.itemsField}`);
+
+  // Resolve EVERY item before executing ANY: an unregistered action id in the
+  // approved list is a refusal, never a partial application.
+  const resolved = [];
+  try {
+    for (const item of items) {
+      const registered = def.actionRegistry?.[item.action];
+      if (!registered?.argv) throw new Error(`action "${item.action}" is not in the closed action registry`);
+      resolved.push({
+        item,
+        argv: substituteArgv(registered.argv, { ...spec.input, ...item, factoryRoot: FACTORY_ROOT }),
+      });
+    }
+  } catch (err) {
+    return fail(err.message);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  const applied = [];
+  const outputs = {};
+  for (const { item, argv } of resolved) {
+    const budget = Math.max(1000, deadline - Date.now());
+    const proc = spawnSync(argv[0], argv.slice(1), { encoding: "utf8", timeout: budget, cwd: FACTORY_ROOT });
+    const raw = `${proc.stdout ?? ""}${proc.stderr ?? ""}`.slice(-OUTPUT_TAIL_CHARS);
+    const key = `${item[def.itemKey]}:${item.action}`;
+    outputs[key] = raw;
+    appendFileSync(log, `$ ${key}: ${argv.join(" ")}\n${raw}\n`, "utf8");
+    if (proc.error?.code === "ETIMEDOUT") {
+      appendFileSync(log, `TIMED OUT after ${applied.length}/${resolved.length}\n`, "utf8");
+      return { exitCode: null, timedOut: true };
+    }
+    if (proc.status !== 0) {
+      // Partial application is a real outcome: the log records what landed,
+      // and the attempt fails so nothing claims success it cannot prove.
+      appendFileSync(log, `FAILED on ${key} (exit ${proc.status}) after ${applied.length} applied\n`, "utf8");
+      return { exitCode: proc.status ?? 1, timedOut: false };
+    }
+    applied.push({ issueId: item[def.itemKey], action: item.action });
+  }
+
+  writeFileSync(
+    path.join(workspaceDir, "result.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: { repo: spec.input.repo, applied },
+        evidence: { commands: resolved.map((r) => r.argv), outputs },
+        artifacts: [{ kind: "log", path: ".actions.log" }],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return { exitCode: 0, timedOut: false };
+}
+
 /**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs }) {
+  // Two closed-registry shapes: a per-item local argv list (OPS-229) and the
+  // remote probe → act → probe flow (OPS-208). The definition picks.
+  if (def.itemsField) return executeItemList({ spec, def, workspaceDir, timeoutMs });
+
   const log = path.join(workspaceDir, ".actions.log");
   const fail = (message) => {
     appendFileSync(log, `REFUSED before execution: ${message}\n`, "utf8");

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -53,6 +53,39 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env }) {
     });
     return { exitCode: 0, timedOut: false };
   }
+  if (spec.outputContract === "factory.triage-plan/v1") {
+    // Repo "clean" → NOOP; anything else proposes one agent-ready transition.
+    const repo = spec.input?.repo;
+    const clean = repo === "clean";
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: clean
+        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: queue already clean" }
+        : {
+            recommendation: "TRIAGE",
+            repo,
+            plan: [{ issueId: "CLNT-999", action: "label-agent-ready", reason: "fake: fully specified" }],
+            summary: `fake triage of ${repo}`,
+          },
+      evidence: { commands: ["fake"], issuesSeen: 1 },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.triage-applied/v1") {
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        repo: spec.input.repo,
+        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action })),
+      },
+      evidence: { commands: ["fake"] },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
   if (spec.outputContract === "factory.disk-diagnosis/v1") {
     // Stale-alert semantics ride on the alert's own number: < 85% → NOOP.
     const stale = (spec.input?.usedPct ?? 100) < 85;

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -13,6 +13,9 @@ import { fileURLToPath } from "node:url";
 /** Absolute path of the event-runtime/ directory inside the factory repo. */
 export const RUNTIME_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
+/** The factory checkout itself — where config/repos.yaml lives (OPS-228). */
+export const FACTORY_ROOT = path.dirname(RUNTIME_ROOT);
+
 export function runtimeHome() {
   return process.env.FACTORY_EVENT_HOME || path.join(homedir(), ".factory", "event-runtime");
 }
@@ -26,6 +29,11 @@ export function workspacesRoot(home = runtimeHome()) {
 }
 
 /** Durable content-addressed artifact store (§7) — survives its workspaces. */
+/** Bare mirrors backing tier-1 repository workspaces (OPS-228). */
+export function mirrorsRoot(home = runtimeHome()) {
+  return path.join(home, "mirrors");
+}
+
 export function artifactsRoot(home = runtimeHome()) {
   return path.join(home, "artifacts");
 }
@@ -33,6 +41,7 @@ export function artifactsRoot(home = runtimeHome()) {
 export function ensureHome(home = runtimeHome()) {
   mkdirSync(workspacesRoot(home), { recursive: true });
   mkdirSync(artifactsRoot(home), { recursive: true });
+  mkdirSync(mirrorsRoot(home), { recursive: true });
   return home;
 }
 

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -14,6 +14,7 @@ import { tx } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun } from "./lifecycle.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
+import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
 
 /**
@@ -121,7 +122,21 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const input = validate(def.inputSchema, envelope.payload);
     if (!input.valid) return humanNeeded(db, event, `invalid_input: ${input.errors[0]}`, at, ttlSeconds);
 
-    const idempotencyKey = idempotencyKeyFor(mapping, def, envelope, hashJson(envelope.payload));
+    // §7 tier 1 (OPS-228): a repository workspace resolves its ref to an
+    // immutable SHA *now*, so the pin is inside the spec's input (and its
+    // inputHash, and the receipt). A run therefore names the exact tree it
+    // read, and dedup distinguishes "same repo, new commit".
+    let payload = envelope.payload;
+    if (def.workspace?.type === "repository") {
+      try {
+        payload = { ...payload, repoPin: pinRepo(payload.repo, payload.ref ?? undefined) };
+      } catch (err) {
+        return humanNeeded(db, event, `repo_pin_failed: ${err.message}`, at, ttlSeconds);
+      }
+    }
+
+    const pinnedEnvelope = payload === envelope.payload ? envelope : { ...envelope, payload };
+    const idempotencyKey = idempotencyKeyFor(mapping, def, pinnedEnvelope, hashJson(payload));
     const existingRun = db.query(`SELECT run_id FROM runs WHERE idempotency_key = ?`).get(idempotencyKey);
     if (existingRun) {
       const proposal = insertProposal(db, {
@@ -133,7 +148,7 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     }
 
     const runId = newRunId();
-    const spec = buildRunSpec(registry, envelope, mapping, { runId, policyVersion, adapterOverride, now });
+    const spec = buildRunSpec(registry, pinnedEnvelope, mapping, { runId, policyVersion, adapterOverride, now });
     const specJson = canonicalJson(spec);
     const specHash = hashJson(spec);
     createRun(db, {

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -39,7 +39,16 @@ function loadAgentDef(root, file) {
       Array.isArray(def.exec) &&
       Object.values(def.actionRegistry).every((a) => typeof a?.remote === "string") &&
       Object.values(def.hosts).every((t) => typeof t === "string");
-    if (!closedArgv && !closedActionRegistry) {
+    // Item-list form (OPS-229): every registered action is a fixed local argv,
+    // applied per approved item — closed by construction, same as the others.
+    const closedItemList =
+      def.actionRegistry !== undefined &&
+      typeof def.itemsField === "string" &&
+      typeof def.itemKey === "string" &&
+      Object.values(def.actionRegistry).every(
+        (a) => Array.isArray(a?.argv) && a.argv.length > 0 && a.argv.every((e) => typeof e === "string"),
+      );
+    if (!closedArgv && !closedActionRegistry && !closedItemList) {
       throw new RegistryError(
         `${file}: mutating agents are admitted only as closed command templates or closed action registries (docs/event-runtime.md §14; OPS-223/OPS-208)`,
       );

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -1,0 +1,78 @@
+/**
+ * Repo facts, read from the factory's existing config/repos.yaml (OPS-228).
+ *
+ * Deliberately a reader, not an owner: repos.yaml is already the single
+ * source of routing truth for the dispatcher (base branch, worktree scripts,
+ * verify command). A second registry inside the event runtime would drift,
+ * and a drifting port or base branch is how two agents collide.
+ *
+ * Tier 1 uses `name`, `path`, `github`, and `base`. The `worktree_*` and
+ * `verify` fields are read but unused until tier 2 (docs/event-runtime-workers.md).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { FACTORY_ROOT } from "./config.mjs";
+
+export class RepoError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RepoError";
+  }
+}
+
+/**
+ * Which factory checkout supplies repos.yaml. Defaults to the running one;
+ * FACTORY_REPOS_ROOT points elsewhere (a runtime serving another checkout —
+ * and the hook that makes these tests hermetic instead of depending on
+ * whichever repos happen to exist on the machine).
+ */
+export function reposRoot() {
+  return process.env.FACTORY_REPOS_ROOT || FACTORY_ROOT;
+}
+
+export function reposConfigPath(root = reposRoot()) {
+  return path.join(root, "config", "repos.yaml");
+}
+
+/** Expand a leading ~ the way the config files write paths. */
+export function expandHome(p) {
+  if (typeof p !== "string") return p;
+  if (p === "~") return process.env.HOME ?? p;
+  if (p.startsWith("~/")) return path.join(process.env.HOME ?? "", p.slice(2));
+  return p;
+}
+
+/**
+ * @returns {Map<string, {name: string, path: string, github: string|null, base: string,
+ *                        worktreeUp: string|null, worktreeDown: string|null, verify: string|null}>}
+ */
+export function loadRepos({ root = reposRoot() } = {}) {
+  const file = reposConfigPath(root);
+  if (!existsSync(file)) throw new RepoError(`no repos config at ${file}`);
+  const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  const repos = new Map();
+  for (const entry of parsed?.repos ?? []) {
+    if (!entry?.name) throw new RepoError(`${file}: a repo entry has no name`);
+    if (!entry.path) throw new RepoError(`${file}: repo ${entry.name} has no path`);
+    repos.set(entry.name, {
+      name: entry.name,
+      path: expandHome(entry.path),
+      github: entry.github ?? null,
+      base: entry.base ?? "main",
+      worktreeUp: entry.worktree_up ?? null,
+      worktreeDown: entry.worktree_down ?? null,
+      verify: entry.verify ?? null,
+    });
+  }
+  return repos;
+}
+
+export function getRepo(repos, name) {
+  const repo = repos.get(name);
+  if (!repo) {
+    throw new RepoError(
+      `repo "${name}" is not in config/repos.yaml (have: ${[...repos.keys()].join(", ") || "none"})`,
+    );
+  }
+  return repo;
+}

--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -1,0 +1,120 @@
+/**
+ * Tier-1 repository workspaces (docs/event-runtime.md §7; OPS-228).
+ *
+ * Read-only access to a repo's source, cheaply and reproducibly:
+ *
+ *   bare mirror (cached, per repo)  →  detached worktree at a pinned SHA
+ *
+ * No dependency install, no ports, no database — reading code does not need
+ * node_modules, and that is the whole reason this tier is separate from the
+ * tier-2 worktree path (which delegates to the repo's own worktree scripts).
+ *
+ * Why a mirror instead of the operator's checkout: the live checkout holds
+ * uncommitted work an agent would read as truth, two runs would race in one
+ * directory, and even a read-only run wants `git fetch`, which writes to
+ * .git. The mirror is the runtime's own cache; the operator's tree is never
+ * touched, never read.
+ *
+ * The SHA is resolved at plan time and pinned into the run's input, so a
+ * result is reproducible and a stale tree can never silently make a shipped
+ * feature read as unshipped.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { mirrorsRoot } from "./config.mjs";
+import { getRepo, loadRepos } from "./repos.mjs";
+
+export class RepositoryWorkspaceError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RepositoryWorkspaceError";
+  }
+}
+
+const git = (args, cwd) => {
+  try {
+    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  } catch (err) {
+    const detail = err.stderr?.toString().trim() || err.message;
+    throw new RepositoryWorkspaceError(`git ${args.slice(0, 2).join(" ")} failed: ${detail}`);
+  }
+};
+
+export function mirrorPath(repoName, root = mirrorsRoot()) {
+  return path.join(root, `${repoName}.git`);
+}
+
+/**
+ * Create the mirror if absent, otherwise fetch it. The source is the local
+ * checkout's path (fast, offline-friendly); it is only ever *read*.
+ */
+export function syncMirror(repo, { root = mirrorsRoot() } = {}) {
+  const mirror = mirrorPath(repo.name, root);
+  if (!existsSync(mirror)) {
+    if (!existsSync(repo.path)) {
+      throw new RepositoryWorkspaceError(`repo ${repo.name}: no checkout at ${repo.path} to mirror from`);
+    }
+    mkdirSync(root, { recursive: true });
+    git(["clone", "--mirror", "--quiet", repo.path, mirror]);
+  } else {
+    git(["fetch", "--prune", "--quiet", "origin"], mirror);
+  }
+  return mirror;
+}
+
+/**
+ * Resolve a ref to an immutable SHA in the mirror. Called at plan time so the
+ * SHA lands in the RunSpec input (and therefore the inputHash and receipt).
+ */
+export function resolveRef(repo, ref = repo.base, { root = mirrorsRoot() } = {}) {
+  const mirror = syncMirror(repo, { root });
+  const sha = git(["rev-parse", `${ref}^{commit}`], mirror);
+  return { mirror, sha };
+}
+
+/** Plan-time helper: repo name + optional ref → the facts a spec should pin. */
+export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = {}) {
+  const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+  const { sha } = resolveRef(repo, ref ?? repo.base, { root: mirrors });
+  return { repo: repo.name, ref: ref ?? repo.base, sha, github: repo.github };
+}
+
+/**
+ * Materialize the run's read-only source tree: a detached worktree of the
+ * mirror at the pinned SHA, inside the run's workspace directory.
+ *
+ * @returns {{ path: string, sha: string }} absolute checkout path
+ */
+export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "repo", mirrors = mirrorsRoot(), reposRoot }) {
+  if (!sha) throw new RepositoryWorkspaceError(`repo ${repoName}: no pinned sha in the run input`);
+  const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+  const mirror = syncMirror(repo, { root: mirrors });
+
+  // Confinement: the checkout must land inside the workspace, always.
+  const target = path.resolve(workspaceDir, subdir);
+  if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
+    throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
+  }
+
+  git(["worktree", "add", "--detach", "--quiet", target, sha], mirror);
+  return { path: target, sha };
+}
+
+/**
+ * Remove a materialized checkout and deregister it from the mirror. The
+ * mirror itself persists as cache — that is the point of the tier.
+ */
+export function releaseCheckout({ checkoutPath, repoName, mirrors = mirrorsRoot(), reposRoot }) {
+  if (!checkoutPath || !existsSync(checkoutPath)) return false;
+  try {
+    const repo = getRepo(loadRepos(reposRoot ? { root: reposRoot } : {}), repoName);
+    const mirror = mirrorPath(repo.name, mirrors);
+    if (existsSync(mirror)) git(["worktree", "remove", "--force", checkoutPath], mirror);
+    else rmSync(checkoutPath, { recursive: true, force: true });
+  } catch {
+    // Never let cleanup mask a run's real outcome; the directory goes either way.
+    rmSync(checkoutPath, { recursive: true, force: true });
+  }
+  return true;
+}

--- a/event-runtime/lib/repository.test.mjs
+++ b/event-runtime/lib/repository.test.mjs
@@ -1,0 +1,154 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expandHome, getRepo, loadRepos, RepoError } from "./repos.mjs";
+import {
+  materializeCheckout,
+  mirrorPath,
+  releaseCheckout,
+  RepositoryWorkspaceError,
+  resolveRef,
+  syncMirror,
+} from "./repository.mjs";
+
+const scratch = [];
+const tmp = (prefix) => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+};
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const git = (args, cwd) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+/** A tiny real repo — the provider's whole job is git, so fake git proves nothing. */
+function makeRepo() {
+  const dir = tmp("evrt-src-");
+  git(["init", "--quiet", "--initial-branch=main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(path.join(dir, "README.md"), "first\n");
+  git(["add", "."], dir);
+  git(["commit", "--quiet", "-m", "first"], dir);
+  const first = git(["rev-parse", "HEAD"], dir);
+  writeFileSync(path.join(dir, "README.md"), "second\n");
+  git(["commit", "--quiet", "-am", "second"], dir);
+  return { dir, first, head: git(["rev-parse", "HEAD"], dir) };
+}
+
+/** A repos.yaml pointing at it, so the loader is exercised for real too. */
+function makeFactoryRoot(repoPath, name = "testrepo") {
+  const root = tmp("evrt-factory-");
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n  - name: ${name}\n    path: ${repoPath}\n    github: watt-mind/${name}\n    base: main\n    worktree_up: bin/worktree-up.sh\n    verify: echo ok\n`,
+  );
+  return root;
+}
+
+describe("repos.yaml is read, not owned", () => {
+  test("loads the fields tier 1 needs and expands ~", () => {
+    const src = makeRepo();
+    const repos = loadRepos({ root: makeFactoryRoot(src.dir) });
+    const repo = getRepo(repos, "testrepo");
+    expect(repo).toMatchObject({
+      name: "testrepo",
+      path: src.dir,
+      github: "watt-mind/testrepo",
+      base: "main",
+      worktreeUp: "bin/worktree-up.sh",
+      verify: "echo ok",
+    });
+    expect(expandHome("~/x")).toBe(path.join(process.env.HOME ?? "", "x"));
+  });
+
+  test("an unknown repo names what is configured instead of failing vaguely", () => {
+    const repos = loadRepos({ root: makeFactoryRoot(makeRepo().dir) });
+    expect(() => getRepo(repos, "nope")).toThrow(/not in config\/repos\.yaml \(have: testrepo\)/);
+  });
+
+  test("a missing config fails closed", () => {
+    expect(() => loadRepos({ root: tmp("evrt-empty-") })).toThrow(RepoError);
+  });
+});
+
+describe("mirror + pinned checkout", () => {
+  test("mirrors on first use, fetches thereafter, and never writes to the source", () => {
+    const src = makeRepo();
+    const mirrors = tmp("evrt-mirrors-");
+    const repo = getRepo(loadRepos({ root: makeFactoryRoot(src.dir) }), "testrepo");
+
+    const mirror = syncMirror(repo, { root: mirrors });
+    expect(mirror).toBe(mirrorPath("testrepo", mirrors));
+    expect(existsSync(path.join(mirror, "HEAD"))).toBe(true);
+
+    // Source stays pristine: no worktrees registered, no new refs.
+    expect(git(["worktree", "list"], src.dir).split("\n")).toHaveLength(1);
+
+    // Second call is a fetch, not a re-clone — and picks up new commits.
+    writeFileSync(path.join(src.dir, "third.txt"), "third\n");
+    git(["add", "."], src.dir);
+    git(["commit", "--quiet", "-m", "third"], src.dir);
+    syncMirror(repo, { root: mirrors });
+    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(git(["rev-parse", "HEAD"], src.dir));
+  });
+
+  test("resolves a ref to an immutable sha — the pin a run is reproducible against", () => {
+    const src = makeRepo();
+    const mirrors = tmp("evrt-mirrors-");
+    const repo = getRepo(loadRepos({ root: makeFactoryRoot(src.dir) }), "testrepo");
+    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
+    expect(resolveRef(repo, src.first, { root: mirrors }).sha).toBe(src.first);
+  });
+
+  test("materializes the pinned tree inside the workspace, then releases it", () => {
+    const src = makeRepo();
+    const mirrors = tmp("evrt-mirrors-");
+    const reposRoot = makeFactoryRoot(src.dir);
+    const workspaceDir = tmp("evrt-ws-");
+
+    // Pinned to the FIRST commit: the checkout must show that tree, not HEAD.
+    const checkout = materializeCheckout({
+      workspaceDir,
+      repoName: "testrepo",
+      sha: src.first,
+      mirrors,
+      reposRoot,
+    });
+    expect(checkout.path).toBe(path.join(workspaceDir, "repo"));
+    expect(readFileSync(path.join(checkout.path, "README.md"), "utf8")).toBe("first\n");
+
+    releaseCheckout({ checkoutPath: checkout.path, repoName: "testrepo", mirrors, reposRoot });
+    expect(existsSync(checkout.path)).toBe(false);
+    // The mirror survives as cache, with no stale worktree registration.
+    expect(existsSync(mirrorPath("testrepo", mirrors))).toBe(true);
+    expect(git(["worktree", "list"], mirrorPath("testrepo", mirrors))).not.toContain(workspaceDir);
+  });
+
+  test("a checkout may not escape its workspace", () => {
+    const src = makeRepo();
+    const mirrors = tmp("evrt-mirrors-");
+    const reposRoot = makeFactoryRoot(src.dir);
+    expect(() =>
+      materializeCheckout({
+        workspaceDir: tmp("evrt-ws-"),
+        repoName: "testrepo",
+        sha: src.head,
+        subdir: "../escaped",
+        mirrors,
+        reposRoot,
+      }),
+    ).toThrow(RepositoryWorkspaceError);
+  });
+
+  test("an unpinned run refuses rather than guessing a ref", () => {
+    expect(() =>
+      materializeCheckout({ workspaceDir: tmp("evrt-ws-"), repoName: "testrepo", sha: null }),
+    ).toThrow(/no pinned sha/);
+  });
+});

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -1,0 +1,213 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as actions from "./adapters/actions.mjs";
+import * as fake from "./adapters/fake.mjs";
+import { resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+const git = (args, cwd) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+// Hermetic repo fixtures: these tests must not depend on which repos happen
+// to be checked out on the machine, so they point FACTORY_REPOS_ROOT at a
+// generated config over two throwaway git repos.
+const fixtures = [];
+let previousReposRoot;
+let mirrorsDir;
+
+function makeGitRepo(name) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  fixtures.push(dir);
+  git(["init", "--quiet", "--initial-branch=develop"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(path.join(dir, "README.md"), `${name}\n`);
+  git(["add", "."], dir);
+  git(["commit", "--quiet", "-m", "init"], dir);
+  return dir;
+}
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  fixtures.push(root);
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  const bj29 = makeGitRepo("bj29");
+  const clean = makeGitRepo("clean");
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: bj29\n    path: ${bj29}\n    github: watt-mind/bj29\n    base: develop\n` +
+      `  - name: clean\n    path: ${clean}\n    github: watt-mind/clean\n    base: develop\n`,
+  );
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  // Mirrors land under the runtime home, which these tests also isolate.
+  mirrorsDir = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  fixtures.push(mirrorsDir);
+  process.env.FACTORY_EVENT_HOME = mirrorsDir;
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-ws-"));
+  const adapters = { claude: fake, actions: fake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+const triageEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.triage.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-13T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("triage chain: scan → approved apply (OPS-229)", () => {
+  test("a TRIAGE verdict proposes the concrete per-issue action list, watched", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, triageEnvelope("bj29", "triage-1"));
+
+    const scan = await approveNext("triage-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1");
+    expect(apply.status).toBe("open"); // never applied without approval
+    expect(apply.spec.input).toEqual({
+      repo: "bj29",
+      plan: [{ issueId: "CLNT-999", action: "label-agent-ready", reason: "fake: fully specified" }],
+    });
+
+    const applied = await approveNext("triage-apply@1");
+    expect(applied.summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json);
+    expect(result.artifact.applied).toEqual([{ issueId: "CLNT-999", action: "label-agent-ready" }]);
+  });
+
+  test("a clean queue converges to NOOP — nothing proposed, nothing applied", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, triageEnvelope("clean", "triage-2"));
+    await approveNext("triage-scan@1");
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "triage-apply@1")).toBeUndefined();
+  });
+
+  test("the scan run's spec pins an immutable sha — reproducible, and dedup sees new commits", async () => {
+    const { db } = harness();
+    admitEvent(db, registry, triageEnvelope("bj29", "triage-3"));
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "triage-scan@1");
+    expect(proposal.spec.input.repo).toBe("bj29");
+    expect(proposal.spec.input.repoPin).toMatchObject({ repo: "bj29", ref: "develop" });
+    expect(proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("an unknown repo parks as human_needed instead of planning a run", async () => {
+    const { db } = harness();
+    admitEvent(db, registry, triageEnvelope("not-a-repo", "triage-4"));
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.decision === "human_needed");
+    expect(proposal.reason).toContain("repo_pin_failed");
+  });
+});
+
+describe("triage-apply is closed by construction (OPS-229)", () => {
+  // A real definition-shaped stand-in whose actions are harmless local argv.
+  function localDef(dir) {
+    return {
+      ref: "test-triage@1",
+      itemsField: "plan",
+      itemKey: "issueId",
+      actionRegistry: {
+        "label-agent-ready": { argv: ["sh", "-c", `echo {issueId} >> ${dir}/applied.txt`] },
+      },
+    };
+  }
+
+  test("applies one registered action per item and records what landed", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-"));
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-ws-"));
+    const outcome = await actions.execute({
+      spec: {
+        input: {
+          repo: "bj29",
+          plan: [
+            { issueId: "CLNT-1", action: "label-agent-ready" },
+            { issueId: "CLNT-2", action: "label-agent-ready" },
+          ],
+        },
+      },
+      def: localDef(dir),
+      workspaceDir,
+      timeoutMs: 10_000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    expect(readFileSync(path.join(dir, "applied.txt"), "utf8").split("\n").filter(Boolean)).toEqual([
+      "CLNT-1",
+      "CLNT-2",
+    ]);
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact.applied).toHaveLength(2);
+  });
+
+  test("an unregistered action refuses before applying ANY item — including the valid ones", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-"));
+    const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-apply-ws-"));
+    const outcome = await actions.execute({
+      spec: {
+        input: {
+          repo: "bj29",
+          plan: [
+            { issueId: "CLNT-1", action: "label-agent-ready" },
+            { issueId: "CLNT-2", action: "delete-everything" },
+          ],
+        },
+      },
+      def: localDef(dir),
+      workspaceDir,
+      timeoutMs: 10_000,
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(() => readFileSync(path.join(dir, "applied.txt"))).toThrow(); // CLNT-1 never ran
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
+      "not in the closed action registry",
+    );
+  });
+
+  test("the registry admits item-list definitions and rejects a mutating one with no closed form", () => {
+    expect(registry.agents.get("triage-apply@1").mutating).toBe(true);
+    expect(registry.agents.get("triage-apply@1").itemsField).toBe("plan");
+    expect(registry.agents.get("triage-scan@1").workspace.type).toBe("repository");
+  });
+});

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -110,6 +110,8 @@ export async function executeClaimed(db, registry, adapters, claim, {
     .get(runId, attempt)?.lease_owner ?? "worker";
   const retain = spec.workspace?.retainOnFailure === true;
   let workspaceDir = null;
+  let checkoutPath = null;
+  const repoName = spec.input?.repoPin?.repo ?? spec.input?.repo ?? null;
 
   /** Terminal failure-shaped write: transition + attempts row, one tx. */
   const failTerminal = (to, journalReason, reasonCode, { requeue = false } = {}) =>
@@ -137,14 +139,18 @@ export async function executeClaimed(db, registry, adapters, claim, {
         .run(iso(now), runId, attempt);
     });
 
-    workspaceDir = createWorkspace({ root: workspacesRoot, runId, attempt, input: spec.input }).dir;
+    const created = createWorkspace({
+      root: workspacesRoot, runId, attempt, input: spec.input, workspace: spec.workspace,
+    });
+    workspaceDir = created.dir;
+    checkoutPath = created.checkout?.path ?? null;
     db.query(`UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`)
       .run(workspaceDir, runId, attempt);
 
     const adapter = adapters[spec.adapter];
     if (!adapter) {
       failTerminal("FAILED", "unknown_adapter", "unknown_adapter");
-      destroyWorkspace(workspaceDir, { retain });
+      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       return { runId, attempt, terminalState: "FAILED", reasonCode: "unknown_adapter" };
     }
     const def = getAgent(registry, spec.agent);
@@ -155,13 +161,13 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     if (timedOut) {
       failTerminal("TIMED_OUT", "timeout", "timeout");
-      destroyWorkspace(workspaceDir, { retain });
+      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       return { runId, attempt, terminalState: "TIMED_OUT", reasonCode: "timeout" };
     }
     if (exitCode !== 0) {
       const reasonCode = `agent_exit_${exitCode}`;
       failTerminal("FAILED", reasonCode, reasonCode, { requeue: true });
-      destroyWorkspace(workspaceDir, { retain });
+      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
 
@@ -191,7 +197,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           });
         }
       });
-      destroyWorkspace(workspaceDir, { retain });
+      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       return { runId, attempt, terminalState: "FAILED", reasonCode: "contract_violation" };
     }
 
@@ -216,7 +222,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         );
         finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, now);
       });
-      destroyWorkspace(workspaceDir);
+      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
       return { runId, attempt, terminalState: "REFUSED", reasonCode: verified.reasonCode };
     }
 
@@ -267,15 +273,15 @@ export async function executeClaimed(db, registry, adapters, claim, {
     });
 
     if (published.fenced) {
-      destroyWorkspace(workspaceDir);
+      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
       return { fenced: true };
     }
-    destroyWorkspace(workspaceDir);
+    destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
     return { runId, attempt, terminalState: "COMPLETED", reasonCode: "ok", receipt: published.receipt };
   } catch (err) {
     if (err instanceof IllegalTransition) {
       // Operator moved the run under us (cancel) — stop quietly, publish nothing.
-      if (workspaceDir) destroyWorkspace(workspaceDir);
+      if (workspaceDir) destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
       return { cancelled: true };
     }
     throw err;

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -11,6 +11,7 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson } from "./canonical.mjs";
+import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 
 export class PathViolation extends Error {
   constructor(workspaceDir, relPath) {
@@ -40,19 +41,38 @@ export function safeJoin(workspaceDir, relPath) {
 /**
  * Create the attempt's directory and materialize its declared input as
  * canonical JSON — the same bytes the spec's inputHash was computed from.
+ *
+ * A `repository` workspace additionally materializes a read-only source tree
+ * at the SHA pinned into the input at plan time (§7 tier 1, OPS-228). The
+ * checkout lives inside this directory, so teardown is still one rm — plus a
+ * `git worktree remove` so the mirror does not accumulate stale registrations.
  */
-export function createWorkspace({ root, runId, attempt, input }) {
+export function createWorkspace({ root, runId, attempt, input, workspace = {} }) {
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "input.json"), `${canonicalJson(input)}\n`, "utf8");
-  return { dir };
+
+  let checkout = null;
+  if (workspace.type === "repository") {
+    const subdir = workspace.checkoutDir ?? "repo";
+    checkout = materializeCheckout({
+      workspaceDir: dir,
+      repoName: input?.repoPin?.repo ?? input?.repo,
+      sha: input?.repoPin?.sha,
+      subdir,
+    });
+  }
+  return { dir, checkout };
 }
 
 /**
  * Remove the workspace unless retention was requested (§7: retain on failure
  * when policy says so). Returns false when retained, true when destroyed.
  */
-export function destroyWorkspace(dir, { retain = false } = {}) {
+export function destroyWorkspace(dir, { retain = false, checkout = null, repoName = null } = {}) {
+  // Deregister a repository checkout even when the directory is retained:
+  // a mirror that keeps stale worktree registrations refuses future adds.
+  if (checkout) releaseCheckout({ checkoutPath: checkout, repoName });
   if (retain) return false;
   rmSync(dir, { recursive: true, force: true });
   return true;

--- a/event-runtime/schemas/triage-applied.output.json
+++ b/event-runtime/schemas/triage-applied.output.json
@@ -1,0 +1,22 @@
+{
+  "title": "factory.triage-applied/v1 output artifact — what was actually applied",
+  "type": "object",
+  "required": ["repo", "applied"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "applied": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/triage-apply.input.json
+++ b/event-runtime/schemas/triage-apply.input.json
@@ -1,0 +1,25 @@
+{
+  "title": "triage-apply input — the approved per-issue action list",
+  "type": "object",
+  "required": ["repo", "plan"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"]
+          },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/triage-scan.input.json
+++ b/event-runtime/schemas/triage-scan.input.json
@@ -1,0 +1,44 @@
+{
+  "title": "triage-scan input \u2014 one repo; repoPin is resolved by the planner (OPS-228)",
+  "type": "object",
+  "required": [
+    "repo"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ref": {
+      "type": "string"
+    },
+    "repoPin": {
+      "type": "object",
+      "required": [
+        "repo",
+        "sha"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "github": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/triage-scan.output.json
+++ b/event-runtime/schemas/triage-scan.output.json
@@ -1,0 +1,26 @@
+{
+  "title": "factory.triage-plan/v1 output artifact — typed, per-issue triage decisions",
+  "type": "object",
+  "required": ["recommendation", "repo", "plan", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": { "enum": ["TRIAGE", "NOOP"] },
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"]
+          },
+          "reason": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}


### PR DESCRIPTION
Fixes OPS-228
Fixes OPS-229

**Tier 1 repository workspace.** Bare mirror per repo + per-run detached worktree at a plan-time-pinned SHA (`input.repoPin`). No install, no ports, no database. Repo facts read from the existing `config/repos.yaml` (`FACTORY_REPOS_ROOT` overrides); the operator's live checkout is never read or written.

**Triage chain.** `factory.triage.requested` → `triage-scan@1` (read-only, repository workspace) emits `TRIAGE` with per-issue actions from a closed set, or `NOOP` → chain proposes `triage-apply@1` → operator approves the concrete list → actions adapter (new item-list mode) applies each action id as one fixed `tools/linear.mjs` call. Unregistered action id ⇒ refuse before applying anything.

**Tier 2 held and documented** (workers doc §5a): delegate to the repo's own worktree scripts, and the real blocker is shared claim/capacity/Owned Paths with the ticket dispatcher (§3), not the workspace provider.

Verification: 169 tests green (15 new, hermetic — they build throwaway git repos rather than depending on machine state; one exposed that pinning previously only worked where bj29 happened to exist). Live: injected a real triage event, planner pinned bj29 develop at 3497450, approval materialized the checkout and the chain proposed triage-apply.