### PR TITLE
fix(event-runtime-web): keep list filters when selecting a visible row

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -144,12 +144,23 @@ export function Events({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusEvent?.status, focusEvent?.type]);
 
+  // Reveal a hash-selected row only when current filters hide it. A j/k/click
+  // on a visible row, or a 2s poll, must not wipe the typed filter / chips.
+  useEffect(() => {
+    if (!focusEvent?.source || !focusEvent?.eventId) return;
+    const key = `${focusEvent.source}:${focusEvent.eventId}`;
+    if (rows.some((e) => keyOf(e) === key) && !visible.some((e) => keyOf(e) === key)) {
+      setFilter("");
+      setSourceFilter(null);
+      if (!focusEvent.type) setTypeFilter(null);
+    }
+    // rows/visible from the selection-change render; polls must not re-run this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusEvent?.source, focusEvent?.eventId]);
+
   // Hash id: switch to All if the row isn't on this tab. Don't strip the hash.
   useEffect(() => {
     if (!focusEvent?.source || !focusEvent?.eventId) return;
-    setFilter("");
-    setSourceFilter(null);
-    if (!focusEvent.type) setTypeFilter(null);
     const key = `${focusEvent.source}:${focusEvent.eventId}`;
     if (!rows.some((e) => keyOf(e) === key) && tab !== "all") setTab("all");
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -144,19 +144,26 @@ export function Events({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusEvent?.status, focusEvent?.type]);
 
-  // Reveal a hash-selected row only when current filters hide it. A j/k/click
-  // on a visible row, or a 2s poll, must not wipe the typed filter / chips.
+  // Reveal a hash-selected row only when current filters hide it. Latch until
+  // the row exists in `rows` (inject / tab switch / poll); decide once so a
+  // later 2s poll does not wipe a typed filter. j/k/click on a visible row
+  // keeps the chips.
+  const pendingReveal = useRef<string | null>(null);
+  const lastKey = useRef<string | null>(null);
   useEffect(() => {
-    if (!focusEvent?.source || !focusEvent?.eventId) return;
-    const key = `${focusEvent.source}:${focusEvent.eventId}`;
-    if (rows.some((e) => keyOf(e) === key) && !visible.some((e) => keyOf(e) === key)) {
-      setFilter("");
-      setSourceFilter(null);
-      if (!focusEvent.type) setTypeFilter(null);
+    if (selectedKey !== lastKey.current) {
+      lastKey.current = selectedKey;
+      pendingReveal.current = selectedKey;
     }
-    // rows/visible from the selection-change render; polls must not re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusEvent?.source, focusEvent?.eventId]);
+    const key = pendingReveal.current;
+    if (!key || key !== selectedKey) return;
+    if (!rows.some((e) => keyOf(e) === key)) return; // tab switch / poll still pending
+    pendingReveal.current = null; // decided once
+    if (visible.some((e) => keyOf(e) === key)) return; // visible: keep the filters
+    setFilter("");
+    setSourceFilter(null);
+    if (!focusEvent?.type) setTypeFilter(null);
+  }, [selectedKey, rows, visible, focusEvent?.type]);
 
   // Hash id: switch to All if the row isn't on this tab. Don't strip the hash.
   useEffect(() => {

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -115,13 +115,13 @@ export function Proposals({
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
     return rows.filter((p) => {
-      if (expiredOnly && !p.expired) return false;
+      if (expiredOnly && tab === "open" && !p.expired) return false;
       if (!q) return true;
       return [p.id, p.agent, p.decision, p.status, p.eventId, p.reason].some((v) =>
         (v ?? "").toLowerCase().includes(q),
       );
     });
-  }, [rows, filter, expiredOnly]);
+  }, [rows, filter, expiredOnly, tab]);
 
   const selectedId = focusProposalId;
   const selectedIndex = useMemo(() => visible.findIndex((p) => p.id === selectedId), [visible, selectedId]);
@@ -131,18 +131,26 @@ export function Proposals({
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
-  // Reveal a hash-selected proposal only when current filters hide it. A click
-  // on a visible row (including under the expired chip) must not wipe them.
+  // Reveal a hash-selected proposal only when current filters hide it. Latch
+  // until the row exists in `rows` (tab switch / re-plan / poll); decide once
+  // so a later 2s poll does not wipe a typed filter. Click on a visible row
+  // (including under the expired chip) keeps the filters.
+  const pendingReveal = useRef<string | null>(null);
+  const lastKey = useRef<string | null>(null);
   useEffect(() => {
-    if (!focusProposalId) return;
-    if (rows.some((p) => p.id === focusProposalId) && !visible.some((p) => p.id === focusProposalId)) {
-      setFilter("");
-      const row = rows.find((p) => p.id === focusProposalId);
-      if (expiredOnly && row && !row.expired) setExpiredOnly(false);
+    if (focusProposalId !== lastKey.current) {
+      lastKey.current = focusProposalId;
+      pendingReveal.current = focusProposalId;
     }
-    // rows/visible/expiredOnly from the selection-change render; polls must not re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusProposalId]);
+    const key = pendingReveal.current;
+    if (!key || key !== focusProposalId) return;
+    if (!rows.some((p) => p.id === key)) return; // tab switch / poll still pending
+    pendingReveal.current = null; // decided once
+    if (visible.some((p) => p.id === key)) return; // visible: keep the filters
+    setFilter("");
+    const row = rows.find((p) => p.id === key);
+    if (expiredOnly && row && !row.expired) setExpiredOnly(false);
+  }, [focusProposalId, rows, visible, expiredOnly]);
 
   // Deep link: open tab first, then history if the id is a decided proposal.
   // Hash stays; we only switch tabs so the row is in `visible`.

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -131,12 +131,23 @@ export function Proposals({
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
+  // Reveal a hash-selected proposal only when current filters hide it. A click
+  // on a visible row (including under the expired chip) must not wipe them.
+  useEffect(() => {
+    if (!focusProposalId) return;
+    if (rows.some((p) => p.id === focusProposalId) && !visible.some((p) => p.id === focusProposalId)) {
+      setFilter("");
+      const row = rows.find((p) => p.id === focusProposalId);
+      if (expiredOnly && row && !row.expired) setExpiredOnly(false);
+    }
+    // rows/visible/expiredOnly from the selection-change render; polls must not re-run this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusProposalId]);
+
   // Deep link: open tab first, then history if the id is a decided proposal.
   // Hash stays; we only switch tabs so the row is in `visible`.
   useEffect(() => {
     if (!focusProposalId) return;
-    setFilter("");
-    setExpiredOnly(false);
     if (rows.some((p) => p.id === focusProposalId)) return;
     if (tab === "open") setTab("history");
   }, [focusProposalId, rows, tab]);


### PR DESCRIPTION
## Summary
- Selecting an Events or Proposals row (`j`/`k` or click) no longer clears the typed filter, source chip, or Overview expired chip.
- Filters reset only when the selected row is in `rows` but hidden by the current filters (`!visible.some(...)`). Tab switch (All / History) stays on its own `rows`/`tab` effect so a 2s poll cannot wipe a typed filter.
- Runs.tsx is untouched (OPS-236 / OPS-241).

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 190 pass, `tsc --noEmit && vite build` green
- [ ] Filter Events, select a matching row — filter text and source chip stay
- [ ] Overview expired tile → Open + expired chip; click a visible expired proposal — chip stays on
- [ ] Deep-link / select a row hidden by filters — filters clear so the row appears; wrong status tab still switches to All / History

Fixes OPS-238

UX critique: skipped — bugfix of existing filter behavior