### PR TITLE
ui-ux(event-runtime-web): nav, hash, g w, and ⌘K for the Workers view

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -14,16 +14,19 @@ import { Graph } from "./views/Graph";
 import { Overview } from "./views/Overview";
 import { Proposals } from "./views/Proposals";
 import { Runs } from "./views/Runs";
+import { Workers } from "./views/Workers";
 
 // Agents rides `g t` ("what is this agent?"): o/e/p/r are taken, and `g a`
 // would double-fire the proposals view's `a` (approve) list key — chord
-// suffixes must never collide with single-key verbs.
+// suffixes must never collide with single-key verbs. Workers keeps its
+// natural `g w`: `w` is no view's list verb.
 const NAV = [
   { key: "overview", label: "Overview", go: "o" },
   { key: "events", label: "Events", go: "e" },
   { key: "proposals", label: "Proposals", go: "p" },
   { key: "runs", label: "Runs", go: "r" },
   { key: "agents", label: "Agents", go: "t" },
+  { key: "workers", label: "Workers", go: "w" },
   { key: "graph", label: "Graph", go: "g" },
 ] as const;
 
@@ -42,6 +45,7 @@ export function App() {
   const focusRunId = view === "runs" ? (route[1] ?? null) : null;
   const focusProposalId = view === "proposals" ? (route[1] ?? null) : null;
   const focusAgentRef = view === "agents" ? (route[1] ?? null) : null;
+  const focusWorkerId = view === "workers" ? (route[1] ?? null) : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
   const hashEvent: EventFocus | null =
     view === "events" && route[1] && route[2]
@@ -84,6 +88,7 @@ export function App() {
     navigate("events");
   };
   const jumpToAgent = (ref: string) => navigate(hashPath("agents", ref));
+  const jumpToWorker = (id: string) => navigate(hashPath("workers", id));
   const jumpToGraph = (nodeId?: string) => navigate(hashPath("graph", nodeId));
 
   const health = useQuery({
@@ -104,6 +109,8 @@ export function App() {
     .reduce((sum, [, n]) => sum + (n ?? 0), 0);
   const eventAttention =
     (status.data?.events.human_needed ?? 0) + (status.data?.events.dead_lettered ?? 0);
+  const busyWorkers = status.data?.workers.busy ?? 0;
+  const staleWorkers = status.data?.workers.stale ?? 0;
 
   const env = health.data?.env;
   const envHue = !connected
@@ -218,14 +225,31 @@ export function App() {
         </div>
         <div className="flex-1 px-2">
           {NAV.map((n) => {
-            const count =
+            // Workers is the one badge whose meaning can flip: a stale
+            // heartbeat is a worker that is gone while claiming to work, so it
+            // outranks the busy count. The word carries that — reading the
+            // count off the tone alone fails in the contrast theme.
+            const badge: { count: number; hue: string; word?: string; title?: string } =
               n.key === "proposals"
-                ? openProposals
+                ? { count: openProposals, hue: "var(--accent)" }
                 : n.key === "runs"
-                  ? activeRuns
+                  ? { count: activeRuns, hue: "var(--accent)" }
                   : n.key === "events"
-                    ? eventAttention
-                    : 0;
+                    ? { count: eventAttention, hue: "var(--accent)" }
+                    : n.key === "workers"
+                      ? staleWorkers > 0
+                        ? {
+                            count: staleWorkers,
+                            hue: "var(--hue-warn)",
+                            word: "stale",
+                            title: `${staleWorkers} worker${staleWorkers === 1 ? "" : "s"} whose heartbeat has gone stale`,
+                          }
+                        : {
+                            count: busyWorkers,
+                            hue: "var(--accent)",
+                            title: `${busyWorkers} worker${busyWorkers === 1 ? "" : "s"} busy`,
+                          }
+                      : { count: 0, hue: "var(--accent)" };
             return (
               <button
                 key={n.key}
@@ -239,15 +263,17 @@ export function App() {
                 }`}
               >
                 <span>{n.label}</span>
-                {count > 0 && (
+                {badge.count > 0 && (
                   <span
                     className="rounded px-1.5 text-[11px] tabular-nums"
+                    title={badge.title}
                     style={{
-                      color: "var(--accent)",
-                      background: "color-mix(in oklch, var(--accent) 14%, transparent)",
+                      color: badge.hue,
+                      background: `color-mix(in oklch, ${badge.hue} 14%, transparent)`,
                     }}
                   >
-                    {count}
+                    {badge.count}
+                    {badge.word && <span className="ml-1">{badge.word}</span>}
                   </span>
                 )}
               </button>
@@ -277,7 +303,7 @@ export function App() {
           </div>
           <div className="mt-1.5 text-(--text-faint)">
             <span className="mono">⌘K</span> commands · <span className="mono">g</span>+
-            <span className="mono">o/e/p/r/t/g</span> · <span className="mono">/</span> filter ·{" "}
+            <span className="mono">o/e/p/r/t/w/g</span> · <span className="mono">/</span> filter ·{" "}
             <span className="mono">i</span> inject · <span className="mono">?</span> keys
           </div>
         </div>
@@ -347,6 +373,11 @@ export function App() {
               focusAgentRef={focusAgentRef}
               onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
             />
+          ) : view === "workers" ? (
+            <Workers
+              focusWorkerId={focusWorkerId}
+              onSelectWorker={(id) => navigate(hashPath("workers", id))}
+            />
           ) : view === "events" ? (
             <Events
               connected={connected}
@@ -391,6 +422,7 @@ export function App() {
         onJumpProposal={jumpToProposal}
         onJumpEvent={jumpToEvent}
         onJumpAgent={jumpToAgent}
+        onJumpWorker={jumpToWorker}
       />
       {injectOpen && (
         <InjectDialog

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -19,12 +19,14 @@ export function CommandPalette({
   onJumpProposal,
   onJumpEvent,
   onJumpAgent,
+  onJumpWorker,
 }: {
   actions: PaletteAction[];
   onJumpRun: (runId: string) => void;
   onJumpProposal: (id: string) => void;
   onJumpEvent: (source: string, eventId: string) => void;
   onJumpAgent: (ref: string) => void;
+  onJumpWorker: (id: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const contextActions = useContextActions();
@@ -39,6 +41,7 @@ export function CommandPalette({
   });
   const events = useQuery({ queryKey: ["events", "all"], queryFn: () => api.events(), enabled: open });
   const agents = useQuery({ queryKey: ["agents"], queryFn: api.agents, enabled: open });
+  const workers = useQuery({ queryKey: ["workers"], queryFn: api.workers, enabled: open });
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -211,6 +214,31 @@ export function CommandPalette({
               <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">agent · {a.outputContract}</span>
             </Command.Item>
           ))}
+            </Command.Group>
+          )}
+          {(workers.data?.workers ?? []).length > 0 && (
+            <Command.Group heading="Workers">
+          {(workers.data?.workers ?? []).map((w) => {
+            // A stale heartbeat outranks what the worker last reported, same
+            // as the Workers view — the palette must not call a dead process busy.
+            const state = w.stale ? "stale" : w.state;
+            return (
+            <Command.Item
+              key={w.workerId}
+              value={`worker ${w.workerId} ${w.host} ${state}`}
+              onSelect={() => {
+                setOpen(false);
+                onJumpWorker(w.workerId);
+              }}
+              className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-[13px] data-[selected=true]:bg-(--surface-3)"
+            >
+              <span className="mono truncate">{w.workerId}</span>
+              <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">
+                worker · {w.host} · {state}
+              </span>
+            </Command.Item>
+            );
+          })}
             </Command.Group>
           )}
         </Command.List>

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -2,7 +2,10 @@ import { Dialog } from "./ui";
 
 const ROWS: { keys: string; does: string }[] = [
   { keys: "⌘K", does: "command palette" },
-  { keys: "g o / e / p / r / t / g", does: "Overview / Events / Proposals / Runs / Agents / Graph" },
+  {
+    keys: "g → o / e / p / r / t / w / g",
+    does: "Overview / Events / Proposals / Runs / Agents / Workers / Graph",
+  },
   { keys: "i", does: "inject event" },
   { keys: "/", does: "focus filter (Events, if none on this view)" },
   { keys: "j k  ↑↓", does: "move list (or graph) selection" },

--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -11,6 +11,8 @@ describe("parseHash", () => {
   test("splits view and id", () => {
     expect(parseHash("#/runs/run_01")).toEqual(["runs", "run_01"]);
     expect(parseHash("#/events/web/evt_1")).toEqual(["events", "web", "evt_1"]);
+    expect(parseHash("#/workers")).toEqual(["workers"]);
+    expect(parseHash("#/workers/wkr_01")).toEqual(["workers", "wkr_01"]);
   });
 
   test("strips a query so ?type= cannot become a path segment", () => {
@@ -42,6 +44,7 @@ describe("hashView", () => {
     expect(hashView("#/runs/run_01")).toBe("runs");
     expect(hashView("#/events?type=factory.ticket.ready")).toBe("events");
     expect(hashView("#/events/web/evt_1")).toBe("events");
+    expect(hashView("#/workers/wkr_01")).toBe("workers");
   });
 });
 
@@ -53,6 +56,9 @@ describe("shouldReplaceHash", () => {
     expect(shouldReplaceHash("#/events/web/evt_1", "events/web/evt_2")).toBe(true);
     expect(shouldReplaceHash("#/agents", "agents/factory-status-report%401")).toBe(true);
     expect(shouldReplaceHash("#/graph", "graph/event%3Afactory.ticket.ready")).toBe(true);
+    expect(shouldReplaceHash("#/workers", "workers/wkr_01")).toBe(true);
+    expect(shouldReplaceHash("#/workers/wkr_01", "workers/wkr_02")).toBe(true);
+    expect(shouldReplaceHash("#/workers/wkr_01", "workers")).toBe(true);
   });
 
   test("query-only changes on the same view replace", () => {
@@ -68,6 +74,8 @@ describe("shouldReplaceHash", () => {
     expect(shouldReplaceHash("#/events/web/evt_1", "runs/run_01")).toBe(false);
     expect(shouldReplaceHash("#/runs/run_01", "proposals")).toBe(false);
     expect(shouldReplaceHash("#/graph", "agents")).toBe(false);
+    expect(shouldReplaceHash("#/runs/run_01", "workers/wkr_01")).toBe(false);
+    expect(shouldReplaceHash("#/workers/wkr_01", "runs")).toBe(false);
   });
 
   test("empty hash and #/overview are the same view", () => {
@@ -109,6 +117,8 @@ describe("hashPath", () => {
     expect(hashPath("graph", "event:factory.ticket.ready")).toBe(
       "graph/event%3Afactory.ticket.ready",
     );
+    expect(hashPath("workers")).toBe("workers");
+    expect(hashPath("workers", "wkr_01")).toBe("workers/wkr_01");
   });
 
   test("drops null/empty ids so a closed panel is the view root", () => {
@@ -120,5 +130,7 @@ describe("hashPath", () => {
   test("round-trips through parseHash", () => {
     const path = hashPath("agents", "factory-status-report@1");
     expect(parseHash(`#/${path}`)).toEqual(["agents", "factory-status-report@1"]);
+    const worker = hashPath("workers", "wkr_lab_4821");
+    expect(parseHash(`#/${worker}`)).toEqual(["workers", "wkr_lab_4821"]);
   });
 });

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -4,7 +4,7 @@
  *
  * `#/overview` `#/events` `#/events?type=` `#/events/:source/:eventId`
  * `#/proposals` `#/proposals/:id` `#/runs` `#/runs/:id` `#/agents`
- * `#/agents/:ref` `#/graph` `#/graph/:nodeId`
+ * `#/agents/:ref` `#/workers` `#/workers/:id` `#/graph` `#/graph/:nodeId`
  */
 
 function pathAndQuery(hash: string): { path: string; query: string } {


### PR DESCRIPTION
The Workers view shipped in OPS-265 (#65) with no way to reach it — no nav item, no route, no chord, no palette entry. This wires the chrome around it.

## What this does

- **Nav** — a Workers item between Agents and Graph, on `g w`. `w` is no view's list verb, so unlike `g a` (which would double-fire the Proposals approve key) the natural letter was free.
- **Routing** — `#/workers` and `#/workers/:id`, deep-linkable and refresh-survivable. No new hash logic was needed: `parseHash`, `hashPath` and `shouldReplaceHash` all key on the first path segment, so selecting a row within Workers replaces the history entry and crossing views pushes. The new tests pin that rather than assume it.
- **Nav badge** — the one place Workers is not like its neighbours. Its count can mean two things, so it carries a hue *and* a word: stale workers in the warning tone, labelled `stale`, because a stale heartbeat is a process that is gone while still holding a run; busy workers in the usual accent when there are none; nothing at all when both are zero. Colour alone would not survive the contrast theme.
- **⌘K** — "Go to Workers", plus a Workers jump group keyed by worker id with a `worker · host · state` caption. The caption applies the same rule the view does, that a stale heartbeat outranks whatever the worker last reported, so the palette never calls a dead process busy.
- **`?` dialog** — the go-chord row gains `w` / Workers, and now reads `g → o / e / …` so the prefix `g` is not confused with the Graph suffix `g`.
- **Document title** — `factory · Workers · <id>` falls out of the existing effect once the NAV entry exists.

`views/Workers.tsx` is deliberately untouched: it still writes `location.hash` for its current-run link, which OPS-286 owns.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 205 pass, 0 fail across 22 files; `tsc --noEmit` clean; vite build green.

UX critique was run against the seeded demo env (2 live workers, 1 stale holding a run) and returned SHIP. Two in-scope polish items came back and are folded in above: the badge now says `stale` rather than relying on tone, and the shortcuts row disambiguates the chord prefix. Browser automation was unavailable in the session, so the critique was code- and API-based rather than click-through; the served bundle was checked to contain the new chrome. **First thing to look at in review is the nav badge in a running UI** — that is the one piece no automated check covers.

`g g` → Graph turns out never to have worked (the chord handler returns early on `g` before the map lookup). Pre-existing, unrelated to this change, filed as OPS-290 rather than fixed here.

Fixes OPS-266