### PR TITLE
fix(event-runtime-web): History empty copy must not mention expired opens (OPS-251)

### DIFF
--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -112,16 +112,19 @@ export function Proposals({
   const reasonRef = useRef<HTMLInputElement>(null);
 
   const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
+  // The expired chip only exists on Open; History rows have no live TTL. Derive
+  // the gate once so the row filter and the empty copy can never disagree.
+  const expiredFilter = expiredOnly && tab === "open";
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
     return rows.filter((p) => {
-      if (expiredOnly && tab === "open" && !p.expired) return false;
+      if (expiredFilter && !p.expired) return false;
       if (!q) return true;
       return [p.id, p.agent, p.decision, p.status, p.eventId, p.reason].some((v) =>
         (v ?? "").toLowerCase().includes(q),
       );
     });
-  }, [rows, filter, expiredOnly, tab]);
+  }, [rows, filter, expiredFilter]);
 
   const selectedId = focusProposalId;
   const selectedIndex = useMemo(() => visible.findIndex((p) => p.id === selectedId), [visible, selectedId]);
@@ -153,11 +156,16 @@ export function Proposals({
   }, [focusProposalId, rows, visible, expiredOnly]);
 
   // Deep link: open tab first, then history if the id is a decided proposal.
-  // Hash stays; we only switch tabs so the row is in `visible`.
+  // Hash stays; we only switch tabs so the row is in `visible` — the selection
+  // is the whole point of the deep link, so unlike selectTab we keep it. The
+  // chip is cleared like selectTab does: it belongs to Open only.
   useEffect(() => {
     if (!focusProposalId) return;
     if (rows.some((p) => p.id === focusProposalId)) return;
-    if (tab === "open") setTab("history");
+    if (tab === "open") {
+      setTab("history");
+      setExpiredOnly(false);
+    }
   }, [focusProposalId, rows, tab]);
 
   useEffect(() => {
@@ -415,10 +423,10 @@ export function Proposals({
               <ListEmpty
                 colSpan={tab === "open" ? 6 : 7}
                 query={tab === "open" ? query : history}
-                filtered={expiredOnly ? false : rows.length > 0}
+                filtered={expiredFilter ? false : rows.length > 0}
                 noun="proposals"
                 empty={
-                  expiredOnly
+                  expiredFilter
                     ? "No expired open proposals."
                     : tab === "open"
                       ? "No open proposals — the operator's work is done, for now."


### PR DESCRIPTION
An empty History list could read "No expired open proposals." — `ListEmpty` keyed both `filtered` and its empty copy off raw `expiredOnly`, while the row filter had already been narrowed to `expiredOnly && tab === "open"`. The two disagreed, so the chip state leaked into History copy about rows that have no live TTL at all.

- Derive the gate once as `expiredFilter = expiredOnly && tab === "open"` and use the same value for the row filter and for `ListEmpty`, so they cannot drift apart again. The Open-tab chip and its "No expired open proposals." copy are unchanged.
- The deep-link effect calls `setTab("history")` directly, bypassing `selectTab`'s `setExpiredOnly(false)`, which is how the stale chip state survived the tab switch — it now clears the chip too. It deliberately does not clear the selection: landing on the deep-linked row is the point.

## Verification

`bun test event-runtime` — 205 pass, 0 fail. `cd event-runtime/web && bun run build` (tsc --noEmit + vite build) — green.

Fixes OPS-251