### PR TITLE
feat(event-runtime-web): name the current theme in the nav footer (OPS-276)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { api } from "./api";
 import { eventsHash, hashPath, hashSearch } from "./hash";
-import { keyGuard, useHashRoute, useTheme } from "./hooks";
+import { keyGuard, useHashRoute, useTheme, type Theme } from "./hooks";
 import type { EventFocus } from "./types";
 import { CommandPalette, useGoSequences, type PaletteAction } from "./components/CommandPalette";
 import { InjectDialog } from "./components/InjectDialog";
@@ -30,10 +30,15 @@ const NAV = [
   { key: "graph", label: "Graph", go: "g" },
 ] as const;
 
+// Display-only mirror of the cycle useTheme() implements: both the footer
+// control and the ⌘K label promise what one click does, so the promise has to
+// name the same order the hook advances in.
+const THEME_ORDER: readonly Theme[] = ["dark", "light", "contrast"];
+
 export function App() {
   const [route, navigate] = useHashRoute();
   const view = route[0];
-  const [, cycleTheme] = useTheme();
+  const [theme, cycleTheme] = useTheme();
   const [injectOpen, setInjectOpen] = useState(false);
   const [injectSeed, setInjectSeed] = useState<Record<string, unknown> | undefined>(undefined);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -176,6 +181,8 @@ export function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, [navigate]);
 
+  const nextTheme = THEME_ORDER[(THEME_ORDER.indexOf(theme) + 1) % THEME_ORDER.length];
+
   const paletteActions: PaletteAction[] = [
     ...NAV.map((n) => ({
       label: `Go to ${n.label}`,
@@ -198,7 +205,7 @@ export function App() {
     },
     { label: "Copy link to this page", run: copyLink },
     { label: "Keyboard shortcuts", hint: "?", run: () => setHelpOpen(true) },
-    { label: "Cycle theme (dark → light → contrast)", run: cycleTheme },
+    { label: `Cycle theme (${THEME_ORDER.join(" → ")})`, run: cycleTheme },
   ];
 
   return (
@@ -331,6 +338,19 @@ export function App() {
             <span className="mono">o/e/p/r/t/w/g</span> · <span className="mono">/</span> filter ·{" "}
             <span className="mono">i</span> inject · <span className="mono">?</span> keys
           </div>
+          {/* Named, not just toggled: "contrast" is the accessibility theme, and
+              an operator who lands in it by accident needs to read where they
+              are before the swatch tells them anything. */}
+          <button
+            type="button"
+            onClick={cycleTheme}
+            title={`Theme ${theme} — click for ${nextTheme}`}
+            aria-label={`Theme: ${theme}. Switch to ${nextTheme}.`}
+            className="mt-2 flex w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-(--border-strong) px-1.5 py-0.5 text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+          >
+            <span>Theme</span>
+            <span className="text-(--text)">{theme}</span>
+          </button>
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary

The three themes (dark → light → contrast) were reachable only through the ⌘K action, so an operator who never opens the palette never found them — and one who landed in `contrast` by accident had nothing on screen telling them where they were.

`useTheme()` already returned the theme name; `App.tsx` was discarding it (`const [, cycleTheme]`). This reads it and puts a control in the nav footer, below the shortcut hints: **Theme** on the left, the current name on the right, click to cycle. The tooltip and `aria-label` name the *next* theme so it is not a mystery box.

The ⌘K path is unchanged. Its label is now built from the same local order constant rather than a second hardcoded `dark → light → contrast` string, so the two promises cannot drift apart.

One file changed, `event-runtime/web/src/App.tsx` — the ticket's only owned path. `hooks.ts` was read, not touched.

## Test plan

- [x] `bun test event-runtime` — 223 pass, 0 fail
- [x] `cd event-runtime/web && bun run build` — `tsc --noEmit` + vite clean
- [x] UX critique against the seeded demo (`bin/worktree-up.sh OPS-276`, ports 7552/7553), all three themes: cycles correctly with no off-by-one between the label and the applied theme, persists across reload, ⌘K and the footer stay in sync, Tab + Enter/Space work, focus ring visible in all three themes. Verdict: ship.
- [x] Acted on the one in-scope critique finding: the control used `--border` and inherited Tailwind v4's non-pointer cursor, so at rest it read as a label rather than a button in `light` and `contrast`. It now uses `--border-strong` + `cursor-pointer`, matching the idiom the app's own `Button` component already uses.

The critic's other finding is systemic — `--border` itself is ~1.1:1 in `light` and ~1.3:1 in `contrast`, affecting every bordered element, not just this one. That belongs in `theme.css`, outside this ticket's owned path, and is filed as [OPS-338](https://linear.app/watt-mind/issue/OPS-338/ui-uxevent-runtime-web-border-is-near-invisible-in-light-and-contrast).

Fixes OPS-276