### PR TITLE
fix(event-runtime): surface ambiguous open proposals on cancel (OPS-245)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -17,7 +17,7 @@ import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, we
 import { admitEvent, verifyWebhook } from "./intake.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { requeueEvent } from "./planner.mjs";
-import { approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
 
@@ -140,6 +140,9 @@ function statusView(db, nowMs) {
       // valid, so nothing has reclaimed the run yet (OPS-233).
       stalledWorkers: stalled.map((w) => ({ workerId: w.workerId, host: w.host, runId: w.currentRun, lastSeen: w.lastSeen })),
       noWorkers: workers.filter((w) => w.state !== "stopped" && !w.stale).length === 0 && (runCounts(db).byState.QUEUED ?? 0) > 0,
+      // Two or more open proposals on one run: cancel fail-closes and leaves
+      // them open (OPS-245). Unreachable on the TTL replan path.
+      ambiguousOpenProposals: ambiguousOpenProposalRuns(db),
     },
   };
 }
@@ -495,6 +498,8 @@ export function createApi({
         try {
           if (verb === "cancel") {
             cancelRun(db, runId, { actor: ACTOR, reason: body.reason ?? "operator_cancel", now: nowMs, policyVersion });
+            const clash = ambiguousOpenProposalRuns(db).find((row) => row.runId === runId);
+            if (clash) return send(res, 200, { cancelled: true, ambiguousOpenProposals: clash.count });
             return send(res, 200, { cancelled: true });
           }
           retryRun(db, runId, { actor: ACTOR, force: body.force === true, now: nowMs, policyVersion });

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -289,6 +289,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(status.anomalies.staleLeases).toBe(0);
     expect(status.anomalies.deadLettered).toEqual([]);
     expect(status.anomalies.unpublishedOutbox).toBe(1); // completion event, not yet published
+    expect(status.anomalies.ambiguousOpenProposals).toEqual([]);
   });
 
   test("approve unknown proposal → 404; approve twice → 409", async () => {
@@ -351,6 +352,30 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(decided.status).toBe("rejected");
     expect(decided.reason).toBe("run_cancelled");
     expect(decided.decided_by).toBe("operator");
+  });
+
+  test("cancel with two open proposals still cancels and signals the ambiguity", async () => {
+    const prop = await planned("can-ambiguous-1");
+    const at = new Date().toISOString();
+    s.db.query(
+      `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+       VALUES (?, ?, ?, ?, 'run', ?, 1800)`,
+    ).run("prop_extra_ambiguous", prop.eventSource, prop.eventId, prop.runId, at);
+
+    expect(await s.client.cancel(prop.runId, "never mind")).toEqual({
+      cancelled: true,
+      ambiguousOpenProposals: 2,
+    });
+    expect((await s.client.run(prop.runId)).run.state).toBe("CANCELLED");
+
+    const open = await s.client.proposals();
+    expect(open.proposals.map((p) => p.id)).toContain(prop.id);
+    expect(open.proposals.map((p) => p.id)).toContain("prop_extra_ambiguous");
+
+    const status = await s.client.status();
+    expect(status.anomalies.ambiguousOpenProposals).toEqual([
+      { runId: prop.runId, count: 2 },
+    ]);
   });
 
   test("retry: 404 on unknown run, 409 when attempts are exhausted, queued with force", async () => {

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -41,7 +41,7 @@ export function ambiguousOpenProposalRuns(db) {
     .query(
       `SELECT run_id AS runId, COUNT(*) AS n
        FROM proposals
-       WHERE status = 'open'
+       WHERE status = 'open' AND run_id IS NOT NULL
        GROUP BY run_id
        HAVING n > 1
        ORDER BY run_id`,

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -32,6 +32,24 @@ export function openProposals(db, { now = Date.now() } = {}) {
     .map((row) => ({ ...withSpec(row), expired: isExpired(row, now) }));
 }
 
+/**
+ * Runs with two or more open proposals. The planner never creates this — it
+ * is a defensive invariant, surfaced on the doctor view if it ever happens.
+ */
+export function ambiguousOpenProposalRuns(db) {
+  return db
+    .query(
+      `SELECT run_id AS runId, COUNT(*) AS n
+       FROM proposals
+       WHERE status = 'open'
+       GROUP BY run_id
+       HAVING n > 1
+       ORDER BY run_id`,
+    )
+    .all()
+    .map((row) => ({ runId: row.runId, count: row.n }));
+}
+
 export function getProposal(db, id) {
   const row = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
   return row ? withSpec(row) : null;
@@ -124,16 +142,20 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
  * Keyed on `run_id` + `status = 'open'`. Zero matches is a no-op — cancelling
  * a QUEUED/LEASED/RUNNING run whose proposal is already decided must still
  * succeed. Two or more open rows for the same run is ambiguous: leave them
- * all untouched rather than guess which one to close. Caller must already
- * hold the transaction that performed the CANCELLED transition.
+ * all untouched rather than guess which one to close, and return `ambiguous`
+ * so the caller can surface it (OPS-245). Caller must already hold the
+ * transaction that performed the CANCELLED transition.
  *
- * @returns {{ closed: true, id: string } | { closed: false }}
+ * @returns {{ closed: true, id: string }
+ *         | { closed: false }
+ *         | { closed: false, ambiguous: true, count: number }}
  */
 export function closeOpenProposalForRun(db, runId, { actor, now = Date.now() } = {}) {
   const open = db
     .query(`SELECT id FROM proposals WHERE run_id = ? AND status = 'open'`)
     .all(runId);
-  if (open.length !== 1) return { closed: false };
+  if (open.length === 0) return { closed: false };
+  if (open.length > 1) return { closed: false, ambiguous: true, count: open.length };
   const at = new Date(now).toISOString();
   db.query(
     `UPDATE proposals SET status = 'rejected', decided_at = ?, decided_by = ?, reason = ? WHERE id = ?`,

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -142,6 +142,25 @@ describe("closeOpenProposalForRun", () => {
   });
 });
 
+describe("ambiguousOpenProposalRuns", () => {
+  test("two open human_needed proposals with NULL run_id are not reported as ambiguous", () => {
+    const db = openDb(":memory:");
+    for (const eventId of ["hn-null-1", "hn-null-2"]) {
+      const admitted = admitEvent(db, registry, envelope({ eventId, type: "totally.unknown.type" }), { now: NOW });
+      expect(admitted.admitted).toBe(true);
+      const outcome = planEvent(
+        db, registry,
+        { source: admitted.event.source, eventId: admitted.event.event_id },
+        { now: NOW },
+      );
+      expect(outcome.decision).toBe("human_needed");
+      expect(outcome.proposal.run_id).toBeNull();
+    }
+    expect(openProposals(db, { now: NOW })).toHaveLength(2);
+    expect(ambiguousOpenProposalRuns(db)).toEqual([]);
+  });
+});
+
 describe("approveProposal after TTL expiry (§12)", () => {
   test("unchanged conditions: re-plan matches, run is approved with a replan reason", () => {
     const { db, proposal, runId } = planned();

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -3,7 +3,7 @@ import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { lifecycleOf, runState } from "./lifecycle.mjs";
 import { planEvent } from "./planner.mjs";
-import { approveProposal, closeOpenProposalForRun, getProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import { ambiguousOpenProposalRuns, approveProposal, closeOpenProposalForRun, getProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -128,15 +128,17 @@ describe("closeOpenProposalForRun", () => {
 
   test("leaves every proposal untouched when more than one is open for the run", () => {
     const { db, proposal, runId } = planned();
+    expect(ambiguousOpenProposalRuns(db)).toEqual([]);
     const at = new Date(NOW).toISOString();
     db.query(
       `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
        VALUES (?, ?, ?, ?, 'run', ?, 1800)`,
     ).run("prop_extra", proposal.event_source, proposal.event_id, runId, at);
     expect(closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }))
-      .toEqual({ closed: false });
+      .toEqual({ closed: false, ambiguous: true, count: 2 });
     expect(getProposal(db, proposal.id).status).toBe("open");
     expect(getProposal(db, "prop_extra").status).toBe("open");
+    expect(ambiguousOpenProposalRuns(db)).toEqual([{ runId, count: 2 }]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Cancelling a run with 2+ open proposals still CANCELLED the run and returned a silent `200 {cancelled:true}` while leaving both proposals open.
- `closeOpenProposalForRun` now distinguishes that case (`ambiguous: true`) from the no-open no-op; unique-open and no-open stay as OPS-237 shipped.
- `POST /runs/:id/cancel` includes `ambiguousOpenProposals` on that path, and `GET /status` doctor anomalies list the run.

## Test plan
- [x] `bun test event-runtime` — 198 pass, 0 fail
- Unique-open cancel still `{ cancelled: true }` and closes the proposal
- No-open cancel still `{ cancelled: true }`
- Two-open cancel returns `{ cancelled: true, ambiguousOpenProposals: 2 }`, both stay open, status anomaly lists the run

UX critique: skipped — API.

Fixes OPS-245