### PR TITLE
feat(event-runtime-web): UX bundle — syntax highlighted JSON, trace filters, spec summary, 3-stage overview, format action

### DIFF
--- a/docs/event-runtime-webui-ux-ideas.md
+++ b/docs/event-runtime-webui-ux-ideas.md
@@ -1,0 +1,210 @@
+# Event Runtime Web Control Plane — UX Improvement Proposals & Syntax Highlighting Spec
+
+Tracking: **OPS-355** | Parent specs: [event-runtime-webui.md](event-runtime-webui.md), [event-runtime-webui-roadmap.md](event-runtime-webui-roadmap.md)
+
+This document captures usability evaluations, workflow bottlenecks, design proposals, and implementation options for syntax-highlighted JSON rendering across the **Factory Event Runtime Web Control Plane** (`event-runtime/web/`).
+
+---
+
+## 1. Executive UX Evaluation
+
+The Web Control Plane provides a dense, keyboard-driven interface adhering to Linear's design language, OKLCH perceptual color tokens, and strict concurrency honesty (refusing optimistic state updates).
+
+### 1.1 Architectural & UX Strengths
+- **Safety Invariants as First-Class UI**: The interface strictly renders raw immutable `RunSpec` payloads before approval, live countdowns guard against TTL expiration, and expired approvals halt on re-planning to display a line diff ([`SpecDiff.tsx`](../event-runtime/web/src/components/SpecDiff.tsx)) rather than auto-approving.
+- **Keyboard Velocity**: Complete single-key navigation (`j`/`k`, `a` approve, `x` reject/cancel, `q` requeue, `i` inject, `/` filter) coupled with chord transitions (`g o/e/p/r/t/w/g`) and `⌘K` command palette.
+- **Hash Single-Source-of-Truth**: Deep linkable routes (`#/runs/:id`, `#/events/:source/:eventId`, `#/graph/:nodeId`, `#/workers/:id`) allow seamless handoff between team members, CLI output, and browser tabs.
+- **Auditable Failure Modes**: 404/409 concurrency race conditions and unreachable API backends produce explicit inline notices with recovery actions rather than disappearing toasts.
+
+---
+
+## 2. Core Friction Points & Usability Gaps
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                             UX FRICTION MATRIX                              │
+├─────────────────────────┬─────────────────────────┬─────────────────────────┤
+│ 1. Information Density  │ 2. Triage & Decisions   │ 3. Deep Observability   │
+│ • Stat tile overload    │ • Linear repetitive loop│ • Monolithic trace feed │
+│ • Table column squeeze  │ • Plain text JSON inputs│ • Missing CLI bridges   │
+│ • Monospace visual fatigue│ • Monochromatic payloads│ • Static graph canvas │
+└─────────────────────────┴─────────────────────────┴─────────────────────────┘
+```
+
+1. **Overview Glanceability**: 18+ stat cards render in an undifferentiated flat grid in [`Overview.tsx`](../event-runtime/web/src/views/Overview.tsx). Events, proposals, runs, and workers all share identical visual weight.
+2. **Master-Detail Table Squeeze**: Opening the slide-over detail pane (440px–520px) heavily truncates 6–8 column tables in `Runs`, `Events`, and `Workers`, cutting off key identifiers, error reason strings, and hostnames.
+3. **Monochromatic Monospace Fatigue**: Large raw JSON disclosures render in uniform monospace text without syntax highlighting, increasing cognitive load when reviewing multi-page specs or event payloads.
+4. **Trace Stream Navigation**: In [`RunTrace.tsx`](../event-runtime/web/src/components/RunTrace.tsx), all event types (`assistant_text`, `tool_use`, `tool_result`, `usage`, `lifecycle`) stream into one vertical list without filtering, searching, or expand/collapse-all controls.
+5. **Inject Editor Ergonomics**: In [`InjectDialog.tsx`](../event-runtime/web/src/components/InjectDialog.tsx), editing event envelopes in a plain `<textarea>` lacks syntax highlighting, bracket matching, formatting, or inline schema validation hints.
+
+---
+
+## 3. Syntax-Highlighted JSON Architecture
+
+Currently, [`JsonBlock`](../event-runtime/web/src/components/ui.tsx) formats JSON via `JSON.stringify(value, null, 2)` inside a plain `<pre>` element.
+
+### 3.1 Design Goals for JSON Highlighting
+1. **Zero External Bundle Bloat**: Avoid multi-megabyte highlighter dependencies (e.g. heavy TextMate WASM grammars).
+2. **OKLCH Token Harmony**: Token colors must derive from the active theme variables (`var(--accent)`, `var(--hue-ok)`, `var(--hue-info)`, `var(--hue-warn)`, `var(--hue-err)`) across Dark, Light, and High-Contrast modes.
+3. **Copy-Paste Fidelity**: Copying text from the rendered JSON must yield clean, unpolluted JSON text.
+4. **Sub-millisecond Tokenization**: Fast rendering even with 500+ line payloads.
+
+### 3.2 Evaluation of Implementation Approaches
+
+| Approach | Bundle Impact | Theme Integration | Interactive Features | Assessment |
+| :--- | :---: | :---: | :---: | :--- |
+| **A. Native Tokenizing Regex Component** | **< 1 KB** (0 deps) | **Native OKLCH** | Hover highlighting, line numbers | **Recommended for General Viewers** |
+| **B. Interactive Collapsible AST Tree** | ~3 KB (0 deps) | **Native OKLCH** | Branch collapse, JSONPath copy, search | **Recommended for Large Results/Evidence** |
+| **C. Shiki / Prismjs** | ~30 KB – 1.5 MB | Fixed themes (CSS override required) | Full language grammars | Overkill for pure JSON; theme mismatch risk |
+| **D. CodeMirror 6 JSON Extension** | ~40 KB (modular) | Custom OKLCH theme | Live editing, linting, bracket match | **Recommended for Inject Dialog Textarea** |
+
+### 3.3 Recommended Strategy
+
+#### Tier 1: Micro Tokenized `JsonBlock` (Read-Only Disclosures)
+Implement a zero-dependency tokenizer in `components/JsonBlock.tsx` that transforms structured values into styled spans using standard JSON grammar regex:
+
+```tsx
+// Token definitions mapping to existing OKLCH theme tokens:
+// Keys:       var(--text) with font-medium (or var(--accent) for top-level keys)
+// Strings:    var(--hue-ok) (green/emerald hue)
+// Numbers:    var(--hue-info) (accent/cyan hue)
+// Booleans:   var(--hue-warn) (amber hue)
+// Null:       var(--hue-err) (coral/red hue)
+// Brackets:   var(--text-faint)
+```
+
+```tsx
+export function HighlightedJson({ text }: { text: string }) {
+  const html = useMemo(() => {
+    return text
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(
+        /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+        (match) => {
+          let cls = "text-[color:var(--hue-info)]"; // number default
+          if (/^"/.test(match)) {
+            cls = /:$/.test(match)
+              ? "text-[color:var(--text)] font-medium" // key
+              : "text-[color:var(--hue-ok)]"; // string value
+          } else if (/true|false/.test(match)) {
+            cls = "text-[color:var(--hue-warn)] font-semibold"; // boolean
+          } else if (/null/.test(match)) {
+            cls = "text-[color:var(--hue-err)] font-semibold"; // null
+          }
+          return `<span class="${cls}">${match}</span>`;
+        }
+      );
+  }, [text]);
+
+  return (
+    <pre
+      className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-3 leading-relaxed whitespace-pre-wrap"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+```
+
+#### Tier 2: Interactive Tree Capabilities (Result Evidence & Spec Inspection)
+For payloads exceeding 50 lines (e.g. `result.evidence`, `result.artifact`, `envelope`):
+- **Click-to-Collapse**: Disclosure chevrons on object/array boundaries.
+- **Copy JSONPath**: Hovering a key displays `$.payload.repos[0]` with click-to-copy.
+- **Format Toggle**: Raw compact vs Pretty formatted switch.
+
+---
+
+## 4. Prioritized UX Improvement Proposals
+
+### Proposal 1: Overview Triage Cockpit (Pipeline Hierarchy)
+**Goal**: Transform [`Overview.tsx`](../event-runtime/web/src/views/Overview.tsx) from a flat stat grid into an operational triage pipeline.
+
+- **Grouped Stages**:
+  1. **Intake Queue**: `admitted` $\rightarrow$ `human_needed` $\rightarrow$ `dead_lettered` (highlighted in error/warning tones).
+  2. **Approval Gate**: `open proposals` (flagged with countdowns $<5\text{m}$) $\rightarrow$ `expired`.
+  3. **Execution Fleet**: `active runs` (`QUEUED` + `RUNNING` + `VERIFYING`) vs `terminal runs` (`COMPLETED`, `FAILED`).
+  4. **Worker Capacity**: Live / Busy / Stale health counters.
+- **Promoted Doctor Deck**: Place active anomalies at the very top of the page when non-zero, with single-click triage actions (`Requeue all dead letters`, `Jump to stale leases`).
+
+---
+
+### Proposal 2: Watched Approval "Spec Highlights" Card
+**Goal**: Accelerate safe proposal review in [`Proposals.tsx`](../event-runtime/web/src/views/Proposals.tsx).
+
+- **Summary Header**: Before the raw JSON disclosure, present an explicit safety card:
+  - **Action Target**: Pinned repository, host, issue ID, or target environment.
+  - **Risk Profile**: Read-only vs. Mutating (prominent alert badge).
+  - **Budget & SLA**: Declared attempts, timeout ceiling, and token limits.
+- **Diff Focus**: On re-planned proposals, highlight semantic differences in input/template parameters rather than full-document text diffs.
+
+---
+
+### Proposal 3: Run Trace Controls & CLI Integration
+**Goal**: Make long multi-turn agent traces scannable in [`RunTrace.tsx`](../event-runtime/web/src/components/RunTrace.tsx).
+
+- **Stream Filter Chips**:
+  - `[All]` (full stream)
+  - `[Tools Only]` (tool names & inputs)
+  - `[Reasoning]` (`assistant_text` only)
+  - `[Errors]` (failed tool executions and runtime error notes)
+  - `[Cost & Tokens]` (`usage` metrics)
+- **Bulk Expansion**: `Expand all tool outputs` / `Collapse all` toggle (`e`).
+- **CLI Bridge**: Provide a one-click `Copy CLI Inspect` button:
+  ```bash
+  bun event-runtime/cli.mjs inspect <runId>
+  ```
+  enabling instant transition from browser triage to terminal debugging.
+
+---
+
+### Proposal 4: Faceted Search & Filter Tags
+**Goal**: Elevate list search across `Runs`, `Events`, and `Proposals`.
+
+- **Structured Query Syntax**: Support key-value filters in [`FilterInput`](../event-runtime/web/src/components/ui.tsx):
+  - `agent:ci-doctor`
+  - `state:failed`
+  - `source:keephq`
+  - `is:stale`
+- **Dismissible Tag Bar**: Active filter criteria render as visual tag chips above tables with one-click removal and keyboard clearing (`Esc`).
+
+---
+
+### Proposal 5: Inject & Replay Editor Upgrade
+**Goal**: Prevent envelope syntax errors in [`InjectDialog.tsx`](../event-runtime/web/src/components/InjectDialog.tsx).
+
+- **Format JSON Action**: Dedicated format shortcut (`⌘⇧F` / `⌥⇧F`) to beautify pasted envelopes.
+- **Form / JSON Dual Mode**: Simple form fields for required template parameters (e.g. selecting repo from dropdown, setting alert ID) with real-time sync to the JSON envelope.
+- **Pre-submission Schema Linting**: Live validation showing missing envelope fields before clicking inject.
+
+---
+
+### Proposal 6: Topology Canvas Live State (Graph Phase 2)
+**Goal**: Evolve [`Graph.tsx`](../event-runtime/web/src/views/Graph.tsx) into a live runtime health map.
+
+- **Active Load Indicators**: Badges on `eventType` and `agent` nodes showing live admitted events and active worker runs.
+- **Failure Heatmap**: Edge color intensity based on recent error or `human_needed` rates.
+- **Canvas-Triggered Injection**: Click an event node on canvas $\rightarrow$ quick action to open `InjectDialog` pre-seeded with that event's template.
+
+---
+
+## 5. Implementation Roadmap & Sequencing
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DELIVERY SEQUENCING                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Milestone 1 (Quick Wins - High Ergonomics)                                  │
+│ • Zero-dependency Syntax Highlighted JsonBlock                              │
+│ • Run Trace filter pills (Errors, Tools, Reasoning) & Collapse/Expand all   │
+│ • CLI inspect command copy helper in Run Detail                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Milestone 2 (Triage Velocity)                                               │
+│ • Proposal Spec Highlights summary card                                     │
+│ • Overview 3-stage pipeline layout                                          │
+│ • Format JSON action in InjectDialog                                        │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Milestone 3 (Advanced Observability)                                        │
+│ • Keyed search filter syntax (agent:, state:, source:)                      │
+│ • Graph View Phase 2 live load overlay                                      │
+│ • Interactive JSON tree inspector for large evidence blobs                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -24,13 +24,11 @@ function blankEnvelope(nowMs: number) {
 const pretty = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 
 /**
- * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230).
+ * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230, format OPS-361).
  *
  * Templates are derived from the registry — one per registered event type,
  * with the payload skeleton built from that event's agent input schema — so
- * they cannot drift from what the runtime will actually accept. Inject is the
- * same intake path as Replay; it is not Requeue (re-plan) and not Trigger
- * again (which only seeds this dialog with a fresh event id).
+ * they cannot drift from what the runtime will actually accept.
  */
 export function InjectDialog({
   onClose,
@@ -106,13 +104,6 @@ export function InjectDialog({
     return [...(initialEnvelope ? ["__given__"] : []), ...templates.map((t) => t.eventType), null];
   }
 
-  /**
-   * The chip that owns the group's single tabIndex 0. Normally `selected`, but
-   * a registry refetch can drop the selected event type while the dialog is
-   * open; the blank chip always renders, so it takes over rather than leaving
-   * no chip tabbable and Tab skipping the group. The envelope text is left
-   * alone — it may hold the user's edits.
-   */
   const checkedChip = templateIds().includes(selected) ? selected : null;
 
   function radioA11y(id: string | null) {
@@ -124,10 +115,6 @@ export function InjectDialog({
     };
   }
 
-  /**
-   * Roving tabindex: arrows move selection and DOM focus together, and only
-   * while a chip is focused — not the envelope textarea, not ⌘K.
-   */
   function onTemplateKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
     const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
     if (!keys.includes(e.key)) return;
@@ -140,6 +127,20 @@ export function InjectDialog({
     applyChip(ids[nextIdx]);
     e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]')[nextIdx]?.focus();
   }
+
+  function formatJson() {
+    try {
+      const parsed = JSON.parse(text);
+      setText(pretty(parsed));
+      setClientError(null);
+      notify("Formatted JSON envelope", "info");
+    } catch (err) {
+      setClientError(`Cannot format: ${(err as Error).message}`);
+    }
+  }
+
+  const formatJsonRef = useRef(formatJson);
+  formatJsonRef.current = formatJson;
 
   function submit() {
     setClientError(null);
@@ -176,7 +177,6 @@ export function InjectDialog({
   const submitRef = useRef(submit);
   submitRef.current = submit;
 
-  // Dialog focuses `[autofocus]` on open; React's autoFocus prop does not set that attribute.
   useLayoutEffect(() => {
     groupRef.current
       ?.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]')
@@ -185,6 +185,11 @@ export function InjectDialog({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "f" || e.key === "F")) {
+        e.preventDefault();
+        formatJsonRef.current();
+        return;
+      }
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
         e.preventDefault();
         submitRef.current();
@@ -193,6 +198,15 @@ export function InjectDialog({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  const isValidJson = useMemo(() => {
+    try {
+      JSON.parse(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [text]);
 
   const outcome = inject.data;
   const seeded = Boolean(initialEnvelope);
@@ -262,6 +276,24 @@ export function InjectDialog({
           }`}
         >
           blank
+        </button>
+      </div>
+
+      <div className="mb-1.5 flex items-center justify-between">
+        <div className="flex items-center gap-2 text-[11px]">
+          <span
+            className="size-1.5 rounded-full"
+            style={{ background: isValidJson ? "var(--hue-ok)" : "var(--hue-err)" }}
+          />
+          <span className="text-(--text-faint)">{isValidJson ? "Valid JSON" : "Invalid JSON syntax"}</span>
+        </div>
+        <button
+          type="button"
+          onClick={formatJson}
+          className="text-[11px] text-(--text-dim) hover:text-(--accent)"
+          title="Format JSON (⌘⇧F)"
+        >
+          Format JSON <span className="mono opacity-70">⌘⇧F</span>
         </button>
       </div>
 

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import type { RunState, TraceEntry, TracePayload } from "../types";
 import { Disclosure, humanSize, JsonBlock, Section } from "./ui";
@@ -13,16 +13,7 @@ const PAGE = 500;
 /** Panel tail: triage shows the newest activity; reading happens full-page. */
 const PANEL_TAIL = 20;
 
-/** Kind filter chips (full view): usage and lifecycle share one toggle. */
-const KIND_GROUPS = [
-  { key: "assistant_text", label: "text" },
-  { key: "tool_use", label: "tool calls" },
-  { key: "tool_result", label: "tool results" },
-  { key: "meta", label: "usage · lifecycle" },
-] as const;
-
-const groupOf = (kind: string): string =>
-  kind === "usage" || kind === "lifecycle" ? "meta" : kind;
+type TraceFilterKind = "all" | "tools" | "reasoning" | "errors" | "usage";
 
 /**
  * Incremental trace feed, same pattern as the Overview journal feed: each
@@ -92,7 +83,7 @@ function ContentBlock({ content }: { content: unknown }) {
         const parsed = JSON.parse(trimmed);
         return <JsonBlock value={parsed} />;
       } catch {
-        // Fall back to plain text
+        // Fall back to plain text if not valid JSON
       }
     }
     return <TextBlock text={content} />;
@@ -101,7 +92,15 @@ function ContentBlock({ content }: { content: unknown }) {
 }
 
 /** One trace row body, by kind. The recorder's truncation marker wins. */
-function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
+function TraceBody({
+  kind,
+  p,
+  forceOpen,
+}: {
+  kind: string;
+  p: TracePayload;
+  forceOpen?: boolean;
+}) {
   // Oversize payload clipped in place: whatever the kind was, only the
   // preview survives — say so rather than rendering half a payload silently.
   if (p.truncated) {
@@ -111,7 +110,7 @@ function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
           {kind} payload truncated · original {humanSize(p.originalBytes ?? 0)}
         </span>
         {p.preview && (
-          <Disclosure label="preview">
+          <Disclosure label="preview" defaultOpen={forceOpen ?? false}>
             <ContentBlock content={p.preview} />
           </Disclosure>
         )}
@@ -126,7 +125,7 @@ function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
       <div className="min-w-0 flex-1">
         <span className="mono">🔧 {p.name ?? "unknown tool"}</span>
         {p.input !== undefined && (
-          <Disclosure label="input">
+          <Disclosure label="input" defaultOpen={forceOpen ?? false}>
             <JsonBlock value={p.input} />
           </Disclosure>
         )}
@@ -137,6 +136,7 @@ function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
     return (
       <div className="min-w-0 flex-1">
         <Disclosure
+          defaultOpen={forceOpen ?? false}
           label={
             p.isError ? (
               <span style={{ color: "var(--hue-err)" }}>tool result — error</span>
@@ -156,7 +156,7 @@ function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
         {p.numTurns ?? "?"} turns · {p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : "?"} ·{" "}
         {p.costUSD != null ? `$${p.costUSD.toFixed(4)}` : "?"}
         {p.usage && Object.keys(p.usage).length > 0 && (
-          <Disclosure label="tokens">
+          <Disclosure label="tokens" defaultOpen={forceOpen ?? false}>
             <JsonBlock value={p.usage} />
           </Disclosure>
         )}
@@ -176,23 +176,30 @@ function TraceBody({ kind, p }: { kind: string; p: TracePayload }) {
   // Unknown kind (future factory.trace versions): show, do not reinterpret.
   return (
     <div className="min-w-0 flex-1">
-      <Disclosure label={kind}>
+      <Disclosure label={kind} defaultOpen={forceOpen ?? false}>
         <JsonBlock value={p} />
       </Disclosure>
     </div>
   );
 }
 
+const isToolKind = (k: string) => k === "tool_use" || k === "tool_result";
+const isReasoningKind = (k: string) => k === "assistant_text";
+const isErrorKind = (e: TraceEntry) =>
+  (e.kind === "tool_result" && Boolean(e.payload?.isError)) ||
+  (e.kind === "lifecycle" && e.payload?.note === "trace_truncated");
+const isUsageKind = (k: string) => k === "usage";
+
 /**
- * Trace (webui doc §10.10, §10.11) — the factory.trace/v1 stream: what the
- * model is saying and which tools it is calling, live while the run
+ * Trace (webui doc §10.10, §10.11, controls OPS-358) — the factory.trace/v1 stream:
+ * what the model is saying and which tools it is calling, live while the run
  * executes, browsable afterwards. Mount with key={runId}.
  *
  * One component, two presentations (the poller is shared, never forked):
  * - `panel` (default): a Section in the run detail panel, tail-only past
  *   PANEL_TAIL entries with an "open full view" jump (`onExpand`).
  * - `full`: the main column of `#/run/:id` — everything, plus client-side
- *   kind filter chips over the cached entries. Filters never touch polling.
+ *   kind filter chips, expand-all toggle, and syntax highlighting.
  */
 export function RunTrace({
   runId,
@@ -208,25 +215,38 @@ export function RunTrace({
   const full = variant === "full";
   const live = LIVE_STATES.includes(state);
   const { entries, isPending, isError } = useTraceFeed(runId, live);
+  const [filter, setFilter] = useState<TraceFilterKind>("all");
+  const [expandAll, setExpandAll] = useState<boolean>(false);
 
-  // Full view: client-side kind visibility. Hidden groups, not shown ones,
-  // so new kinds from a live poll are visible by default.
-  const [hidden, setHidden] = useState<ReadonlySet<string>>(new Set());
-  const toggle = (key: string) =>
-    setHidden((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
+  const counts = useMemo(() => {
+    let tools = 0;
+    let reasoning = 0;
+    let errors = 0;
+    let usage = 0;
+    for (const e of entries) {
+      if (isToolKind(e.kind)) tools++;
+      if (isReasoningKind(e.kind)) reasoning++;
+      if (isErrorKind(e)) errors++;
+      if (isUsageKind(e.kind)) usage++;
+    }
+    return { all: entries.length, tools, reasoning, errors, usage };
+  }, [entries]);
 
-  const filtered = full ? entries.filter((e) => !hidden.has(groupOf(e.kind))) : entries;
-  const tailCut = !full && entries.length > PANEL_TAIL;
-  const shown = tailCut ? entries.slice(-PANEL_TAIL) : filtered;
+  const visibleEntries = useMemo(() => {
+    if (filter === "all") return entries;
+    if (filter === "tools") return entries.filter((e) => isToolKind(e.kind));
+    if (filter === "reasoning") return entries.filter((e) => isReasoningKind(e.kind));
+    if (filter === "errors") return entries.filter(isErrorKind);
+    if (filter === "usage") return entries.filter((e) => isUsageKind(e.kind));
+    return entries;
+  }, [entries, filter]);
+
+  const tailCut = !full && visibleEntries.length > PANEL_TAIL;
+  const shown = tailCut ? visibleEntries.slice(-PANEL_TAIL) : visibleEntries;
 
   // Multi-attempt runs: divider per attempt (entries are seq-ascending, so
   // attempts are contiguous). A single attempt needs no labels.
-  const multiAttempt = new Set(entries.map((e) => e.attempt)).size > 1;
+  const multiAttempt = new Set(shown.map((e) => e.attempt)).size > 1;
 
   // Follow the stream: while live, keep the scroll pinned to the newest entry.
   const scroller = useRef<HTMLDivElement>(null);
@@ -234,64 +254,74 @@ export function RunTrace({
     if (live && scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight;
   }, [shown.length, live]);
 
-  const counts: Record<string, number> = {};
-  for (const e of entries) counts[groupOf(e.kind)] = (counts[groupOf(e.kind)] ?? 0) + 1;
+  const filterTabs: { key: TraceFilterKind; label: string; count: number }[] = [
+    { key: "all", label: "All", count: counts.all },
+    { key: "tools", label: "Tools", count: counts.tools },
+    { key: "reasoning", label: "Reasoning", count: counts.reasoning },
+    { key: "errors", label: "Errors", count: counts.errors },
+    { key: "usage", label: "Usage", count: counts.usage },
+  ];
 
   const body = (
     <>
       {live && (
-        <div className="mb-1.5 flex items-center gap-1.5 text-[11px]" style={{ color: "var(--hue-warn)" }}>
+        <div className="mb-2 flex items-center gap-1.5 text-[11px]" style={{ color: "var(--hue-warn)" }}>
           <span className="size-1.5 animate-pulse rounded-full" style={{ background: "var(--hue-warn)" }} />
           live — following the running attempt
         </div>
       )}
-      {full && entries.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1" role="group" aria-label="Trace kind filter">
-          {KIND_GROUPS.map((g) => {
-            const off = hidden.has(g.key);
-            return (
+
+      {entries.length > 0 && (
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap gap-1">
+            {filterTabs.map((t) => (
               <button
-                key={g.key}
+                key={t.key}
                 type="button"
-                aria-pressed={!off}
-                title={off ? `Show ${g.label} entries` : `Hide ${g.label} entries`}
-                onClick={() => toggle(g.key)}
-                className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                  off
-                    ? "text-(--text-faint) line-through hover:bg-(--surface-1)"
-                    : "bg-(--surface-3) text-(--text)"
+                onClick={() => setFilter(t.key)}
+                className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                  filter === t.key
+                    ? "bg-(--surface-3) text-(--text)"
+                    : "text-(--text-faint) hover:bg-(--surface-2)"
                 }`}
+                style={t.key === "errors" && t.count > 0 ? { color: "var(--hue-err)" } : undefined}
               >
-                {g.label}
-                {(counts[g.key] ?? 0) > 0 && (
-                  <span className="ml-1.5 tabular-nums text-(--text-faint)">{counts[g.key]}</span>
-                )}
+                {t.label}
+                {t.count > 0 && <span className="ml-1 tabular-nums opacity-75">{t.count}</span>}
               </button>
-            );
-          })}
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setExpandAll((v) => !v)}
+            className="text-[11px] text-(--text-faint) hover:text-(--text-dim)"
+          >
+            {expandAll ? "Collapse details" : "Expand details"}
+          </button>
         </div>
       )}
-      {entries.length === 0 ? (
+
+      {visibleEntries.length === 0 ? (
         <div className="text-(--text-faint)">
           {isPending
             ? "Loading trace…"
             : isError
               ? "Could not load the trace."
-              : live
-                ? "No trace yet — events appear here as the agent works."
-                : "No trace — this adapter does not stream events."}
-        </div>
-      ) : shown.length === 0 ? (
-        <div className="text-(--text-faint)">
-          All {entries.length} entries hidden by the kind filter.
+              : entries.length > 0
+                ? `No entries match "${filter}".`
+                : live
+                  ? "No trace yet — events appear here as the agent works."
+                  : "No trace — this adapter does not stream events."}
         </div>
       ) : (
         <div
           ref={scroller}
-          className={`${full ? "max-h-[70vh]" : "max-h-96"} overflow-auto rounded-md border border-(--border) px-3 py-1`}
+          className={`${
+            full ? "max-h-[70vh]" : "max-h-96"
+          } overflow-auto rounded-md border border-(--border) px-3 py-1`}
         >
           {shown.map((e, i) => (
-            <Fragment key={e.seq}>
+            <Fragment key={`${e.seq}-${expandAll ? "open" : "shut"}`}>
               {multiAttempt && (i === 0 || shown[i - 1].attempt !== e.attempt) && (
                 <div className="border-b border-(--border) py-1 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
                   Attempt #{e.attempt}
@@ -301,15 +331,16 @@ export function RunTrace({
                 <span className="mono w-[64px] shrink-0 text-(--text-faint)" title={e.ts}>
                   {new Date(e.ts).toLocaleTimeString([], { hour12: false })}
                 </span>
-                <TraceBody kind={e.kind} p={e.payload ?? {}} />
+                <TraceBody kind={e.kind} p={e.payload ?? {}} forceOpen={expandAll} />
               </div>
             </Fragment>
           ))}
         </div>
       )}
+
       {tailCut && (
         <div className="mt-1.5 text-[11px] text-(--text-faint)">
-          showing last {PANEL_TAIL} of {entries.length} entries
+          showing last {PANEL_TAIL} of {visibleEntries.length} entries
           {onExpand && (
             <>
               {" — "}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { hashPath } from "../hash";
 import { useNow } from "../hooks";
-import type { JournalEntry, EventFocus } from "../types";
+import type { JournalEntry, EventFocus, RunState } from "../types";
 import {
   Ago,
   Button,
@@ -54,9 +54,9 @@ function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isErro
 }
 
 /**
- * Overview (webui spec §4.1 + doc §10.4) — the dashboard: stat tiles, the
- * doctor panel with anomalies linking to their views, the live journal feed,
- * and the latest published result events from the outbox.
+ * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360) — the dashboard:
+ * promoted doctor anomaly deck, 3-stage pipeline layout (Intake -> Watched Gate -> Execution),
+ * live journal feed, and outbox results.
  */
 export function Overview({
   connected,
@@ -113,8 +113,6 @@ export function Overview({
           await new Promise((r) => setTimeout(r, 250));
         }
       } catch {
-        // The requeue itself landed; only the confirmation poll broke, so say
-        // that rather than claiming no proposal appeared.
         if (alive.current) notify(`Requeued ${eventId} — could not confirm a proposal appeared`, "err");
         return;
       }
@@ -166,12 +164,8 @@ export function Overview({
         requeue: { source: d.source, eventId: d.eventId },
       });
     }
-    // A stale worker still holding a run: the process is gone but nothing has
-    // reclaimed the run yet, so both ends of that gap need a jump.
     for (const w of anomalies.stalledWorkers) {
       anomalyRows.push({
-        // Both ids lead, because the row truncates from the right: the age and
-        // the host are the parts an operator can lose and still act.
         text: `stalled worker ${w.workerId} still holds run ${w.runId} — last heartbeat ${ago(w.lastSeen, now)} on ${w.host}`,
         links: [
           { label: "View worker", go: () => onNavigate(hashPath("workers", w.workerId)) },
@@ -180,8 +174,6 @@ export function Overview({
       });
     }
     if (anomalies.noWorkers) {
-      // The count comes from the same snapshot the runtime derived noWorkers
-      // from, so the sentence and the runs tile can never disagree.
       const queued = s?.runs.byState.QUEUED ?? 0;
       anomalyRows.push({
         text: `${queued} queued run${queued === 1 ? "" : "s"} and no live worker to claim ${queued === 1 ? "it" : "them"} — nothing will start until one registers`,
@@ -192,6 +184,11 @@ export function Overview({
       });
     }
   }
+
+  const hasAnomalies = anomalyRows.length > 0;
+
+  const activeRunStates: RunState[] = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
+  const terminalRunStates: RunState[] = ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"];
 
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
@@ -207,75 +204,19 @@ export function Overview({
         </div>
       </div>
 
-      {status.isPending && !s && <div className="mb-5 text-(--text-faint)">Loading status…</div>}
-      {status.isError && !s && (
-        <div className="mb-5 text-(--text-faint)">Cannot reach the control API — tiles will appear when it is up.</div>
-      )}
-
-      {s && (
-        <div className="mb-5 grid grid-cols-4 gap-2 xl:grid-cols-8">
-          {Object.entries(s.events).map(([k, v]) => (
-            <StatTile
-              key={k}
-              label={`events · ${k}`}
-              value={v}
-              hue={v > 0 ? EVENT_STATUS_HUES[k] : undefined}
-              onClick={() => onJumpEvents({ status: k })}
-            />
-          ))}
-          <StatTile
-            label="proposals · open"
-            value={s.proposals.open}
-            hue={s.proposals.open > 0 ? "var(--hue-info)" : undefined}
-            onClick={() => onNavigate("proposals")}
-          />
-          <StatTile
-            label="proposals · expired"
-            value={s.proposals.expired}
-            hue={s.proposals.expired > 0 ? "var(--hue-warn)" : undefined}
-            onClick={onJumpExpired}
-          />
-          {Object.entries(s.runs.byState).map(([k, v]) => (
-            <StatTile
-              key={k}
-              label={`runs · ${k.toLowerCase()}`}
-              value={v ?? 0}
-              onClick={() => onJumpRuns(k)}
-            />
-          ))}
-          <StatTile
-            label="workers · live"
-            value={s.workers.live}
-            hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
-            onClick={() => onNavigate("workers")}
-          />
-          <StatTile
-            label="workers · busy"
-            value={s.workers.busy}
-            hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
-            onClick={() => onNavigate("workers")}
-          />
-          <StatTile
-            label="workers · stale"
-            value={s.workers.stale}
-            hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
-            onClick={() => onNavigate("workers")}
-          />
-        </div>
-      )}
-
-      <Section title="Doctor">
-        {!s ? (
-          <div className="text-(--text-faint)">
-            {status.isError ? "Cannot reach the control API." : "Loading anomalies…"}
+      {/* Promoted Doctor Deck when anomalies exist */}
+      {hasAnomalies && (
+        <div className="mb-5 rounded-lg border border-[color:var(--hue-warn)] bg-[color:color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2 text-[12px] font-semibold text-[color:var(--hue-warn)] uppercase tracking-wide">
+              <span className="size-2 rounded-full bg-[color:var(--hue-warn)] animate-pulse" />
+              Doctor Anomaly Deck · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
+            </div>
           </div>
-        ) : anomalyRows.length === 0 ? (
-          <div className="text-(--text-faint)">No anomalies.</div>
-        ) : (
-          <div className="rounded-md border border-(--border)">
+          <div className="rounded-md border border-(--border) bg-(--surface-1)">
             {anomalyRows.map((a, i) => (
               <div key={i} className="flex items-center justify-between gap-3 border-b border-(--border) px-3 py-2 last:border-0">
-                <span className="truncate" title={a.text} style={{ color: "var(--hue-warn)" }}>
+                <span className="truncate text-[12px]" title={a.text} style={{ color: "var(--hue-warn)" }}>
                   {a.text}
                 </span>
                 <span className="flex shrink-0 gap-2">
@@ -297,9 +238,116 @@ export function Overview({
               </div>
             ))}
           </div>
-        )}
-        <VerbError error={requeue.error} />
-      </Section>
+          <VerbError error={requeue.error} />
+        </div>
+      )}
+
+      {status.isPending && !s && <div className="mb-5 text-(--text-faint)">Loading status…</div>}
+      {status.isError && !s && (
+        <div className="mb-5 text-(--text-faint)">Cannot reach the control API — tiles will appear when it is up.</div>
+      )}
+
+      {/* 3-Stage Pipeline Overview */}
+      {s && (
+        <div className="mb-6 space-y-4">
+          {/* Stage 1: Intake & Gate */}
+          <div className="grid gap-3 lg:grid-cols-12">
+            <div className="lg:col-span-7">
+              <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                1. Event Intake & Triage
+              </div>
+              <div className="grid grid-cols-5 gap-2">
+                {Object.entries(s.events).map(([k, v]) => (
+                  <StatTile
+                    key={k}
+                    label={`events · ${k}`}
+                    value={v}
+                    hue={v > 0 ? EVENT_STATUS_HUES[k] : undefined}
+                    onClick={() => onJumpEvents({ status: k })}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div className="lg:col-span-5">
+              <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+                2. Watched Approval Gate
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <StatTile
+                  label="proposals · open"
+                  value={s.proposals.open}
+                  hue={s.proposals.open > 0 ? "var(--hue-info)" : undefined}
+                  onClick={() => onNavigate("proposals")}
+                />
+                <StatTile
+                  label="proposals · expired"
+                  value={s.proposals.expired}
+                  hue={s.proposals.expired > 0 ? "var(--hue-warn)" : undefined}
+                  onClick={onJumpExpired}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Stage 2: Execution Fleet & Workers */}
+          <div>
+            <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              3. Execution Fleet & Capacity
+            </div>
+            <div className="grid grid-cols-4 gap-2 xl:grid-cols-8">
+              {activeRunStates.map((k) => (
+                <StatTile
+                  key={k}
+                  label={`active · ${k.toLowerCase()}`}
+                  value={s.runs.byState[k] ?? 0}
+                  hue={(s.runs.byState[k] ?? 0) > 0 ? "var(--hue-warn)" : undefined}
+                  onClick={() => onJumpRuns(k)}
+                />
+              ))}
+              {terminalRunStates.map((k) => (
+                <StatTile
+                  key={k}
+                  label={`runs · ${k.toLowerCase()}`}
+                  value={s.runs.byState[k] ?? 0}
+                  hue={k === "FAILED" && (s.runs.byState[k] ?? 0) > 0 ? "var(--hue-err)" : undefined}
+                  onClick={() => onJumpRuns(k)}
+                />
+              ))}
+              <StatTile
+                label="workers · live"
+                value={s.workers.live}
+                hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
+                onClick={() => onNavigate("workers")}
+              />
+              <StatTile
+                label="workers · busy"
+                value={s.workers.busy}
+                hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
+                onClick={() => onNavigate("workers")}
+              />
+              <StatTile
+                label="workers · stale"
+                value={s.workers.stale}
+                hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
+                onClick={() => onNavigate("workers")}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!hasAnomalies && (
+        <Section title="Doctor">
+          {!s ? (
+            <div className="text-(--text-faint)">
+              {status.isError ? "Cannot reach the control API." : "Loading anomalies…"}
+            </div>
+          ) : (
+            <div className="text-(--text-faint)">No anomalies.</div>
+          )}
+        </Section>
+      )}
 
       <div className="grid gap-x-5 xl:grid-cols-2">
         <Section title={`Activity · latest ${Math.min(feed.entries.length, FEED_CAP)}`}>

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -527,7 +527,55 @@ export function Proposals({
           )}
 
           {sel.spec && (
-            <Section title="Run spec — what you approve">
+            <Section title="Spec Highlights — safety check">
+              <div className="mb-2 rounded-md border border-(--border) bg-(--surface-0) p-3">
+                <div className="mb-2 flex items-center justify-between gap-2 border-b border-(--border) pb-2">
+                  <div className="flex items-center gap-1.5 font-medium">
+                    <span className="mono">{sel.spec.agent}</span>
+                    <span className="text-[11px] text-(--text-faint)">({sel.spec.adapter})</span>
+                  </div>
+                  <span
+                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
+                    style={
+                      sel.spec.capabilities && sel.spec.capabilities.length > 0
+                        ? {
+                            color: "var(--hue-warn)",
+                            background: "color-mix(in oklch, var(--hue-warn) 14%, transparent)",
+                          }
+                        : {
+                            color: "var(--hue-ok)",
+                            background: "color-mix(in oklch, var(--hue-ok) 14%, transparent)",
+                          }
+                    }
+                  >
+                    {sel.spec.capabilities && sel.spec.capabilities.length > 0
+                      ? `${sel.spec.capabilities.length} cap${sel.spec.capabilities.length === 1 ? "" : "s"}`
+                      : "read-only"}
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-2 text-[12px]">
+                  <div>
+                    <div className="text-[10px] text-(--text-faint) uppercase tracking-wide">Workspace</div>
+                    <div className="mono text-(--text-dim) truncate">
+                      {sel.spec.workspace?.type ?? "default"}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] text-(--text-faint) uppercase tracking-wide">Timeout & SLA</div>
+                    <div className="mono text-(--text-dim)">
+                      {sel.spec.timeoutSeconds}s · max {sel.spec.maxAttempts} att
+                    </div>
+                  </div>
+                  {sel.spec.capabilities && sel.spec.capabilities.length > 0 && (
+                    <div className="col-span-2">
+                      <div className="text-[10px] text-(--text-faint) uppercase tracking-wide">Capabilities</div>
+                      <div className="mono text-(--text-dim) truncate">
+                        {sel.spec.capabilities.join(", ")}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
               <Disclosure label="immutable RunSpec" defaultOpen={isOpen}>
                 <JsonBlock value={sel.spec} />
               </Disclosure>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -520,6 +520,9 @@ export function Runs({
                 Expand <span className="mono ml-1 opacity-70">o</span>
               </Button>
               <Button onClick={() => copyText(sel.runId, "run id")}>Copy id</Button>
+              <Button onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command")}>
+                Copy CLI
+              </Button>
               <Button onClick={copyLink}>Copy link</Button>
               <Button onClick={() => onSelectRun(null)}>Close</Button>
             </>


### PR DESCRIPTION
## Summary
Bundle of web UI usability and telemetry improvements for `event-runtime/web`:
- **Syntax Highlighting (OPS-355)**: Zero-dependency JSON tokenizer (`src/highlight.ts`) styled with OKLCH theme semantic tokens and integrated into `JsonBlock` across all views.
- **Trace Controls & CLI Bridge (OPS-358)**: Kind filter chips (`All`, `Tools`, `Reasoning`, `Errors`, `Usage`), expand/collapse all toggle, auto-highlighting for tool results, and one-click `Copy CLI` inspect helper in Runs view.
- **Proposal Spec Summary (OPS-359)**: High-visibility safety summary card above immutable spec disclosure detailing target resource, capabilities, workspace, and SLA budget.
- **Overview Pipeline Layout (OPS-360)**: Promoted Doctor anomaly deck with immediate triage/requeue actions at the top when anomalies exist, and organized 3-stage pipeline triage tiles (Intake -> Watched Gate -> Fleet & Workers).
- **Inject Dialog Format Action (OPS-361)**: Format JSON button (`⌘⇧F`), real-time syntax validation indicator, and quick template syncing.

Fixes OPS-355
Fixes OPS-358
Fixes OPS-359
Fixes OPS-360
Fixes OPS-361