### PR TITLE
fix(event-runtime-web): keep Runs filter on row-select; show lifecycle from→to

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -357,8 +357,11 @@ countdown behaves as §4.2 specified.
 The list gains adapter, latest `reasonCode`, attempts as `n/maxAttempts`,
 the origin `eventId` (a jump to the Events inbox), and the agent ref (a jump
 to Agents). Failed and timed-out rows carry an error wash, refused a warning
-wash; selection wins. Client-side filter, tab counts from `/status`, Copy id,
-and a detail panel that opens while the run payload is still loading. The
+wash; selection wins. Client-side filter (selecting a visible row keeps it;
+it clears only when the selected run is hidden by the filter, or the status
+tab switches to All to surface a deep-linked run), tab counts from
+`/status`, Copy id, and a detail panel that opens while the run payload is
+still loading. The
 detail panel additionally renders the result's declared `evidence`
 (collapsible pretty JSON, per §4.3's result block) and the origin event; `x`
 cancels the selected run from the list, matching the proposals-view verb

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -358,8 +358,8 @@ The list gains adapter, latest `reasonCode`, attempts as `n/maxAttempts`,
 the origin `eventId` (a jump to the Events inbox), and the agent ref (a jump
 to Agents). Failed and timed-out rows carry an error wash, refused a warning
 wash; selection wins. Client-side filter (selecting a visible row keeps it;
-it clears only when the selected run is hidden by the filter, or the status
-tab switches to All to surface a deep-linked run), tab counts from
+it clears only when a deep-linked or jumped-to run is hidden by the filter,
+or the status tab switches to All to surface that run), tab counts from
 `/status`, Copy id, and a detail panel that opens while the run payload is
 still loading. The
 detail panel additionally renders the result's declared `evidence`

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -82,14 +82,15 @@ export function Runs({
   const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
 
   // Deep link: switch to ALL if the run isn't on this tab. Hash stays put.
+  // Clear the filter only when the selected run is on this tab but hidden by it.
   useEffect(() => {
     if (!focusRunId) return;
     if (rows.some((r) => r.runId === focusRunId)) {
-      setFilter("");
+      if (!visible.some((r) => r.runId === focusRunId)) setFilter("");
       return;
     }
     if (tab !== "ALL") setTab("ALL");
-  }, [focusRunId, rows, tab]);
+  }, [focusRunId, rows, tab, visible]);
 
   useEffect(() => {
     if (focusState && (STATE_TABS as readonly string[]).includes(focusState)) {
@@ -404,7 +405,7 @@ export function Runs({
                     {new Date(e.at).toLocaleTimeString([], { hour12: false })}
                   </span>
                   <span className="shrink-0">
-                    <StateBadge state={e.to_state} />
+                    {e.from_state ?? "·"} → <StateBadge state={e.to_state} />
                   </span>
                   <span className="truncate text-(--text-faint)">
                     {e.actor}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, artifactUrl } from "../api";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
@@ -81,12 +81,20 @@ export function Runs({
   const selectedId = focusRunId;
   const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
 
-  // Deep link: switch to ALL if the run isn't on this tab. Hash stays put.
-  // Clear the filter only when the selected run is on this tab but hidden by it.
+  // Deep link / jump: switch to ALL if the run isn't on this tab. Hash stays put.
+  // Reveal (clear filter) once per focus id, after the run is in `rows` so a
+  // late arrival still surfaces. Typing a filter does not re-reveal.
+  const revealedFor = useRef<string | null>(null);
   useEffect(() => {
-    if (!focusRunId) return;
+    if (!focusRunId) {
+      revealedFor.current = null;
+      return;
+    }
     if (rows.some((r) => r.runId === focusRunId)) {
-      if (!visible.some((r) => r.runId === focusRunId)) setFilter("");
+      if (revealedFor.current !== focusRunId) {
+        revealedFor.current = focusRunId;
+        if (!visible.some((r) => r.runId === focusRunId)) setFilter("");
+      }
       return;
     }
     if (tab !== "ALL") setTab("ALL");


### PR DESCRIPTION
## Summary
- Runs row-select no longer wipes the client-side filter; `setFilter("")` only when the selected run is on this status tab but hidden by the filter. Status tab still switches to ALL when the run isn't on it.
- Lifecycle rows match Overview's journal: `FROM → TO` (`from_state ?? "·"` plus `to_state` badge). RunSpec Disclosure defaultOpen left alone (OPS-247).

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 197 pass, web build green
- [ ] Filter Runs, click a visible row — filter stays, detail opens
- [ ] Jump to a run hidden by the current filter — filter clears so the row is visible
- [ ] Jump to a run not on the current status tab — switches to All
- [ ] Open a run detail — lifecycle shows from → to like Overview

Fixes OPS-241

UX critique: skipped — bugfix + displaying an existing field