### PR TITLE
fix(event-runtime-web): log the graph layout rejection before failing over (OPS-297)

### DIFF
--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -93,8 +93,9 @@ export function Graph({
       )
       // A stale index.html after a redeploy points at a chunk that is no longer
       // there; without this the view sits on "Laying out…" and reads as busy.
-      .catch(() => {
+      .catch((err: unknown) => {
         if (cancelled) return;
+        console.error("graph layout failed", err);
         setLayoutFailed(true);
       });
     return () => {


### PR DESCRIPTION
## What

The layout effect's `.catch()` swallowed the rejection silently. Before the async-chunk split, a failed dynamic import at least produced `Uncaught (in promise)` in the browser console; afterwards a stale `index.html` pointing at a deleted chunk left zero evidence — just the honest empty state with no way to tell layout failure from an empty registry.

The catch now `console.error`s the rejection, still behind the existing cancel guard, before flipping `layoutFailed`.

## Scope

One file, `event-runtime/web/src/views/Graph.tsx`, +2/-1. The empty-state copy is untouched.

## Verification

- `cd event-runtime/web && bun run build` — green (`tsc --noEmit` + `vite build`, 8.26s)
- `bun test event-runtime` — 223 pass, 0 fail across 24 files

Fixes OPS-297