### PR TITLE
ci(factory): typecheck and build event-runtime/web on Verify (OPS-243)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         # regenerate — never to edit the generated file.
         run: bun build/emit.mjs --check
 
+      # Agents already typecheck/build the web UI locally; a green Verify on a
+      # TSX PR said nothing about compilation until this step existed (OPS-243).
+      - name: Typecheck and build event-runtime/web
+        run: cd event-runtime/web && bun install --frozen-lockfile && bun run build
+
       - name: Schedule renders
         run: bun deploy/gen.mjs
 


### PR DESCRIPTION
## Summary
- Add a Verify step that installs `event-runtime/web` from its lockfile and runs `bun run build` (`tsc --noEmit && vite build`) on the existing self-hosted Linux runner.
- Existing `bun test` and `emit --check` steps stay; `runs-on` remains `[self-hosted, Linux]`.

## Test plan
- [x] `bun test && bun build/emit.mjs --check` — 358 pass, emit-check ok
- [x] Workflow step `cd event-runtime/web && bun install --frozen-lockfile && bun run build` is present
- [x] No `ubuntu-latest`; runner is still `[self-hosted, Linux]`
- [ ] PR Verify job itself runs the new step (CI on this PR)

UX critique: skipped — CI only.

Fixes OPS-243