### PR TITLE
feat(event-runtime): GET /repos lists config/repos.yaml (OPS-299)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -52,6 +52,7 @@ usage: bun event-runtime/cli.mjs <command>
   proposals                      open proposals with TTL age
   agents                         registered agent definitions and event routing
   workers                        worker processes: host, labels, state, heartbeat
+  repos                          factory repos: team, base, dispatch vs report-only
   approve <proposal-id>          approve an open proposal
   reject <proposal-id> <reason>  reject an open proposal
   inject <envelope.json|->       replay an event envelope (same intake as the webhook)
@@ -548,6 +549,25 @@ async function workers(client) {
   }
 }
 
+/**
+ * The factory repo registry (OPS-299). MODE is the column an operator actually
+ * scans for — a report-only repo is one the loop reports on but never dispatches
+ * to — and CLEANUP says whether the janitor has a teardown script to call.
+ */
+async function repos(client) {
+  const { repos: rows } = await client.repos();
+  if (rows.length === 0) {
+    console.log("no repos in config/repos.yaml");
+    return;
+  }
+  console.log(`${pad("REPO", 16)}${pad("TEAM", 6)}${pad("MODE", 12)}${pad("BASE", 10)}${pad("DEPLOY", 10)}${pad("CAP", 5)}${pad("CLEANUP", 9)}WORKTREE ROOT`);
+  for (const r of rows) {
+    console.log(
+      `${pad(r.name, 16)}${pad(r.team, 6)}${pad(r.reportOnly ? "report-only" : "dispatch", 12)}${pad(r.base, 10)}${pad(r.deployBranch, 10)}${pad(r.maxInFlight, 5)}${pad(r.hasWorktreeDown ? "yes" : "no", 9)}${r.worktreeRoot ?? "-"}`,
+    );
+  }
+}
+
 async function agents(client) {
   const { agents: defs } = await client.agents();
   for (const d of defs) {
@@ -604,6 +624,9 @@ async function main() {
 
     case "workers":
       return withClient(workers);
+
+    case "repos":
+      return withClient(repos);
 
     case "approve": {
       if (!args[0]) fail("usage: approve <proposal-id>");

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -18,6 +18,7 @@ import { admitEvent, verifyWebhook } from "./intake.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import { loadRepos, RepoError, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
@@ -377,6 +378,11 @@ export function createApi({
   policyVersion = "unknown",
   env = { name: environmentName(), home: runtimeHome(), adapter: null },
   onEvent = () => {},
+  // Read per request, not once at startup: repos.yaml is a file an operator
+  // edits, and a registry cached at boot would answer with yesterday's config
+  // until someone restarted serve. Injectable so tests can point at a fixture
+  // instead of whichever repos exist on the machine.
+  repos = () => loadRepos(),
 } = {}) {
   const ACTOR = "operator"; // one local operator in the MVP (§14)
 
@@ -429,6 +435,20 @@ export function createApi({
 
       if (route === "GET /agents") {
         return send(res, 200, agentsView(registry));
+      }
+
+      // The factory repo registry (OPS-299): which projects exist, which are
+      // dispatch targets, and where their worktrees live.
+      if (route === "GET /repos") {
+        try {
+          return send(res, 200, { repos: reposView(repos()) });
+        } catch (err) {
+          // A missing or malformed repos.yaml is an operator-fixable config
+          // problem; the generic 500 below would hide it behind
+          // "internal_error" and send them reading the runtime's source.
+          if (err instanceof RepoError) return send(res, 500, { error: err.message });
+          throw err;
+        }
       }
 
       const artifactGet = url.pathname.match(/^\/artifacts\/([0-9a-f]{64})$/);

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
@@ -9,6 +9,7 @@ import { apiClient } from "./client.mjs";
 import { openDb } from "./db.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
 import { loadRegistry } from "./registry.mjs";
+import { loadRepos } from "./repos.mjs";
 import { runOnce } from "./worker.mjs";
 
 const registry = loadRegistry();
@@ -45,13 +46,14 @@ function sign(rawBody, timestamp, secret = SECRET) {
   return `sha256=${createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")}`;
 }
 
-async function makeServer({ secret = SECRET } = {}) {
+async function makeServer({ secret = SECRET, ...opts } = {}) {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-api-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const onEvents = [];
   const server = startApi({
     db, registry, secret, policyVersion: PV, port: 0,
     onEvent: (kind) => onEvents.push(kind),
+    ...opts,
   });
   await new Promise((resolve) => server.on("listening", resolve));
   const port = server.address().port;
@@ -654,6 +656,58 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(def.mutating).toBe(false);
       expect(contracts["factory.agent-result/v1"].properties.terminalState.enum).toContain("refused");
     } finally {
+      server.close();
+    }
+  });
+
+  test("GET /repos serves the repos.yaml registry, dispatch mode included (OPS-299)", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-api-repos-"));
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    writeFileSync(
+      path.join(root, "config", "repos.yaml"),
+      `repos:\n  - name: dispatchable\n    path: ~/Develop/dispatchable\n    github: watt-mind/dispatchable\n    team: CLNT\n    base: develop\n    deploy_branch: master\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ~/Develop/.worktrees/dispatchable\n    max_in_flight: 20\n    escalate_paths:\n      - src/auth/**\n  - name: watched\n    path: ~/Develop/watched\n    team: OPS\n    report_only: true\n`,
+    );
+    const { server, port, close } = await makeServer({ repos: () => loadRepos({ root }) });
+    const client = apiClient({ port });
+    try {
+      const { repos: rows } = await client.repos();
+      expect(rows.map((r) => r.name)).toEqual(["dispatchable", "watched"]);
+      expect(rows[0]).toEqual({
+        name: "dispatchable",
+        path: path.join(process.env.HOME ?? "", "Develop/dispatchable"),
+        github: "watt-mind/dispatchable",
+        team: "CLNT",
+        project: null,
+        base: "develop",
+        deployBranch: "master",
+        reportOnly: false,
+        maxInFlight: 20,
+        worktreeRoot: path.join(process.env.HOME ?? "", "Develop/.worktrees/dispatchable"),
+        hasWorktreeUp: false,
+        hasWorktreeDown: true,
+        hasWorktreeWarm: false,
+        verify: null,
+      });
+      expect(rows[1]).toMatchObject({ reportOnly: true, maxInFlight: null, hasWorktreeDown: false });
+      // Merge-policy paths are config, not registry: the wire never carries them.
+      expect(JSON.stringify(rows)).not.toContain("src/auth");
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("GET /repos names a missing repos.yaml instead of a bare internal_error", async () => {
+    const empty = mkdtempSync(path.join(os.tmpdir(), "evrt-api-norepos-"));
+    const { server, port, close } = await makeServer({ repos: () => loadRepos({ root: empty }) });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/repos`);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toContain("no repos config at");
+      expect(body.error).not.toBe("internal_error");
+    } finally {
+      close();
       server.close();
     }
   });

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -58,6 +58,8 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
       call("POST", "/events/requeue", { body: JSON.stringify({ source, eventId }) }),
     agents: () => call("GET", "/agents"),
     workers: () => call("GET", "/workers"),
+    /** Factory repo registry from config/repos.yaml (OPS-299). */
+    repos: () => call("GET", "/repos"),
     approve: (id) => call("POST", `/proposals/${encodeURIComponent(id)}/approve`, { body: "{}" }),
     reject: (id, reason) =>
       call("POST", `/proposals/${encodeURIComponent(id)}/reject`, { body: JSON.stringify({ reason }) }),

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -8,6 +8,9 @@
  *
  * Tier 1 uses `name`, `path`, `github`, and `base`. The `worktree_*` and
  * `verify` fields are read but unused until tier 2 (docs/event-runtime-workers.md).
+ * The registry fields (`team`, `project`, `report_only`, `max_in_flight`,
+ * `deploy_branch`) are what an operator needs to tell a dispatch target from a
+ * report-only one, and where its worktrees live (OPS-299).
  */
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
@@ -44,7 +47,10 @@ export function expandHome(p) {
 
 /**
  * @returns {Map<string, {name: string, path: string, github: string|null, base: string,
- *                        worktreeUp: string|null, worktreeDown: string|null, verify: string|null}>}
+ *                        deployBranch: string|null, team: string|null, project: string|null,
+ *                        reportOnly: boolean, maxInFlight: number|null, worktreeRoot: string|null,
+ *                        worktreeUp: string|null, worktreeDown: string|null,
+ *                        worktreeWarm: string|null, verify: string|null}>}
  */
 export function loadRepos({ root = reposRoot() } = {}) {
   const file = reposConfigPath(root);
@@ -59,12 +65,57 @@ export function loadRepos({ root = reposRoot() } = {}) {
       path: expandHome(entry.path),
       github: entry.github ?? null,
       base: entry.base ?? "main",
+      deployBranch: entry.deploy_branch ?? null,
+      team: entry.team ?? null,
+      project: entry.project ?? null,
+      // Absent means dispatchable: report_only is the guard a repo opts into,
+      // so anything but an explicit `true` must read as false rather than
+      // "maybe" — an operator reading "dispatch" off a null would be wrong.
+      reportOnly: entry.report_only === true,
+      // Null, not a default: the cap's fallback lives with the dispatcher, and
+      // inventing a number here would state a limit this file never set.
+      maxInFlight: Number.isFinite(entry.max_in_flight) ? entry.max_in_flight : null,
+      worktreeRoot: entry.worktree_root ? expandHome(entry.worktree_root) : null,
       worktreeUp: entry.worktree_up ?? null,
       worktreeDown: entry.worktree_down ?? null,
+      worktreeWarm: entry.worktree_warm ?? null,
       verify: entry.verify ?? null,
     });
   }
   return repos;
+}
+
+/**
+ * The repo registry as the control API serves it (OPS-299): one row per
+ * repos.yaml entry, in file order.
+ *
+ * An explicit allow-list, not the parsed entry: repos.yaml also carries
+ * `escalate_paths`, `security`, and whatever the next policy field turns out to
+ * be, and a passthrough would publish each new key the moment someone adds it.
+ * Nothing here reads `.env` or any credential — these are paths, branches, and
+ * commands the repo already documents.
+ *
+ * `hasWorktree*` are booleans rather than the script paths because that is the
+ * question a reader has ("can the janitor tear this repo's worktrees down?");
+ * the path itself is only meaningful to the process that executes it.
+ */
+export function reposView(repos) {
+  return [...repos.values()].map((repo) => ({
+    name: repo.name,
+    path: repo.path,
+    github: repo.github,
+    team: repo.team,
+    project: repo.project,
+    base: repo.base,
+    deployBranch: repo.deployBranch,
+    reportOnly: repo.reportOnly,
+    maxInFlight: repo.maxInFlight,
+    worktreeRoot: repo.worktreeRoot,
+    hasWorktreeUp: repo.worktreeUp !== null,
+    hasWorktreeDown: repo.worktreeDown !== null,
+    hasWorktreeWarm: repo.worktreeWarm !== null,
+    verify: repo.verify,
+  }));
 }
 
 export function getRepo(repos, name) {

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -1,0 +1,140 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadRepos, RepoError, reposView } from "./repos.mjs";
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * A factory checkout with a repos.yaml, so the real parser runs against real
+ * YAML. Hermetic on purpose: reading the repo's own config/repos.yaml would
+ * make these assertions a description of today's registry.
+ */
+function factoryRoot(yaml) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-repos-"));
+  scratch.push(root);
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
+  return root;
+}
+
+// One fully configured dispatch target and one report-only repo with nothing
+// but the minimum — between them they cover every field's present and absent
+// case. The policy keys are here to prove the view does not publish them.
+const YAML = `repos:
+  - name: full
+    path: ~/Develop/full
+    github: watt-mind/full
+    team: CLNT
+    project: Full Project
+    base: develop
+    deploy_branch: master
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
+    worktree_warm: bin/worktree-warm.sh
+    worktree_root: ~/Develop/.worktrees/full
+    max_in_flight: 20
+    verify: npm run typecheck
+    security:
+      python_version: "3.12"
+    escalate_paths:
+      - src/auth/**
+
+  - name: bare
+    path: ~/Develop/bare
+    team: OPS
+    report_only: true
+`;
+
+describe("loadRepos reads the registry fields the operator surfaces need (OPS-299)", () => {
+  const repos = loadRepos({ root: factoryRoot(YAML) });
+  const home = process.env.HOME ?? "";
+
+  test("a fully configured repo carries team, project, branches, cap, and worktree lifecycle", () => {
+    expect(repos.get("full")).toEqual({
+      name: "full",
+      path: path.join(home, "Develop/full"),
+      github: "watt-mind/full",
+      team: "CLNT",
+      project: "Full Project",
+      base: "develop",
+      deployBranch: "master",
+      reportOnly: false,
+      maxInFlight: 20,
+      worktreeRoot: path.join(home, "Develop/.worktrees/full"),
+      worktreeUp: "bin/worktree-up.sh",
+      worktreeDown: "bin/worktree-down.sh",
+      worktreeWarm: "bin/worktree-warm.sh",
+      verify: "npm run typecheck",
+    });
+  });
+
+  test("absent fields are null and report_only is honoured; base still defaults to main", () => {
+    expect(repos.get("bare")).toMatchObject({
+      name: "bare",
+      path: path.join(home, "Develop/bare"),
+      github: null,
+      project: null,
+      base: "main",
+      deployBranch: null,
+      reportOnly: true,
+      // Null, not a number: the dispatcher owns the fallback cap, and a
+      // fabricated one here would read as a limit repos.yaml never set.
+      maxInFlight: null,
+      worktreeRoot: null,
+      worktreeDown: null,
+      verify: null,
+    });
+  });
+
+  test("report_only reads false unless it is exactly true — a guard is never 'maybe'", () => {
+    const repos = loadRepos({
+      root: factoryRoot(`repos:\n  - name: a\n    path: /tmp/a\n  - name: b\n    path: /tmp/b\n    report_only: false\n`),
+    });
+    expect(repos.get("a").reportOnly).toBe(false);
+    expect(repos.get("b").reportOnly).toBe(false);
+  });
+
+  test("a missing config fails closed rather than reporting an empty registry", () => {
+    const empty = mkdtempSync(path.join(os.tmpdir(), "evrt-repos-empty-"));
+    scratch.push(empty);
+    expect(() => loadRepos({ root: empty })).toThrow(RepoError);
+  });
+});
+
+describe("reposView is what the control API serves", () => {
+  const rows = reposView(loadRepos({ root: factoryRoot(YAML) }));
+
+  test("one row per entry, in file order", () => {
+    expect(rows.map((r) => r.name)).toEqual(["full", "bare"]);
+  });
+
+  test("worktree scripts are reported as capability, not as paths to run", () => {
+    expect(rows[0]).toMatchObject({ hasWorktreeUp: true, hasWorktreeDown: true, hasWorktreeWarm: true });
+    expect(rows[1]).toMatchObject({ hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false });
+    // The script path itself is meaningless to a reader and only the janitor
+    // executes it, so it stays server-side.
+    expect(rows[0]).not.toHaveProperty("worktreeDown");
+  });
+
+  test("the projection is an allow-list, so policy keys cannot leak by being added", () => {
+    for (const row of rows) {
+      expect(Object.keys(row).sort()).toEqual([
+        "base", "deployBranch", "github", "hasWorktreeDown", "hasWorktreeUp", "hasWorktreeWarm",
+        "maxInFlight", "name", "path", "project", "reportOnly", "team", "verify", "worktreeRoot",
+      ]);
+    }
+    const serialized = JSON.stringify(rows);
+    expect(serialized).not.toContain("escalate_paths");
+    expect(serialized).not.toContain("src/auth");
+    expect(serialized).not.toContain("python_version");
+  });
+
+  test("the dispatch/report-only distinction survives the wire", () => {
+    expect(rows.map((r) => [r.name, r.reportOnly])).toEqual([["full", false], ["bare", true]]);
+  });
+});


### PR DESCRIPTION
## Summary

`GET /repos` serves the factory repo registry from `config/repos.yaml`, so the web app's Projects tab (OPS-300) and the janitor verb behind it (OPS-301) have an API to read. Slice A of the pipeline — read-only API, no UI.

- **`loadRepos` extended, not duplicated.** It already parses `config/repos.yaml` for worker placement, so the registry fields join it there: `team`, `project`, `deploy_branch`, `report_only`, `worktree_root`, `worktree_warm`, `max_in_flight`. No second yaml parser. `report_only` reads `false` unless it is exactly `true` — a dispatch guard is never "maybe" — and `max_in_flight` stays `null` when absent, because the fallback cap belongs to the dispatcher rather than to this reader.
- **`reposView` is an allow-list.** `repos.yaml` also carries `escalate_paths` and `security` blocks, and a passthrough of the parsed entry would publish whatever policy key someone adds there next. Worktree scripts become `hasWorktreeUp/Down/Warm` booleans: "can the janitor tear this repo's worktrees down?" is the question a reader has, and the script path only means something to the process that executes it. Nothing reads `.env` or any credential.
- **`GET /repos`** reads the registry per request, so an operator editing `repos.yaml` sees it on refresh instead of after a `serve` restart. A missing config answers `500` with the `RepoError` message rather than a bare `internal_error`, which would send an operator reading runtime source for a config problem. `createApi` takes an injectable `repos` loader so the API test runs against a fixture, not against whichever repos happen to exist on the machine.
- **`client.repos()` and `cli.mjs repos`**, table styled like `workers`, with MODE (dispatch vs report-only) and CLEANUP as the columns an operator actually scans.

## Test plan

- [x] `bun test event-runtime` — 233 pass, 0 fail. New `lib/repos.test.mjs` covers the extended loader (present/absent field cases, `~` expansion, `report_only` coercion, missing config failing closed) and `reposView` (file order, derived booleans, exact key set, policy keys absent from the serialized rows).
- [x] `lib/api.test.mjs` covers `GET /repos` against a fixture registry — full row shape, the report-only row, `escalate_paths` absent from the wire — plus the named-error path for a missing `repos.yaml`.
- [x] `bun event-runtime/cli.mjs repos` against a live `serve` on 7598: all ten configured repos, dispatch/report-only and cleanup columns correct.

No UX critique: API and CLI only, no user-completable web flow in this slice.

Fixes OPS-299