### PR TITLE
fix(event-runtime-web): toast when Events requeue never produces a proposal (OPS-244)

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -194,6 +194,7 @@ export function Events({
         }
         await new Promise((r) => setTimeout(r, 250));
       }
+      if (alive.current) notify(`Requeued ${e.eventId} — no open proposal appeared`, "info");
     },
     onError: invalidate, // 404/409 mean someone else acted — converge on truth
   });


### PR DESCRIPTION
## What

Events' Requeue toasted `Requeued <eventId>` and then polled up to 8s for a matching open proposal. When the planner was slow and no proposal appeared, the poll loop simply fell through: the operator stayed on the event with a success toast and no indication the re-plan had not produced anything.

Overview already handles this honestly. This copies that behaviour into Events — after the poll budget expires without a match, emit the same timeout toast, guarded by `alive.current` so an unmounted view stays quiet.

## Change

One line in `event-runtime/web/src/views/Events.tsx`:

```
if (alive.current) notify(`Requeued ${e.eventId} — no open proposal appeared`, "info");
```

Success path is untouched: a matching proposal still jumps to `#/proposals/:id`. `Overview.tsx` is not edited.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 205 pass, 0 fail; tsc + vite build clean.

Fixes OPS-244