### PR TITLE
perf(event-runtime-web): code-split xyflow/elk off the main chunk

### DIFF
--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -12,7 +12,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { keyGuard } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
-import { layoutGraph, NODE_HEIGHT, NODE_WIDTH } from "../graph/layout";
 import { nodeTypes } from "../graph/nodes";
 import type { EventFocus } from "../types";
 import { Button, DetailPane, JsonBlock, JumpLink, KV, Section, copyText, copyLink } from "../components/ui";
@@ -56,34 +55,39 @@ export function Graph({
   useEffect(() => {
     if (!graph) return;
     let cancelled = false;
-    layoutGraph(graph).then((positions) => {
-      if (cancelled) return;
-      setPositioned({
-        nodes: graph.nodes.map((node) => ({
-          id: node.id,
-          type: node.kind,
-          position: positions.get(node.id) ?? { x: 0, y: 0 },
-          data: { node },
-          draggable: true,
-          width: NODE_WIDTH,
-          height: NODE_HEIGHT,
-        })),
-        edges: graph.edges.map((edge) => ({
-          id: edge.id,
-          source: edge.source,
-          target: edge.target,
-          label: edge.label,
-          animated: false,
-          style: {
-            stroke: edge.kind === "recommends" ? "var(--accent)" : "var(--border-strong)",
-            strokeWidth: 1.5,
-            strokeDasharray: edge.kind === "recommends" ? "4 3" : undefined,
-          },
-          labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
-          labelBgStyle: { fill: "var(--surface-0)" },
-        })),
-      });
-    });
+    // elkjs is ~1.4 MB of pre-minified layout engine, so it rides in its own
+    // async chunk (OPS-255) — fetched the first time there is a graph to lay
+    // out, never by the list views.
+    import("../graph/layout").then(({ layoutGraph, NODE_HEIGHT, NODE_WIDTH }) =>
+      layoutGraph(graph).then((positions) => {
+        if (cancelled) return;
+        setPositioned({
+          nodes: graph.nodes.map((node) => ({
+            id: node.id,
+            type: node.kind,
+            position: positions.get(node.id) ?? { x: 0, y: 0 },
+            data: { node },
+            draggable: true,
+            width: NODE_WIDTH,
+            height: NODE_HEIGHT,
+          })),
+          edges: graph.edges.map((edge) => ({
+            id: edge.id,
+            source: edge.source,
+            target: edge.target,
+            label: edge.label,
+            animated: false,
+            style: {
+              stroke: edge.kind === "recommends" ? "var(--accent)" : "var(--border-strong)",
+              strokeWidth: 1.5,
+              strokeDasharray: edge.kind === "recommends" ? "4 3" : undefined,
+            },
+            labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
+            labelBgStyle: { fill: "var(--surface-0)" },
+          })),
+        });
+      }),
+    );
     return () => {
       cancelled = true;
     };

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -2,10 +2,60 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+// The Graph view's two heavyweights get their own chunks (OPS-255). Left in
+// the entry chunk they made Overview/Events/Runs pay ~2 MB before painting a
+// single row. `elk` is also async — Graph.tsx imports the layout module
+// dynamically, so the layout engine is fetched only when a graph is drawn.
+//
+// Accepted warning: the `elk` chunk is ~1.4 MB and still trips Vite's 500 kB
+// notice. elkjs ships as one pre-minified GWT artifact (a single module, no
+// tree-shakeable surface), so there is nothing left to split — the only lever
+// is dropping the dependency, and hand-rolled DAG layout is worse. We do not
+// raise build.chunkSizeWarningLimit to silence it: that would also stop the
+// warning from firing on the entry chunk, which is the one worth watching.
+const VENDOR_CHUNKS: Array<[chunk: string, packages: string[]]> = [
+  ["elk", ["elkjs"]],
+  [
+    "xyflow",
+    [
+      "@xyflow/react",
+      "@xyflow/system",
+      "classcat",
+      "zustand",
+      "use-sync-external-store",
+      "d3-color",
+      "d3-dispatch",
+      "d3-drag",
+      "d3-ease",
+      "d3-interpolate",
+      "d3-selection",
+      "d3-timer",
+      "d3-transition",
+      "d3-zoom",
+    ],
+  ],
+];
+
+function vendorChunk(id: string): string | undefined {
+  const marker = "/node_modules/";
+  const at = id.lastIndexOf(marker);
+  if (at === -1) return undefined;
+  const rest = id.slice(at + marker.length);
+  for (const [chunk, packages] of VENDOR_CHUNKS) {
+    if (packages.some((pkg) => rest === pkg || rest.startsWith(`${pkg}/`))) return chunk;
+  }
+  return undefined;
+}
+
 // Dev-server proxy mirrors serve.mjs: the browser sees one origin, /api/*
 // forwards to the loopback control API (webui spec §3).
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: {
+    rollupOptions: {
+      output: { manualChunks: vendorChunk },
+    },
+  },
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary

`event-runtime/web` shipped one 2,033 kB entry chunk, so Overview/Events/Runs each downloaded the Graph view's layout engine before painting a row.

- `vite.config.ts` — `manualChunks` puts `elkjs` and the `@xyflow/react` + d3 interaction stack in their own chunks.
- `src/views/Graph.tsx` — the layout module is now imported dynamically inside the layout effect, so the elk chunk is fetched the first time there is a graph to lay out and never by the list views.

Chunk sizes, before → after:

| chunk | before | after |
| --- | --- | --- |
| entry `index` | 2,033 kB (623 kB gz) | 374 kB (112 kB gz) |
| `xyflow` | — | 197 kB (64 kB gz) |
| `elk` (async) | — | 1,441 kB (438 kB gz) |

## The warning is not fully gone, on purpose

Vite still prints the 500 kB notice, now for the `elk` chunk alone. elkjs ships as a single pre-minified GWT artifact with no tree-shakeable surface, so there is nothing left to split — the only lever would be dropping the dependency, and hand-rolled DAG layout is worse. I documented that in `vite.config.ts` rather than raising `build.chunkSizeWarningLimit`, because raising it would also stop the warning firing on the entry chunk, which is the one worth watching. Happy to silence it instead if you prefer a clean build log.

Graph is not lazy-loaded as a *view* — that would mean `React.lazy` in `App.tsx`, which is outside this ticket's Owned Paths.

## Test plan

- [x] `cd event-runtime/web && bun run build` green (`tsc --noEmit` + vite build)
- [x] Headless Chrome via CDP against the OPS-255 demo env (API 7510 / web 7511): `#/graph` renders 18 nodes and 15 edges in layered columns, no console errors
- [x] Same check on `#/` (Overview) requests only `index` and `xyflow` — the 1.4 MB elk chunk is never fetched

Fixes OPS-255