### PR TITLE
fix(event-runtime-web): requeue poll toasts when proposals fetch throws (OPS-282)

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -185,14 +185,21 @@ export function Events({
       invalidate();
       notify(`Requeued event ${e.eventId}`, "ok");
       const deadline = Date.now() + 8000;
-      while (alive.current && Date.now() < deadline) {
-        const { proposals } = await api.proposals();
-        const match = proposals.find((p) => p.eventSource === e.source && p.eventId === e.eventId);
-        if (match && alive.current) {
-          onJumpProposal(match.id);
-          return;
+      try {
+        while (alive.current && Date.now() < deadline) {
+          const { proposals } = await api.proposals();
+          const match = proposals.find((p) => p.eventSource === e.source && p.eventId === e.eventId);
+          if (match && alive.current) {
+            onJumpProposal(match.id);
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 250));
         }
-        await new Promise((r) => setTimeout(r, 250));
+      } catch {
+        // The requeue itself landed; only the confirmation poll broke, so say
+        // that rather than claiming no proposal appeared.
+        if (alive.current) notify(`Requeued ${e.eventId} — could not confirm a proposal appeared`, "err");
+        return;
       }
       if (alive.current) notify(`Requeued ${e.eventId} — no open proposal appeared`, "info");
     },

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -100,14 +100,21 @@ export function Overview({
       queryClient.invalidateQueries();
       notify(`Requeued event ${eventId}`, "ok");
       const deadline = Date.now() + 8000;
-      while (alive.current && Date.now() < deadline) {
-        const { proposals } = await api.proposals();
-        const match = proposals.find((p) => p.eventSource === source && p.eventId === eventId);
-        if (match && alive.current) {
-          onJumpProposal(match.id);
-          return;
+      try {
+        while (alive.current && Date.now() < deadline) {
+          const { proposals } = await api.proposals();
+          const match = proposals.find((p) => p.eventSource === source && p.eventId === eventId);
+          if (match && alive.current) {
+            onJumpProposal(match.id);
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 250));
         }
-        await new Promise((r) => setTimeout(r, 250));
+      } catch {
+        // The requeue itself landed; only the confirmation poll broke, so say
+        // that rather than claiming no proposal appeared.
+        if (alive.current) notify(`Requeued ${eventId} — could not confirm a proposal appeared`, "err");
+        return;
       }
       if (alive.current) notify(`Requeued ${eventId} — no open proposal appeared`, "info");
     },


### PR DESCRIPTION
## Summary

The post-requeue proposal poll in `Events.tsx` and `Overview.tsx` awaited `api.proposals()` inside an 8s deadline loop with nothing catching a rejection. A network blip mid-poll rejected the async `onSuccess` promise, so the loop never reached its timeout toast and the operator was left with only the "Requeued event …" success toast — no signal at all that the confirmation had failed.

Both views now wrap the loop in a try/catch and toast on throw. The message is deliberately different from the timeout one: the requeue itself did land, so claiming "no open proposal appeared" would be a guess. The throw path says `Requeued <id> — could not confirm a proposal appeared` with the error tone, while the benign fall-through keeps its existing info toast.

The success path is untouched — a match still calls `onJumpProposal(match.id)` and returns before the catch can see anything.

## Notes

A review comment on the ticket asked for a shared `useRequeuePoll` so these two copies cannot drift apart again (that drift is what produced OPS-244 and then this ticket). The extraction target `event-runtime/web/src/hooks.ts` is outside this ticket's Owned Paths, so rather than widen the path set mid-ticket the fix is two mirrored try/catches and the extraction is filed as [OPS-293](https://linear.app/watt-mind/issue/OPS-293).

UX critique: skipped — toast error path on an existing verb.

## Test plan

- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 205 pass, 0 fail; tsc clean, vite build succeeded
- [ ] Reviewer check: the two catches are byte-for-byte equivalent apart from the `eventId` / `e.eventId` binding

Fixes OPS-282