### PR TITLE
fix(event-runtime-web): Esc hint on any active proposal filter (OPS-304)

### DIFF
--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -135,6 +135,14 @@ export function Proposals({
     [rows, expiredFilter],
   );
 
+  // Esc clears the text filter and the expired chip together, so the hint is
+  // owed whenever either is set — including when the unfiltered set is itself
+  // empty, where `filtered` is false so the copy can stay specific ("No expired
+  // open proposals."). ListEmpty renders its own hint from `filtered` and its
+  // `action` slot in exactly the complementary case, so this lands in the same
+  // cell — never doubled — and stays quiet while loading or the API is down.
+  const escClearsFilter = filter.trim() !== "" || expiredFilter;
+
   const selectedId = focusProposalId;
   const selectedIndex = useMemo(() => visible.findIndex((p) => p.id === selectedId), [visible, selectedId]);
   const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
@@ -440,6 +448,9 @@ export function Proposals({
                     : tab === "open"
                       ? "No open proposals — the operator's work is done, for now."
                       : "No decided proposals yet."
+                }
+                action={
+                  escClearsFilter ? <span className="text-[11px]">Esc clears the filter</span> : undefined
                 }
               />
             )}


### PR DESCRIPTION
## Problem

The Esc-clears-filter hint under an empty Proposals list was gated on `ListEmpty`'s `filtered` prop, which means *the text filter hid rows* (`unfilteredCount > 0`). Two states missed it even though Esc would clear something:

- expired chip on, a text filter typed, and **zero** expired opens → `unfilteredCount === 0`, so no hint
- chip off, Open list empty, filter typed → same shape

Copy was accurate in both; only the affordance was missing.

## Change

One file, one derived flag. `filtered` stays exactly as it was, so the copy keeps distinguishing *no expired opens* ("No expired open proposals.") from *the filter hid rows* ("No proposals match this filter."). The hint for the missing case rides `ListEmpty`'s existing `action` slot, which renders under `!filtered && !isPending && !isError` — precisely the complementary case:

- same table cell as the copy, no extra row
- never doubled: when `filtered` is true, `ListEmpty` renders its own hint and drops `action`
- stays quiet during first load and while the control API is unreachable

`components/ui.tsx` is untouched — no signature change was needed, so it stays free for OPS-278.

## Behaviour

| State | Copy | Esc hint |
| --- | --- | --- |
| Open, chip on, filter typed, no expired opens | No expired open proposals. | yes (new) |
| Open, chip on, filter hid the expired rows | No proposals match this filter. | yes (unchanged) |
| Open, chip off, filter typed, list empty | No open proposals — … | yes (new) |
| Open, no filter, list empty | No open proposals — … | no (unchanged) |
| History, filter typed, nothing decided | No decided proposals yet. | yes (new) |
| History, no filter | No decided proposals yet. | no (unchanged) |

History copy is unchanged in every case.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 230 pass / 0 fail, `tsc --noEmit` and `vite build` clean, on the branch rebased onto `origin/develop@c75672d`.

Visual pass skipped: the demo on 7608/7609 is not running.

Fixes OPS-304