### PR TITLE
docs(event-runtime): note cancel closes the unique open proposal (OPS-246)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -634,7 +634,9 @@ lifecycle transitions with the operator as actor:
 - **status** — admitted events, open proposals and their TTL age, runs by
   state, lease ages, retained workspaces, dead-lettered events.
 - **cancel** — any run before `RUNNING` (§8); a running attempt gets TERM then
-  KILL.
+  KILL. In the same transaction, the unique open proposal for that run is
+  closed with reason `run_cancelled`; none, or more than one, is left
+  untouched.
 - **retry** — a new attempt under a new attempt identity. Retrying past
   `maxAttempts` requires an explicit operator override and records it.
 - **inspect** — the retained workspace path, receipt, and transcript for any


### PR DESCRIPTION
## Summary
- Document that the §13 **cancel** verb closes the unique open proposal for that run in the same transaction with reason `run_cancelled` (none, or more than one, left untouched).
- Docs-only; no code change. From merge review of OPS-237 / PR #48 (finding 3).

## Test plan
- [x] `bun test event-runtime` — 197 pass, 0 fail
- [x] Diff is `docs/event-runtime.md` only

UX critique: skipped — docs

Fixes OPS-246