### PR TITLE
feat(event-runtime): loopback janitor Dry + Apply (OPS-301)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -44,16 +44,22 @@ Made by the operator, recorded here so nobody relitigates them mid-build:
 ## 2. Non-goals
 
 - No authentication, sessions, or multi-operator identity (see above).
-- No new mutation surface: the UI exposes exactly the verbs the API has —
-  approve, reject, cancel, retry, replay. Nothing else.
+- No new mutation surface except the loopback janitor verb
+  (`POST /repos/:name/janitor`, OPS-301): Dry and Apply, 127.0.0.1, actor
+  `operator`, same trust as typing `factory janitor` on the machine. Apply
+  never passes `--force`. The Projects-tab buttons (typed confirm, Dry
+  before Apply) are a follow-up (OPS-362); this records the API exception.
+  Everything else the UI exposes is still approve, reject, cancel, retry,
+  replay.
 - No database access, no imports from `event-runtime/lib/`.
 - No SSE/WebSocket work in the first version.
 - No transcript/artifact *content* viewer. `GET /runs/:id` returns the
   retained workspace *path*; a browser cannot read local paths, and an
   artifact-fetch endpoint is new API surface. Deferred (§8) — the UI shows
   the path and hashes, and `cli.mjs inspect` remains the deep-inspection tool.
-- No involvement in the emit pipeline, `shared/`, or the orchestrator (§3 of
-  the parent doc applies unchanged).
+- No involvement in the emit pipeline or `shared/`. The control API may
+  spawn `factory janitor` for the Projects verb (OPS-301); the web app still
+  does not import the orchestrator.
 
 ---
 
@@ -281,8 +287,13 @@ and shared with the CLI:
 - **`GET /outbox`** (`?limit=`) — emitted result events, the runtime's
   actual output.
 - **`POST /events/requeue`** — re-plan a dead-lettered or `human_needed`
-  event (CLI `requeue`); the only non-read addition, audited like every
-  other verb.
+  event (CLI `requeue`); audited like every other verb.
+- **`GET /repos`** — `config/repos.yaml` as an allow-listed registry (OPS-299).
+- **`POST /repos/:name/janitor`** — loopback spawn of `factory janitor`
+  `--json` for that one name (OPS-301). Body `{ apply: false | true }`;
+  omitted `apply` is Dry. Apply never `--force`. Unknown name 404; Apply on
+  a `report_only` repo without `worktree_down` 409. Actor `"operator"`. The
+  UI confirm is OPS-362, not this endpoint.
 - **`GET /artifacts/:sha256`** — content-addressed artifact/transcript bytes
   (the §8 deferral, since triggered and shipped).
 - **`GET /workers`** — the worker registry the CLI `workers` command prints,

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -10,10 +10,12 @@
  * no signature. Operator verbs record "operator" as actor — authenticated
  * actor identity is the web-app step, not this one.
  */
+import { spawnSync } from "node:child_process";
 import { createReadStream, readFileSync } from "node:fs";
 import http from "node:http";
+import path from "node:path";
 import { findArtifact } from "./artifacts.mjs";
