### PR TITLE
feat(event-runtime-web): UX bundle — spec placement, in-panel artifact previews, ambiguous open proposals anomaly

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -105,9 +105,9 @@ The landing view. Stat tiles for event counts by status (`admitted`,
 `planned`, `noop`, `human_needed`, `dead_lettered`), open/expired proposal
 counts, and runs by FSM state. Below them, the **doctor panel** — the §13
 anomalies rendered as a list, empty state included: expired open proposals,
-stale leases, unpublished outbox rows, and dead-lettered events with their
-`lastError`. A dead-letter row offers **replay** (`POST /replay` with the
-stored envelope — which requires the UI to have the envelope body; see §7).
+ambiguous open proposals, stale leases, unpublished outbox rows, and dead-lettered
+events with their `lastError`. A dead-letter row offers **replay** (`POST /replay`
+with the stored envelope — which requires the UI to have the envelope body; see §7).
 
 `GET /health` drives a connection indicator in the nav rail: green with the
 reported `policyVersion`, red "runtime unreachable" when polling fails. Every

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -648,7 +648,7 @@ lifecycle transitions with the operator as actor:
   state, lease ages, retained workspaces, dead-lettered events.
 - **cancel** — any run before `RUNNING` (§8); a running attempt gets TERM then
   KILL. In the same transaction, the unique open proposal for that run is
-  closed with reason `run_cancelled`; none, or more than one, is left
+  closed with reason `run_cancelled`; none, or more than one (`ambiguousOpenProposals`), is left
   untouched.
 - **retry** — a new attempt under a new attempt identity. Retrying past
   `maxAttempts` requires an explicit operator override and records it.
@@ -669,7 +669,8 @@ attempts) parks as dead-lettered with its last error, visible in status and
 eligible for replay after a fix. A poison event must not wedge the planner or
 silently vanish.
 
-**Doctor checks.** Expired leases not reclaimed, proposals past TTL, outbox
+**Doctor checks.** Expired leases not reclaimed, proposals past TTL, ambiguous
+open proposals (more than one open proposal referencing the same run), outbox
 rows never published, workspace directories with no corresponding run,
 journal sequence gaps, a worker holding a run whose heartbeat has gone stale
 (its lease may still be valid, so nothing has reclaimed the run yet), and

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -408,6 +408,9 @@ async function status(client) {
   if (a.staleLeases > 0) anomalyLines.push(`stale leases: ${a.staleLeases}`);
   if (a.unpublishedOutbox > 0) anomalyLines.push(`unpublished outbox rows: ${a.unpublishedOutbox}`);
   for (const d of a.deadLettered) anomalyLines.push(`dead-lettered (${d.source}, ${d.eventId}): ${d.lastError}`);
+  for (const amb of a.ambiguousOpenProposals ?? []) {
+    anomalyLines.push(`ambiguous open proposals for run ${amb.runId}: ${amb.count} open proposals exist for one run`);
+  }
   if (anomalyLines.length === 0) console.log(`${pad("anomalies", 11)}none`);
   else for (const line of anomalyLines) console.log(`${pad("anomalies", 11)}${line}`);
 }

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -29,6 +29,7 @@ export interface RunSpec {
   timeoutSeconds: number;
   maxAttempts: number;
   idempotencyKey: string;
+  placement?: Record<string, unknown> | null;
 }
 
 export interface Proposal {

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -173,6 +173,15 @@ export function Overview({
         ],
       });
     }
