### PR TITLE
ui-ux(event-runtime-web): Overview Doctor Requeue jumps like Events (OPS-240)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -371,7 +371,9 @@ proposals → Proposals, run state → that Runs tab). Added: (a) the **doctor p
 its view (expired proposal → that proposal, stale leases → runs,
 dead-lettered → that event's row on the Events dead_lettered tab, unpublished
 outbox → scroll to the outbox feed) and offers requeue
-directly on dead-letter rows; (b) a **live activity feed** off `GET /journal`
+directly on dead-letter rows — toast, poll for the new open proposal, jump to
+`#/proposals/:id` (or an honest toast if none appears, same 8s budget as Events);
+(b) a **live activity feed** off `GET /journal`
 — first fetch seeds the latest entries, then each poll passes
 `since=<last head>` and prepends only what is new, capped at 50 shown, each
 entry rendered as `run · FROM → TO by actor (reason)` with a relative
@@ -456,7 +458,8 @@ no new API.
   Requeue (re-plan) / Replay (same id through intake) / Trigger again (fresh
   id) / Inject (blank or template) distinct.
 - **Overview.** Expired-proposals tile lands on the Open tab with the expired
-  chip on. Quiet Graph and Inject jumps in the header.
+  chip on. Quiet Graph and Inject jumps in the header. Doctor Requeue jumps to
+  the new open proposal like Events.
 - **⌘K** includes decided proposals (`GET /proposals?status=all`). Dialogs
   expose `role=dialog` `aria-modal`. Runs state tabs scroll on one row
   (LEASED and VERIFYING included — the Overview stale-lease jump lands there).

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { useNow } from "../hooks";
 import type { JournalEntry, EventFocus } from "../types";
@@ -15,6 +15,7 @@ import {
   StatTile,
   VerbError,
   copyText,
+  notify,
 } from "../components/ui";
 
 const FEED_CAP = 50;
@@ -78,6 +79,13 @@ export function Overview({
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
   const status = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
   const outbox = useQuery({
     queryKey: ["outbox"],
@@ -88,7 +96,21 @@ export function Overview({
 
   const requeue = useMutation({
     mutationFn: ({ source, eventId }: { source: string; eventId: string }) => api.requeue(source, eventId),
-    onSuccess: () => queryClient.invalidateQueries(),
+    onSuccess: async (_, { source, eventId }) => {
+      queryClient.invalidateQueries();
+      notify(`Requeued event ${eventId}`, "ok");
+      const deadline = Date.now() + 8000;
+      while (alive.current && Date.now() < deadline) {
+        const { proposals } = await api.proposals();
+        const match = proposals.find((p) => p.eventSource === source && p.eventId === eventId);
+        if (match && alive.current) {
+          onJumpProposal(match.id);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      if (alive.current) notify(`Requeued ${eventId} — no open proposal appeared`, "info");
+    },
     onError: () => queryClient.invalidateQueries(),
   });
 


### PR DESCRIPTION
## Summary
- Overview Doctor Requeue now matches Events: success toast, poll `GET /proposals` for 8s, jump to `#/proposals/:id`.
- If no open proposal appears within that budget, an honest info toast instead of silent stay-put.
- Doc note in `docs/event-runtime-webui.md` §10.4 / §10.8.

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 190 pass, web build green
- [ ] From Overview Doctor, Requeue a dead-lettered event; land on the new open proposal
- [ ] If planning does not produce a proposal within 8s, see the honest toast

UX critique: skipped — mirroring an existing success path is not a new flow.

Fixes OPS-240