### PR TITLE
test(event-runtime-web): fail the build if the entry chunk exceeds 500 kB

### DIFF
--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -1,6 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 // The Graph view's two heavyweights get their own chunks (OPS-255). Left in
 // the entry chunk they made Overview/Events/Runs pay ~2 MB before painting a
@@ -47,10 +47,44 @@ function vendorChunk(id: string): string | undefined {
   return undefined;
 }
 
+// VENDOR_CHUNKS hardcodes @xyflow/react's transitive deps, so a rename or a new
+// one on the next bump silently rejoins the entry chunk and the entry grows back
+// with nothing failing (OPS-288). Vite's own 500 kB notice is not that guard:
+// it is a warning, and the accepted elk one above trains everyone to skim past
+// it. Budget the entry chunk only — async chunks (elk, xyflow) are not entries,
+// are fetched on demand, and are deliberately over the limit. kB is 1000 bytes
+// here to match how Vite reports sizes.
+const ENTRY_CHUNK_LIMIT_BYTES = 500 * 1000;
+
+function entryChunkBudget(): Plugin {
+  return {
+    name: "entry-chunk-budget",
+    apply: "build",
+    writeBundle(_options, bundle) {
+      const oversized: string[] = [];
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk" || !output.isEntry) continue;
+        const bytes = Buffer.byteLength(output.code, "utf8");
+        if (bytes > ENTRY_CHUNK_LIMIT_BYTES) {
+          oversized.push(`${output.fileName} is ${(bytes / 1000).toFixed(2)} kB`);
+        }
+      }
+      if (oversized.length === 0) return;
+      const detail = oversized.join(", ");
+      throw new Error(
+        `Entry chunk budget exceeded: ${detail} (limit ${ENTRY_CHUNK_LIMIT_BYTES / 1000} kB). ` +
+          "A dependency that used to be split out is back in the entry chunk — most likely a " +
+          "@xyflow/react transitive dep missing from VENDOR_CHUNKS in vite.config.ts. Add it " +
+          "there (or code-split the new import); do not raise the limit.",
+      );
+    },
+  };
+}
+
 // Dev-server proxy mirrors serve.mjs: the browser sees one origin, /api/*
 // forwards to the loopback control API (webui spec §3).
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), entryChunkBudget()],
   build: {
     rollupOptions: {
       output: { manualChunks: vendorChunk },


### PR DESCRIPTION
## What

Adds an `entry-chunk-budget` Vite plugin (`writeBundle`) that throws — and so exits `vite build` non-zero — when any **entry** chunk exceeds 500 kB.

`VENDOR_CHUNKS` hardcodes `@xyflow/react`'s transitive deps, so an upstream rename or a newly added dep silently rejoins the entry chunk and the entry grows back with nothing failing. Vite's own 500 kB notice is only a warning, and the accepted ~1.4 MB `elk` warning trains everyone to skim past it.

- Only entry chunks are measured, so the async `elk` (1.44 MB) and `xyflow` (197 kB) chunks are excluded by construction — they are fetched on demand and are deliberately over the limit.
- `build.chunkSizeWarningLimit` is untouched, so Vite's warning still fires as before.
- No new script; CI already runs `cd event-runtime/web && bun run build`, so the guard runs there automatically.

## Verification

`cd event-runtime/web && bun run build`

- Green on this branch: entry `index-CV4rNJdY.js` is **382.16 kB**, `elk` 1,440.95 kB (async, ignored).
- Negative test: temporarily removing the `xyflow` entry from `VENDOR_CHUNKS` pushes the entry to 580.17 kB and the build fails with exit 1 and `[entry-chunk-budget] Entry chunk budget exceeded: assets/index-….js is 580.17 kB (limit 500 kB)`. Reverted afterwards.

Note on headroom: with the entry at 382 kB, the 500 kB cap tolerates ~118 kB of regression, so a *partial* leak (dropping `@xyflow/react` alone puts the entry at 469 kB) still passes. 500 kB is the threshold the ticket specifies; tightening it to a ratchet near the current size would be a separate call.

Fixes OPS-288