### PR TITLE
feat(event-runtime-web): consume workers endpoints in the client types (OPS-264)

### DIFF
--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -9,6 +9,7 @@ import type {
   RunDetail,
   RunListItem,
   StatusView,
+  Worker,
 } from "./types";
 
 // Same contract as lib/client.mjs: one function per endpoint, an Error with
@@ -72,6 +73,8 @@ export const api = {
     call<{ requeued: boolean }>("POST", "/events/requeue", { source, eventId }),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
+  // The worker registry: which processes are alive, where, and what they run.
+  workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
 };
 
 /** Browser URL for a stored artifact's bytes (streamed by the control API). */

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -214,6 +214,34 @@ export interface AgentsView {
   contracts: Record<string, unknown>;
 }
 
+/** A worker's own report of what it is doing; "stopped" is a clean exit. */
+export type WorkerState = "idle" | "busy" | "stopped";
+
+/** One registered worker process (GET /workers) — the fleet, not the leases. */
+export interface Worker {
+  workerId: string;
+  host: string;
+  pid: number;
+  /** Placement labels the worker declared, e.g. `{ node: "lab" }`. */
+  labels: Record<string, string>;
+  adapters: string[];
+  state: WorkerState;
+  currentRun: string | null;
+  lastSeen: string;
+  /** Heartbeat older than the stale window: gone, whatever `state` claims. */
+  stale: boolean;
+  startedAt: string;
+  stoppedAt: string | null;
+}
+
+/** A stale worker still holding a run — the doctor's projection, not the row. */
+export interface StalledWorker {
+  workerId: string;
+  host: string;
+  runId: string | null;
+  lastSeen: string;
+}
+
 /** Which runtime this UI is pointed at — live vs dev, adapter override. */
 export interface EnvIdentity {
   name: string;
@@ -226,11 +254,17 @@ export interface StatusView {
   events: Record<string, number>;
   proposals: { open: number; expired: number };
   runs: { byState: Partial<Record<RunState, number>> };
+  /** Fleet counts; `live` and `busy` exclude stale workers, as the API does. */
+  workers: { live: number; busy: number; stale: number };
   anomalies: {
     expiredOpenProposals: string[];
     staleLeases: number;
     unpublishedOutbox: number;
     deadLettered: { source: string; eventId: string; lastError: string | null }[];
+    stalledWorkers: StalledWorker[];
+    /** Queued runs with no live worker to claim them. */
+    noWorkers: boolean;
+    ambiguousOpenProposals: { runId: string; count: number }[];
   };
 }
 


### PR DESCRIPTION
## Summary

The web client was behind the control API on workers (OPS-233): `GET /workers`, `status.workers`, and the `stalledWorkers` / `noWorkers` doctor fields already existed in `lib/api.mjs` and the CLI, but `web/src` had no types for them, so any workers UI would have had to invent local shapes and drift.

- `types.ts`: `WorkerState` (`idle` | `busy` | `stopped` — the three values `lib/workers.mjs` writes), `Worker` (workerId, host, pid, labels, adapters, state, currentRun, lastSeen, stale, startedAt, stoppedAt) mirroring `listWorkers`, and `StalledWorker` mirroring the doctor projection.
- `types.ts`: `StatusView.workers: { live, busy, stale }` plus `anomalies.stalledWorkers`, `anomalies.noWorkers`, and `anomalies.ambiguousOpenProposals` (on the wire since OPS-245). All required, because `statusView()` always sends them.
- `api.ts`: `api.workers()` calls `GET /workers` and returns the `{ workers }` envelope the API sends, mirroring `lib/client.mjs`.

Types and client only — no nav item, no view, no Overview rendering, by design. Overview only reads `anomalies` and nothing in `web/src` constructs a `StatusView` literal, so the new required fields do not break the existing destructures.

## Test plan

- [x] `bun test event-runtime` — 205 pass, 0 fail across 22 files
- [x] `cd event-runtime/web && bun run build` — `tsc --noEmit` clean, vite build succeeded
- [x] Field names checked against `lib/workers.mjs` `listWorkers`, `lib/api.mjs` `statusView`, and `lib/proposals.mjs` `ambiguousOpenProposalRuns` (`{ runId, count }`, not a bare id list)

Fixes OPS-264