### PR TITLE
a11y(event-runtime-web): toasts use aria-live; errors assertive (OPS-278)

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -305,6 +305,11 @@ function dismissToast(id: string) {
   toastListeners.forEach((l) => l(activeToasts));
 }
 
+/**
+ * Both regions stay mounted even while empty: a screen reader only announces
+ * nodes inserted into a live region that already existed, so mounting the
+ * region together with its first toast would swallow that toast.
+ */
 export function ToastContainer() {
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   useEffect(() => {
@@ -314,13 +319,30 @@ export function ToastContainer() {
     };
   }, []);
 
-  if (toasts.length === 0) return null;
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+      <ToastRegion role="status" live="polite" toasts={toasts.filter((t) => t.type !== "err")} />
+      <ToastRegion role="alert" live="assertive" toasts={toasts.filter((t) => t.type === "err")} />
+    </div>
+  );
+}
+
+function ToastRegion({
+  role,
+  live,
+  toasts,
+}: {
+  role: "status" | "alert";
+  live: "polite" | "assertive";
+  toasts: ToastMessage[];
+}) {
+  return (
+    // aria-atomic="false" — both roles default to atomic, which re-reads every
+    // surviving toast whenever one is added or dismissed.
+    <div role={role} aria-live={live} aria-atomic="false" className="flex flex-col gap-2">
       {toasts.map((t) => (
         <div
           key={t.id}
-          role="status"
           title="Dismiss"
           onClick={() => dismissToast(t.id)}
           className="pointer-events-auto flex cursor-pointer items-center gap-2 rounded-md border bg-(--surface-1) px-3 py-2 text-[12px] shadow-xl transition-all"


### PR DESCRIPTION
## What

`ToastContainer` was a purely visual surface: a screen reader user approving a proposal, requeueing a dead-lettered event, or hitting a failed fetch got no announcement at all, and an error toast was exactly as silent as a success one.

The stack is now two live regions inside the same fixed bottom-right container:

- `role="status"` / `aria-live="polite"` for `ok` and `info` — waits for a pause, never interrupts.
- `role="alert"` / `aria-live="assertive"` for `err` — interrupts, because a failed verb is not something to find out about later.

## Notes for review

Two details that are easy to get wrong and are the reason the diff is shaped this way:

- **Regions stay mounted while empty.** The old `if (toasts.length === 0) return null` meant the region and its first toast appeared in the same DOM mutation, and a live region that did not exist beforehand does not announce its initial content — the first toast, the one that matters, would be swallowed. The empty container is `pointer-events-none` and renders nothing visible.
- **`aria-atomic="false"` on both regions.** `status` and `alert` are both implicitly atomic, which makes every add or dismiss re-read every toast still on screen. With it off, only the inserted toast is announced.

The per-toast `role="status"` is removed — inside a live region it would have nested one live region in another. Click-to-dismiss, the 3s auto-dismiss, the 5-toast cap, and the visual treatment are unchanged. Errors now group below the polite toasts rather than interleaving strictly by arrival time; within the bottom-right stack that reads fine and is what keeps each toast in the right region.

## Verification

Ticket command, both green:

- `bun test event-runtime` — 223 pass, 0 fail
- `cd event-runtime/web && bun run build` — `tsc --noEmit` + vite build clean, entry chunk still under the OPS-288 cap

Also ran the full root `bun test` that CI runs: 384 pass, 0 fail.

No UX pass: nothing was listening on the demo ports (7556/7557), so there was no live surface to drive a screen reader against. The change is announcement semantics only, with no visual delta.

Fixes OPS-278