-import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
+import { API_HOST, DEFAULT_PORT, FACTORY_ROOT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
 import { admitEvent, verifyWebhook } from "./intake.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { requeueEvent } from "./planner.mjs";
@@ -349,6 +351,31 @@ function runView(db, runId) {
 }
 
 /**
+ * Spawn `orchestrator/janitor.mjs --json` for one repos.yaml name (OPS-301).
+ * Never passes `--force`. Injectable on createApi so tests never hit Linear
+ * or real worktrees. Actor is the loopback operator — this is a host-side
+ * spawn, the same trust as typing `factory janitor` on the machine.
+ */
+export function spawnFactoryJanitor(name, { apply = false } = {}) {
+  const script = path.join(FACTORY_ROOT, "orchestrator", "janitor.mjs");
+  const args = [script, "--repo", name, "--json"];
+  if (apply === true) args.push("--apply");
+  const r = spawnSync(process.execPath, args, { encoding: "utf8", cwd: FACTORY_ROOT });
+  const stdout = (r.stdout || "").trim();
+  if (r.status === 2) {
+    const err = new Error(`unknown repo ${name}`);
+    err.status = 404;
+    throw err;
+  }
+  if (r.status !== 0) {
+    const err = new Error((r.stderr || "").trim() || `janitor exit ${r.status}`);
+    err.status = 500;
+    throw err;
+  }
+  return JSON.parse(stdout);
+}
+
+/**
  * Both admission routes converge here — the §15 requirement that webhook and
  * replay call the same intake function. onEvent("admitted") lets a foreground
  * serve loop plan immediately instead of waiting a tick.
@@ -383,6 +410,9 @@ export function createApi({
   // until someone restarted serve. Injectable so tests can point at a fixture
   // instead of whichever repos exist on the machine.
   repos = () => loadRepos(),
+  // Host-side janitor spawn (OPS-301). Tests inject a fake; production
+  // shells out to orchestrator/janitor.mjs --json, never --force.
+  janitor = spawnFactoryJanitor,
 } = {}) {
   const ACTOR = "operator"; // one local operator in the MVP (§14)
 
@@ -448,6 +478,40 @@ export function createApi({
           // "internal_error" and send them reading the runtime's source.
           if (err instanceof RepoError) return send(res, 500, { error: err.message });
           throw err;
+        }
+      }
+
+      // Loopback janitor (OPS-301): Dry is the default; Apply never --force.
+      // Same actor as every other operator verb. UI confirm lives in OPS-362.
+      const janitorPost = url.pathname.match(/^\/repos\/([^/]+)\/janitor$/);
+      if (req.method === "POST" && janitorPost) {
+        const name = decodeURIComponent(janitorPost[1]);
+        let registry;
+        try {
+          registry = repos();
+        } catch (err) {
+          if (err instanceof RepoError) return send(res, 500, { error: err.message });
+          throw err;
+        }
+        const repo = registry.get(name);
+        if (!repo) return send(res, 404, { error: `unknown repo ${name}` });
+        const body = parseJson(await readBody(req)).value ?? {};
+        if (body.apply !== undefined && typeof body.apply !== "boolean") {
+          return send(res, 422, { error: "apply must be a boolean" });
+        }
+        const apply = body.apply === true;
+        if (apply && repo.reportOnly && !repo.worktreeDown) {
+          return send(res, 409, {
+            error: `report-only repo "${name}" has no worktree_down script; refusing apply`,
+          });
+        }
+        try {
+          const result = await janitor(name, { apply, repo, actor: ACTOR });
+          return send(res, 200, { actor: ACTOR, apply, ...result });
+        } catch (err) {
+          const status = Number.isInteger(err.status) ? err.status : 500;
+          if (status === 500) return send(res, 500, { error: "internal_error" });
+          return send(res, status, { error: err.message });
         }
       }
 

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -15,12 +15,12 @@ import { createReadStream, readFileSync } from "node:fs";
 import http from "node:http";
 import path from "node:path";
 import { findArtifact } from "./artifacts.mjs";
-import { API_HOST, DEFAULT_PORT, FACTORY_ROOT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
+import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
 import { admitEvent, verifyWebhook } from "./intake.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
-import { loadRepos, RepoError, reposView } from "./repos.mjs";
+import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
@@ -350,6 +350,22 @@ function runView(db, runId) {
   };
 }
 
+/** Bound so a hung Linear call cannot freeze serve forever (OPS-301 review). */
+const JANITOR_TIMEOUT_MS = 120_000;
+const JANITOR_MAX_BUFFER = 1_000_000;
+
+/**
+ * Argv for one repos.yaml name. `--force` is not a flag and must never become
+ * one — the worktree_down refusal on dirty trees is the safety property.
+ * Spawn runs against `reposRoot()` so FACTORY_REPOS_ROOT cannot survey one
+ * yaml and tear down another.
+ */
+export function janitorArgv(name, { apply = false } = {}) {
+  const args = [path.join(reposRoot(), "orchestrator", "janitor.mjs"), "--repo", name, "--json"];
+  if (apply === true) args.push("--apply");
+  return args;
+}
+
 /**
  * Spawn `orchestrator/janitor.mjs --json` for one repos.yaml name (OPS-301).
  * Never passes `--force`. Injectable on createApi so tests never hit Linear
@@ -357,10 +373,19 @@ function runView(db, runId) {
  * spawn, the same trust as typing `factory janitor` on the machine.
  */
 export function spawnFactoryJanitor(name, { apply = false } = {}) {
-  const script = path.join(FACTORY_ROOT, "orchestrator", "janitor.mjs");
-  const args = [script, "--repo", name, "--json"];
-  if (apply === true) args.push("--apply");
-  const r = spawnSync(process.execPath, args, { encoding: "utf8", cwd: FACTORY_ROOT });
+  const args = janitorArgv(name, { apply });
+  const root = reposRoot();
+  const r = spawnSync(process.execPath, args, {
+    encoding: "utf8",
+    cwd: root,
+    timeout: JANITOR_TIMEOUT_MS,
+    maxBuffer: JANITOR_MAX_BUFFER,
+  });
+  if (r.error?.code === "ETIMEDOUT") {
+    const err = new Error("janitor timed out");
+    err.status = 504;
+    throw err;
+  }
   const stdout = (r.stdout || "").trim();
   if (r.status === 2) {
     const err = new Error(`unknown repo ${name}`);
@@ -372,7 +397,13 @@ export function spawnFactoryJanitor(name, { apply = false } = {}) {
     err.status = 500;
     throw err;
   }
-  return JSON.parse(stdout);
+  const parsed = JSON.parse(stdout);
+  if (parsed && Array.isArray(parsed.results)) {
+    const err = new Error("janitor returned multiple repos; expected one");
+    err.status = 500;
+    throw err;
+  }
+  return parsed;
 }
 
 /**

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
-import { startApi } from "./api.mjs";
+import { janitorArgv, startApi } from "./api.mjs";
 import { apiClient } from "./client.mjs";
 import { openDb } from "./db.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
@@ -827,5 +827,17 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       close();
       server.close();
     }
+  });
+
+  test("janitorArgv never includes --force and adds --apply only when asked (OPS-301)", () => {
+    const dry = janitorArgv("bj29");
+    expect(dry).toContain("--json");
+    expect(dry).toContain("bj29");
+    expect(dry).not.toContain("--force");
+    expect(dry).not.toContain("--apply");
+    const apply = janitorArgv("bj29", { apply: true });
+    expect(apply).toContain("--apply");
+    expect(apply).not.toContain("--force");
+    expect(apply.filter((a) => a === "--apply")).toHaveLength(1);
   });
 });

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -711,4 +711,121 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       server.close();
     }
   });
+
+  test("POST /repos/:name/janitor dry-runs by default and never calls apply (OPS-301)", async () => {
+    const calls = [];
+    const fixture = new Map([
+      ["dispatchable", { name: "dispatchable", reportOnly: false, worktreeDown: "bin/worktree-down.sh" }],
+    ]);
+    const { server, port, close } = await makeServer({
+      repos: () => fixture,
+      janitor: async (name, opts) => {
+        calls.push({ name, apply: opts.apply });
+        return { name, reclaimable: [{ id: "OPS-1", state: "Done" }], kept: [], named: [], unknown: [], removed: [], refused: [] };
+      },
+    });
+    const client = apiClient({ port });
+    try {
+      const body = await client.janitor("dispatchable");
+      expect(body.actor).toBe("operator");
+      expect(body.apply).toBe(false);
+      expect(body.reclaimable).toEqual([{ id: "OPS-1", state: "Done" }]);
+      expect(calls).toEqual([{ name: "dispatchable", apply: false }]);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("POST /repos/:name/janitor apply true reaches the injected janitor (OPS-301)", async () => {
+    const calls = [];
+    const fixture = new Map([
+      ["dispatchable", { name: "dispatchable", reportOnly: false, worktreeDown: "bin/worktree-down.sh" }],
+    ]);
+    const { server, port, close } = await makeServer({
+      repos: () => fixture,
+      janitor: async (name, opts) => {
+        calls.push({ name, apply: opts.apply });
+        return { name, reclaimable: [{ id: "OPS-1", state: "Done" }], removed: ["OPS-1"], refused: [], kept: [], named: [], unknown: [] };
+      },
+    });
+    const client = apiClient({ port });
+    try {
+      const body = await client.janitor("dispatchable", { apply: true });
+      expect(body.apply).toBe(true);
+      expect(body.removed).toEqual(["OPS-1"]);
+      expect(calls).toEqual([{ name: "dispatchable", apply: true }]);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("POST /repos/:name/janitor 404s an unknown repo without spawning (OPS-301)", async () => {
+    let spawned = false;
+    const { server, port, close } = await makeServer({
+      repos: () => new Map([["dispatchable", { name: "dispatchable", reportOnly: false, worktreeDown: "bin/worktree-down.sh" }]]),
+      janitor: async () => {
+        spawned = true;
+        return {};
+      },
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/repos/nope/janitor`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "unknown repo nope" });
+      expect(spawned).toBe(false);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("POST /repos/:name/janitor apply on report_only without worktree_down is 409 (OPS-301)", async () => {
+    let spawned = false;
+    const { server, port, close } = await makeServer({
+      repos: () => new Map([["watched", { name: "watched", reportOnly: true, worktreeDown: null }]]),
+      janitor: async () => {
+        spawned = true;
+        return {};
+      },
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/repos/watched/janitor`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ apply: true }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/report-only repo "watched" has no worktree_down/);
+      expect(spawned).toBe(false);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("POST /repos/:name/janitor rejects a non-boolean apply (OPS-301)", async () => {
+    const { server, port, close } = await makeServer({
+      repos: () => new Map([["dispatchable", { name: "dispatchable", reportOnly: false, worktreeDown: "bin/worktree-down.sh" }]]),
+      janitor: async () => ({}),
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/repos/dispatchable/janitor`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ apply: "please" }),
+      });
+      expect(res.status).toBe(422);
+      expect(await res.json()).toEqual({ error: "apply must be a boolean" });
+    } finally {
+      close();
+      server.close();
+    }
+  });
 });

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -60,6 +60,15 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
     workers: () => call("GET", "/workers"),
     /** Factory repo registry from config/repos.yaml (OPS-299). */
     repos: () => call("GET", "/repos"),
+    /**
+     * Loopback janitor for one repos.yaml entry (OPS-301). `apply: false`
+     * (the default) is a dry survey; `apply: true` tears down finished-ticket
+     * worktrees via the repo's worktree_down, never `--force`.
+     */
+    janitor: (name, { apply = false } = {}) =>
+      call("POST", `/repos/${encodeURIComponent(name)}/janitor`, {
+        body: JSON.stringify({ apply: apply === true }),
+      }),
     approve: (id) => call("POST", `/proposals/${encodeURIComponent(id)}/approve`, { body: "{}" }),
     reject: (id, reason) =>
       call("POST", `/proposals/${encodeURIComponent(id)}/reject`, { body: JSON.stringify({ reason }) }),

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -78,8 +78,9 @@ function emptySurvey(repo) {
   };
 }
 
-async function survey(repo) {
+async function survey(repo, { apply }) {
   const result = emptySurvey(repo);
+  result.apply = apply;
   const root = expand(repo.worktree_root ?? "");
   const repoPath = expand(repo.path);
   if (!root || !existsSync(root)) {
@@ -110,7 +111,7 @@ async function survey(repo) {
   result.unknown = tickets.filter((t) => !states[t]);
   result.reclaimable = finished.map((t) => ({ id: t, state: states[t].name }));
 
-  if (!APPLY || !finished.length) return result;
+  if (!apply || !finished.length) return result;
 
   // `report_only` disables dispatch, not safe cleanup. A repo with its own
   // configured teardown script can be reclaimed; one without it is surveyed
@@ -175,7 +176,8 @@ function printHuman(repo, result) {
 
 const surveys = [];
 for (const repo of repos) {
-  const result = await survey(repo);
+  // `--gate` is a probe: it must never tear down, even if `--apply` is also set.
+  const result = await survey(repo, { apply: APPLY && !GATE });
   surveys.push(result);
   if (GATE) continue;
   if (!quiet) printHuman(repo, result);

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -5,6 +5,7 @@
  *   bun orchestrator/janitor.mjs --repo bj29           # dry run
  *   bun orchestrator/janitor.mjs --repo bj29 --apply
  *   bun orchestrator/janitor.mjs --repo bj29 --gate    # exit 0 if there is work
+ *   bun orchestrator/janitor.mjs --repo bj29 --json    # same survey, machine-readable
  *
  * Every worktree holds a checkout and (here) a per-ticket database. The merge
  * stage is supposed to tear its own down, but a crashed run, a merge done by
@@ -18,6 +19,11 @@
  * worktree with uncommitted changes or unpushed commits refuses to be removed.
  * Losing an agent's unpushed work would be far worse than the disk it holds.
  * Never add --force here; if a worktree won't go, that is a finding to look at.
+ *
+ * `--json` (OPS-301) is the same survey the human CLI prints, as one object
+ * per `--repo` so the loopback control API can spawn this script rather than
+ * reimplement Linear + worktree discovery. Stdout is JSON only; the colour
+ * log is skipped. `--force` is still not a flag and must never become one.
  */
 import { readFileSync, existsSync, readdirSync, mkdirSync, appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -30,6 +36,7 @@ const argv = process.argv.slice(2);
 const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
 const APPLY = argv.includes("--apply");
 const GATE = argv.includes("--gate");
+const JSON_OUT = argv.includes("--json");
 const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
 
 const expand = (p) => p.replace(/^~/, homedir());
@@ -41,6 +48,8 @@ const c = {
   dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
   green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
+
+const quiet = JSON_OUT || GATE;
 
 // Keep a lightweight per-repo run marker. Unlike worktree discovery this does
 // not depend on there being an orphan, so `factory status` can accurately say
@@ -54,12 +63,29 @@ if (!GATE) {
   } catch { /* observability must never block safe cleanup */ }
 }
 
-let totalReclaimable = 0;
+function emptySurvey(repo) {
+  return {
+    name: repo.name,
+    apply: APPLY,
+    missingRoot: false,
+    reclaimable: [],
+    kept: [],
+    named: [],
+    unknown: [],
+    removed: [],
+    refused: [],
+    skippedApplyReason: null,
+  };
+}
 
-for (const repo of repos) {
+async function survey(repo) {
+  const result = emptySurvey(repo);
   const root = expand(repo.worktree_root ?? "");
   const repoPath = expand(repo.path);
-  if (!root || !existsSync(root)) continue;
+  if (!root || !existsSync(root)) {
+    result.missingRoot = true;
+    return result;
+  }
 
   // Only ever consider <TEAM>-<number> directories. Named worktrees (a release
   // branch, a scratch checkout) are somebody's deliberate workspace and are not
@@ -67,9 +93,7 @@ for (const repo of repos) {
   const pattern = new RegExp(`^${repo.team}-\\d+$`);
   const all = readdirSync(root);
   const tickets = all.filter((d) => pattern.test(d));
-  const named = all.filter((d) => !pattern.test(d) && !d.startsWith("."));
-
-  if (!GATE) console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${tickets.length} ticket worktree(s) in ${repo.worktree_root}`));
+  result.named = all.filter((d) => !pattern.test(d) && !d.startsWith("."));
 
   let states = {};
   if (tickets.length) {
@@ -80,60 +104,95 @@ for (const repo of repos) {
   }
 
   const finished = tickets.filter((t) => ["completed", "canceled"].includes(states[t]?.type));
-  const live = tickets.filter((t) => states[t] && !["completed", "canceled"].includes(states[t].type));
-  const unknown = tickets.filter((t) => !states[t]);
-  totalReclaimable += finished.length;
+  result.kept = tickets
+    .filter((t) => states[t] && !["completed", "canceled"].includes(states[t].type))
+    .map((t) => ({ id: t, state: states[t].name }));
+  result.unknown = tickets.filter((t) => !states[t]);
+  result.reclaimable = finished.map((t) => ({ id: t, state: states[t].name }));
 
-  if (GATE) continue;
-
-  if (live.length) console.log(c.dim(`  keeping ${live.length} live: ${live.map((t) => `${t} (${states[t].name})`).join(", ")}`));
-  if (named.length) console.log(c.dim(`  ignoring ${named.length} named worktree(s): ${named.join(", ")}`));
-  if (unknown.length) console.log(c.yellow(`  ${unknown.length} worktree(s) with no matching ticket — left alone: ${unknown.join(", ")}`));
-
-  if (!finished.length) { console.log(c.green("  nothing to reclaim")); continue; }
-
-  console.log(`  ${c.bold(String(finished.length))} reclaimable (ticket finished):`);
-  for (const t of finished) console.log(`    ${t}  ${c.dim(states[t].name)}`);
-
-  if (!APPLY) {
-    console.log(c.dim(`\n  dry run — re-run with --apply to remove them`));
-    continue;
-  }
+  if (!APPLY || !finished.length) return result;
 
   // `report_only` disables dispatch, not safe cleanup. A repo with its own
   // configured teardown script can be reclaimed; one without it is surveyed
   // only, because removing a worktree by hand leaves its database behind.
   const down = repo.worktree_down;
   if (repo.report_only && !down) {
-    console.log(c.yellow(`\n  report-only: ${repo.name} has no worktree teardown script (PC-15 pending).`));
-    console.log(c.dim(`  Not removing anything. These need the repo's own worktree-down.sh so the`));
-    console.log(c.dim(`  per-ticket database goes with the checkout.`));
-    continue;
+    result.skippedApplyReason = `report-only: ${repo.name} has no worktree teardown script (PC-15 pending)`;
+    return result;
   }
 
   if (!down || !existsSync(path.join(repoPath, down))) {
-    console.log(c.red(`  ! ${repo.name} has no worktree_down script (${down}) — refusing to remove by hand`));
-    continue;
+    result.skippedApplyReason = `${repo.name} has no worktree_down script (${down}) — refusing to remove by hand`;
+    return result;
   }
 
-  let removed = 0, refused = 0;
   for (const t of finished) {
     // No --force, deliberately: the script's refusal on uncommitted or unpushed
     // work is the safety property, not an obstacle to work around.
     const r = spawnSync("/bin/bash", [down, t], { cwd: repoPath, encoding: "utf8" });
-    if (r.status === 0) { removed++; console.log(`    ${c.green("removed")} ${t}`); }
+    if (r.status === 0) result.removed.push(t);
     else {
-      refused++;
-      const msg = (r.stderr || r.stdout || "").trim().split("\n").pop() || `exit ${r.status}`;
-      console.log(`    ${c.yellow("kept")}    ${t} — ${msg}`);
+      const reason = (r.stderr || r.stdout || "").trim().split("\n").pop() || `exit ${r.status}`;
+      result.refused.push({ id: t, reason });
     }
   }
-  console.log(`\n  ${removed} removed, ${refused} kept (unpushed or uncommitted work).`);
+  return result;
+}
+
+function printHuman(repo, result) {
+  if (result.missingRoot) return;
+  const n = result.reclaimable.length + result.kept.length + result.unknown.length;
+  console.log(c.bold(`\n${repo.name}`) + c.dim(`  ${n} ticket worktree(s) in ${repo.worktree_root}`));
+  if (result.kept.length) {
+    console.log(c.dim(`  keeping ${result.kept.length} live: ${result.kept.map((t) => `${t.id} (${t.state})`).join(", ")}`));
+  }
+  if (result.named.length) console.log(c.dim(`  ignoring ${result.named.length} named worktree(s): ${result.named.join(", ")}`));
+  if (result.unknown.length) {
+    console.log(c.yellow(`  ${result.unknown.length} worktree(s) with no matching ticket — left alone: ${result.unknown.join(", ")}`));
+  }
+  if (!result.reclaimable.length) {
+    console.log(c.green("  nothing to reclaim"));
+    return;
+  }
+  console.log(`  ${c.bold(String(result.reclaimable.length))} reclaimable (ticket finished):`);
+  for (const t of result.reclaimable) console.log(`    ${t.id}  ${c.dim(t.state)}`);
+  if (!APPLY) {
+    console.log(c.dim(`\n  dry run — re-run with --apply to remove them`));
+    return;
+  }
+  if (result.skippedApplyReason) {
+    console.log(c.yellow(`\n  ${result.skippedApplyReason}`));
+    if (result.skippedApplyReason.startsWith("report-only:")) {
+      console.log(c.dim(`  Not removing anything. These need the repo's own worktree-down.sh so the`));
+      console.log(c.dim(`  per-ticket database goes with the checkout.`));
+    }
+    return;
+  }
+  for (const t of result.removed) console.log(`    ${c.green("removed")} ${t}`);
+  for (const t of result.refused) console.log(`    ${c.yellow("kept")}    ${t.id} — ${t.reason}`);
+  console.log(`\n  ${result.removed.length} removed, ${result.refused.length} kept (unpushed or uncommitted work).`);
+}
+
+const surveys = [];
+for (const repo of repos) {
+  const result = await survey(repo);
+  surveys.push(result);
+  if (GATE) continue;
+  if (!quiet) printHuman(repo, result);
 }
 
 if (GATE) {
+  const totalReclaimable = surveys.reduce((n, s) => n + s.reclaimable.length, 0);
   if (totalReclaimable > 0) { console.log(`${totalReclaimable} reclaimable worktree(s)`); process.exit(0); }
   console.log("no worktrees to reclaim");
   process.exit(1);
 }
-console.log();
+
+if (JSON_OUT) {
+  // One `--repo` is the API's contract (a single selected project). Several
+  // names wrap in `{ results }` so a human ` --repo a,b --json` still parses.
+  const payload = surveys.length === 1 ? surveys[0] : { apply: APPLY, results: surveys };
+  console.log(JSON.stringify(payload));
+} else {
+  console.log();
+}


### PR DESCRIPTION
## Summary
- Adds `POST /repos/:name/janitor` (`{ apply: false | true }`, default Dry) as a loopback spawn of `factory janitor --json`. Apply never passes `--force`.
- Unknown repo → 404; Apply on `report_only` without `worktree_down` → 409. Tests inject the janitor so CI never hits Linear or real worktrees.
- Spec §2 records the mutation-surface exception. Projects-tab buttons (typed confirm, Dry before Apply) are [OPS-362](https://linear.app/watt-mind/issue/OPS-362).

## Test plan
- [x] `bun test event-runtime` (257 pass)
- [x] `cd event-runtime/web && bun run build`
- [ ] Reviewer: confirm `--force` is absent from spawn args and janitor.mjs still refuses dirty trees

Fixes OPS-301