### PR TITLE
a11y(event-runtime-web): inject chip group keeps a tabbable chip when a template vanishes (OPS-263)

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -106,8 +106,17 @@ export function InjectDialog({
     return [...(initialEnvelope ? ["__given__"] : []), ...templates.map((t) => t.eventType), null];
   }
 
+  /**
+   * The chip that owns the group's single tabIndex 0. Normally `selected`, but
+   * a registry refetch can drop the selected event type while the dialog is
+   * open; the blank chip always renders, so it takes over rather than leaving
+   * no chip tabbable and Tab skipping the group. The envelope text is left
+   * alone — it may hold the user's edits.
+   */
+  const checkedChip = templateIds().includes(selected) ? selected : null;
+
   function radioA11y(id: string | null) {
-    const checked = selected === id;
+    const checked = checkedChip === id;
     return {
       role: "radio" as const,
       "aria-checked": checked,
@@ -125,7 +134,7 @@ export function InjectDialog({
     if (!(e.target instanceof HTMLElement) || e.target.getAttribute("role") !== "radio") return;
     e.preventDefault();
     const ids = templateIds();
-    const idx = selected === null ? ids.length - 1 : Math.max(ids.indexOf(selected), 0);
+    const idx = checkedChip === null ? ids.length - 1 : Math.max(ids.indexOf(checkedChip), 0);
     const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
     const nextIdx = (idx + delta + ids.length) % ids.length;
     applyChip(ids[nextIdx]);
@@ -217,7 +226,7 @@ export function InjectDialog({
             {...radioA11y("__given__")}
             onClick={() => applyChip("__given__")}
             className={`rounded-md border px-2 py-1 text-[11.5px] ${
-              selected === "__given__"
+              checkedChip === "__given__"
                 ? "border-(--accent) bg-(--surface-3) text-(--text)"
                 : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
             }`}
@@ -233,7 +242,7 @@ export function InjectDialog({
             title={`${t.agent} · payload: ${t.summary}`}
             onClick={() => applyChip(t.eventType)}
             className={`rounded-md border px-2 py-1 text-left text-[11.5px] ${
-              selected === t.eventType
+              checkedChip === t.eventType
                 ? "border-(--accent) bg-(--surface-3) text-(--text)"
                 : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
             }`}
@@ -247,7 +256,7 @@ export function InjectDialog({
           {...radioA11y(null)}
           onClick={() => applyChip(null)}
           className={`rounded-md border px-2 py-1 text-[11.5px] ${
-            selected === null
+            checkedChip === null
               ? "border-(--accent) bg-(--surface-3) text-(--text)"
               : "border-(--border) text-(--text-faint) hover:bg-(--surface-2)"
           }`}


### PR DESCRIPTION
## Summary

`radioA11y` gave `tabIndex: 0` only to the chip matching `selected`. If a registry refetch removed the selected event type while Inject was open, no chip owned `tabIndex 0`, `[aria-checked="true"]` matched nothing, and Tab skipped the entire radiogroup.

- Derive `checkedChip`: `selected` when it still renders a chip, otherwise `null` — the blank chip, which always renders. `aria-checked` and `tabIndex` key off it, so the group always has exactly one tabbable, checked chip.
- Route the three chip highlight classNames through the same value so the visual selection can never disagree with `aria-checked`.
- Route the arrow-key start index through it too, so arrows resume from the chip that is actually focusable instead of falling back to index 0 via `indexOf() === -1`.
- `selected` state and the envelope textarea are deliberately untouched — the text may hold the user's edits, so this does not reset it. Explicitly clicking blank still self-heals `selected`.

Follow-up to [OPS-248](https://linear.app/watt-mind/issue/OPS-248) / [#58](https://github.com/watt-mind/factory/pull/58) (merge-review finding 4). Diff is confined to the ticket's single Owned Path.

## Test plan

- [x] `bun test event-runtime` — 223 pass, 0 fail
- [x] `cd event-runtime/web && bun run build` — `tsc --noEmit` clean, vite build green
- [ ] UX pass skipped: demo on 7526/7527 is down, and the scenario needs a registry mutation mid-dialog rather than a clickable path

Fixes OPS-263