### PR TITLE
feat(event-runtime): split the worker into its own process (OPS-233)

### DIFF
--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -40,6 +40,7 @@ fi
 
 RUN_DIR="$(run_dir "$WT")"
 stop_daemon "$RUN_DIR/web.pid" "web server"
+stop_daemon "$RUN_DIR/worker.pid" "worker"
 stop_daemon "$RUN_DIR/serve.pid" "event runtime"
 
 if [[ "$HERE" -eq 1 ]]; then

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -113,6 +113,21 @@ else
   echo $! >"$RUN_DIR/serve.pid"
 fi
 
+# The worker is its own process (OPS-233): restarting the runtime or the web
+# server must never interrupt a running agent.
+if pid_alive "$RUN_DIR/worker.pid"; then
+  info "worker already running (pid $(cat "$RUN_DIR/worker.pid"))"
+else
+  info "starting worker (fake adapter)"
+  (
+    cd "$WT" || exit 1
+    exec env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+      bun event-runtime/cli.mjs work --adapter-override fake \
+      </dev/null >"$RUN_DIR/worker.log" 2>&1
+  ) &
+  echo $! >"$RUN_DIR/worker.pid"
+fi
+
 if pid_alive "$RUN_DIR/web.pid"; then
   info "web server already running (pid $(cat "$RUN_DIR/web.pid"), port $WEB_PORT)"
 else
@@ -158,7 +173,7 @@ $(info "ready — $LABEL")
   event home $HOME_DIR
   control    http://127.0.0.1:$API_PORT      (fake adapter — approvals are harmless)
   web UI     http://127.0.0.1:$WEB_PORT
-  logs       $RUN_DIR/{serve,web}.log
+  logs       $RUN_DIR/{serve,worker,web}.log
 
   status:  FACTORY_EVENT_PORT=$API_PORT bun event-runtime/cli.mjs status
   verify:  cd $WT && bun test event-runtime/ && bun event-runtime/demo/verify.mjs --port $API_PORT

--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -28,16 +28,34 @@ Two consequences worth stating because they answer real operator questions:
   fencing token already make this safe to change — they were built for the
   multi-worker future, and guard nothing today.
 
-## 2. Stage 1 — worker as a process (same machine)
+## 2. Stage 1 — worker as a process (same machine) — **shipped, OPS-233**
 
 The smallest real step, and a prerequisite for everything after:
 
-- **Substrate: Postgres** replaces SQLite — same schema, same contracts.
-  `claimNext` gains `FOR UPDATE SKIP LOCKED` (§10 names this as the
-  mechanism that is meaningless before a second claimant exists).
+- **Substrate: SQLite, for now.** A correction to this note's original plan:
+  splitting the process does **not** require Postgres. SQLite in WAL mode
+  already supports multiple processes on one machine — what it needed was
+  `BEGIN IMMEDIATE` on the claim (the default deferred transaction lets two
+  workers read the same QUEUED row before either writes) and `busy_timeout`
+  set *before* `journal_mode`, or a second process opening the database
+  fails with `SQLITE_BUSY_RECOVERY`. Postgres with `FOR UPDATE SKIP LOCKED`
+  is the **remote node** requirement (stage 2), not the multi-process one;
+  the claim path is one module so that swap stays an implementation change.
 - **`cli.mjs work`** — a standalone process running the loop `runOnce`
   already contains: claim → workspace → adapter → verify → fenced publish.
-  `serve` keeps API, planner, approval, and outbox, and stops executing.
+  `serve` keeps API, planner, approval, outbox, and the reaper, and no longer
+  executes (`--with-worker` restores the all-in-one for a quick demo).
+- **Worker registry and heartbeats.** Leases prove an *attempt* is held; the
+  registry answers which processes are alive, where, and with what labels —
+  the difference between "busy on a long run" and "died holding a lease".
+  The heartbeat runs on its own timer, never inside the claim loop, because
+  that loop blocks for the whole duration of an agent run.
+- **Bounded graceful drain.** SIGTERM stops claiming and lets the in-flight
+  attempt finish, but only for a grace period (`--drain-timeout`, default
+  60s): waiting out a ten-minute run trains operators to SIGKILL, which
+  orphans the agent process and leaves a lying registry row. On timeout the
+  worker leaves honestly and says what happens next — the lease expires and
+  the reaper requeues.
 - **Concurrency becomes a worker count**, still deliberately small. Two
   `work` processes are the correctness proof (leases and fencing under real
   contention); raising agent-run parallelism beyond that waits for an answer

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -26,6 +26,7 @@ bun event-runtime/cli.mjs ps [state]                     # running event process
 bun event-runtime/cli.mjs runs [state]                   # event runs, optionally filtered by state
 bun event-runtime/cli.mjs proposals                   # open proposals with TTL age
 bun event-runtime/cli.mjs agents                      # registered agents and event routing
