### PR TITLE
ui-ux(event-runtime-web): nav footer shows live worker count next to policyVersion

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -111,6 +111,9 @@ export function App() {
     (status.data?.events.human_needed ?? 0) + (status.data?.events.dead_lettered ?? 0);
   const busyWorkers = status.data?.workers.busy ?? 0;
   const staleWorkers = status.data?.workers.stale ?? 0;
+  // null until the first status lands: reading "no workers" off a pending
+  // fetch is the same false alarm as flashing "unreachable" on first load.
+  const liveWorkers = status.data?.workers.live ?? null;
 
   const env = health.data?.env;
   const envHue = !connected
@@ -290,12 +293,34 @@ export function App() {
         <div className="border-t border-(--border) px-4 py-3 text-[11px]">
           <div className="flex items-center gap-2">
             <span
-              className="size-2 rounded-full"
+              className="size-2 shrink-0 rounded-full"
               style={{ background: connected ? "var(--hue-ok)" : "var(--hue-err)" }}
             />
             {connected ? (
               <span className="text-(--text-dim)">
                 connected · <span className="mono">{health.data?.policyVersion}</span>
+                {liveWorkers !== null && (
+                  <>
+                    {" "}
+                    {/* One unbreakable token: at this nav width the fragment
+                        always wraps, and a bare "1" ending the line above its
+                        own "worker" reads as a different number. */}
+                    <span
+                      className="whitespace-nowrap"
+                      style={staleWorkers > 0 ? { color: "var(--hue-warn)" } : undefined}
+                      title={
+                        staleWorkers > 0
+                          ? `${liveWorkers} live · ${staleWorkers} worker${staleWorkers === 1 ? "" : "s"} whose heartbeat has gone stale`
+                          : `${liveWorkers} live worker${liveWorkers === 1 ? "" : "s"}`
+                      }
+                    >
+                      ·{" "}
+                      {liveWorkers === 0
+                        ? "no workers"
+                        : `${liveWorkers} worker${liveWorkers === 1 ? "" : "s"}`}
+                    </span>
+                  </>
+                )}
               </span>
             ) : (
               <span style={{ color: "var(--hue-err)" }}>runtime unreachable</span>


### PR DESCRIPTION
## What

The nav footer read `connected · <policyVersion>` — a state that stays reassuring while the fleet is gone: control API up, nothing alive to claim a run. It now carries the live worker count from `status.workers.live` next to the version:

- `connected · git:17bb134 · 1 worker` / `· 12 workers` / `· no workers`
- that fragment switches to `--hue-warn` whenever `status.workers.stale > 0`, matching the Workers nav badge, which also lets stale outrank busy

Two details the demo forced:

- **The count is withheld until the first `/status` lands.** Defaulting to `0` while the fetch is pending flashes "no workers" at a healthy fleet — the same false alarm the health banner already avoids on first load.
- **The fragment is one unbreakable token.** The footer has 159px of text room and `connected · git:17bb134 · 1 worker` needs 191px, so it always wraps at the real nav width. Without `whitespace-nowrap` the break landed inside the fragment, leaving a bare `1` at the end of one line above its own `worker` on the next — which reads as a different number. Now the break falls between fragments: `connected · git:17bb134` / `· 1 worker`.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 205 pass, 0 fail; build clean.

Checked on the seeded demo env (ports 7544/7545) in all three real states: `1 worker` with `stale > 0` (warn), `no workers` with `stale > 0` (warn), and the fragment's legibility in the dark, light, and contrast themes.

## Reviewer note

With `live == 0` **and** `stale == 0` — no worker registered at all, which is exactly the scenario in the ticket's problem statement — the footer says `no workers` in the dimmest tone the theme has, because the acceptance criteria tie the warning hue to `stale > 0`. `anomalies.noWorkers` is not rendered anywhere in `web/src`, and the Workers nav badge hides itself at zero, so this footer fragment is the only client-side signal. Filed separately rather than widened here.

Scope: `event-runtime/web/src/App.tsx` only. No change to the OPS-266 nav badge, no Graph lazy-loading (OPS-289), no badge-ternary refactor (OPS-292).

Fixes OPS-272