### PR TITLE
test(event-runtime-web): ratchet the entry-chunk budget closer to current size (OPS-303)

### DIFF
--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -76,10 +76,20 @@ function entryChunkBudget(): Plugin {
         }
       }
       if (oversized.length === 0) return;
+      // Vite's size reporter runs later in writeBundle; throwing here skips it,
+      // so print the inventory ourselves instead of pointing at missing output.
+      const inventory = Object.values(bundle)
+        .filter((output) => output.type === "chunk")
+        .map(
+          (output) =>
+            `${output.fileName} ${(Buffer.byteLength(output.code, "utf8") / 1000).toFixed(2)} kB`,
+        )
+        .join("\n  ");
       const detail = oversized.join(", ");
       throw new Error(
-        `Entry chunk budget exceeded: ${detail} (budget ${ENTRY_CHUNK_BUDGET_BYTES / 1000} kB). ` +
-          "Check the chunk list above first: if the xyflow chunk shrank or vanished, a " +
+        `Entry chunk budget exceeded: ${detail} (budget ${ENTRY_CHUNK_BUDGET_BYTES / 1000} kB).\n` +
+          `Chunks:\n  ${inventory}\n` +
+          "Check the list above: if the xyflow chunk shrank or vanished, a " +
           "@xyflow/react transitive dep is missing from VENDOR_CHUNKS in vite.config.ts — add it " +
           "there (or code-split the new import) rather than raising the budget. If the split " +
           "chunks look right and this is genuine app growth, re-baseline ENTRY_CHUNK_BUDGET_BYTES " +

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -54,7 +54,13 @@ function vendorChunk(id: string): string | undefined {
 // it. Budget the entry chunk only — async chunks (elk, xyflow) are not entries,
 // are fetched on demand, and are deliberately over the limit. kB is 1000 bytes
 // here to match how Vite reports sizes.
-const ENTRY_CHUNK_LIMIT_BYTES = 500 * 1000;
+//
+// The budget tracks the measured entry (391 kB as of OPS-303) with ~7% of slack,
+// not a round number well above it: at 500 kB, dropping @xyflow/react alone —
+// the exact regression this guards — landed at 479 kB and still passed. Slack
+// this thin means ordinary feature work will eventually trip it; that is the
+// trade, and re-baselining is a normal move (see the error message below).
+const ENTRY_CHUNK_BUDGET_BYTES = 420 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {
@@ -65,17 +71,20 @@ function entryChunkBudget(): Plugin {
       for (const output of Object.values(bundle)) {
         if (output.type !== "chunk" || !output.isEntry) continue;
         const bytes = Buffer.byteLength(output.code, "utf8");
-        if (bytes > ENTRY_CHUNK_LIMIT_BYTES) {
+        if (bytes > ENTRY_CHUNK_BUDGET_BYTES) {
           oversized.push(`${output.fileName} is ${(bytes / 1000).toFixed(2)} kB`);
         }
       }
       if (oversized.length === 0) return;
       const detail = oversized.join(", ");
       throw new Error(
-        `Entry chunk budget exceeded: ${detail} (limit ${ENTRY_CHUNK_LIMIT_BYTES / 1000} kB). ` +
-          "A dependency that used to be split out is back in the entry chunk — most likely a " +
-          "@xyflow/react transitive dep missing from VENDOR_CHUNKS in vite.config.ts. Add it " +
-          "there (or code-split the new import); do not raise the limit.",
+        `Entry chunk budget exceeded: ${detail} (budget ${ENTRY_CHUNK_BUDGET_BYTES / 1000} kB). ` +
+          "Check the chunk list above first: if the xyflow chunk shrank or vanished, a " +
+          "@xyflow/react transitive dep is missing from VENDOR_CHUNKS in vite.config.ts — add it " +
+          "there (or code-split the new import) rather than raising the budget. If the split " +
+          "chunks look right and this is genuine app growth, re-baseline ENTRY_CHUNK_BUDGET_BYTES " +
+          "to the measured size plus a little slack, in its own commit, so the raise is a " +
+          "reviewable decision instead of a silent drift.",
       );
     },
   };


### PR DESCRIPTION
## Summary

The entry-chunk budget added in OPS-288 was set to 500 kB, ~109 kB above the entry chunk's measured 391 kB. That gap was wide enough to swallow the exact regression the guard exists to catch: removing `@xyflow/react` from `VENDOR_CHUNKS` pushes the entry to 479 kB, which passed a 500 kB cap without complaint.

This ratchets `ENTRY_CHUNK_BUDGET_BYTES` to 420 kB — about 7% of slack over the measured size — and renames it from `ENTRY_CHUNK_LIMIT_BYTES` to match the plugin's own vocabulary.

Slack that thin means normal feature work will eventually trip the budget, which the old failure message handled badly: it said "do not raise the limit" full stop, so the only advice for legitimate growth was advice not to follow. The message now describes how to tell the two cases apart (did the split `xyflow` chunk shrink or disappear?) and says that a measured re-baseline in its own commit is a legitimate fix. The point is to make a raise a reviewable decision, not to forbid it.

Async chunks are untouched and still exempt — the plugin only inspects `isEntry` chunks, so `elk` (1441 kB) and `xyflow` (197 kB) remain deliberately over the limit and fetched on demand.

## Test plan

- [x] `cd event-runtime/web && bun run build` — green, entry chunk 391.39 kB, `xyflow` and `elk` split as before
- [x] Negative test: removing `@xyflow/react` from `VENDOR_CHUNKS` fails the build with exit 1 (`assets/index-*.js is 478.84 kB (budget 420 kB)`); `@xyflow/react` restored and re-verified green afterward
- [x] Diff confined to the ticket's owned path, `event-runtime/web/vite.config.ts`

Fixes OPS-303