### PR TITLE
ui-ux(event-runtime-web): Agents event-routing rows jump to #/events?type=

### DIFF
--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -4,10 +4,18 @@ import { api } from "../api";
 import { useListKeys } from "../hooks";
 import type { AgentDef } from "../types";
 import { Button, DetailPane, Disclosure, FilterInput, JsonBlock, KV, ListEmpty, ListPane, Section, copyText, copyLink } from "../components/ui";
+import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
 
 const caps = (a: AgentDef) =>
   [a.capabilities.filesystem, ...(a.capabilities.services ?? [])].filter(Boolean).join(", ") || "none";
+
+/**
+ * Events already owns `#/events?type=` (the same target Graph jumps to). A real
+ * link, not a callback through App, keeps that route single-owner and makes the
+ * jump behave like one: middle-click, copy link, Back.
+ */
+const eventsTypeHref = (type: string) => `#/${eventsHash(null, null, type)}`;
 
 /**
  * Agents (webui doc §10.6) — the registry, fully readable. An operator
@@ -228,13 +236,18 @@ export function Agents({
             ) : (
               <div className="rounded-md border border-(--border) px-3 py-1">
                 {sel.eventTypes.map((r) => (
-                  <div key={r.type} className="border-b border-(--border) py-1.5 last:border-0">
-                    <div className="mono">{r.type}</div>
+                  <a
+                    key={r.type}
+                    href={eventsTypeHref(r.type)}
+                    title={`Show ${r.type} in Events`}
+                    className="group -mx-3 block border-b border-(--border) px-3 py-1.5 last:border-0 hover:bg-(--surface-1)"
+                  >
+                    <div className="mono text-(--accent) group-hover:underline">{r.type}</div>
                     <div className="text-[11px] text-(--text-faint)">
                       adapter {r.adapter} · idempotency {r.idempotencyScope}
                       {r.proposalTtlSeconds != null ? ` · proposal TTL ${r.proposalTtlSeconds}s` : ""}
                     </div>
-                  </div>
+                  </a>
                 ))}
               </div>
             )}


### PR DESCRIPTION
## What

The Agents detail pane already listed which event types route to an agent — it just would not take you there. Each row in **Event routing** is now a link to `#/events?type=<type>`, the same destination Graph's "Show in Events" button jumps to, built with the shared `eventsHash(null, null, type)` helper.

## Why an `<a href>` and not a callback

`Events` owns the `#/events?type=` route and `App` already reads the type out of the hash. A link needs no new prop threaded through `App`, and it behaves the way an operator expects a jump to behave: middle-click opens a second tab, "copy link address" yields a shareable URL, and Back returns to the agent (the hash write pushes, since it crosses views).

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 205 pass / 0 fail, build green (`build` runs `tsc --noEmit` first).

Behaviour checked against the seeded demo env (ports 7558/7559) by driving headless Chrome over CDP:

- `href="#/events?type=github.workflow-run.failed"`, `title="Show … in Events"`, one link per routing row.
- Clicking lands on `#/events?type=factory.status-report.requested` with 9 of 9 visible rows of that type, and `document.title` becomes `factory · Events · factory.status-report.requested`.
- Back returns to `#/agents/factory-status-report%401` — the jump pushed, it did not replace.
- A type with no events yet falls through to the Events view's own empty state ("No events match this filter. Esc clears the filter"), so the operator is never stranded.

## UX notes

- Affordance is the accent-coloured type plus underline on hover, a full-row hover background, and a title tooltip — matching the existing artifact "Open" links in Runs.
- The row is the hit target: 46px tall, spanning the full width of the routing card.
- Keyboard reachable, picking up the global `:focus-visible` outline.
- Accent-on-surface contrast clears WCAG AA in all three themes: 5.66:1 dark, 5.46:1 light, 9.69:1 high-contrast.

Fixes OPS-279