### PR TITLE
fix(event-runtime-web): route Overview worker jumps through onNavigate (OPS-314)

### DIFF
--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -23,15 +23,6 @@ import {
 const FEED_CAP = 50;
 
 /**
- * Workers has no jump callback from App (there is no `onJumpWorker`), so write
- * the hash the router already reads — a cross-view write, which pushes history
- * exactly like the nav rail does.
- */
-function jumpWorkers(workerId?: string): void {
-  window.location.hash = `#/${hashPath("workers", workerId)}`;
-}
-
-/**
  * Live activity feed off GET /journal: first fetch seeds the latest entries,
  * then each 2 s poll asks only for `since=<last head>` and prepends what is
  * new — an append-only log consumed incrementally, capped at FEED_CAP shown.
@@ -83,7 +74,7 @@ export function Overview({
   onJumpProposal: (id: string) => void;
   onJumpEvents: (focus: EventFocus) => void;
   onJumpRuns: (state?: string) => void;
-  onNavigate: (view: string) => void;
+  onNavigate: (path: string) => void;
   onJumpExpired: () => void;
   onJumpGraph: () => void;
   onInject: () => void;
@@ -183,7 +174,7 @@ export function Overview({
         // the host are the parts an operator can lose and still act.
         text: `stalled worker ${w.workerId} still holds run ${w.runId} — last heartbeat ${ago(w.lastSeen, now)} on ${w.host}`,
         links: [
-          { label: "View worker", go: () => jumpWorkers(w.workerId) },
+          { label: "View worker", go: () => onNavigate(hashPath("workers", w.workerId)) },
           { label: "View run", go: () => onJumpRun(w.runId) },
         ],
       });
@@ -195,7 +186,7 @@ export function Overview({
       anomalyRows.push({
         text: `${queued} queued run${queued === 1 ? "" : "s"} and no live worker to claim ${queued === 1 ? "it" : "them"} — nothing will start until one registers`,
         links: [
-          { label: "View workers", go: () => jumpWorkers() },
+          { label: "View workers", go: () => onNavigate("workers") },
           { label: "View queued runs", go: () => onJumpRuns("QUEUED") },
         ],
       });
@@ -256,19 +247,19 @@ export function Overview({
             label="workers · live"
             value={s.workers.live}
             hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
-            onClick={() => jumpWorkers()}
+            onClick={() => onNavigate("workers")}
           />
           <StatTile
             label="workers · busy"
             value={s.workers.busy}
             hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
-            onClick={() => jumpWorkers()}
+            onClick={() => onNavigate("workers")}
           />
           <StatTile
             label="workers · stale"
             value={s.workers.stale}
             hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
-            onClick={() => jumpWorkers()}
+            onClick={() => onNavigate("workers")}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

`Overview.tsx` had a local `jumpWorkers` helper that wrote `window.location.hash` directly, even though Overview already receives App's `navigate` as `onNavigate` and uses it for the proposals tile. Behavior was identical today, but the helper duplicated the router's write path and skipped its no-op guard and same-view `replaceState` branch.

- `jumpWorkers` deleted.
- The three worker stat tiles (live/busy/stale) and the no-live-worker doctor row now call `onNavigate("workers")`.
- The stalled-worker doctor row now calls `onNavigate(hashPath("workers", w.workerId))`.
- Corrected the `onNavigate` prop type's parameter name from `view` to `path`, since it takes a full hash path (`navigate` in `App.tsx` is `(path: string) => void`).

Diff is confined to the ticket's Owned Path, `event-runtime/web/src/views/Overview.tsx`.

## Test plan

`bun test event-runtime && cd event-runtime/web && bun run build` — green: 223 pass / 0 fail, `tsc --noEmit` clean, vite build succeeded.

UX review skipped: navigation plumbing only, no user-visible flow change (destination and history-push behavior are unchanged).

Fixes OPS-314