### PR TITLE
ui-ux(event-runtime-web): run attempt lease_owner jumps to that worker

### DIFF
--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -448,9 +448,10 @@ export function Runs({
                     {e.from_state ?? "·"} → <StateBadge state={e.to_state} />
                   </span>
                   <span className="truncate text-(--text-faint)">
-                    {/* `.mono` is 11.5px; the actors beside it are 13px prose,
-                        so the clickable one must not read as the smallest text. */}
-                    <ActorRef actor={e.actor} className="text-[13px]" />
+                    {/* `.mono` is unlayered author CSS at 11.5px; a utility
+                        `text-[13px]` loses the cascade. The important modifier
+                        is what actually matches the 13px prose beside it. */}
+                    <ActorRef actor={e.actor} className="text-[13px]!" />
                     {e.reason ? ` · ${e.reason}` : ""}
                   </span>
                 </div>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, artifactUrl } from "../api";
+import { hashPath } from "../hash";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
 import type { RunState } from "../types";
@@ -34,6 +35,37 @@ function rowWash(state: string): string {
   if (state === "FAILED" || state === "TIMED_OUT") return "row-wash-err";
   if (state === "REFUSED") return "row-wash-warn";
   return "";
+}
+
+/**
+ * A worker id is minted as `worker_<pid>_<rand>` (lib/ids.mjs); every other
+ * actor the runtime records is a bare word — `operator`, `planner`, `reaper`,
+ * or the `worker` fallback for an attempt whose owner was lost. Only the
+ * prefixed form addresses a row in the fleet, so only it becomes a jump.
+ */
+const isWorkerId = (actor: string): boolean => /^worker_.+/.test(actor);
+
+/** Workers owns `#/workers/:id`; this view is a way in, not a second router. */
+const openWorker = (workerId: string) => {
+  window.location.hash = `#/${hashPath("workers", workerId)}`;
+};
+
+/**
+ * Who did this — the lease owner of an attempt, or the actor on a lifecycle
+ * row. A worker id is a process you can go look at; an operator or a planner
+ * is not, and pretending otherwise would be a link to nowhere.
+ */
+function ActorRef({ actor, className }: { actor: string; className?: string }) {
+  if (!isWorkerId(actor)) return <>{actor}</>;
+  return (
+    <JumpLink
+      onClick={() => openWorker(actor)}
+      title={`Which process was this? Open ${actor} in Workers`}
+      className={className}
+    >
+      {actor}
+    </JumpLink>
+  );
 }
 
 /** Runs (webui spec §4.3): state tabs, lifecycle timeline, guarded verbs. */
@@ -416,7 +448,9 @@ export function Runs({
                     {e.from_state ?? "·"} → <StateBadge state={e.to_state} />
                   </span>
                   <span className="truncate text-(--text-faint)">
-                    {e.actor}
+                    {/* `.mono` is 11.5px; the actors beside it are 13px prose,
+                        so the clickable one must not read as the smallest text. */}
+                    <ActorRef actor={e.actor} className="text-[13px]" />
                     {e.reason ? ` · ${e.reason}` : ""}
                   </span>
                 </div>
@@ -434,6 +468,10 @@ export function Runs({
                   </div>
                   <div className="mono truncate text-[11px] text-(--text-faint)">
                     {a.reason_code ?? ""} {a.workspace_path ?? ""}
+                  </div>
+                  <div className="flex items-baseline gap-1.5 truncate text-[11px] text-(--text-faint)">
+                    <span>owner</span>
+                    {a.lease_owner ? <ActorRef actor={a.lease_owner} /> : <span className="mono">unclaimed</span>}
                   </div>
                   {(a.started_at || a.finished_at) && (
                     <div className="mt-1 flex gap-3 text-[11px] text-(--text-faint)">


### PR DESCRIPTION
An attempt's `lease_owner` and a lifecycle row's `actor` answer "which process did this". Until now the answer was a dead string an operator had to copy into the Workers filter by hand — and the attempt's owner was not rendered in the UI at all, only present in `GET /runs/:id`.

Both now jump to `#/workers/:id` when the string is a minted worker id.

## What decides "looks like a worker id"

Worker ids are minted as `worker_<pid>_<rand>` (`lib/ids.mjs`); every other actor the runtime records is a bare word — `operator` (API verbs), `planner`, `reaper`, and the `worker` fallback for an attempt whose owner was lost. Only the prefixed form addresses a row in the fleet, so only it becomes a jump. `operator`/`planner`/`reaper` and a null owner stay inert text rather than a link to nowhere.

The jump writes `window.location.hash` directly, the way `Workers.tsx` already opens `#/runs/:id`; threading an `onJumpWorker` callback would mean editing `App.tsx`, which is outside this ticket's owned paths.

## Verification

`bun test event-runtime` → 205 pass / 0 fail. `cd event-runtime/web && bun run build` → clean (the pre-existing elk chunk-size warning is unchanged).

Walked live against the seeded demo env on 7536/7537, where the fixture is unusually good for this: the RUNNING run's lease owner is a **stale** worker that still holds it, so clicking the owner lands on the red "heartbeat has gone stale — it still holds run_…" banner. That round trip is the whole point of the ticket, and Back returns to the run with its detail pane open.

A UX round on the new path returned **ship** with one in-scope fix, applied here: `.mono` hard-codes 11.5px, so a clickable worker actor rendered *smaller* than the plain `operator`/`planner` text beside it in the 13px lifecycle row — the interactive element was the least prominent thing in the row. It now keeps the mono family (it is a machine id) at body size.

Two findings were out of scope and are filed separately as OPS-313: a double-click on a worker link pushes two history entries because this bypasses the `navigate` dedup guard in `App.tsx` (unowned here), and the null `from_state` placeholder `·` collides with the `·` used as the reason separator in the same row.

Fixes OPS-268
