### PR TITLE
feat(event-runtime-web): two-column sidebar layout for template selection in inject dialog

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -24,11 +24,9 @@ function blankEnvelope(nowMs: number) {
 const pretty = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 
 /**
- * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230, format OPS-361).
+ * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230, format OPS-361, 2-column sidebar OPS-363).
  *
- * Templates are derived from the registry — one per registered event type,
- * with the payload skeleton built from that event's agent input schema — so
- * they cannot drift from what the runtime will actually accept.
+ * Left sidebar lists registered templates with instant search, right side houses the JSON editor and formatting tools.
  */
 export function InjectDialog({
   onClose,
@@ -48,12 +46,24 @@ export function InjectDialog({
     [registry.data, openedAt],
   );
 
+  const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<string | null>(initialEnvelope ? "__given__" : null);
   const [text, setText] = useState(() => pretty(initialEnvelope ?? blankEnvelope(openedAt)));
   const [clientError, setClientError] = useState<string | null>(null);
   const [unregisteredAck, setUnregisteredAck] = useState(false);
   const [confirming, setConfirming] = useState(false);
-  const groupRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filteredTemplates = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter(
+      (t) =>
+        t.eventType.toLowerCase().includes(q) ||
+        t.agent.toLowerCase().includes(q) ||
+        t.summary.toLowerCase().includes(q),
+    );
+  }, [templates, search]);
 
   const inject = useMutation({
     mutationFn: (envelope: Record<string, unknown>) => api.replay(envelope),
@@ -78,7 +88,7 @@ export function InjectDialog({
     inject.reset();
   }
 
-  function applyChip(next: string | null) {
+  function applySelection(next: string | null) {
     if (next === selected) return;
     if (next === null) {
       setSelected(null);
@@ -101,13 +111,17 @@ export function InjectDialog({
   }
 
   function templateIds(): Array<string | null> {
-    return [...(initialEnvelope ? ["__given__"] : []), ...templates.map((t) => t.eventType), null];
+    return [
+      ...(initialEnvelope ? ["__given__"] : []),
+      ...filteredTemplates.map((t) => t.eventType),
+      null,
+    ];
   }
 
-  const checkedChip = templateIds().includes(selected) ? selected : null;
+  const checkedId = templateIds().includes(selected) ? selected : null;
 
   function radioA11y(id: string | null) {
-    const checked = checkedChip === id;
+    const checked = checkedId === id;
     return {
       role: "radio" as const,
       "aria-checked": checked,
@@ -121,11 +135,11 @@ export function InjectDialog({
     if (!(e.target instanceof HTMLElement) || e.target.getAttribute("role") !== "radio") return;
     e.preventDefault();
     const ids = templateIds();
-    const idx = checkedChip === null ? ids.length - 1 : Math.max(ids.indexOf(checkedChip), 0);
+    const idx = checkedId === null ? ids.length - 1 : Math.max(ids.indexOf(checkedId), 0);
     const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
     const nextIdx = (idx + delta + ids.length) % ids.length;
-    applyChip(ids[nextIdx]);
-    e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]')[nextIdx]?.focus();
+    applySelection(ids[nextIdx]);
+    listRef.current?.querySelectorAll<HTMLElement>('[role="radio"]')[nextIdx]?.focus();
   }
 
   function formatJson() {
@@ -178,7 +192,7 @@ export function InjectDialog({
   submitRef.current = submit;
 
   useLayoutEffect(() => {
-    groupRef.current
+    listRef.current
       ?.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]')
       ?.setAttribute("autofocus", "");
   }, []);
@@ -211,143 +225,177 @@ export function InjectDialog({
   const outcome = inject.data;
   const seeded = Boolean(initialEnvelope);
   return (
-    <Dialog title={seeded ? "Trigger again — inject with a fresh event id" : "Inject event"} onClose={onClose} wide>
+    <Dialog
+      title={seeded ? "Trigger again — inject with a fresh event id" : "Inject event"}
+      onClose={onClose}
+      extraWide
+    >
       <div className="mb-3 text-[12px] text-(--text-dim)">
         {seeded
-          ? "Trigger again copies this envelope with a new event id so intake admits it as a new event. It is not Replay (same id, dedup no-op) and not Requeue (re-plan an already-admitted event)."
-          : "Templates come from the registry — payload fields are the ones each agent's input schema requires. Inject sends the envelope through intake, the same path as Replay. Duplicate event ids are a no-op. This is not Requeue."}
+          ? "Trigger again copies this envelope with a new event id so intake admits it as a new event."
+          : "Templates come from the agent registry. Select an event type on the left to load its required schema skeleton, or paste a custom envelope."}
       </div>
 
-      {registry.isPending && !registry.data && (
-        <div className="mb-3 text-[12px] text-(--text-faint)">Loading templates…</div>
-      )}
-      {registry.isError && !registry.data && (
-        <div className="mb-3 text-[12px] text-(--text-faint)">
-          Cannot reach the control API — templates will appear when it is up. You can still paste a raw envelope.
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
+        {/* Left Column: Template Selection Sidebar */}
+        <div className="md:col-span-5 flex flex-col min-h-0 border-b md:border-b-0 md:border-r border-(--border) pb-3 md:pb-0 md:pr-3">
+          <div className="mb-2">
+            <input
+              type="text"
+              placeholder="Search event types / agents…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-md border border-(--border) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none focus:border-(--border-strong)"
+            />
+          </div>
+
+          {registry.isPending && !registry.data && (
+            <div className="py-2 text-[12px] text-(--text-faint)">Loading templates…</div>
+          )}
+          {registry.isError && !registry.data && (
+            <div className="py-2 text-[12px] text-(--text-faint)">
+              Cannot reach control API — templates will appear when it is up.
+            </div>
+          )}
+
+          <div
+            ref={listRef}
+            className="max-h-[380px] overflow-y-auto space-y-1 pr-1"
+            role="radiogroup"
+            aria-label="Event type templates"
+            onKeyDown={onTemplateKeyDown}
+          >
+            {initialEnvelope && (
+              <button
+                type="button"
+                {...radioA11y("__given__")}
+                onClick={() => applySelection("__given__")}
+                className={`w-full rounded-md border p-2 text-left transition-colors ${
+                  checkedId === "__given__"
+                    ? "border-(--accent) bg-(--surface-3) text-(--text)"
+                    : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
+                }`}
+              >
+                <div className="font-medium text-[12px]">this envelope</div>
+                <div className="text-[11px] text-(--text-faint) truncate">original triggering payload</div>
+              </button>
+            )}
+
+            {filteredTemplates.map((t) => (
+              <button
+                key={t.eventType}
+                type="button"
+                {...radioA11y(t.eventType)}
+                onClick={() => applySelection(t.eventType)}
+                className={`w-full rounded-md border p-2 text-left transition-colors ${
+                  checkedId === t.eventType
+                    ? "border-(--accent) bg-(--surface-3) text-(--text)"
+                    : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
+                }`}
+              >
+                <div className="mono font-medium text-[12px] truncate">{t.eventType}</div>
+                <div className="mt-0.5 flex items-center justify-between text-[11px] text-(--text-faint)">
+                  <span className="truncate">{t.agent}</span>
+                  <span className="ml-1 shrink-0 opacity-75">{t.summary || "no params"}</span>
+                </div>
+              </button>
+            ))}
+
+            {filteredTemplates.length === 0 && search && (
+              <div className="py-3 text-center text-[12px] text-(--text-faint)">
+                No templates matching &quot;{search}&quot;
+              </div>
+            )}
+
+            <button
+              type="button"
+              {...radioA11y(null)}
+              onClick={() => applySelection(null)}
+              className={`w-full rounded-md border p-2 text-left transition-colors ${
+                checkedId === null
+                  ? "border-(--accent) bg-(--surface-3) text-(--text)"
+                  : "border-(--border) text-(--text-faint) hover:bg-(--surface-2)"
+              }`}
+            >
+              <div className="font-medium text-[12px]">blank envelope</div>
+              <div className="text-[11px] text-(--text-faint)">empty starter envelope</div>
+            </button>
+          </div>
         </div>
-      )}
 
-      <div
-        ref={groupRef}
-        className="mb-3 flex flex-wrap gap-1.5"
-        role="radiogroup"
-        aria-label="Event type templates"
-        onKeyDown={onTemplateKeyDown}
-      >
-        {initialEnvelope && (
-          <button
-            type="button"
-            {...radioA11y("__given__")}
-            onClick={() => applyChip("__given__")}
-            className={`rounded-md border px-2 py-1 text-[11.5px] ${
-              checkedChip === "__given__"
-                ? "border-(--accent) bg-(--surface-3) text-(--text)"
-                : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
-            }`}
-          >
-            this envelope
-          </button>
-        )}
-        {templates.map((t) => (
-          <button
-            key={t.eventType}
-            type="button"
-            {...radioA11y(t.eventType)}
-            title={`${t.agent} · payload: ${t.summary}`}
-            onClick={() => applyChip(t.eventType)}
-            className={`rounded-md border px-2 py-1 text-left text-[11.5px] ${
-              checkedChip === t.eventType
-                ? "border-(--accent) bg-(--surface-3) text-(--text)"
-                : "border-(--border) text-(--text-dim) hover:bg-(--surface-2)"
-            }`}
-          >
-            <span className="mono">{t.eventType}</span>
-            <span className="ml-1.5 text-(--text-faint)">{t.summary}</span>
-          </button>
-        ))}
-        <button
-          type="button"
-          {...radioA11y(null)}
-          onClick={() => applyChip(null)}
-          className={`rounded-md border px-2 py-1 text-[11.5px] ${
-            checkedChip === null
-              ? "border-(--accent) bg-(--surface-3) text-(--text)"
-              : "border-(--border) text-(--text-faint) hover:bg-(--surface-2)"
-          }`}
-        >
-          blank
-        </button>
-      </div>
+        {/* Right Column: JSON Editor & Controls */}
+        <div className="md:col-span-7 flex flex-col min-h-0">
+          <div className="mb-1.5 flex items-center justify-between">
+            <div className="flex items-center gap-2 text-[11px]">
+              <span
+                className="size-1.5 rounded-full"
+                style={{ background: isValidJson ? "var(--hue-ok)" : "var(--hue-err)" }}
+              />
+              <span className="text-(--text-faint)">{isValidJson ? "Valid JSON" : "Invalid JSON syntax"}</span>
+            </div>
+            <button
+              type="button"
+              onClick={formatJson}
+              className="text-[11px] text-(--text-dim) hover:text-(--accent)"
+              title="Format JSON (⌘⇧F)"
+            >
+              Format JSON <span className="mono opacity-70">⌘⇧F</span>
+            </button>
+          </div>
 
-      <div className="mb-1.5 flex items-center justify-between">
-        <div className="flex items-center gap-2 text-[11px]">
-          <span
-            className="size-1.5 rounded-full"
-            style={{ background: isValidJson ? "var(--hue-ok)" : "var(--hue-err)" }}
+          <textarea
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              setClientError(null);
+              setUnregisteredAck(false);
+              setConfirming(false);
+            }}
+            spellCheck={false}
+            rows={15}
+            aria-label="Event envelope JSON"
+            className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] leading-relaxed text-(--text) outline-none focus:border-(--border-strong)"
           />
-          <span className="text-(--text-faint)">{isValidJson ? "Valid JSON" : "Invalid JSON syntax"}</span>
+
+          {clientError && <VerbError error={new Error(clientError)} />}
+          <VerbError error={inject.error} />
+          {outcome && (
+            <div
+              className="mt-2 rounded-md px-2.5 py-1.5 text-[12px]"
+              style={{
+                color: outcome.duplicate ? "var(--hue-warn)" : "var(--hue-ok)",
+                background: `color-mix(in oklch, ${outcome.duplicate ? "var(--hue-warn)" : "var(--hue-ok)"} 10%, transparent)`,
+              }}
+            >
+              {outcome.duplicate
+                ? `duplicate — event ${outcome.eventId} was already admitted (dedup working as designed)`
+                : `admitted event ${outcome.eventId} — the planner proposes next`}
+            </div>
+          )}
+
+          {confirming && !outcome && (
+            <div className="mt-2 text-[12px] text-(--text-dim)">
+              Confirm sends this envelope through intake. A known event id is reported as a duplicate and
+              does nothing — that is Replay&apos;s demo, not a new event. Use Trigger again for a fresh id.
+            </div>
+          )}
+
+          <div className="mt-3 flex justify-end gap-2">
+            <Button onClick={onClose}>Close</Button>
+            {confirming ? (
+              <>
+                <Button onClick={() => setConfirming(false)}>Back</Button>
+                <Button variant="primary" onClick={submit} disabled={inject.isPending} autoFocus>
+                  Confirm inject
+                </Button>
+              </>
+            ) : (
+              <Button variant="primary" onClick={submit} disabled={inject.isPending}>
+                Inject… <span className="ml-1 font-normal opacity-70">⌘↵</span>
+              </Button>
+            )}
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={formatJson}
-          className="text-[11px] text-(--text-dim) hover:text-(--accent)"
-          title="Format JSON (⌘⇧F)"
-        >
-          Format JSON <span className="mono opacity-70">⌘⇧F</span>
-        </button>
-      </div>
-
-      <textarea
-        value={text}
-        onChange={(e) => {
-          setText(e.target.value);
-          setClientError(null);
-          setUnregisteredAck(false);
-          setConfirming(false);
-        }}
-        spellCheck={false}
-        rows={14}
-        aria-label="Event envelope JSON"
-        className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-(--text) outline-none focus:border-(--border-strong)"
-      />
-
-      {clientError && <VerbError error={new Error(clientError)} />}
-      <VerbError error={inject.error} />
-      {outcome && (
-        <div
-          className="mt-2 rounded-md px-2.5 py-1.5 text-[12px]"
-          style={{
-            color: outcome.duplicate ? "var(--hue-warn)" : "var(--hue-ok)",
-            background: `color-mix(in oklch, ${outcome.duplicate ? "var(--hue-warn)" : "var(--hue-ok)"} 10%, transparent)`,
-          }}
-        >
-          {outcome.duplicate
-            ? `duplicate — event ${outcome.eventId} was already admitted (dedup working as designed)`
-            : `admitted event ${outcome.eventId} — the planner proposes next`}
-        </div>
-      )}
-
-      {confirming && !outcome && (
-        <div className="mt-2 text-[12px] text-(--text-dim)">
-          Confirm sends this envelope through intake. A known event id is reported as a duplicate and
-          does nothing — that is Replay&apos;s demo, not a new event. Use Trigger again for a fresh id.
-        </div>
-      )}
-
-      <div className="mt-3 flex justify-end gap-2">
-        <Button onClick={onClose}>Close</Button>
-        {confirming ? (
-          <>
-            <Button onClick={() => setConfirming(false)}>Back</Button>
-            <Button variant="primary" onClick={submit} disabled={inject.isPending} autoFocus>
-              Confirm inject
-            </Button>
-          </>
-        ) : (
-          <Button variant="primary" onClick={submit} disabled={inject.isPending}>
-            Inject… <span className="ml-1 font-normal opacity-70">⌘↵</span>
-          </Button>
-        )}
       </div>
     </Dialog>
   );

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -528,11 +528,13 @@ export function Dialog({
   onClose,
   children,
   wide,
+  extraWide,
 }: {
   title: string;
   onClose: () => void;
   children: ReactNode;
   wide?: boolean;
+  extraWide?: boolean;
 }) {
   const titleId = useId();
   const panelRef = useRef<HTMLDivElement>(null);
@@ -555,7 +557,7 @@ export function Dialog({
   }, [onClose]);
   return (
     <div
-      className="fixed inset-0 z-40 flex items-start justify-center bg-black/50 pt-[12vh]"
+      className="fixed inset-0 z-40 flex items-start justify-center bg-black/50 pt-[10vh]"
       onMouseDown={(e) => e.target === e.currentTarget && onClose()}
     >
       <div
@@ -564,7 +566,7 @@ export function Dialog({
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
-        className={`${wide ? "w-[720px]" : "w-[480px]"} max-h-[70vh] overflow-auto rounded-lg border border-(--border-strong) bg-(--surface-1) p-4 shadow-2xl outline-none`}
+        className={`${extraWide ? "w-[920px] max-w-[95vw]" : wide ? "w-[720px]" : "w-[480px]"} max-h-[80vh] overflow-auto rounded-lg border border-(--border-strong) bg-(--surface-1) p-4 shadow-2xl outline-none`}
       >
         <div id={titleId} className="display mb-3 text-[15px] font-semibold">
           {title}


### PR DESCRIPTION
## Summary
Refactor InjectDialog template selection from horizontal wrap chips into a scrollable two-column layout with instant search/filter sidebar on the left and full-height JSON editor on the right.

Fixes OPS-363