### PR TITLE
fix(event-runtime-web): expired empty copy must not hide a text filter

### DIFF
--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -126,6 +126,15 @@ export function Proposals({
     });
   }, [rows, filter, expiredFilter]);
 
+  // What the list would show without the text filter. An empty list under the
+  // expired chip has two causes and needs two messages: no expired opens exist
+  // (chip copy, nothing for Esc to clear) or the text filter hid the expired
+  // ones (filter copy + the Esc hint).
+  const unfilteredCount = useMemo(
+    () => (expiredFilter ? rows.filter((p) => p.expired).length : rows.length),
+    [rows, expiredFilter],
+  );
+
   const selectedId = focusProposalId;
   const selectedIndex = useMemo(() => visible.findIndex((p) => p.id === selectedId), [visible, selectedId]);
   const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
@@ -423,7 +432,7 @@ export function Proposals({
               <ListEmpty
                 colSpan={tab === "open" ? 6 : 7}
                 query={tab === "open" ? query : history}
-                filtered={expiredFilter ? false : rows.length > 0}
+                filtered={unfilteredCount > 0}
                 noun="proposals"
                 empty={
                   expiredFilter


### PR DESCRIPTION
## Problem

On the Proposals **Open** tab with the `expired` chip active, `filtered` was passed to `ListEmpty` as a hard `false`:

```tsx
filtered={expiredFilter ? false : rows.length > 0}
```

`ListEmpty` uses `filtered` for two things — the "No proposals match this filter." message and the "Esc clears the filter" hint. Forcing it false meant that typing a text filter which hid every remaining expired row still rendered **"No expired open proposals."** and swallowed the Esc hint, even though the text filter (not an empty expired list) was the actual reason the table was empty.

## Fix

Derive `filtered` from how many rows survive the chip *before* the text filter is applied:

```tsx
const unfilteredCount = useMemo(
  () => (expiredFilter ? rows.filter((p) => p.expired).length : rows.length),
  [rows, expiredFilter],
);
```

- No expired opens exist → `unfilteredCount === 0` → "No expired open proposals.", no Esc hint (there is nothing for Esc to clear).
- Expired opens exist but the text filter hid them → `unfilteredCount > 0` → filter copy **plus** the Esc-clears-filter hint.

Off the chip this reduces to the previous `rows.length > 0`, so nothing else changes. The **History** tab copy from OPS-251 is untouched — `expiredFilter` is already gated on `tab === "open"`, so history never took the chip branch.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build`

- 205 pass / 0 fail across 22 files
- build clean (`tsc --noEmit` + `vite build`)

UX review skipped — empty-state copy only, no new user journey.

Fixes OPS-285