+    for (const amb of anomalies.ambiguousOpenProposals ?? []) {
+      anomalyRows.push({
+        text: `ambiguous open proposals: ${amb.count} open proposals exist for run ${amb.runId}`,
+        links: [
+          { label: "View run", go: () => onJumpRun(amb.runId) },
+          { label: "View proposals", go: () => onNavigate("proposals") },
+        ],
+      });
+    }
     if (anomalies.noWorkers) {
       const queued = s?.runs.byState.QUEUED ?? 0;
       anomalyRows.push({

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -574,6 +574,12 @@ export function Proposals({
                       </div>
                     </div>
                   )}
+                  <div className="col-span-2">
+                    <div className="text-[10px] text-(--text-faint) uppercase tracking-wide">Placement</div>
+                    <div className="mono text-(--text-dim) truncate">
+                      {sel.spec.placement ? JSON.stringify(sel.spec.placement) : "any worker"}
+                    </div>
+                  </div>
                 </div>
               </div>
               <Disclosure label="immutable RunSpec" defaultOpen={isOpen}>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -5,7 +5,7 @@ import { hashPath } from "../hash";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
-import type { Attempt, RunState } from "../types";
+import type { Attempt, ArtifactRef, RunState } from "../types";
 import {
   Ago,
   Button,
@@ -203,6 +203,99 @@ export function ActorRef({ actor, className }: { actor: string; className?: stri
     >
       {actor}
     </JumpLink>
+  );
+}
+
+function isTextArtifact(kind: string) {
+  const k = kind.toLowerCase();
+  return (
+    k === "transcript" ||
+    k === "diff" ||
+    k === "report" ||
+    k === "evidence" ||
+    k.endsWith(".txt") ||
+    k.endsWith(".json") ||
+    k.endsWith(".jsonl") ||
+    k.endsWith(".md") ||
+    k.endsWith(".log")
+  );
+}
+
+function ArtifactRow({ a }: { a: ArtifactRef }) {
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textFriendly = isTextArtifact(a.kind);
+
+  const togglePreview = async () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (content === null && !loading) {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(artifactUrl(a.sha256));
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const txt = await res.text();
+        setContent(txt);
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="border-b border-(--border) py-1.5 last:border-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate">
+          {a.kind}
+          <span className="mono ml-2 text-[11px] text-(--text-faint)" title={a.sha256}>
+            {a.sha256.slice(0, 12)}
+          </span>
+        </span>
+        <span className="flex shrink-0 items-baseline gap-3">
+          <span className="tabular-nums text-(--text-faint)">{humanSize(a.sizeBytes)}</span>
+          {textFriendly && (
+            <button
+              type="button"
+              onClick={togglePreview}
+              className="text-[12px] text-(--text-dim) hover:text-(--accent)"
+            >
+              {open ? "Hide" : "Preview"}
+            </button>
+          )}
+          <a
+            href={artifactUrl(a.sha256)}
+            target="_blank"
+            rel="noreferrer"
+            className="text-(--accent) hover:underline"
+          >
+            Open
+          </a>
+        </span>
+      </div>
+      {open && (
+        <div className="mt-2">
+          {loading && <div className="text-[11px] text-(--text-faint)">Loading artifact preview…</div>}
+          {error && (
+            <div className="text-[11px]" style={{ color: "var(--hue-err)" }}>
+              Failed to load preview: {error}
+            </div>
+          )}
+          {content !== null && (
+            <pre className="mono max-h-64 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap">
+              {content}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -572,6 +665,7 @@ export function Runs({
             <KV k="workspace" v={d.workspace} />
             <KV k="created" v={<Ago iso={d.run.created_at} now={now} />} />
             <KV k="updated" v={<Ago iso={d.run.updated_at} now={now} />} />
+            <KV k="placement" v={d.run.spec.placement ? JSON.stringify(d.run.spec.placement) : "any worker"} />
             <Disclosure label="immutable RunSpec" defaultOpen>
               <JsonBlock value={d.run.spec} />
             </Disclosure>
@@ -728,28 +822,7 @@ export function Runs({
               ) : (
                 <div className="rounded-md border border-(--border) px-3 py-1">
                   {(d.result.artifacts ?? []).map((a) => (
-                    <div
-                      key={a.sha256}
-                      className="flex items-baseline justify-between gap-3 border-b border-(--border) py-1.5 last:border-0"
-                    >
-                      <span className="truncate">
-                        {a.kind}
-                        <span className="mono ml-2 text-[11px] text-(--text-faint)" title={a.sha256}>
-                          {a.sha256.slice(0, 12)}
-                        </span>
-                      </span>
-                      <span className="flex shrink-0 items-baseline gap-3">
-                        <span className="tabular-nums text-(--text-faint)">{humanSize(a.sizeBytes)}</span>
-                        <a
-                          href={artifactUrl(a.sha256)}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-(--accent) hover:underline"
-                        >
-                          Open
-                        </a>
-                      </span>
-                    </div>
+                    <ArtifactRow key={a.sha256} a={a} />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary
Bundle of UI/UX improvements:
- **Spec Placement Display (OPS-269)**: Surfaced `spec.placement` requirements in Proposals SpecHighlights and Runs detail, reading 'any worker' when unconstrained.
- **In-Panel Artifact Previews (OPS-277)**: Added inline text/jsonl previewer for run artifacts (transcripts, diffs, reports) in Runs detail without leaving the view.
- **Ambiguous Open Proposals Anomaly (OPS-259)**: Surfaced ambiguous-open-proposal doctor anomaly in Overview Doctor deck, CLI status command, and documentation.
- **Header Logo (OPS-219)**: Verified Watt Mind logo in sidebar header.

Fixes OPS-269
Fixes OPS-277
Fixes OPS-259
Fixes OPS-219