+bun event-runtime/cli.mjs workers                     # worker processes: host, labels, state, heartbeat
 bun event-runtime/cli.mjs requeue <source> <event-id> # re-plan a dead-lettered/human_needed event
 bun event-runtime/cli.mjs approve <proposal-id>
 bun event-runtime/cli.mjs reject <proposal-id> "<reason>"
@@ -179,6 +180,7 @@ spec (§12).
 | `lib/worker.mjs` | single worker: lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
+| `lib/workers.mjs` | worker registry, heartbeats, placement predicate (OPS-233) |
 | `lib/repos.mjs` `lib/repository.mjs` | repos.yaml reader; mirror + pinned read-only checkout (OPS-228) |
 | `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |
 | `lib/chain.mjs` `edges.json` | discovered chains: typed recommendation → internal event → watched proposal (OPS-223) |

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -15,6 +15,7 @@
  */
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
 import * as actions from "./lib/adapters/actions.mjs";
 import * as claude from "./lib/adapters/claude.mjs";
 import * as command from "./lib/adapters/command.mjs";
@@ -30,7 +31,8 @@ import { resolveChains } from "./lib/chain.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
 import { startApi } from "./lib/api.mjs";
-import { reapExpiredLeases, runOnce } from "./lib/worker.mjs";
+import { claimNext, executeClaimed, reapExpiredLeases, runOnce } from "./lib/worker.mjs";
+import { deregisterWorker, heartbeat, registerWorker } from "./lib/workers.mjs";
 
 const USAGE = `event-runtime — watched event → agent runtime (docs/event-runtime.md)
 
@@ -47,6 +49,7 @@ usage: bun event-runtime/cli.mjs <command>
   runs [state]                   runs (optionally filtered by state)
   proposals                      open proposals with TTL age
   agents                         registered agent definitions and event routing
+  workers                        worker processes: host, labels, state, heartbeat
   approve <proposal-id>          approve an open proposal
   reject <proposal-id> <reason>  reject an open proposal
   inject <envelope.json|->       replay an event envelope (same intake as the webhook)
@@ -166,9 +169,14 @@ async function serve(args) {
     }
   }
 
