### PR TITLE
fix(event-runtime-web): scope inject arrow keys to the template radiogroup (OPS-239)

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { api } from "../api";
 import { buildTemplates, triggerId, type TriggerTemplate } from "../templates";
 import { Button, Dialog, VerbError, notify } from "./ui";
@@ -79,6 +79,42 @@ export function InjectDialog({
     inject.reset();
   }
 
+  function applyChip(next: string | null) {
+    if (next === null) {
+      setSelected(null);
+      setText(pretty(blankEnvelope(openedAt)));
+      setUnregisteredAck(false);
+      setConfirming(false);
+      inject.reset();
+      return;
+    }
+    if (next === "__given__" && initialEnvelope) {
+      setSelected("__given__");
+      setText(pretty(initialEnvelope));
+      setUnregisteredAck(false);
+      setConfirming(false);
+      inject.reset();
+      return;
+    }
+    const t = templates.find((x) => x.eventType === next);
+    if (t) choose(t);
+  }
+
+  /** Arrows only when a chip (or the group) is focused — not document-wide. */
+  function onTemplateKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
+    if (!keys.includes(e.key)) return;
+    e.preventDefault();
+    const ids: Array<string | null> = [
+      ...(initialEnvelope ? ["__given__"] : []),
+      ...templates.map((t) => t.eventType),
+      null,
+    ];
+    const idx = selected === null ? ids.length - 1 : Math.max(ids.indexOf(selected), 0);
+    const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
+    applyChip(ids[(idx + delta + ids.length) % ids.length]);
+  }
+
   function submit() {
     setClientError(null);
     let envelope: Record<string, unknown>;
@@ -125,43 +161,6 @@ export function InjectDialog({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.target instanceof HTMLTextAreaElement) return;
-      const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
-      if (!keys.includes(e.key)) return;
-      e.preventDefault();
-      const ids: Array<string | null> = [
-        ...(initialEnvelope ? ["__given__"] : []),
-        ...templates.map((t) => t.eventType),
-        null,
-      ];
-      const idx = selected === null ? ids.length - 1 : Math.max(ids.indexOf(selected), 0);
-      const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
-      const next = ids[(idx + delta + ids.length) % ids.length];
-      if (next === null) {
-        setSelected(null);
-        setText(pretty(blankEnvelope(openedAt)));
-        setUnregisteredAck(false);
-        setConfirming(false);
-        inject.reset();
-        return;
-      }
-      if (next === "__given__" && initialEnvelope) {
-        setSelected("__given__");
-        setText(pretty(initialEnvelope));
-        setUnregisteredAck(false);
-        setConfirming(false);
-        inject.reset();
-        return;
-      }
-      const t = templates.find((x) => x.eventType === next);
-      if (t) choose(t);
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [templates, selected, initialEnvelope, openedAt]);
-
   const outcome = inject.data;
   const seeded = Boolean(initialEnvelope);
   return (
@@ -181,19 +180,18 @@ export function InjectDialog({
         </div>
       )}
 
-      <div className="mb-3 flex flex-wrap gap-1.5" role="radiogroup" aria-label="Event type templates">
+      <div
+        className="mb-3 flex flex-wrap gap-1.5"
+        role="radiogroup"
+        aria-label="Event type templates"
+        onKeyDown={onTemplateKeyDown}
+      >
         {initialEnvelope && (
           <button
             type="button"
             role="radio"
             aria-checked={selected === "__given__"}
-            onClick={() => {
-              setSelected("__given__");
-              setText(pretty(initialEnvelope));
-              setUnregisteredAck(false);
-              setConfirming(false);
-              inject.reset();
-            }}
+            onClick={() => applyChip("__given__")}
             className={`rounded-md border px-2 py-1 text-[11.5px] ${
               selected === "__given__"
                 ? "border-(--accent) bg-(--surface-3) text-(--text)"
@@ -225,13 +223,7 @@ export function InjectDialog({
           type="button"
           role="radio"
           aria-checked={selected === null}
-          onClick={() => {
-            setSelected(null);
-            setText(pretty(blankEnvelope(openedAt)));
-            setUnregisteredAck(false);
-            setConfirming(false);
-            inject.reset();
-          }}
+          onClick={() => applyChip(null)}
           className={`rounded-md border px-2 py-1 text-[11.5px] ${
             selected === null
               ? "border-(--accent) bg-(--surface-3) text-(--text)"


### PR DESCRIPTION
## Summary
- Inject template arrows no longer register on `window`. They live on the template radiogroup `onKeyDown`, so they only `preventDefault` and change chips when a chip (or the group) is focused.
- Envelope textarea, other inputs, and ⌘K-on-top-of-inject keep their own arrow handling. Unsaved envelope JSON can no longer be overwritten by an accidental arrow.
- CommandPalette was not changed (Owned Paths: InjectDialog only).

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 190 pass, tsc+vite build green
- [ ] Open inject, focus a template chip, arrows still cycle templates
- [ ] Open inject, focus the envelope textarea, arrows edit text and do not change chips
- [ ] Open inject, then ⌘K: arrows move the palette, not inject chips

UX critique: skipped — keyboard scoping bugfix, no new flow

Fixes OPS-239