### PR TITLE
docs(event-runtime-web): Overview tiles and lease_owner jumps have shipped (OPS-317)

### DIFF
--- a/docs/event-runtime-webui-roadmap.md
+++ b/docs/event-runtime-webui-roadmap.md
@@ -48,8 +48,8 @@ Operators can dynamically group any view by:
 ## 2. Module Feature Roadmap
 
 ### 2.1 Executive Dashboard & Operations Center (`/overview`)
-* Real-time stat grid (events, proposals, runs). Worker tiles are **not on Overview yet** (OPS-267) — `GET /status` already returns `workers.{live,busy,stale}`, and the fleet is readable today at `/workers` (§2.7).
-* Doctor anomaly resolution panel (dead letters, stale leases, prompt hash drift).
+* Real-time stat grid (events, proposals, runs, and `workers.{live,busy,stale}` from `GET /status` — shipped OPS-267, each tile a jump to `/workers` (§2.7)).
+* Doctor anomaly resolution panel (dead letters, stale leases, prompt hash drift, stalled workers still holding a run, no live worker for queued runs).
 * Append-only live activity journal (`GET /journal?since=<seq>`).
 * Published outbox result stream (`factory.agent-result/v1`).
 
@@ -86,4 +86,4 @@ Operators can dynamically group any view by:
 * Registry list from `GET /workers`: host, pid, health, placement labels, adapters, current run, heartbeat age.
 * Heartbeat as the lie detector: `stale` outranks the worker's own `busy`/`idle` report (90 s window), and the nav badge flips from the busy count to the stale count.
 * Detail inspector: process identity, declared adapters, placement labels; jump to the held run (`#/runs/:id`).
-* Pending: Overview worker tiles and doctor stalled/no-worker anomalies (OPS-267), and `lease_owner` → worker jumps from a run's attempts (OPS-268).
+* Shipped since: Overview worker tiles and doctor stalled/no-worker anomalies (OPS-267), and `lease_owner` → worker jumps from a run's attempts and lifecycle actors (OPS-268).

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -497,7 +497,7 @@ no new API.
   obvious. Click a toast to dismiss it. The document title follows the hash
   (`factory · Runs · run_id`).
 
-### 10.9 Workers view (`#/workers`, `g w`) — OPS-265, OPS-266
+### 10.9 Workers view (`#/workers`, `g w`) — OPS-265, OPS-266, OPS-267, OPS-268
 
 The fleet became plural (OPS-233), so §1's single-worker claim stopped being
 true and the registry needed a view. Workers answers one question: **who could
@@ -545,11 +545,24 @@ is the reason the view exists.
   there because tone alone does not survive the high-contrast theme. Counts
   come from `/status`'s `workers` block.
 
-Two AC items of the parent pass are **not on this tree and remain follow-ups**:
-the Overview doctor tiles for `stalledWorkers` / `noWorkers` (OPS-267) and
-`lease_owner` jumps from a run's attempts to the owning worker (OPS-268) — the
-API already returns all three fields (§7), but no Overview or Runs UI reads
-them yet.
+The two AC items of the parent pass that shipped separately are **now on this
+tree**, so the fields §7 already returned are all read by a view:
+
+- **Overview tiles and worker anomalies (OPS-267).** The Overview stat grid
+  gains `workers · live` / `busy` / `stale` from `/status`, each hued only when
+  non-zero (ok, info, warn) and each a jump to `#/workers`. The Overview doctor
+  panel gains a row per `stalledWorkers` entry — naming the worker, the run it
+  still holds, and the heartbeat age, with a jump to both ends of that gap —
+  and a row for `noWorkers` that counts the queued runs waiting on a
+  registration. Anomaly rows carry a link list rather than one link, because a
+  stalled worker legitimately has two destinations.
+- **`lease_owner` jumps (OPS-268).** A run's attempts now render their lease
+  owner, and both it and a lifecycle row's actor become a jump to
+  `#/workers/:id` when the string is a worker id (`worker_<pid>_<rand>`,
+  `lib/ids.mjs`). Every other actor the runtime records is a bare word
+  (`operator`, `planner`, `reaper`, or the `worker` fallback for an attempt
+  whose owner was lost) and stays inert text, since none of them addresses a
+  row in the fleet; a missing owner reads `unclaimed`.
 
 ### 10.10 Live trace in run detail (OPS-295)
 


### PR DESCRIPTION
## Why

§10.9 of `docs/event-runtime-webui.md` and the roadmap both still said the two
remaining AC items of the Workers parent pass were *not on this tree and remain
follow-ups*. Both landed earlier today, so the docs were pointing operators at
missing features that are in fact on their screen:

- **OPS-267** — `5840580` *Overview worker tiles and stalled/noWorkers doctor*, merged as #75 (`342fd17`)
- **OPS-268** — `38e4815` *lease_owner and worker actors jump to Workers*, merged as #78 (`152ad96`)

Both tickets are `Done` in Linear. Evidence read from `origin/develop@152ad96`.

Note this is wider than the originating ticket's body, which said to leave
`lease_owner` pending until OPS-268 landed — it has since landed, so both
sentences flip.

## What changed

Docs only — no code, no test, no config touched.

- `docs/event-runtime-webui.md` §10.9 — the "remain follow-ups" paragraph is
  replaced by two bullets describing what each change actually renders: the
  hued live/busy/stale tiles and their jump, the per-`stalledWorkers` doctor row
  with a jump to both ends of the gap, the `noWorkers` row, then the attempt's
  lease owner plus which actor strings become `#/workers/:id` jumps
  (`worker_<pid>_<rand>`) and why bare-word actors stay inert. Section heading
  now credits OPS-267 and OPS-268 alongside OPS-265/266.
- `docs/event-runtime-webui-roadmap.md` — §2.1 stat-grid bullet no longer says
  worker tiles are "not on Overview yet"; §2.1 doctor bullet gains the two
  worker anomalies; §2.7's `Pending:` bullet becomes `Shipped since:`.

§4 was deliberately left alone: the doc's convention is that beyond-spec
changes are recorded in §10, not retrofitted into the original spec sections.

## Verification

The ticket's command (`rg -n "Overview doctor"`) only proves a string exists, so
it was run alongside stricter checks that the pending claims are actually gone:

```
$ rg -n "Overview doctor" docs/event-runtime-webui.md docs/event-runtime-webui-roadmap.md
docs/event-runtime-webui.md:553:  ... The Overview doctor

$ rg -n "not on Overview|not on this tree|remain follow-up|Pending: Overview|no Overview or Runs UI" docs/*.md
(no matches — exit 1)

$ rg -n "one worker" docs/event-runtime-webui.md; test $? -eq 1
PASS  (§1's single-worker claim stays retired)

$ git status --porcelain
 M docs/event-runtime-webui-roadmap.md
 M docs/event-runtime-webui.md   # no code files
```

No UX review: documentation change with no user-facing surface.

Fixes OPS-317