+  // The worker is its own process now (OPS-233): restarting the API to
+  // iterate must not kill a running agent. `--with-worker` restores the old
+  // all-in-one behaviour for a quick single-process demo.
+  const withWorker = args.includes("--with-worker");
+
   let busy = false;
   async function tick() {
-    if (busy) return; // runOnce is async — never overlap the single worker (§3)
+    if (busy) return; // never overlap: planning and (optional) execution share this tick
     busy = true;
     try {
       const nowMs = Date.now();
@@ -176,9 +184,11 @@ async function serve(args) {
       announceProposals();
       announceTransitions();
       reapExpiredLeases(db, { now: nowMs, policyVersion: pv });
-      await runOnce(db, registry, adapters, {
-        workspacesRoot: workspacesRoot(), owner, now: Date.now(), policyVersion: pv,
-      });
+      if (withWorker) {
+        await runOnce(db, registry, adapters, {
+          workspacesRoot: workspacesRoot(), owner, now: Date.now(), policyVersion: pv,
+        });
+      }
       announceTransitions();
       // Watched-mode outbox sink (§15): display the result event, stamp it published.
       publishOutbox(db, {
@@ -209,6 +219,11 @@ async function serve(args) {
   server.on("listening", () => {
     log(`environment "${env.name}" — control API on http://${API_HOST}:${port} (db ${dbPath()}, policy ${pv})`);
     if (adapterOverride) log(`adapter override: all new run specs use "${adapterOverride}"`);
+    log(
+      withWorker
+        ? "worker: in-process (--with-worker) — restarting serve interrupts running agents"
+        : "worker: none in this process — start one with: bun event-runtime/cli.mjs work",
+    );
   });
   server.on("error", (err) => fail(`serve: ${err.message}`));
 
@@ -236,6 +251,133 @@ async function serve(args) {
   };
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
+}
+
+// ---------------------------------------------------------------------------
+// work — the worker process (OPS-233; docs/event-runtime-workers.md §2)
+// ---------------------------------------------------------------------------
+
+/**
+ * A worker owns exactly one thing: claim → execute → verify → publish. It
+ * never serves the API and never plans, so `serve` can restart under it
+ * freely — the whole point of the split. It talks to the same database, and
+ * on one machine SQLite (WAL + BEGIN IMMEDIATE claims) makes concurrent
+ * claiming correct; Postgres is what remote nodes need, not this.
+ *
+ *   bun event-runtime/cli.mjs work [--label k=v ...] [--adapter-override fake]
+ */
+async function work(args) {
+  const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
+  const adapters = { actions, claude, command, fake };
+  if (adapterOverride && !adapters[adapterOverride]) {
+    fail(`work: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
+  }
+
+  // --label node=lab --label can=infra-exec  → placement (§4)
+  const labels = {};
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] !== "--label") continue;
+    const [key, ...rest] = String(args[i + 1] ?? "").split("=");
+    if (!key || rest.length === 0) fail("work: --label expects key=value");
+    labels[key] = rest.join("=");
+  }
+
+  ensureHome();
+  const db = openDb();
+  const registry = loadRegistry();
+  const pv = policyVersion();
+  const workerId = newWorkerId();
+  const adapterNames = adapterOverride ? [adapterOverride] : Object.keys(adapters);
+
+  registerWorker(db, { workerId, labels, adapters: adapterNames });
+  log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
+  if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
+  if (adapterOverride) log(`adapter override: executing every run with "${adapterOverride}"`);
+
+  let draining = false;
+  let inFlight = null;
+
+  // The heartbeat runs on its own timer, NOT inside the claim loop: that loop
+  // blocks for the whole duration of an agent run (up to the spec timeout),
+  // so a loop-driven heartbeat would mark every legitimately busy worker as
+  // stale — and the doctor's "stalled worker" check exists precisely to tell
+  // busy apart from dead.
+  const beat = setInterval(
+    () => heartbeat(db, workerId, { state: inFlight ? "busy" : "idle", runId: inFlight }),
+    15_000,
+  );
+  beat.unref?.();
+
+  async function loop() {
+    while (!draining) {
+      try {
+        heartbeat(db, workerId, { state: inFlight ? "busy" : "idle", runId: inFlight });
+        const claim = claimNext(db, {
+          owner: workerId, policyVersion: pv, labels,
+          adapters: adapterOverride ? null : adapterNames,
+        });
+        if (!claim) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          continue;
+        }
+        inFlight = claim.runId;
+        heartbeat(db, workerId, { state: "busy", runId: claim.runId });
+        log(`claimed ${claim.runId} attempt ${claim.attempt} (${claim.spec.agent})`);
+        const summary = await executeClaimed(db, registry, adapters, claim, {
+          workspacesRoot: workspacesRoot(), policyVersion: pv,
+          ...(adapterOverride ? { adapterOverride } : {}),
+        });
+        log(`${claim.runId} → ${summary?.terminalState ?? "?"} (${summary?.reasonCode ?? "-"})`);
+      } catch (err) {
+        log(`worker error: ${err.message}`);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      } finally {
+        inFlight = null;
+      }
+    }
+  }
+
+  // Graceful drain: stop claiming, let the attempt in flight finish — the
+  // agent subprocess keeps its own timeout discipline, and killing it here
+  // would be the interruption this split exists to prevent.
+  //
+  // Bounded, though: waiting out a 10-minute agent run trains operators to
+  // SIGKILL, which orphans the agent AND leaves a lying registry row. After
+  // the grace period the worker leaves honestly and says what happens next —
+  // the lease expires and the reaper requeues the run.
+  const drainTimeoutMs = Number(flagValue(args, "--drain-timeout") ?? 60) * 1000;
+  const finish = (reason) => {
+    clearInterval(beat);
+    deregisterWorker(db, workerId);
+    log(`worker stopped (${reason})`);
+    process.exit(0);
+  };
+  const drain = (signal) => {
+    if (draining) {
+      // A second signal means "now": the operator has decided.
+      log("second signal — leaving immediately");
+      return finish("forced");
+    }
+    draining = true;
+    if (!inFlight) return finish(signal);
+    log(`draining (${signal}) — finishing ${inFlight}, up to ${drainTimeoutMs / 1000}s`);
+    const deadline = Date.now() + drainTimeoutMs;
+    const poll = setInterval(() => {
+      if (!inFlight) {
+        clearInterval(poll);
+        return finish(signal);
+      }
+      if (Date.now() >= deadline) {
+        clearInterval(poll);
+        log(`drain timeout — leaving ${inFlight} to its lease; the reaper will requeue it`);
+        finish("drain_timeout");
+      }
+    }, 250);
+  };
+  process.on("SIGINT", () => drain("SIGINT"));
+  process.on("SIGTERM", () => drain("SIGTERM"));
+
+  await loop();
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +498,20 @@ async function inspect(client, runId) {
   }
 }
 
+async function workers(client) {
+  const { workers: rows } = await client.workers();
+  if (rows.length === 0) {
+    console.log("no workers have registered — start one with: bun event-runtime/cli.mjs work");
+    return;
+  }
+  console.log(`${pad("WORKER", 26)}${pad("HOST", 18)}${pad("STATE", 10)}${pad("LABELS", 24)}${pad("CURRENT RUN", 42)}LAST SEEN`);
+  for (const w of rows) {
+    const state = w.stale ? `${w.state}!stale` : w.state;
+    const labels = Object.entries(w.labels).map(([k, v]) => `${k}=${v}`).join(",") || "-";
+    console.log(`${pad(w.workerId, 26)}${pad(w.host, 18)}${pad(state, 10)}${pad(labels, 24)}${pad(w.currentRun ?? "-", 42)}${w.lastSeen}`);
+  }
+}
+
 async function agents(client) {
   const { agents: defs } = await client.agents();
   for (const d of defs) {
@@ -389,6 +545,9 @@ async function main() {
     case "serve":
       return serve(args);
 
+    case "work":
+      return work(args);
+
     case "status":
       return withClient(status);
 
@@ -406,6 +565,9 @@ async function main() {
 
     case "agents":
       return withClient(agents);
+
+    case "workers":
+      return withClient(workers);
 
     case "approve": {
       if (!args[0]) fail("usage: approve <proposal-id>");

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -19,6 +19,7 @@ import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { requeueEvent } from "./planner.mjs";
 import { approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
+import { listWorkers, stalledWorkers } from "./workers.mjs";
 
 /** §14 size limit: a control-plane payload has no business being megabytes. */
 const MAX_BODY_BYTES = 1024 * 1024;
@@ -118,15 +119,27 @@ function statusView(db, nowMs) {
     .all()
     .map((row) => ({ source: row.source, eventId: row.event_id, lastError: row.last_plan_error }));
 
+  const workers = listWorkers(db, { now: nowMs });
+  const stalled = stalledWorkers(db, { now: nowMs });
+
   return {
     events: eventCounts(db),
     proposals: { open: open.length, expired: expiredOpen.length },
     runs: runCounts(db),
+    workers: {
+      live: workers.filter((w) => w.state !== "stopped" && !w.stale).length,
+      busy: workers.filter((w) => w.state === "busy" && !w.stale).length,
+      stale: workers.filter((w) => w.stale).length,
+    },
     anomalies: {
       expiredOpenProposals: expiredOpen.map((p) => p.id),
       staleLeases,
       unpublishedOutbox,
       deadLettered,
+      // A worker holding a run whose heartbeat stopped: its lease may still be
+      // valid, so nothing has reclaimed the run yet (OPS-233).
+      stalledWorkers: stalled.map((w) => ({ workerId: w.workerId, host: w.host, runId: w.currentRun, lastSeen: w.lastSeen })),
+      noWorkers: workers.filter((w) => w.state !== "stopped" && !w.stale).length === 0 && (runCounts(db).byState.QUEUED ?? 0) > 0,
     },
   };
 }
@@ -404,6 +417,10 @@ export function createApi({
         const status = url.searchParams.get("status");
         if (status) return send(res, 200, { proposals: proposalHistory(db, status === "all" ? null : status) });
         return send(res, 200, { proposals: openProposals(db, { now: nowMs }).map(proposalView) });
+      }
+
+      if (route === "GET /workers") {
+        return send(res, 200, { workers: listWorkers(db, { now: nowMs }) });
       }
 
       if (route === "GET /agents") {

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -57,6 +57,7 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
     requeue: (source, eventId) =>
       call("POST", "/events/requeue", { body: JSON.stringify({ source, eventId }) }),
     agents: () => call("GET", "/agents"),
+    workers: () => call("GET", "/workers"),
     approve: (id) => call("POST", `/proposals/${encodeURIComponent(id)}/approve`, { body: "{}" }),
     reject: (id, reason) =>
       call("POST", `/proposals/${encodeURIComponent(id)}/reject`, { body: JSON.stringify({ reason }) }),

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -108,6 +108,19 @@ CREATE TABLE IF NOT EXISTS outbox (
   published_at  TEXT
 );
 
+CREATE TABLE IF NOT EXISTS workers (
+  worker_id   TEXT PRIMARY KEY,
+  host        TEXT NOT NULL,
+  pid         INTEGER NOT NULL,
+  labels_json TEXT NOT NULL DEFAULT '{}',
+  adapters    TEXT NOT NULL DEFAULT '',
+  started_at  TEXT NOT NULL,
+  last_seen   TEXT NOT NULL,
+  state       TEXT NOT NULL DEFAULT 'idle',
+  current_run TEXT,
+  stopped_at  TEXT
+);
+
 CREATE TABLE IF NOT EXISTS counters (
   name  TEXT PRIMARY KEY,
   value INTEGER NOT NULL
@@ -116,14 +129,19 @@ CREATE TABLE IF NOT EXISTS counters (
 CREATE INDEX IF NOT EXISTS idx_runs_state ON runs (state);
 CREATE INDEX IF NOT EXISTS idx_proposals_status ON proposals (status);
 CREATE INDEX IF NOT EXISTS idx_lifecycle_run ON lifecycle_events (run_id, seq);
+CREATE INDEX IF NOT EXISTS idx_workers_last_seen ON workers (last_seen);
 `;
 
 export function openDb(file = dbPath()) {
   if (file !== ":memory:") mkdirSync(path.dirname(file), { recursive: true });
   const db = new Database(file, { create: true });
+  // busy_timeout FIRST: switching journal modes takes a brief exclusive lock,
+  // and a second process opening the database concurrently must wait for it
+  // rather than failing with SQLITE_BUSY_RECOVERY. Ordering matters here —
+  // observed live the moment serve and work became separate processes.
+  db.exec("PRAGMA busy_timeout = 5000;");
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec("PRAGMA foreign_keys = ON;");
-  db.exec("PRAGMA busy_timeout = 5000;");
   db.exec(SCHEMA);
   return db;
 }
@@ -131,6 +149,20 @@ export function openDb(file = dbPath()) {
 /** Run `fn` inside one SQLite transaction; returns its result. */
 export function tx(db, fn) {
   return db.transaction(fn)();
+}
+
+/**
+ * A write transaction that takes its lock up front (OPS-233).
+ *
+ * SQLite's default DEFERRED transaction acquires a read lock first and only
+ * upgrades on the first write — so two workers can both SELECT the same
+ * QUEUED run before either writes, and one then loses the upgrade with
+ * SQLITE_BUSY. BEGIN IMMEDIATE serializes claimants at the start, which is
+ * what makes multi-process claiming correct on one machine. (Postgres uses
+ * FOR UPDATE SKIP LOCKED for the same job when workers span hosts.)
+ */
+export function txImmediate(db, fn) {
+  return db.transaction(fn).immediate();
 }
 
 /** Monotonic named counter — fencing tokens come from here (§8). */

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -13,10 +13,11 @@
 import { storeCollected } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot } from "./config.mjs";
-import { nextCounter, tx } from "./db.mjs";
+import { nextCounter, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
+import { satisfiesPlacement } from "./workers.mjs";
 import { createWorkspace, destroyWorkspace } from "./workspace.mjs";
 
 /**
@@ -65,17 +66,30 @@ function originatingEvent(db, runId) {
  *
  * @returns {{ runId: string, attempt: number, fencingToken: number, spec: object } | null}
  */
-export function claimNext(db, { owner, now = Date.now(), policyVersion = "unknown" } = {}) {
-  return tx(db, () => {
-    const row = db
+export function claimNext(db, { owner, now = Date.now(), policyVersion = "unknown", labels = {}, adapters = null } = {}) {
+  // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
+  // not both read the same QUEUED row before either writes (OPS-233).
+  return txImmediate(db, () => {
+    // Oldest-first, but skip runs this worker may not take — placement
+    // requirements (§4) and adapters it does not have. Filtering in JS keeps
+    // the rule in one predicate; Postgres can push it into SQL later.
+    const candidates = db
       .query(
         `SELECT run_id, spec_json, attempts FROM runs
-         WHERE state = 'QUEUED' ORDER BY created_at, run_id LIMIT 1`,
+         WHERE state = 'QUEUED' ORDER BY created_at, run_id LIMIT 50`,
       )
-      .get();
+      .all();
+    let row = null;
+    let spec = null;
+    for (const candidate of candidates) {
+      const candidateSpec = JSON.parse(candidate.spec_json);
+      if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
+      if (adapters && !adapters.includes(candidateSpec.adapter)) continue;
+      row = candidate;
+      spec = candidateSpec;
+      break;
+    }
     if (!row) return null;
-
-    const spec = JSON.parse(row.spec_json);
     const attempt = row.attempts + 1;
     const fencingToken = nextCounter(db, "fencing");
     const leaseExpiresAt = iso(now + (spec.timeoutSeconds + LEASE_GRACE_SECONDS) * 1000);

--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -1,0 +1,95 @@
+/**
+ * Worker registry and heartbeats (OPS-233; docs/event-runtime-workers.md §2, §4).
+ *
+ * Leases prove that an *attempt* is held. This answers a different question:
+ * which worker processes are alive, where, and what are they allowed to run.
+ * A lease alone cannot distinguish "a worker is busy on a long agent run"
+ * from "a worker died and its lease has not expired yet" — the heartbeat can,
+ * and the doctor view says so.
+ *
+ * Labels are the placement mechanism (§4): a worker declares what and where
+ * it is, a spec may declare requirements, and the claim query filters. There
+ * is no scheduler process — the claim IS the scheduler.
+ */
+import { hostname } from "node:os";
+import { tx } from "./db.mjs";
+
+/** A worker is considered gone if it has not checked in for this long. */
+export const HEARTBEAT_STALE_MS = 90_000;
+
+const iso = (now) => new Date(now).toISOString();
+
+export function registerWorker(db, { workerId, labels = {}, adapters = [], now = Date.now() }) {
+  const at = iso(now);
+  db.query(
+    `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'idle')
+     ON CONFLICT(worker_id) DO UPDATE SET
+       host = excluded.host, pid = excluded.pid, labels_json = excluded.labels_json,
+       adapters = excluded.adapters, last_seen = excluded.last_seen,
+       state = 'idle', stopped_at = NULL`,
+  ).run(workerId, hostname(), process.pid, JSON.stringify(labels), adapters.join(","), at, at);
+  return { workerId, host: hostname(), pid: process.pid, labels, adapters };
+}
+
+/** Called every loop tick: proof of life, plus what the worker is doing. */
+export function heartbeat(db, workerId, { state = "idle", runId = null, now = Date.now() } = {}) {
+  db.query(`UPDATE workers SET last_seen = ?, state = ?, current_run = ? WHERE worker_id = ?`)
+    .run(iso(now), state, runId, workerId);
+}
+
+/** Clean exit: recorded, so a stopped worker is distinguishable from a dead one. */
+export function deregisterWorker(db, workerId, { now = Date.now() } = {}) {
+  db.query(`UPDATE workers SET state = 'stopped', stopped_at = ?, current_run = NULL WHERE worker_id = ?`)
+    .run(iso(now), workerId);
+}
+
+export function listWorkers(db, { now = Date.now() } = {}) {
+  return db
+    .query(`SELECT * FROM workers ORDER BY started_at DESC`)
+    .all()
+    .map((row) => ({
+      workerId: row.worker_id,
+      host: row.host,
+      pid: row.pid,
+      labels: JSON.parse(row.labels_json),
+      adapters: row.adapters ? row.adapters.split(",") : [],
+      startedAt: row.started_at,
+      lastSeen: row.last_seen,
+      state: row.state,
+      currentRun: row.current_run,
+      stoppedAt: row.stopped_at,
+      stale: row.state !== "stopped" && now - Date.parse(row.last_seen) > HEARTBEAT_STALE_MS,
+    }));
+}
+
+/**
+ * Doctor input (§13): a worker holding a run whose heartbeat has gone stale.
+ * Its lease may still be valid, so nothing has reclaimed the run yet — that
+ * gap is exactly what an operator wants told, not discovered.
+ */
+export function stalledWorkers(db, { now = Date.now() } = {}) {
+  return listWorkers(db, { now }).filter((w) => w.stale && w.currentRun);
+}
+
+/** Drop long-stopped workers so the registry reflects the fleet, not history. */
+export function pruneWorkers(db, { olderThanMs = 24 * 60 * 60 * 1000, now = Date.now() } = {}) {
+  return tx(db, () => {
+    const cutoff = iso(now - olderThanMs);
+    const { changes } = db
+      .query(`DELETE FROM workers WHERE state = 'stopped' AND stopped_at < ?`)
+      .run(cutoff);
+    return changes ?? 0;
+  });
+}
+
+/**
+ * Placement (§4): does this worker satisfy a spec's requirements? Absent
+ * requirements mean any worker; a declared key must match exactly. Kept as a
+ * pure predicate so the SQLite claim can filter in JS today and Postgres can
+ * push the same rule into SQL later.
+ */
+export function satisfiesPlacement(labels, placement) {
+  if (!placement || Object.keys(placement).length === 0) return true;
+  return Object.entries(placement).every(([key, value]) => String(labels?.[key]) === String(value));
+}

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openDb } from "./db.mjs";
+import { createRun } from "./lifecycle.mjs";
+import { claimNext } from "./worker.mjs";
+import {
+  deregisterWorker,
+  HEARTBEAT_STALE_MS,
+  heartbeat,
+  listWorkers,
+  pruneWorkers,
+  registerWorker,
+  satisfiesPlacement,
+  stalledWorkers,
+} from "./workers.mjs";
+
+const PV = "git:test-pv";
+const db = () => openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-workers-")), "runtime.db"));
+
+/** A QUEUED run, straight through the real lifecycle. */
+function queueRun(database, { runId, placement, adapter = "fake" }) {
+  const spec = {
+    schemaVersion: "factory.run-spec/v1",
+    runId,
+    agent: "a@1",
+    input: {},
+    adapter,
+    timeoutSeconds: 60,
+    maxAttempts: 1,
+    ...(placement ? { placement } : {}),
+  };
+  createRun(database, {
+    runId,
+    idempotencyKey: runId,
+    spec,
+    specJson: JSON.stringify(spec),
+    specHash: `sha256:${runId}`,
+    actor: "planner",
+    policyVersion: PV,
+  });
+  database.query(`UPDATE runs SET state = 'QUEUED' WHERE run_id = ?`).run(runId);
+  return spec;
+}
+
+describe("cross-process claiming (OPS-233)", () => {
+  test("two workers contending for one run: exactly one wins", () => {
+    const d = db();
+    queueRun(d, { runId: "run_contended" });
+
+    const first = claimNext(d, { owner: "worker-a", policyVersion: PV });
+    const second = claimNext(d, { owner: "worker-b", policyVersion: PV });
+
+    expect(first?.runId).toBe("run_contended");
+    expect(second).toBeNull(); // no double-claim, no second attempt row
+    expect(d.query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`).get("run_contended").n).toBe(1);
+    expect(d.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_contended").state).toBe("LEASED");
+  });
+
+  test("each worker takes a different run, oldest first", () => {
+    const d = db();
+    queueRun(d, { runId: "run_1" });
+    queueRun(d, { runId: "run_2" });
+
+    const a = claimNext(d, { owner: "worker-a", policyVersion: PV });
+    const b = claimNext(d, { owner: "worker-b", policyVersion: PV });
+    expect([a.runId, b.runId]).toEqual(["run_1", "run_2"]);
+    expect(claimNext(d, { owner: "worker-c", policyVersion: PV })).toBeNull();
+  });
+
+  test("fencing tokens are monotonic across workers — the publish guard still holds", () => {
+    const d = db();
+    queueRun(d, { runId: "run_1" });
+    queueRun(d, { runId: "run_2" });
+    const a = claimNext(d, { owner: "worker-a", policyVersion: PV });
+    const b = claimNext(d, { owner: "worker-b", policyVersion: PV });
+    expect(b.fencingToken).toBeGreaterThan(a.fencingToken);
+  });
+});
+
+describe("placement (OPS-233, workers doc §4)", () => {
+  test("a worker only claims runs whose placement its labels satisfy", () => {
+    const d = db();
+    queueRun(d, { runId: "run_lab", placement: { node: "lab" } });
+
+    expect(claimNext(d, { owner: "web-worker", policyVersion: PV, labels: { node: "web" } })).toBeNull();
+    const claimed = claimNext(d, { owner: "lab-worker", policyVersion: PV, labels: { node: "lab" } });
+    expect(claimed?.runId).toBe("run_lab");
+  });
+
+  test("an unplaced run is claimable by any worker", () => {
+    const d = db();
+    queueRun(d, { runId: "run_any" });
+    expect(claimNext(d, { owner: "w", policyVersion: PV, labels: { node: "anywhere" } })?.runId).toBe("run_any");
+  });
+
+  test("a placed run is skipped, not blocking: the next eligible run is claimed", () => {
+    const d = db();
+    queueRun(d, { runId: "run_lab_first", placement: { node: "lab" } });
+    queueRun(d, { runId: "run_unplaced" });
+    const claimed = claimNext(d, { owner: "web-worker", policyVersion: PV, labels: { node: "web" } });
+    expect(claimed?.runId).toBe("run_unplaced");
+  });
+
+  test("a worker skips adapters it does not have", () => {
+    const d = db();
+    queueRun(d, { runId: "run_claude", adapter: "claude" });
+    expect(claimNext(d, { owner: "w", policyVersion: PV, adapters: ["command"] })).toBeNull();
+    expect(claimNext(d, { owner: "w", policyVersion: PV, adapters: ["claude"] })?.runId).toBe("run_claude");
+  });
+
+  test("satisfiesPlacement: every declared key must match; no requirement means anywhere", () => {
+    expect(satisfiesPlacement({ node: "lab" }, undefined)).toBe(true);
+    expect(satisfiesPlacement({ node: "lab" }, {})).toBe(true);
+    expect(satisfiesPlacement({ node: "lab", can: "infra-exec" }, { node: "lab" })).toBe(true);
+    expect(satisfiesPlacement({ node: "lab" }, { node: "lab", can: "infra-exec" })).toBe(false);
+    expect(satisfiesPlacement({}, { node: "lab" })).toBe(false);
+  });
+});
+
+describe("worker registry and heartbeats (OPS-233)", () => {
+  test("registers, heartbeats with its current run, and deregisters cleanly", () => {
+    const d = db();
+    registerWorker(d, { workerId: "w1", labels: { node: "lab" }, adapters: ["fake"] });
+    let [w] = listWorkers(d);
+    expect(w).toMatchObject({ workerId: "w1", state: "idle", labels: { node: "lab" }, adapters: ["fake"] });
+    expect(w.stale).toBe(false);
+
+    heartbeat(d, "w1", { state: "busy", runId: "run_1" });
+    [w] = listWorkers(d);
+    expect(w).toMatchObject({ state: "busy", currentRun: "run_1" });
+
+    deregisterWorker(d, "w1");
+    [w] = listWorkers(d);
+    expect(w.state).toBe("stopped");
+    expect(w.currentRun).toBeNull();
+    expect(w.stale).toBe(false); // stopped is not stale — it left on purpose
+  });
+
+  test("a silent worker goes stale; holding a run makes it a doctor anomaly", () => {
+    const d = db();
+    const started = Date.now();
+    registerWorker(d, { workerId: "w1", now: started });
+    heartbeat(d, "w1", { state: "busy", runId: "run_1", now: started });
+
+    const later = started + HEARTBEAT_STALE_MS + 1000;
+    expect(listWorkers(d, { now: later })[0].stale).toBe(true);
+    expect(stalledWorkers(d, { now: later })).toHaveLength(1);
+
+    // An idle worker that goes quiet is stale but not an anomaly: nothing is stuck.
+    heartbeat(d, "w1", { state: "idle", runId: null, now: started });
+    expect(stalledWorkers(d, { now: later })).toHaveLength(0);
+  });
+
+  test("re-registering the same id revives it rather than duplicating", () => {
+    const d = db();
+    registerWorker(d, { workerId: "w1" });
+    deregisterWorker(d, "w1");
+    registerWorker(d, { workerId: "w1", labels: { node: "web" } });
+    const rows = listWorkers(d);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ state: "idle", labels: { node: "web" }, stoppedAt: null });
+  });
+
+  test("pruning drops long-stopped workers only", () => {
+    const d = db();
+    const old = Date.now() - 48 * 60 * 60 * 1000;
+    registerWorker(d, { workerId: "old", now: old });
+    deregisterWorker(d, "old", { now: old });
+    registerWorker(d, { workerId: "live" });
+    expect(pruneWorkers(d)).toBe(1);
+    expect(listWorkers(d).map((w) => w.workerId)).toEqual(["live"]);
+  });
+});


### PR DESCRIPTION
Fixes OPS-233

Decouples the API/web backend from execution so the stack can be iterated without interrupting in-flight agents, built so multiple worker nodes are a later config change rather than a refactor.

- **`cli.mjs work`** — standalone worker: claim → execute → verify → fenced publish. `serve` keeps API, planner, approval, outbox, reaper (`--with-worker` restores all-in-one).
- **Atomic cross-process claim** — `BEGIN IMMEDIATE`; the deferred transaction let two workers read the same QUEUED row. Plus `busy_timeout` before `journal_mode` (a second process opening the DB was failing `SQLITE_BUSY_RECOVERY` — found the moment the processes split).
- **Worker registry + heartbeat** — `GET /workers`, `cli.mjs workers`, status counts, and a doctor anomaly for a worker holding a run with a stale heartbeat. Heartbeat runs on its own timer, not in the claim loop (which blocks for a whole agent run).
- **Placement labels** — `work --label node=lab`; specs may declare `placement`; the claim filters. Second node becomes config.
- **Bounded graceful drain** — SIGTERM finishes the in-flight attempt up to `--drain-timeout` (60s), then leaves honestly and says the lease will expire and the reaper will requeue. A second signal exits now.
- `bin/worktree-up.sh`/`down` manage the worker as a third daemon.

**Substrate:** SQLite stays correct for multiple processes on one machine; Postgres is the remote-node requirement (workers doc §2, corrected).

Verification: 181 tests green (12 new — two-worker contention proving exactly one claim, fencing monotonicity, placement filtering/skipping, heartbeat staleness vs stopped, prune). Live: approved a hang run, restarted `serve` under it — worker survived, run stayed RUNNING; SIGTERM with `--drain-timeout 5` drained and exited exactly as designed.