### PR TITLE
fix(event-runtime-web): coalesce j/k hash writes under Safari's history cap (OPS-256)

### DIFF
--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { eventsHash, hashPath, hashSearch, hashView, parseHash, shouldReplaceHash } from "./hash";
+import type { HashWriteScheduler } from "./hash";
+import {
+  createHashWriter,
+  eventsHash,
+  hashPath,
+  hashSearch,
+  hashView,
+  HASH_WRITE_INTERVAL_MS,
+  parseHash,
+  shouldReplaceHash,
+} from "./hash";
 
 describe("parseHash", () => {
   test("empty hash is overview's empty route", () => {
@@ -103,6 +113,129 @@ describe("eventsHash", () => {
     expect(eventsHash("web", "evt_1", "factory.ticket.ready")).toBe(
       "events/web/evt_1?type=factory.ticket.ready",
     );
+  });
+});
+
+/** Manual clock: the coalescing is about elapsed time, not about real waiting. */
+function fakeScheduler() {
+  let now = 0;
+  let timers: Array<{ at: number; fn: () => void }> = [];
+  const scheduler: HashWriteScheduler = {
+    now: () => now,
+    after: (fn, ms) => {
+      const timer = { at: now + ms, fn };
+      timers.push(timer);
+      return () => {
+        timers = timers.filter((t) => t !== timer);
+      };
+    },
+  };
+  return {
+    scheduler,
+    advance(ms: number) {
+      now += ms;
+      const due = timers.filter((t) => t.at <= now);
+      timers = timers.filter((t) => t.at > now);
+      for (const t of due) t.fn();
+    },
+  };
+}
+
+describe("createHashWriter", () => {
+  function harness(write?: (hash: string, replace: boolean) => void) {
+    const clock = fakeScheduler();
+    const writes: Array<{ hash: string; replace: boolean }> = [];
+    const writer = createHashWriter((hash, replace) => {
+      writes.push({ hash, replace });
+      write?.(hash, replace);
+    }, clock.scheduler);
+    return { writer, writes, advance: clock.advance };
+  }
+
+  test("a single same-view write lands immediately, as a replace", () => {
+    const { writer, writes } = harness();
+    writer.replace("#/runs/run_01");
+    expect(writes).toEqual([{ hash: "#/runs/run_01", replace: true }]);
+  });
+
+  test("a burst inside one interval collapses to the last row", () => {
+    const { writer, writes, advance } = harness();
+    for (let i = 1; i <= 100; i++) writer.replace(`#/runs/run_${i}`);
+    expect(writes).toEqual([{ hash: "#/runs/run_1", replace: true }]);
+    advance(HASH_WRITE_INTERVAL_MS);
+    expect(writes).toEqual([
+      { hash: "#/runs/run_1", replace: true },
+      { hash: "#/runs/run_100", replace: true },
+    ]);
+  });
+
+  test("holding j for 30s stays under Safari's ~100 writes per 30s", () => {
+    const { writer, writes, advance } = harness();
+    // Key repeat is ~30/s once the hold takes; the old code wrote every one.
+    for (let i = 1; i <= 900; i++) {
+      writer.replace(`#/runs/run_${i}`);
+      advance(33);
+    }
+    expect(writes.length).toBeLessThan(100);
+    expect(writes.every((w) => w.replace)).toBe(true);
+    // Releasing the key lands the row the operator stopped on, so the URL is
+    // still shareable after a hold (OPS-230).
+    advance(HASH_WRITE_INTERVAL_MS);
+    expect(writes.at(-1)?.hash).toBe("#/runs/run_900");
+  });
+
+  test("a view change pushes, landing the buffered selection first", () => {
+    const { writer, writes } = harness();
+    writer.replace("#/runs/run_01");
+    writer.replace("#/runs/run_02");
+    writer.push("#/events");
+    expect(writes).toEqual([
+      { hash: "#/runs/run_01", replace: true },
+      { hash: "#/runs/run_02", replace: true },
+      { hash: "#/events", replace: false },
+    ]);
+  });
+
+  test("a throwing write does not escape into the keydown handler", () => {
+    const { writer, writes, advance } = harness(() => {
+      throw new Error("SecurityError: history write cap");
+    });
+    expect(() => writer.replace("#/runs/run_01")).not.toThrow();
+    writer.replace("#/runs/run_02");
+    expect(() => advance(HASH_WRITE_INTERVAL_MS)).not.toThrow();
+    expect(() => writer.push("#/events")).not.toThrow();
+    expect(writes.length).toBe(3);
+  });
+
+  test("cancel drops the buffered write so Back is not clobbered", () => {
+    const { writer, writes, advance } = harness();
+    writer.replace("#/runs/run_01");
+    writer.replace("#/runs/run_02");
+    writer.cancel();
+    advance(HASH_WRITE_INTERVAL_MS * 2);
+    expect(writes).toEqual([{ hash: "#/runs/run_01", replace: true }]);
+  });
+
+  test("flush lands a buffered write now, and only once", () => {
+    const { writer, writes, advance } = harness();
+    writer.replace("#/events");
+    writer.replace("#/events?type=factory.ticket.ready");
+    writer.flush();
+    expect(writes).toEqual([
+      { hash: "#/events", replace: true },
+      { hash: "#/events?type=factory.ticket.ready", replace: true },
+    ]);
+    advance(HASH_WRITE_INTERVAL_MS * 2);
+    expect(writes.length).toBe(2);
+  });
+
+  test("a write after the interval is immediate again", () => {
+    const { writer, writes, advance } = harness();
+    writer.replace("#/runs/run_01");
+    advance(HASH_WRITE_INTERVAL_MS);
+    writer.replace("#/runs/run_02");
+    expect(writes.length).toBe(2);
+    expect(writes.at(-1)?.hash).toBe("#/runs/run_02");
   });
 });
 

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -57,6 +57,102 @@ export function hashPath(view: string, ...ids: Array<string | null | undefined>)
   return parts.join("/");
 }
 
+/**
+ * Safari throws `SecurityError` past ~100 history writes per 30s, and a held
+ * `j` fires ~30 keydowns a second — three seconds of hold used to break the
+ * write and freeze the selection. One history write per interval keeps a
+ * sustained hold an order of magnitude under the cap.
+ */
+export const HASH_WRITE_INTERVAL_MS = 500;
+
+/** Clock + timer seam so the coalescing is testable without real time. */
+export type HashWriteScheduler = {
+  now: () => number;
+  /** Runs `fn` after `ms`; the returned function cancels that pending run. */
+  after: (fn: () => void, ms: number) => () => void;
+};
+
+export type HashWriter = {
+  /** Same-view write: at most one per interval, last value wins. */
+  replace: (hash: string) => void;
+  /** View change: lands now, after any buffered same-view write. */
+  push: (hash: string) => void;
+  /** Write the buffered value now — for a change a reader must see at once. */
+  flush: () => void;
+  /** Drop the buffered value: the URL moved under us and it would clobber. */
+  cancel: () => void;
+};
+
+const timerScheduler: HashWriteScheduler = {
+  now: () => Date.now(),
+  after: (fn, ms) => {
+    const id = setTimeout(fn, ms);
+    return () => clearTimeout(id);
+  },
+};
+
+/**
+ * Rate-limits history writes. `write` gets the hash and whether it replaces;
+ * the caller keeps its own idea of the current hash, because the URL trails
+ * the intent by up to one interval while a key is held.
+ */
+export function createHashWriter(
+  write: (hash: string, replace: boolean) => void,
+  scheduler: HashWriteScheduler = timerScheduler,
+  intervalMs: number = HASH_WRITE_INTERVAL_MS,
+): HashWriter {
+  let buffered: string | null = null;
+  let cancelTimer: (() => void) | null = null;
+  let wroteAt = -Infinity;
+
+  const send = (hash: string, replace: boolean) => {
+    wroteAt = scheduler.now();
+    try {
+      write(hash, replace);
+    } catch {
+      // A history-rate SecurityError must not escape into the keydown handler
+      // that caused it: the selection has already moved, and the next write
+      // once the browser's window rolls over lands the real URL.
+    }
+  };
+  const drop = () => {
+    cancelTimer?.();
+    cancelTimer = null;
+    buffered = null;
+  };
+  const flush = () => {
+    const hash = buffered;
+    drop();
+    if (hash !== null) send(hash, true);
+  };
+
+  return {
+    replace(hash) {
+      const since = scheduler.now() - wroteAt;
+      if (since >= intervalMs) {
+        drop();
+        send(hash, true);
+        return;
+      }
+      buffered = hash;
+      if (!cancelTimer) {
+        cancelTimer = scheduler.after(() => {
+          cancelTimer = null;
+          flush();
+        }, intervalMs - since);
+      }
+    },
+    push(hash) {
+      // Land the buffered selection first so Back returns to the row the
+      // operator was actually on, not the one the last write happened to catch.
+      flush();
+      send(hash, false);
+    },
+    flush,
+    cancel: drop,
+  };
+}
+
 /** Events view hash, optionally with a shareable type filter. */
 export function eventsHash(
   source?: string | null,

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { parseHash, shouldReplaceHash } from "./hash";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { HashWriter } from "./hash";
+import { createHashWriter, hashSearch, parseHash, shouldReplaceHash } from "./hash";
 
 /** Open-modal depth: global list-navigation keys stand down while a dialog is up. */
 export const modal = { depth: 0 };
@@ -18,29 +19,58 @@ export function useHashRoute(): [string[], (path: string) => void] {
   // Query-only hash changes (`#/events?type=`) keep the same path segments;
   // tick so readers of window.location.hash re-render.
   const [, setHash] = useState(window.location.hash);
+  // Held j/k writes the URL at most once per interval, so the URL is not the
+  // current route while a key is down — this is.
+  const intended = useRef(window.location.hash);
+  const writer = useRef<HashWriter | null>(null);
+  if (!writer.current) {
+    writer.current = createHashWriter((hash, replace) => {
+      if (!replace) {
+        window.location.hash = hash;
+        return;
+      }
+      history.replaceState(
+        history.state,
+        "",
+        `${window.location.pathname}${window.location.search}${hash}`,
+      );
+      // replaceState does not fire hashchange — tick readers of the URL itself.
+      setHash(window.location.hash);
+    });
+  }
   useEffect(() => {
     const onChange = () => {
+      // Back, or a view writing window.location.hash directly: the URL is
+      // authoritative again, and a buffered write would clobber it.
+      writer.current?.cancel();
+      intended.current = window.location.hash;
       setRoute(read());
       setHash(window.location.hash);
     };
     window.addEventListener("hashchange", onChange);
-    return () => window.removeEventListener("hashchange", onChange);
+    return () => {
+      window.removeEventListener("hashchange", onChange);
+      writer.current?.cancel();
+    };
   }, []);
   const navigate = useCallback((path: string) => {
     const next = `#/${path}`;
-    if (window.location.hash === next) return;
-    if (shouldReplaceHash(window.location.hash, path)) {
-      // replaceState does not fire hashchange — tick route state here.
-      history.replaceState(
-        history.state,
-        "",
-        `${window.location.pathname}${window.location.search}${next}`,
-      );
-      setRoute(read());
-      setHash(window.location.hash);
+    if (intended.current === next) return;
+    const replace = shouldReplaceHash(intended.current, path);
+    // App reads `?type=` off window.location.hash as it renders, so a query
+    // change cannot sit buffered; only same-view path moves (j/k) coalesce.
+    const queryChanged = hashSearch(intended.current).toString() !== hashSearch(next).toString();
+    intended.current = next;
+    setRoute(parseHash(next));
+    setHash(next);
+    const write = writer.current;
+    if (!write) return;
+    if (!replace) {
+      write.push(next);
       return;
     }
-    window.location.hash = next;
+    write.replace(next);
+    if (queryChanged) write.flush();
   }, []);
   return [route.length ? route : ["overview"], navigate];
 }


### PR DESCRIPTION
## Summary

Holding `j`/`k` fired one `history.replaceState` per keydown (~30/s). Safari throws `SecurityError` past ~100 history writes per 30 seconds — about three seconds of hold — and because the throw happened inside the keydown handler, `setRoute` never ran and the selection froze.

- `hash.ts`: new `createHashWriter(write, scheduler, intervalMs = 500)`. The first same-view write lands immediately; further ones are buffered and written on the trailing edge, last value wins. `push` flushes the buffered selection first so Back returns to the row the operator was actually on. `cancel` drops the buffer when the URL moves under us (Back, a view writing `location.hash` directly). Every history write is wrapped, so a rate error can never escape into the handler that caused it.
- `hooks.ts`: `useHashRoute` keeps an `intended` hash ref as the routing source of truth, since the URL now trails by up to one interval while a key is held. Route state still ticks per keydown, so selection moves at key-repeat speed. A `?type=` query change flushes immediately, because `App` reads it straight off `window.location.hash` while rendering.

Coalescing is time-based, so it is tested on a fake clock rather than by waiting: 900 keydowns spread over 30 seconds produce fewer than 100 history writes, and the final row lands on release.

## Test plan

- [x] `bun test event-runtime` — 231 pass, 0 fail (8 new writer tests)
- [x] `cd event-runtime/web && bun run build` — `tsc --noEmit` + vite clean
- [x] Same-view writes still replace, view changes still push — asserted in `shouldReplaceHash` and `createHashWriter` tests
- [ ] Manual Safari hold-`j`/`k` check: demo on 7512/7513 was down this run, so the browser pass was skipped

Fixes OPS-256