### PR TITLE
feat(event-runtime-web): parked event rows carry their last plan error (OPS-274)

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -376,12 +376,22 @@ export function Events({
                 <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
                   {e.subject ?? "-"}
                 </td>
-                <td className="border-b border-(--border) px-3 py-1.5">
-                  <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
-                  {e.planFailures > 0 && (
-                    <span className="ml-2 text-[11px]" style={{ color: "var(--hue-err)" }}>
-                      {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
-                    </span>
+                <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
+                  <div>
+                    <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                    {e.planFailures > 0 && (
+                      <span className="ml-2 whitespace-nowrap text-[11px]" style={{ color: "var(--hue-err)" }}>
+                        {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
+                      </span>
+                    )}
+                  </div>
+                  {/* Why the event is parked, on the row: `.mono` carries its own
+                      11.5px, so no size utility (it is unlayered and would win).
+                      The detail pane keeps the untruncated error. */}
+                  {e.lastPlanError && (
+                    <div className="mono mt-0.5 truncate text-(--text-dim)" title={e.lastPlanError}>
+                      {e.lastPlanError}
+                    </div>
                   )}
                 </td>
                 <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">


### PR DESCRIPTION
## What

The Events list Status cell already showed `{n} plan failure(s)` beside the badge; the *reason* was detail-pane only, so an operator opened every parked row to read it. `lastPlanError` now renders under the badge, truncated to the column with the full text as the `title`, and the detail pane's `Planning` section still carries it untruncated.

- `max-w-56` on the `td` so a long error caps the column instead of stretching it — the same `max-w-* truncate` + `title` idiom as the other columns and Proposals/Workers.
- No size utility next to `.mono`: it is unlayered author CSS at 11.5px and beats a Tailwind `text-[11px]` (the trap ce3dde9 fixed for OPS-268). `.mono`'s own 11.5px is the intended size.
- Failure-count behaviour is unchanged; the new line is null-guarded, so rows without an error look exactly as before.

## Reviewer note

`planner.mjs` writes `last_plan_error` only when `planEvent` **throws**. The `human_needed` path puts its reason on the *proposal* and leaves the event's error NULL, so in practice this row line lights up for `dead_lettered` and for `admitted` events mid-retry; a plain `human_needed` row still shows only the badge. Closing that is a data change in `lib/api.mjs` + `types.ts`, outside this ticket's Owned Paths — filed as OPS-332.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — pass. 223 tests, 0 fail; `tsc --noEmit` clean, vite build clean.

UX critique: skipped — demo down on this worktree's ports (API 7548 / web 7549 both refuse connections, OPS-306), so there was no live surface to critique. The change is one truncated text line inside an existing table cell, on an internal operator surface, using the file's existing truncation idiom.

Fixes OPS-274