### PR TITLE
fix(event-runtime-web): StalledWorker.runId is never null (OPS-283)

### DIFF
--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -238,7 +238,8 @@ export interface Worker {
 export interface StalledWorker {
   workerId: string;
   host: string;
-  runId: string | null;
+  /** Always set: the projection only emits workers that hold a run. */
+  runId: string;
   lastSeen: string;
 }
 


### PR DESCRIPTION
## What

Narrows `StalledWorker.runId` from `string | null` to `string` in `event-runtime/web/src/types.ts`. Types only — one field, no runtime code.

## Why null is unreachable

Verified against the source rather than assumed:

- `event-runtime/lib/workers.mjs:72` — `stalledWorkers()` filters `w.stale && w.currentRun`, so every emitted row holds a truthy run.
- `event-runtime/lib/api.mjs:141` — `statusView` maps `runId: w.currentRun` straight off that filtered list, so the API cannot emit `null` for this field.

`Worker.currentRun` is a different field that genuinely is nullable (a stopped or idle worker holds no run) and stays `string | null`.

## Impact on consumers

None today: `StalledWorker` is referenced only in `types.ts` within `web/src`, so nothing null-guards `runId` yet. `tsc --noEmit` stays green, which confirms no consumer assumed the nullable shape — no follow-up ticket needed. The workers view (OPS-265) can now treat `runId` as always present instead of writing a guard for a value the API never sends.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — pass. 205 tests, 0 failures; `tsc --noEmit` plus `vite build` clean.

UX critique: skipped — type-only change with no user-visible surface.

Fixes OPS-283