### PR TITLE
ci(factory): run Verify on pushes to develop (OPS-254)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: ["main"]
+    branches: ["develop", "main"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` had `on.push.branches: ["main"]`, but this repo's base branch is `develop`. Merging a PR into develop started no CI run, so the protocol's "base-branch CI green after the merge" gate had nothing to read — post-merge confidence rested entirely on the pre-merge `pull_request` Verify.

## Change

One line: `branches: ["develop", "main"]`. `main` is kept for release PRs.

Nothing else in the workflow is touched — the `pull_request` trigger, `runs-on: [self-hosted, Linux]`, and every step (including the `event-runtime/web` typecheck+build added by OPS-243) are unchanged.

## Verification

```
$ rg -n 'branches:|runs-on:' .github/workflows/ci.yml
6:    branches: ["develop", "main"]
21:    runs-on: [self-hosted, Linux]

$ bun test && bun build/emit.mjs --check
366 pass / 0 fail (39 files)
ok — 90 generated files match shared/
```

Acceptance criterion "a push to develop actually starts the Verify job" is proven when this PR merges: the merge commit on develop should itself trigger a Verify run.

Fixes OPS-254