### PR TITLE
ui-ux(event-runtime-web): open RunSpec by default to match proposals (OPS-247)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -141,7 +141,7 @@ recognizable at a glance across every view.
 The detail panel shows the five blocks `GET /runs/:id` returns:
 
 - **run** — state, attempts, `idempotencyKey`, `specHash`, and the full spec
-  (same raw rendering as proposals);
+  in a disclosure that defaults open (same raw rendering as proposals);
 - **lifecycle** — the journal as a vertical timeline: state → state, actor,
   reason code, attempt, timestamp. This is the audit trail; it is the point
   of the page;

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -377,7 +377,7 @@ export function Runs({
             <KV k="workspace" v={d.workspace} />
             <KV k="created" v={<Ago iso={d.run.created_at} now={now} />} />
             <KV k="updated" v={<Ago iso={d.run.updated_at} now={now} />} />
-            <Disclosure label="immutable RunSpec">
+            <Disclosure label="immutable RunSpec" defaultOpen>
               <JsonBlock value={d.run.spec} />
             </Disclosure>
           </Section>


### PR DESCRIPTION
## Summary
- Runs detail now opens the immutable RunSpec disclosure by default, matching proposals (`defaultOpen={isOpen}`).
- §4.3 now says the spec lives in a disclosure that defaults open (same raw rendering as proposals).
- Filter/reveal latches untouched.

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 197 pass, vite build ok
- [ ] Open a run in the web UI: RunSpec JSON is visible without clicking the disclosure; collapse still works

UX critique: skipped — default-open of an existing disclosure.

Fixes OPS-247