### PR TITLE
docs(event-runtime-web): §4.2 matches the RunSpec disclosure (OPS-253)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -113,7 +113,10 @@ detail panel showing **the full immutable `RunSpec`, rendered raw** — agent
 and version, input, `inputHash`, capabilities, timeout, attempts,
 `idempotencyKey`, workspace type — plus the planner's reason. §12 is explicit
 that the operator approves a specific spec, not a summary of one; the spec
-JSON is therefore always visible, not behind a disclosure.
+JSON therefore sits in a disclosure that defaults open while the proposal is
+undecided, so it is in front of the operator without being asked for. Once the
+proposal is decided the panel is an audit record rather than something to act
+on, and the disclosure defaults closed.
 
 Verbs:
 


### PR DESCRIPTION
## What

§4.2 claimed the proposal `RunSpec` JSON "is therefore always visible, not behind a disclosure". `Proposals.tsx` renders it as `<Disclosure label="immutable RunSpec" defaultOpen={isOpen}>`, where `isOpen` is `sel.status === "open"` — so it *is* behind a disclosure, open by default while the proposal is undecided and closed once it has been decided.

Reworded the sentence to describe that rendering while keeping the §12 argument it was making: the operator approves a specific spec, so the spec is in front of them without being asked for while the decision is still live; a decided proposal is an audit record, and the disclosure defaults closed.

## Why

OPS-247 added §4.3 wording ("in a disclosure that defaults open (same raw rendering as proposals)") that pointed at the now-contradictory §4.2 sentence. §4.3 needed no change — it already matches the code and now matches §4.2 too.

## Verification

- `rg -n "always visible, not behind a disclosure" docs/event-runtime-webui.md` → exit 1 (ticket's command)
- `rg -n "not behind a disclosure" docs/event-runtime-webui.md` → exit 1
- `bun test event-runtime` → 205 pass, 0 fail
- `cd event-runtime/web && bun run build` → built clean

Docs-only; no code touched. The file has pre-existing prettier deltas (`*emphasis*` vs `_emphasis_`, table padding) elsewhere in it that this PR deliberately leaves alone — the repo has no prettier config or md hook, and reformatting would bury a 4-line change.

Fixes OPS-253