### PR TITLE
fix(event-runtime-web): layer .mono so size utilities win (OPS-321)

### DIFF
--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -62,9 +62,14 @@ body {
   letter-spacing: -0.01em;
 }
 
-.mono {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 11.5px;
+/* In @layer components so `text-*` utilities override the default size: Tailwind
+   emits utilities into a later layer, which unlayered author CSS would beat at
+   equal specificity no matter what the utility declares (OPS-321). */
+@layer components {
+  .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11.5px;
+  }
 }
 
 /* Status washes on inbox rows — declared before .row-selected so selection wins. */


### PR DESCRIPTION
## Problem

`.mono` in `theme.css` was **unlayered** author CSS setting `font-size: 11.5px`. Tailwind v4 emits utilities into `@layer utilities`, and unlayered author styles beat *any* cascade layer regardless of specificity — so every `mono` + `text-[11px]` pairing in the app rendered 11.5px, not 11px. The 0.5px gap hid it until OPS-268's 13px lifecycle actor made it visible; that one call site now carries `text-[13px]!`, and the rest of the pairings were still inert.

## Fix

Moved the rule into `@layer components`. `@import "tailwindcss"` declares `@layer theme, base, components, utilities`, so utilities now outrank `.mono` on layer order at equal specificity (both are a single class) and `text-*` applies without `!`.

This takes the **second** branch of the acceptance criterion ("size utilities outrank it without `!`") rather than dropping `font-size` outright. Dropping it would regress ~47 bare `.mono` call sites — table cells across Runs/Events/Workers/Proposals/Agents, CommandPalette rows, `pre` blocks, keycap hints — from 11.5px to the inherited 13px, and repairing those means editing ten files outside this wave's Owned Paths (`ui.tsx` among them, held by OPS-278). The layer move fixes the cascade with **zero call-site churn**.

Scope: `event-runtime/web/src/theme.css` only.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — **223 pass / 0 fail**, `tsc --noEmit` + `vite build` clean.

No test covers CSS cascade, so the ordering was confirmed against the compiled stylesheet (`dist/assets/index-*.css`):

- `@layer components{.mono{font-family:...;font-size:11.5px}}` at byte 6030 — the components layer contains nothing else
- `@layer utilities{` begins at 6121, with `.text-[11px]{font-size:11px}` and `.text-[13px]{font-size:13px}` inside it
- no unlayered `.mono` rule remains anywhere in the output
- OPS-268's `font-size:13px!important` is still emitted, so that call site is unaffected (its `!` is now redundant but harmless)

Equal specificity + later layer ⇒ utilities win, per the CSS Cascade Layers spec.

Rendered-pixel confirmation was **not** obtained: the IDE browser tool would not create a tab, and headless Chrome on this host hangs without dumping. Filed separately as harness friction.

Fixes OPS-321