### PR TITLE
feat(factory): add Actions cache usage guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ labels failures to fetch or missing metadata as **unknown**—never as a stale
 deploy—and distinguishes an older deploy from an unrelated revision. It also
 shows when the reaper and per-repository janitor last ran.
 
+### GitHub Actions cache storage guard
+
+`factory actions-cache` reports the organization-wide GitHub Actions cache footprint by repository and exits non-zero once it reaches the configured warning percentage. It is read-only; it does not delete caches.
+
+```bash
+factory actions-cache
+factory actions-cache --json
+factory actions-cache --included-gb 73 --warning-percent 60
+```
+
+The organization, included allowance, and warning threshold live in `config/policy.yaml`. Confirm the allowance against GitHub billing when it changes; the initial 73 GB value was inferred from the August 2026 90%-used alert.
+
 ### CLI notification wrapper
 
 `factory notify` is the cwd-independent human interrupt channel used by the factory floor:

--- a/bin/factory
+++ b/bin/factory
@@ -71,6 +71,7 @@ case "$cmd" in
   friction)     run_bun orchestrator/friction.mjs "$@" ;;
   economics)    run_bun orchestrator/economics.mjs "$@" ;;
   ci)           run_bun orchestrator/ci.mjs "$@" ;;
+  actions-cache) run_bun orchestrator/actions-cache.mjs "$@" ;;
   label-guard)  run_bun orchestrator/label-guard.mjs "$@" ;;
   digest)       run_bun orchestrator/digest.mjs "$@" ;;
   doctor)       run_bun orchestrator/doctor.mjs "$@" ;;
@@ -160,6 +161,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   friction      orchestrator/friction.mjs
   economics     orchestrator/economics.mjs
   ci            orchestrator/ci.mjs
+  actions-cache Actions cache usage guard (exits non-zero at warning threshold)
   label-guard   orchestrator/label-guard.mjs
   digest        orchestrator/digest.mjs
   doctor        orchestrator/doctor.mjs

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -11,6 +11,15 @@ concurrency:
   # produce a base-CI failure that belongs to neither.
   max_concurrent_merges: 1
 
+actions_cache:
+  # GitHub's cache API reports decimal bytes. The initial 73 GB quota is
+  # derived from the 2026-08 Actions alert (65.67 GB shown as 90% used); update
+  # it immediately if GitHub billing displays a different included allowance.
+  organization: watt-mind
+  included_gb: 73
+  # This command exits non-zero at the warning threshold, before billing risk.
+  warning_percent: 60
+
 budget:
   # AUTH IS THE SUBSCRIPTION (claude.ai OAuth), not the API. run-agent.sh unsets
   # ANTHROPIC_API_KEY unless --use-api is passed, because with it set every run

--- a/lib/actions-cache.mjs
+++ b/lib/actions-cache.mjs
@@ -1,0 +1,56 @@
+const BYTES_PER_GB = 1_000_000_000;
+
+export function formatGigabytes(bytes) {
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+}
+
+/** Turn GitHub's org cache-usage payload into a stable, display-ready snapshot. */
+export function summarizeActionsCacheUsage(payload, { includedGb, warningPercent }) {
+  if (!Number.isFinite(includedGb) || includedGb <= 0) {
+    throw new Error("includedGb must be a positive number");
+  }
+  if (!Number.isFinite(warningPercent) || warningPercent <= 0 || warningPercent > 100) {
+    throw new Error("warningPercent must be between 0 and 100");
+  }
+
+  const repositories = (payload.repository_cache_usages ?? [])
+    .map((repo) => ({
+      name: repo.full_name,
+      count: repo.active_caches_count ?? 0,
+      bytes: repo.active_caches_size_in_bytes ?? 0,
+    }))
+    .sort((a, b) => b.bytes - a.bytes || a.name.localeCompare(b.name));
+  const bytes = payload.total_active_caches_size_in_bytes
+    ?? repositories.reduce((total, repo) => total + repo.bytes, 0);
+  const count = payload.total_active_caches_count
+    ?? repositories.reduce((total, repo) => total + repo.count, 0);
+  const percent = (bytes / (includedGb * BYTES_PER_GB)) * 100;
+
+  return {
+    bytes,
+    count,
+    includedGb,
+    warningPercent,
+    percent,
+    warning: percent >= warningPercent,
+    repositories,
+  };
+}
+
+export function renderActionsCacheUsage(summary) {
+  const lines = [
+    `GitHub Actions cache storage: ${formatGigabytes(summary.bytes)} / ${summary.includedGb.toFixed(2)} GB (${summary.percent.toFixed(1)}%)`,
+    `Active entries: ${summary.count}; warning threshold: ${summary.warningPercent}%`,
+    "",
+    "Repository                         Entries       Storage",
+  ];
+
+  for (const repo of summary.repositories) {
+    lines.push(`${repo.name.padEnd(34)} ${String(repo.count).padStart(7)}  ${formatGigabytes(repo.bytes).padStart(12)}`);
+  }
+
+  if (summary.warning) {
+    lines.push("", `WARNING: Actions cache storage is at or above the ${summary.warningPercent}% threshold.`);
+  }
+  return lines.join("\n");
+}

