### PR TITLE
fix(event-runtime): close the open proposal when a run is cancelled (OPS-237)

### DIFF
--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -335,6 +335,24 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(unknown.message).toBe("unknown run run_nope");
   });
 
+  test("cancel a PROPOSED run closes its open proposal", async () => {
+    const prop = await planned("can-proposed-1");
+    expect((await s.client.run(prop.runId)).run.state).toBe("PROPOSED");
+    expect((await s.client.proposals()).proposals.map((p) => p.id)).toContain(prop.id);
+
+    expect(await s.client.cancel(prop.runId, "never mind")).toEqual({ cancelled: true });
+    expect((await s.client.run(prop.runId)).run.state).toBe("CANCELLED");
+
+    const open = await s.client.proposals();
+    expect(open.proposals.map((p) => p.id)).not.toContain(prop.id);
+
+    const history = await s.client.proposals("all");
+    const decided = history.proposals.find((p) => p.id === prop.id);
+    expect(decided.status).toBe("rejected");
+    expect(decided.reason).toBe("run_cancelled");
+    expect(decided.decided_by).toBe("operator");
+  });
+
   test("retry: 404 on unknown run, 409 when attempts are exhausted, queued with force", async () => {
     const prop = await planned("retry-1");
     const { runId } = await s.client.approve(prop.id);

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -119,6 +119,29 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
 }
 
 /**
+ * Close the unique open proposal for a cancelled run (reason `run_cancelled`).
+ *
+ * Keyed on `run_id` + `status = 'open'`. Zero matches is a no-op — cancelling
+ * a QUEUED/LEASED/RUNNING run whose proposal is already decided must still
+ * succeed. Two or more open rows for the same run is ambiguous: leave them
+ * all untouched rather than guess which one to close. Caller must already
+ * hold the transaction that performed the CANCELLED transition.
+ *
+ * @returns {{ closed: true, id: string } | { closed: false }}
+ */
+export function closeOpenProposalForRun(db, runId, { actor, now = Date.now() } = {}) {
+  const open = db
+    .query(`SELECT id FROM proposals WHERE run_id = ? AND status = 'open'`)
+    .all(runId);
+  if (open.length !== 1) return { closed: false };
+  const at = new Date(now).toISOString();
+  db.query(
+    `UPDATE proposals SET status = 'rejected', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`,
+  ).run(at, actor, "run_cancelled", open[0].id);
+  return { closed: true, id: open[0].id };
+}
+
+/**
  * Reject an open proposal. A run still sitting in PROPOSED is cancelled with
  * reason 'proposal_rejected' and the operator recorded as actor (§8).
  */

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -3,7 +3,7 @@ import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { lifecycleOf, runState } from "./lifecycle.mjs";
 import { planEvent } from "./planner.mjs";
-import { approveProposal, getProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import { approveProposal, closeOpenProposalForRun, getProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -99,6 +99,44 @@ describe("rejectProposal", () => {
     expect(journal.at(-1).to_state).toBe("CANCELLED");
     expect(journal.at(-1).reason).toBe("proposal_rejected");
     expect(journal.at(-1).actor).toBe("operator");
+  });
+});
+
+describe("closeOpenProposalForRun", () => {
+  test("closes the unique open proposal with reason run_cancelled", () => {
+    const { db, proposal, runId } = planned();
+    const later = NOW + 1000;
+    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: later }))
+      .toEqual({ closed: true, id: proposal.id });
+    const row = getProposal(db, proposal.id);
+    expect(row.status).toBe("rejected");
+    expect(row.reason).toBe("run_cancelled");
+    expect(row.decided_by).toBe("operator");
+    expect(row.decided_at).toBe(new Date(later).toISOString());
+    expect(openProposals(db, { now: later })).toHaveLength(0);
+  });
+
+  test("no-op when the run has no open proposal", () => {
+    const { db, proposal, runId } = planned();
+    approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW });
+    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }))
+      .toEqual({ closed: false });
+    expect(getProposal(db, proposal.id).status).toBe("approved");
+    expect(closeOpenProposalForRun(db, "run_missing", { actor: "operator", now: NOW }))
+      .toEqual({ closed: false });
+  });
+
+  test("leaves every proposal untouched when more than one is open for the run", () => {
+    const { db, proposal, runId } = planned();
+    const at = new Date(NOW).toISOString();
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+       VALUES (?, ?, ?, ?, 'run', ?, 1800)`,
+    ).run("prop_extra", proposal.event_source, proposal.event_id, runId, at);
+    expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }))
+      .toEqual({ closed: false });
+    expect(getProposal(db, proposal.id).status).toBe("open");
+    expect(getProposal(db, "prop_extra").status).toBe("open");
   });
 });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -16,6 +16,7 @@ import { artifactsRoot } from "./config.mjs";
 import { nextCounter, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
+import { closeOpenProposalForRun } from "./proposals.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
 import { satisfiesPlacement } from "./workers.mjs";
 import { createWorkspace, destroyWorkspace } from "./workspace.mjs";
@@ -335,10 +336,16 @@ export async function runOnce(db, registry, adapters, opts = {}) {
 
 /**
  * Operator cancel (§13): legal from any state before VERIFYING; a VERIFYING
- * or terminal run throws IllegalTransition to the caller.
+ * or terminal run throws IllegalTransition to the caller. A still-open
+ * proposal for the run is closed in the same transaction (reason
+ * `run_cancelled`); none, or more than one, is left untouched.
  */
 export function cancelRun(db, runId, { actor, reason = "operator_cancel", now = Date.now(), policyVersion } = {}) {
-  return transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now });
+  return tx(db, () => {
+    const result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now });
+    closeOpenProposalForRun(db, runId, { actor, now });
+    return result;
+  });
 }
 
 /**

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -280,6 +280,57 @@ describe("worker", () => {
     expect(() => cancelRun(db, spec.runId, { actor: "operator" })).toThrow(IllegalTransition);
   });
 
+  test("cancelRun on a PROPOSED run closes its unique open proposal", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec();
+    createRun(db, {
+      runId: spec.runId, idempotencyKey: spec.idempotencyKey,
+      spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
+      actor: "test", policyVersion: "test", now: T0,
+    });
+    linkEvent(db, spec.runId);
+    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+    const proposal = db.query(`SELECT * FROM proposals WHERE run_id = ?`).get(spec.runId);
+    expect(proposal.status).toBe("rejected");
+    expect(proposal.reason).toBe("run_cancelled");
+    expect(proposal.decided_by).toBe("operator");
+    expect(proposal.decided_at).toBe(new Date(T0).toISOString());
+  });
+
+  test("cancelRun with no open proposal still cancels", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec();
+    createRun(db, {
+      runId: spec.runId, idempotencyKey: spec.idempotencyKey,
+      spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
+      actor: "test", policyVersion: "test", now: T0,
+    });
+    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(0);
+  });
+
+  test("cancelRun with two open proposals for the run closes neither", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec();
+    createRun(db, {
+      runId: spec.runId, idempotencyKey: spec.idempotencyKey,
+      spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
+      actor: "test", policyVersion: "test", now: T0,
+    });
+    linkEvent(db, spec.runId);
+    const at = new Date(T0).toISOString();
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+       VALUES (?, ?, ?, ?, 'RUN_SPEC', ?, 1800)`,
+    ).run(`prop-${spec.runId}-extra`, "test", `evt-${spec.runId}`, spec.runId, at);
+    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+    const open = db.query(`SELECT COUNT(*) AS n FROM proposals WHERE run_id = ? AND status = 'open'`).get(spec.runId);
+    expect(open.n).toBe(2);
+  });
+
   test("retryRun: exhausted attempts throw without force, re-queue with force", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] } }));


### PR DESCRIPTION
## Summary
- `cancelRun` now closes the unique open proposal for that run in the same SQLite transaction as the `CANCELLED` transition, with reason `run_cancelled` (status `rejected`).
- Lookup is fail-closed: zero open proposals is a no-op (QUEUED/LEASED/RUNNING cancel still works); two or more open rows for the same `run_id` closes none of them.
- Helper is `closeOpenProposalForRun` in `event-runtime/lib/proposals.mjs`. API cancel path is unchanged — it already goes through `cancelRun`. No web UI changes.

## Test plan
- [x] `bun test event-runtime` — 197 pass, 0 fail
- [x] Existing cancel tests still pass
- [x] New coverage: PROPOSED + unique open proposal; no open proposal; ambiguous (>1 open); GET `/proposals` drops it while `?status=all` shows it decided

Fixes OPS-237