### PR TITLE
fix(event-runtime-web): j/k selection replaces history instead of pushing (OPS-242)

### DIFF
--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { eventsHash, hashPath, hashSearch, parseHash } from "./hash";
+import { eventsHash, hashPath, hashSearch, hashView, parseHash, shouldReplaceHash } from "./hash";
 
 describe("parseHash", () => {
   test("empty hash is overview's empty route", () => {
@@ -27,6 +27,52 @@ describe("parseHash", () => {
       "graph",
       "event:factory.ticket.ready",
     ]);
+  });
+});
+
+describe("hashView", () => {
+  test("empty hash is overview", () => {
+    expect(hashView("")).toBe("overview");
+    expect(hashView("#")).toBe("overview");
+    expect(hashView("#/")).toBe("overview");
+    expect(hashView("#/overview")).toBe("overview");
+  });
+
+  test("reads the first path segment, ignoring ids and query", () => {
+    expect(hashView("#/runs/run_01")).toBe("runs");
+    expect(hashView("#/events?type=factory.ticket.ready")).toBe("events");
+    expect(hashView("#/events/web/evt_1")).toBe("events");
+  });
+});
+
+describe("shouldReplaceHash", () => {
+  test("j/k selection on the same view replaces", () => {
+    expect(shouldReplaceHash("#/runs", "runs/run_01")).toBe(true);
+    expect(shouldReplaceHash("#/runs/run_01", "runs/run_02")).toBe(true);
+    expect(shouldReplaceHash("#/runs/run_02", "runs")).toBe(true);
+    expect(shouldReplaceHash("#/events/web/evt_1", "events/web/evt_2")).toBe(true);
+    expect(shouldReplaceHash("#/agents", "agents/factory-status-report%401")).toBe(true);
+    expect(shouldReplaceHash("#/graph", "graph/event%3Afactory.ticket.ready")).toBe(true);
+  });
+
+  test("query-only changes on the same view replace", () => {
+    expect(shouldReplaceHash("#/events", "events?type=factory.ticket.ready")).toBe(true);
+    expect(shouldReplaceHash("#/events?type=a", "events?type=b")).toBe(true);
+    expect(shouldReplaceHash("#/events?type=a", "events/web/evt_1")).toBe(true);
+  });
+
+  test("crossing views pushes so Back returns", () => {
+    expect(shouldReplaceHash("#/events", "runs")).toBe(false);
+    expect(shouldReplaceHash("#/overview", "events")).toBe(false);
+    expect(shouldReplaceHash("", "events")).toBe(false);
+    expect(shouldReplaceHash("#/events/web/evt_1", "runs/run_01")).toBe(false);
+    expect(shouldReplaceHash("#/runs/run_01", "proposals")).toBe(false);
+    expect(shouldReplaceHash("#/graph", "agents")).toBe(false);
+  });
+
+  test("empty hash and #/overview are the same view", () => {
+    expect(shouldReplaceHash("", "overview")).toBe(true);
+    expect(shouldReplaceHash("#/overview", "overview")).toBe(true);
   });
 });
 

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -28,6 +28,20 @@ export function parseHash(hash: string): string[] {
     });
 }
 
+/** First path segment; empty hash is the overview view. */
+export function hashView(hash: string): string {
+  return parseHash(hash)[0] ?? "overview";
+}
+
+/**
+ * Same-view hash writes (j/k selection, closing a panel, type query) should
+ * replace the current history entry. Crossing views (nav rail, `g e`) must
+ * push so Back returns to the previous view.
+ */
+export function shouldReplaceHash(currentHash: string, nextPath: string): boolean {
+  return hashView(currentHash) === hashView(`#/${nextPath}`);
+}
+
 /** Query after `?` in the hash (`#/events?type=…`). Empty when none. */
 export function hashSearch(hash: string): URLSearchParams {
   return new URLSearchParams(pathAndQuery(hash).query);

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { parseHash } from "./hash";
+import { parseHash, shouldReplaceHash } from "./hash";
 
 /** Open-modal depth: global list-navigation keys stand down while a dialog is up. */
 export const modal = { depth: 0 };
@@ -29,6 +29,17 @@ export function useHashRoute(): [string[], (path: string) => void] {
   const navigate = useCallback((path: string) => {
     const next = `#/${path}`;
     if (window.location.hash === next) return;
+    if (shouldReplaceHash(window.location.hash, path)) {
+      // replaceState does not fire hashchange — tick route state here.
+      history.replaceState(
+        history.state,
+        "",
+        `${window.location.pathname}${window.location.search}${next}`,
+      );
+      setRoute(read());
+      setHash(window.location.hash);
+      return;
+    }
     window.location.hash = next;
   }, []);
   return [route.length ? route : ["overview"], navigate];


### PR DESCRIPTION
## Summary
- `j`/`k` (and other same-view hash writes: row select, closing a panel, type query) now use `history.replaceState`, so walking a list no longer stacks Back entries.
- Crossing views (nav rail / `g e`) still assigns `location.hash` and pushes, so Back returns to the previous view.
- Shareable hashes still update the address bar. `replaceState` does not fire `hashchange`; `useHashRoute` ticks route state itself.

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 203 pass, vite build green
- [ ] Walk a list with `j`/`k`; one Back leaves the view
- [ ] Switch views via nav rail or `g e`; Back returns to the previous view
- [ ] Paste or copy a `#/runs/:id` hash — address bar still updates

UX critique: skipped — navigation history, no new flow.

Fixes OPS-242