### PR TITLE
fix(event-runtime-web): floor stale overdue to a second, never 0:00 (OPS-315)

### DIFF
--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -56,7 +56,10 @@ type Heartbeat = { kind: "stale"; overdueMs: number } | { kind: "live"; remainin
  */
 const heartbeatOf = (w: Worker, now: number): Heartbeat => {
   const deadline = Date.parse(w.lastSeen) + HEARTBEAT_STALE_MS;
-  if (w.stale) return { kind: "stale", overdueMs: Math.max(0, now - deadline) };
+  // Floored to a second, because `dur` renders the first sub-second of overdue as
+  // `0:00` and "stale for no time at all" reads as a broken badge rather than a
+  // fresh one. Same floor the countdown below uses, so the flip reads 0:01 next.
+  if (w.stale) return { kind: "stale", overdueMs: Math.max(1000, now - deadline) };
   if (w.state === "stopped") return { kind: "none" };
   // Whole seconds, rounded up: the last fraction of a second reads 0:01, and only
   // a genuinely spent window reads 0 — which is what `overdue` keys off.


### PR DESCRIPTION
## Problem

When the runtime flips a worker `stale` (`now - lastSeen > 90_000`), the client's `overdueMs = Math.max(0, now - deadline)` is under a second on the first render, and `dur` floors that to `0:00`. For one tick the row reads `stale for 0:00` and the detail banner reads "Heartbeat went stale 0:00 ago" — a badge contradicting itself. Mirror image of the `stale in 0:00` fixed on the countdown side in #76.

## Change

One line in `heartbeatOf`: the stale branch floors to `Math.max(1000, now - deadline)`, the counterpart of the ceil-to-whole-seconds the live branch already does immediately below. The flip now reads `0:01` and counts up from there.

Fixing it at the source rather than in the two format sites covers every surface the sub-second value reached — the row badge, its `title` tooltip, and the detail-pane banner — and keeps the "how far past the window are we" arithmetic in the one function that owns it. `HeartbeatMeter` is unaffected: it hardcodes a full bar for `stale` and never reads `overdueMs`.

A negative `now - deadline` (client clock behind the server that flipped the worker) previously clamped to `0:00` too, and now also reads `0:01` — still the honest "the server says stale, we just got here" rather than a zero.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — **223 pass / 0 fail**, `tsc --noEmit` and `vite build` clean.

No UX critic pass: the change is countdown copy, and the state is a sub-second transient that self-corrects on the next tick, so it cannot be posed in a browser.

Fixes OPS-315