### PR TITLE
ui-ux(event-runtime-web): put the immutable RunSpec with the run block (OPS-236)

### DIFF
--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -368,6 +368,9 @@ export function Runs({
             <KV k="workspace" v={d.workspace} />
             <KV k="created" v={<Ago iso={d.run.created_at} now={now} />} />
             <KV k="updated" v={<Ago iso={d.run.updated_at} now={now} />} />
+            <Disclosure label="immutable RunSpec">
+              <JsonBlock value={d.run.spec} />
+            </Disclosure>
           </Section>
 
           <div className="mb-4 flex gap-2">
@@ -503,12 +506,6 @@ export function Runs({
               ))}
             </Section>
           )}
-
-          <Section title="Spec">
-            <Disclosure label="immutable RunSpec">
-              <JsonBlock value={d.run.spec} />
-            </Disclosure>
-          </Section>
             </>
           )}
         </DetailPane>


### PR DESCRIPTION
## Summary
- Move the existing immutable RunSpec (`Disclosure`/`JsonBlock`) into the Runs detail **run** block, with state/agent/hashes, before lifecycle.
- Lifecycle, attempts, result, artifacts, and receipt stay in that order. No API or verb changes.
- Docs §4.3 already specified this placement; no §10 note needed.

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 190 pass, web build green
- [ ] Open a run in the web UI: Spec is in the run block, not after receipt

UX critique: skipped — reordering an existing detail section, no new flow

Fixes OPS-236