--- a/lib/actions-cache.test.mjs
+++ b/lib/actions-cache.test.mjs
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test";
+import { renderActionsCacheUsage, summarizeActionsCacheUsage } from "./actions-cache.mjs";
+
+const usage = {
+  total_active_caches_size_in_bytes: 45_000_000_000,
+  total_active_caches_count: 9,
+  repository_cache_usages: [
+    { full_name: "watt-mind/small", active_caches_size_in_bytes: 5_000_000_000, active_caches_count: 2 },
+    { full_name: "watt-mind/large", active_caches_size_in_bytes: 40_000_000_000, active_caches_count: 7 },
+  ],
+};
+
+test("summarizeActionsCacheUsage sorts repositories and warns at the threshold", () => {
+  const summary = summarizeActionsCacheUsage(usage, { includedGb: 70, warningPercent: 60 });
+  expect(summary.percent).toBeCloseTo(64.2857, 3);
+  expect(summary.warning).toBe(true);
+  expect(summary.repositories.map((repo) => repo.name)).toEqual(["watt-mind/large", "watt-mind/small"]);
+  expect(renderActionsCacheUsage(summary)).toContain("WARNING: Actions cache storage is at or above the 60% threshold.");
+});
+
+test("summarizeActionsCacheUsage falls back to repository totals", () => {
+  const summary = summarizeActionsCacheUsage({ repository_cache_usages: usage.repository_cache_usages }, { includedGb: 100, warningPercent: 60 });
+  expect(summary.bytes).toBe(45_000_000_000);
+  expect(summary.count).toBe(9);
+  expect(summary.warning).toBe(false);
+});

--- a/orchestrator/actions-cache.mjs
+++ b/orchestrator/actions-cache.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+/**
+ * Report GitHub Actions cache storage before it reaches the billing limit.
+ *
+ *   factory actions-cache
+ *   factory actions-cache --json
+ *   factory actions-cache --included-gb 73 --warning-percent 60
+ *
+ * Reads the organization-level Actions cache API; it does not mutate caches.
+ * The command exits 1 at the configured warning threshold so it can be used as
+ * a watched/manual gate or a future alert integration.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { ROOT } from "../lib/schedule.mjs";
+import { renderActionsCacheUsage, summarizeActionsCacheUsage } from "../lib/actions-cache.mjs";
+
+const argv = process.argv.slice(2);
+const value = (flag) => {
+  const index = argv.indexOf(flag);
+  return index === -1 ? null : argv[index + 1];
+};
+const number = (flag, fallback) => {
+  const raw = value(flag);
+  if (raw === null) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`${flag} must be a positive number`);
+    process.exit(2);
+  }
+  return parsed;
+};
+
+const policy = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/policy.yaml"), "utf8"));
+const configured = policy.actions_cache ?? {};
+const organization = value("--org") ?? configured.organization;
+const includedGb = number("--included-gb", configured.included_gb);
+const warningPercent = number("--warning-percent", configured.warning_percent);
+const json = argv.includes("--json");
+
+if (!organization || !includedGb || !warningPercent) {
+  console.error("Actions-cache policy is incomplete; set organization, included_gb, and warning_percent in config/policy.yaml.");
+  process.exit(2);
+}
+
+let raw;
+if (process.env.FACTORY_ACTIONS_CACHE_USAGE_JSON) {
+  // Test-only fixture seam: production always reads the GitHub API.
+  raw = process.env.FACTORY_ACTIONS_CACHE_USAGE_JSON;
+} else {
+  const api = Bun.spawnSync([
+    "gh", "api", `orgs/${organization}/actions/cache/usage-by-repository?per_page=100`,
+  ]);
+  if (api.exitCode !== 0) {
+    process.stderr.write(api.stderr);
+    process.exit(api.exitCode || 1);
+  }
+  raw = api.stdout.toString();
+}
+
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  console.error("GitHub returned invalid Actions cache usage JSON.");
+  process.exit(1);
+}
+
+const summary = summarizeActionsCacheUsage(payload, { includedGb, warningPercent });
+if (json) console.log(JSON.stringify(summary, null, 2));
+else console.log(renderActionsCacheUsage(summary));
+process.exit(summary.warning ? 1 : 0);

--- a/orchestrator/actions-cache.test.mjs
+++ b/orchestrator/actions-cache.test.mjs
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test";
+import path from "node:path";
+
+const CLI = path.join(import.meta.dir, "actions-cache.mjs");
+const usage = JSON.stringify({
+  total_active_caches_size_in_bytes: 45_000_000_000,
+  total_active_caches_count: 9,
+  repository_cache_usages: [
+    { full_name: "watt-mind/example", active_caches_size_in_bytes: 45_000_000_000, active_caches_count: 9 },
+  ],
+});
+
+function run(args = []) {
+  return Bun.spawnSync({
+    cmd: ["bun", CLI, ...args],
+    env: { ...process.env, FACTORY_ACTIONS_CACHE_USAGE_JSON: usage },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+test("actions-cache exits non-zero and renders a warning at the configured threshold", () => {
+  const result = run(["--included-gb", "70", "--warning-percent", "60"]);
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout.toString()).toContain("64.3%");
+  expect(result.stdout.toString()).toContain("WARNING");
+});
+
+test("actions-cache can output its report as JSON", () => {
+  const result = run(["--included-gb", "100", "--json"]);
+  expect(result.exitCode).toBe(0);
+  expect(JSON.parse(result.stdout.toString())).toMatchObject({ bytes: 45_000_000_000, warning: false });
+});


### PR DESCRIPTION
## Summary
- add read-only organization cache-usage report and warning exit gate
- configure inferred 73 GB allowance and 60% warning threshold
- document and test the command

## Verification
- `bun test`
- `bun build/emit.mjs --check`
- `factory actions-cache`

Fixes OPS-345