### PR TITLE
feat(event-runtime-web): operator context tabs — All, repo filter, In flight (OPS-356)

### DIFF
--- a/docs/event-runtime-webui-roadmap.md
+++ b/docs/event-runtime-webui-roadmap.md
@@ -24,6 +24,7 @@ Operators can dynamically group any view by:
 
 ### 1.3 Filter Engine & Saved Views
 * **Structured Query Bar**: Dropdown chips for multi-attribute queries (e.g. `status:failed agent:factory-status-report adapter:claude created:>1h`).
+* **Context tabs (OPS-356)**: All / In flight / a factory-repo *filter* above the inverted-L. Not a container for agents; unscoped work stays in All. Pin-a-run document tabs are OPS-357.
 * **Saved Views (Bookmarks)**: Custom view tabs saved in top bar or sidebar bookmarks:
   * *"Failed Runs Today"* (`status:failed created:>24h`)
   * *"Pending Approvals"* (`status:open decision:run`)

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -658,3 +658,25 @@ wrong for *reading* — a trace deserves a page. `#/run/:id` is that page.
 - **Panel trace is now tail-only** (last 20 entries) with a "showing last 20
   of N — open full view" line: triage reads the newest activity, reading the
   whole thing is what the page is for.
+
+### 10.12 Operator context tabs (OPS-356)
+
+Linear-style strip **above** the inverted-L. A tab is a filter context, not a
+project container and not a second nav rail. Decisions: [product-decisions.md](product-decisions.md).
+
+- **All** — default, never closable. Today's UI. Unscoped work lives here.
+- **In flight** — Runs in `LEASED` or `RUNNING`, every repo. Not a fake
+  project. Selecting it lands on `#/runs`.
+- **A factory repo** — opened with `+` from `GET /repos`. Filters Events /
+  Proposals / Runs to rows whose `repos: string[]` (from spec input /
+  envelope payload: `repoPin.repo`, `repo`, `repos[]`) includes that name.
+  Empty `repos` only appear under All. Closing the tab returns to All.
+- **Agents / Workers / Graph / Inject** stay global. When a repo tab is
+  active they caption that they are not scoped to it.
+- **Hash.** View + selection stay in the path (`#/runs/:id`). Optional
+  `?project=` (`inflight` reserved) restores the active filter on refresh.
+  The open-repo set is `sessionStorage`. A pasted `#/runs/:id` without
+  `?project=` opens All. `g e` / j/k / Esc stay inside the context; `[` / `]`
+  still cycle status tabs.
+- Pinning a run as a document tab on this strip is OPS-357, not this
+  section. The Projects *view* (OPS-300) is a separate registry list.

--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -1,0 +1,42 @@
+# Product decisions
+
+Recorded so the next agent does not re-litigate them. The webui spec
+(`docs/event-runtime-webui.md`) is the view-level contract; this file is the
+cross-cutting calls that several tickets share.
+
+## Operator context tabs (OPS-356)
+
+The Linear-style strip above the inverted-L is a **filter context**, not a
+container every agent must live in, and not a replacement for the nav rail.
+
+- **All** is the default, never closable, and byte-identical to the pre-tab UI.
+  It is the home for anything that is not a `repos.yaml` project: unscoped
+  runs, registry agents, workers, the graph, inject.
+- **A factory repo tab** filters Events / Proposals / Runs (and Overview
+  lists that can be filtered honestly) to rows whose spec or envelope *names*
+  that repo. It does not remount a different app. A run's repo is optional
+  input (`repoPin.repo` / `input.repo` / `input.repos[]`), not a foreign key.
+- **In flight** is a query tab, not a fake repo: Runs in `LEASED` or
+  `RUNNING` across every repo. Landing on it shows the Runs list.
+- Project tabs **do not own agents**. The Agents rail is always the global
+  registry. Workers, Graph, and Inject stay global in every context — hiding
+  the fleet behind a repo would lie about who can claim the next run. Those
+  views caption that they are unscoped when a project filter is on.
+- Unscoped rows (`repos: []`) appear only under All (and In flight, if live).
+  There is no "Unscoped" project tab; All already is that bucket.
+- The hash still names **view + selection** (`#/runs/:id`). The strip is
+  session chrome (`sessionStorage`). Optional `?project=` on the hash keeps
+  the active filter across refresh (`inflight` is reserved). A pasted
+  `#/runs/:id` without that query opens All and selects the row.
+- `g e` / `g r` / `j`/`k` / Esc stay inside the current context. Do not steal
+  `[` / `]` (status tabs). One poller; background tabs restore a filter on
+  focus, they are not keep-alive iframes.
+- The Projects *view* (OPS-300) is a list of the registry, including janitor
+  later. Context tabs *use* `GET /repos`; they do not replace that view.
+- Pinning a specific run as a document tab on the same strip is OPS-357
+  (v2) — not this decision.
+
+## Janitor Dry + Apply (OPS-301)
+
+See that ticket. Dry is default; Apply is behind a typed confirm of the repo
+name, and only after a Dry in the same panel. Out of scope for context tabs.

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -25,6 +25,27 @@ import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
 
+/**
+ * Repo names a run or event actually names — optional spec input, not a
+ * foreign key (OPS-356). Unscoped work is `[]` and belongs only under All.
+ */
+export function repoNamesFromInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return [];
+  const names = [];
+  const add = (value) => {
+    if (typeof value === "string" && value !== "" && !names.includes(value)) names.push(value);
+  };
+  if (input.repoPin && typeof input.repoPin === "object") add(input.repoPin.repo);
+  add(input.repo);
+  if (Array.isArray(input.repos)) {
+    for (const entry of input.repos) {
+      if (typeof entry === "string") add(entry);
+      else if (entry && typeof entry === "object") add(entry.name);
+    }
+  }
+  return names;
+}
+
 /** §14 size limit: a control-plane payload has no business being megabytes. */
 const MAX_BODY_BYTES = 1024 * 1024;
 
@@ -77,6 +98,7 @@ function proposalView(row) {
     eventSource: row.event_source,
     agent: row.spec?.agent ?? null,
     spec: row.spec,
+    repos: repoNamesFromInput(row.spec?.input),
   };
 }
 
@@ -171,23 +193,27 @@ function eventsView(db, status) {
     ${status ? "WHERE e.status = ?" : ""}
     ORDER BY e.admitted_at DESC, e.rowid DESC`;
   const rows = status ? db.query(sql).all(status) : db.query(sql).all();
-  return rows.map((row) => ({
-    source: row.source,
-    eventId: row.event_id,
-    type: row.type,
-    subject: row.subject,
-    status: row.status,
-    occurredAt: row.occurred_at,
-    receivedAt: row.received_at,
-    correlationId: row.correlation_id,
-    causationId: row.causation_id,
-    planFailures: row.plan_failures,
-    lastPlanError: row.last_plan_error,
-    admittedAt: row.admitted_at,
-    proposalId: row.proposal_id ?? null,
-    runId: row.run_id ?? null,
-    envelope: JSON.parse(row.envelope_json),
-  }));
+  return rows.map((row) => {
+    const envelope = JSON.parse(row.envelope_json);
+    return {
+      source: row.source,
+      eventId: row.event_id,
+      type: row.type,
+      subject: row.subject,
+      status: row.status,
+      occurredAt: row.occurred_at,
+      receivedAt: row.received_at,
+      correlationId: row.correlation_id,
+      causationId: row.causation_id,
+      planFailures: row.plan_failures,
+      lastPlanError: row.last_plan_error,
+      admittedAt: row.admitted_at,
+      proposalId: row.proposal_id ?? null,
+      runId: row.run_id ?? null,
+      envelope,
+      repos: repoNamesFromInput(envelope.payload),
+    };
+  });
 }
 
 /**
@@ -220,6 +246,7 @@ function runsView(db, state) {
       eventSource: row.event_source ?? null,
       created_at: row.created_at,
       updated_at: row.updated_at,
+      repos: repoNamesFromInput(spec.input),
     };
   });
 }

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
-import { janitorArgv, startApi } from "./api.mjs";
+import { janitorArgv, repoNamesFromInput, startApi } from "./api.mjs";
 import { apiClient } from "./client.mjs";
 import { openDb } from "./db.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
@@ -67,6 +67,17 @@ async function makeServer({ secret = SECRET, ...opts } = {}) {
     },
   };
 }
+
+describe("repoNamesFromInput (OPS-356)", () => {
+  test("unscoped is []; repoPin / repo / repos[] (string or {name}); dedupes", () => {
+    expect(repoNamesFromInput(null)).toEqual([]);
+    expect(repoNamesFromInput({})).toEqual([]);
+    expect(repoNamesFromInput({ repoPin: { repo: "bj29" } })).toEqual(["bj29"]);
+    expect(repoNamesFromInput({ repo: "coach-wattz" })).toEqual(["coach-wattz"]);
+    expect(repoNamesFromInput({ repos: ["ok", { name: "bj29" }] })).toEqual(["ok", "bj29"]);
+    expect(repoNamesFromInput({ repo: "bj29", repoPin: { repo: "bj29" }, repos: ["bj29"] })).toEqual(["bj29"]);
+  });
+});
 
 describe("webhook intake (§14)", () => {
   let s;
@@ -149,6 +160,7 @@ describe("webhook intake (§14)", () => {
     expect(events[0].eventId).toBe("hook-1");
     expect(events[0].status).toBe("admitted");
     expect(events[0].envelope.payload).toEqual({ repos: ["ok"] });
+    expect(events[0].repos).toEqual(["ok"]);
     expect(events[0].envelope.eventId).toBe("hook-1");
     expect(events[0].proposalId).toBeNull();
     expect(events[0].runId).toBeNull();
@@ -203,6 +215,23 @@ describe("missing configured secret fails closed (§14)", () => {
   });
 });
 
+describe("list views carry repos[] (OPS-356)", () => {
+  test("GET /events exposes repos from payload; unscoped is []", async () => {
+    const s = await makeServer();
+    try {
+      await s.client.replay(envelope({ eventId: "repos-ok", payload: { repos: ["ok"] } }));
+      await s.client.replay(envelope({ eventId: "repos-pin", payload: { repoPin: { repo: "bj29", ref: "develop" } } }));
+      await s.client.replay(envelope({ eventId: "repos-none", payload: {} }));
+      const { events } = await s.client.events();
+      expect(events.find((e) => e.eventId === "repos-ok").repos).toEqual(["ok"]);
+      expect(events.find((e) => e.eventId === "repos-pin").repos).toEqual(["bj29"]);
+      expect(events.find((e) => e.eventId === "repos-none").repos).toEqual([]);
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("watched flow and operator verbs (§12, §13, §15)", () => {
   let s;
   let flowProposalId;
@@ -246,6 +275,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(prop.decision).toBe("run");
     expect(prop.expired).toBe(false);
     expect(prop.agent).toBe("factory-status-report@1");
+    expect(prop.repos).toEqual(["ok"]);
     expect(prop.spec.adapter).toBe("claude");
     expect(prop.ttl_seconds).toBe(1800);
     flowProposalId = prop.id;
@@ -276,6 +306,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     const list = await s.client.runs();
     expect(list.runs.map((r) => r.runId)).toContain(flowRunId);
     expect(list.runs[0].agent).toBe("factory-status-report@1");
+    expect(list.runs[0].repos).toEqual(["ok"]);
     expect((await s.client.runs("COMPLETED")).runs).toHaveLength(1);
     expect((await s.client.runs("QUEUED")).runs).toHaveLength(0);
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -1,7 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "./api";
-import { eventsHash, hashPath, hashSearch } from "./hash";
+import { ContextTabs } from "./components/ContextTabs";
+import {
+  CONTEXT_STORAGE_KEY,
+  contextFromProject,
+  projectFromContext,
+  readContextTabs,
+  rememberOpenRepo,
+  type OperatorContext,
+} from "./context";
+import { eventsHash, hashPath, hashProject, hashSearch, withProject } from "./hash";
 import { keyGuard, useHashRoute, useTheme, type Theme } from "./hooks";
 import type { EventFocus } from "./types";
 import { CommandPalette, useGoSequences, type PaletteAction } from "./components/CommandPalette";
@@ -39,8 +48,59 @@ const NAV = [
 const THEME_ORDER: readonly Theme[] = ["dark", "light", "contrast"];
 
 export function App() {
-  const [route, navigate] = useHashRoute();
+  const [route, navigateRaw] = useHashRoute();
   const view = route[0];
+  const project = hashProject(window.location.hash);
+  const context = contextFromProject(project);
+  const [openRepos, setOpenRepos] = useState<string[]>(() => {
+    try {
+      return readContextTabs(sessionStorage.getItem(CONTEXT_STORAGE_KEY)).openRepos;
+    } catch {
+      return [];
+    }
+  });
+  const navigate = useCallback(
+    (path: string) => navigateRaw(withProject(path, hashProject(window.location.hash))),
+    [navigateRaw],
+  );
+  const hashPathNow = () => window.location.hash.replace(/^#\/?/, "") || "overview";
+  const selectContext = (next: OperatorContext) => {
+    const nextProject = projectFromContext(next);
+    if (next.kind === "inflight" && view !== "runs") {
+      navigateRaw(withProject("runs", nextProject));
+      return;
+    }
+    navigateRaw(withProject(hashPathNow(), nextProject));
+  };
+  const openRepo = (name: string) => {
+    setOpenRepos((prev) => rememberOpenRepo(prev, name));
+    navigateRaw(withProject(hashPathNow(), name));
+  };
+  const closeRepo = (name: string) => {
+    setOpenRepos((prev) => prev.filter((n) => n !== name));
+    if (context.kind === "repo" && context.name === name) {
+      navigateRaw(withProject(hashPathNow(), null));
+    }
+  };
+
+  const reposQ = useQuery({ queryKey: ["repos"], queryFn: api.repos, refetchInterval: 30_000 });
+
+  useEffect(() => {
+    if (!project || project === "all" || project === "inflight") return;
+    setOpenRepos((prev) => rememberOpenRepo(prev, project));
+  }, [project]);
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(
+        CONTEXT_STORAGE_KEY,
+        JSON.stringify({ openRepos, active: project ?? "all" }),
+      );
+    } catch {
+      // Private mode / blocked storage: the strip still works for this load.
+    }
+  }, [openRepos, project]);
+
   const [theme, cycleTheme] = useTheme();
   const [injectOpen, setInjectOpen] = useState(false);
   const [injectSeed, setInjectSeed] = useState<Record<string, unknown> | undefined>(undefined);
@@ -123,6 +183,8 @@ export function App() {
     .reduce((sum, [, n]) => sum + (n ?? 0), 0);
   const eventAttention =
     (status.data?.events.human_needed ?? 0) + (status.data?.events.dead_lettered ?? 0);
+  const scopedNav = context.kind === "repo";
+  const scopedRunsNav = context.kind !== "all";
   const busyWorkers = status.data?.workers.busy ?? 0;
   const staleWorkers = status.data?.workers.stale ?? 0;
   // null until the first status lands: reading "no workers" off a pending
@@ -218,7 +280,17 @@ export function App() {
   ];
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen flex-col">
+      <ContextTabs
+        repos={reposQ.data?.repos ?? []}
+        reposError={reposQ.isError}
+        openRepos={openRepos}
+        active={context}
+        onSelect={selectContext}
+        onOpen={openRepo}
+        onClose={closeRepo}
+      />
+      <div className="flex min-h-0 flex-1">
       <nav className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)">
         <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
           <div className="flex items-center gap-2">
@@ -250,11 +322,11 @@ export function App() {
             // count off the tone alone fails in the contrast theme.
             const badge: { count: number; hue: string; word?: string; title?: string } =
               n.key === "proposals"
-                ? { count: openProposals, hue: "var(--accent)" }
+                ? { count: scopedNav ? 0 : openProposals, hue: "var(--accent)" }
                 : n.key === "runs"
-                  ? { count: activeRuns, hue: "var(--accent)" }
+                  ? { count: scopedRunsNav ? 0 : activeRuns, hue: "var(--accent)" }
                   : n.key === "events"
-                    ? { count: eventAttention, hue: "var(--accent)" }
+                    ? { count: scopedNav ? 0 : eventAttention, hue: "var(--accent)" }
                     : n.key === "workers"
                       ? staleWorkers > 0
                         ? {
@@ -397,6 +469,7 @@ export function App() {
           {view === "proposals" ? (
             <Proposals
               connected={connected}
+              context={context}
               onRunQueued={jumpToRun}
               focusProposalId={focusProposalId}
               onSelectProposal={(id) => navigate(hashPath("proposals", id))}
@@ -416,6 +489,7 @@ export function App() {
           ) : view === "runs" || view === "run" ? (
             <Runs
               connected={connected}
+              context={context}
               focusRunId={focusRunId}
               onSelectRun={(id) => navigate(hashPath("runs", id))}
               onOpenFull={openRunFull}
@@ -432,6 +506,7 @@ export function App() {
             />
           ) : view === "graph" ? (
             <Graph
+              context={context}
               focusNodeId={focusGraphNode}
               onSelectNode={(id) => navigate(hashPath("graph", id))}
               onJumpAgent={jumpToAgent}
@@ -439,17 +514,20 @@ export function App() {
             />
           ) : view === "agents" ? (
             <Agents
+              context={context}
               focusAgentRef={focusAgentRef}
               onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
             />
           ) : view === "workers" ? (
             <Workers
+              context={context}
               focusWorkerId={focusWorkerId}
               onSelectWorker={(id) => navigate(hashPath("workers", id))}
             />
           ) : view === "events" ? (
             <Events
               connected={connected}
+              context={context}
               focusEvent={hasEventFocus ? focusEvent : null}
               onFocusConsumed={() => setEphemeralEvent(null)}
               onSelectEvent={(source, eventId) =>
@@ -469,6 +547,7 @@ export function App() {
           ) : (
             <Overview
               connected={connected}
+              context={context}
               onJumpRun={jumpToRun}
               onJumpProposal={jumpToProposal}
               onJumpEvents={jumpToEvents}
@@ -484,6 +563,7 @@ export function App() {
           )}
         </div>
       </main>
+      </div>
 
       <CommandPalette
         actions={paletteActions}

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -79,13 +79,13 @@ export const api = {
     call<{ requeued: boolean }>("POST", "/events/requeue", { source, eventId }),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
-  // The worker registry: which processes are alive, where, and what they run.
-  workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
-  // Configured factory repositories (config/repos.yaml)
+  // Configured factory repositories (config/repos.yaml) — context tabs open from this list.
   repos: () => call<{ repos: RepoItem[] }>("GET", "/repos"),
   // Janitor worktree scan and cleanup (apply: false for dry run, apply: true for teardown)
   janitor: (name: string, apply = false) =>
     call<JanitorResult>("POST", `/repos/${encodeURIComponent(name)}/janitor`, { apply }),
+  // The worker registry: which processes are alive, where, and what they run.
+  workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
 };
 
 /** Browser URL for a stored artifact's bytes (streamed by the control API). */

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { OperatorContext } from "../context";
+import { INFLIGHT } from "../context";
+import type { RepoItem } from "../types";
+
+export function ScopeCaption({
+  context,
+  surface,
+}: {
+  context: OperatorContext;
+  surface: "fleet" | "registry" | "graph" | "overview";
+}) {
+  if (context.kind === "all") return null;
+  const text =
+    context.kind === "inflight"
+      ? surface === "overview"
+        ? "In flight scopes the Runs list — counts below are factory-wide."
+        : "In flight scopes the Runs list — this view is not."
+      : surface === "fleet"
+        ? `Fleet is not scoped to ${context.name}.`
+        : surface === "registry"
+          ? `The registry is not scoped to ${context.name}.`
+          : surface === "graph"
+            ? `The graph is not scoped to ${context.name}.`
+            : `Overview counts are factory-wide — they are not scoped to ${context.name}.`;
+  return <p className="mb-3 text-[11px] text-(--text-faint)">{text}</p>;
+}
+
+/**
+ * Linear-style context strip: All (pinned) · open repos · In flight (pinned) · +.
+ * A tab is a filter, not a container. Closing a repo tab returns to All.
+ */
+export function ContextTabs({
+  repos,
+  reposError,
+  openRepos,
+  active,
+  onSelect,
+  onOpen,
+  onClose,
+}: {
+  repos: RepoItem[];
+  reposError: boolean;
+  openRepos: string[];
+  active: OperatorContext;
+  onSelect: (ctx: OperatorContext) => void;
+  onOpen: (name: string) => void;
+  onClose: (name: string) => void;
+}) {
+  const [picker, setPicker] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const available = useMemo(
+    () => repos.filter((r) => !openRepos.includes(r.name)),
+    [repos, openRepos],
+  );
+  const activeId = active.kind === "repo" ? active.name : active.kind;
+
+  useEffect(() => {
+    if (!picker) return;
+    function onDoc(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPicker(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      setPicker(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    window.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      window.removeEventListener("keydown", onKey, true);
+    };
+  }, [picker]);
+
+  const tabClass = (id: string) =>
+    `flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+      activeId === id ? "bg-(--surface-3) text-(--text)" : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+    }`;
+
+  return (
+    <div className="flex h-9 shrink-0 items-stretch gap-0.5 border-b border-(--border) bg-(--surface-1) px-2">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active.kind === "all"}
+        className={tabClass("all")}
+        onClick={() => onSelect({ kind: "all" })}
+      >
+        All
+      </button>
+      <div
+        className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+        role="tablist"
+        aria-label="Open repo contexts"
+      >
+        {openRepos.map((name) => (
+          <div key={name} className="flex shrink-0 items-center">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active.kind === "repo" && active.name === name}
+              className={tabClass(name)}
+              onClick={() => onSelect({ kind: "repo", name })}
+            >
+              {name}
+            </button>
+            <button
+              type="button"
+              aria-label={`Close ${name}`}
+              title={`Close ${name}`}
+              className="rounded px-1 text-[11px] text-(--text-faint) hover:text-(--text)"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose(name);
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active.kind === "inflight"}
+        className={tabClass(INFLIGHT)}
+        onClick={() => onSelect({ kind: "inflight" })}
+      >
+        In flight
+      </button>
+      <div className="relative flex shrink-0 items-center" ref={pickerRef}>
+        <button
+          type="button"
+          aria-expanded={picker}
+          aria-haspopup="listbox"
+          aria-controls="repo-picker-listbox"
+          aria-label="Open a repo tab"
+          title="Open a repo"
+          className="rounded-md px-2 py-1 text-[14px] text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+          onClick={() => setPicker((open) => !open)}
+        >
+          +
+        </button>
+        {picker && (
+          <div
+            id="repo-picker-listbox"
+            role="listbox"
+            aria-label="Factory repos"
+            className="absolute top-full right-0 z-30 mt-1 max-h-72 min-w-48 overflow-auto rounded-md border border-(--border) bg-(--surface-1) py-1 shadow-lg"
+          >
+            {reposError ? (
+              <div className="px-3 py-2 text-[12px] text-(--text-faint)">Cannot reach /repos.</div>
+            ) : available.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-(--text-faint)">
+                {repos.length === 0 ? "No repos in the registry." : "All repos are open."}
+              </div>
+            ) : (
+              available.map((r) => (
+                <button
+                  key={r.name}
+                  type="button"
+                  role="option"
+                  className="block w-full px-3 py-1.5 text-left text-[12px] text-(--text) hover:bg-(--surface-2)"
+                  onClick={() => {
+                    onOpen(r.name);
+                    setPicker(false);
+                  }}
+                >
+                  {r.name}
+                  {r.team ? <span className="ml-2 text-(--text-faint)">{r.team}</span> : null}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/event-runtime/web/src/context.test.ts
+++ b/event-runtime/web/src/context.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONTEXT_STORAGE_KEY,
+  INFLIGHT,
+  contextFromProject,
+  matchesInFlight,
+  matchesRepo,
+  projectFromContext,
+  readContextTabs,
+  rememberOpenRepo,
+} from "./context";
+
+describe("contextFromProject / projectFromContext", () => {
+  test("null and all are All; inflight is reserved; anything else is a repo", () => {
+    expect(contextFromProject(null)).toEqual({ kind: "all" });
+    expect(contextFromProject("all")).toEqual({ kind: "all" });
+    expect(contextFromProject(INFLIGHT)).toEqual({ kind: "inflight" });
+    expect(contextFromProject("bj29")).toEqual({ kind: "repo", name: "bj29" });
+    expect(projectFromContext({ kind: "all" })).toBeNull();
+    expect(projectFromContext({ kind: "inflight" })).toBe(INFLIGHT);
+    expect(projectFromContext({ kind: "repo", name: "bj29" })).toBe("bj29");
+  });
+});
+
+describe("matchesRepo / matchesInFlight", () => {
+  test("All and In flight pass every row; a repo tab requires the name", () => {
+    expect(matchesRepo([], { kind: "all" })).toBe(true);
+    expect(matchesRepo([], { kind: "inflight" })).toBe(true);
+    expect(matchesRepo([], { kind: "repo", name: "bj29" })).toBe(false);
+    expect(matchesRepo(["ok", "bj29"], { kind: "repo", name: "bj29" })).toBe(true);
+    expect(matchesRepo(undefined, { kind: "repo", name: "bj29" })).toBe(false);
+  });
+
+  test("In flight is LEASED or RUNNING only", () => {
+    expect(matchesInFlight("COMPLETED", { kind: "all" })).toBe(true);
+    expect(matchesInFlight("LEASED", { kind: "inflight" })).toBe(true);
+    expect(matchesInFlight("RUNNING", { kind: "inflight" })).toBe(true);
+    expect(matchesInFlight("QUEUED", { kind: "inflight" })).toBe(false);
+    expect(matchesInFlight("LEASED", { kind: "repo", name: "bj29" })).toBe(true);
+  });
+});
+
+describe("readContextTabs", () => {
+  test("empty, invalid, and reserved names", () => {
+    expect(readContextTabs(null)).toEqual({ openRepos: [], active: "all" });
+    expect(readContextTabs("{")).toEqual({ openRepos: [], active: "all" });
+    expect(readContextTabs(JSON.stringify({ openRepos: ["bj29", "all", INFLIGHT, ""], active: "bj29" }))).toEqual({
+      openRepos: ["bj29"],
+      active: "bj29",
+    });
+    expect(readContextTabs(JSON.stringify({ openRepos: ["ok"], active: "gone" }))).toEqual({
+      openRepos: ["ok"],
+      active: "all",
+    });
+    expect(CONTEXT_STORAGE_KEY).toBe("factory.contextTabs");
+  });
+});
+
+describe("rememberOpenRepo", () => {
+  test("appends a real repo once", () => {
+    expect(rememberOpenRepo(["ok"], "bj29")).toEqual(["ok", "bj29"]);
+    expect(rememberOpenRepo(["bj29"], "bj29")).toEqual(["bj29"]);
+    expect(rememberOpenRepo([], INFLIGHT)).toEqual([]);
+    expect(rememberOpenRepo([], "all")).toEqual([]);
+  });
+});

--- a/event-runtime/web/src/context.ts
+++ b/event-runtime/web/src/context.ts
@@ -1,0 +1,66 @@
+/**
+ * Operator context tabs (OPS-356): All / a factory-repo filter / In flight.
+ * The strip is session chrome; the hash still names view + selection.
+ */
+
+export const CONTEXT_STORAGE_KEY = "factory.contextTabs";
+export const INFLIGHT = "inflight";
+
+export type OperatorContext =
+  | { kind: "all" }
+  | { kind: "inflight" }
+  | { kind: "repo"; name: string };
+
+export type ContextTabsPersisted = {
+  openRepos: string[];
+  active: string;
+};
+
+export function contextFromProject(project: string | null | undefined): OperatorContext {
+  if (!project || project === "all") return { kind: "all" };
+  if (project === INFLIGHT) return { kind: "inflight" };
+  return { kind: "repo", name: project };
+}
+
+export function projectFromContext(ctx: OperatorContext): string | null {
+  if (ctx.kind === "all") return null;
+  if (ctx.kind === "inflight") return INFLIGHT;
+  return ctx.name;
+}
+
+/** A repo tab filters to rows that name that repo. All and In flight do not. */
+export function matchesRepo(repos: string[] | undefined, ctx: OperatorContext): boolean {
+  if (ctx.kind !== "repo") return true;
+  return (repos ?? []).includes(ctx.name);
+}
+
+export function matchesInFlight(state: string, ctx: OperatorContext): boolean {
+  if (ctx.kind !== "inflight") return true;
+  return state === "LEASED" || state === "RUNNING";
+}
+
+export function readContextTabs(raw: string | null): ContextTabsPersisted {
+  if (!raw) return { openRepos: [], active: "all" };
+  try {
+    const value = JSON.parse(raw) as { openRepos?: unknown; active?: unknown };
+    const openRepos = Array.isArray(value.openRepos)
+      ? value.openRepos.filter(
+          (name): name is string =>
+            typeof name === "string" && name !== "" && name !== "all" && name !== INFLIGHT,
+        )
+      : [];
+    // Dedup while preserving order — sessionStorage can be written twice in Strict Mode.
+    const seen = new Set<string>();
+    const unique = openRepos.filter((name) => (seen.has(name) ? false : (seen.add(name), true)));
+    let active = typeof value.active === "string" ? value.active : "all";
+    if (active !== "all" && active !== INFLIGHT && !unique.includes(active)) active = "all";
+    return { openRepos: unique, active };
+  } catch {
+    return { openRepos: [], active: "all" };
+  }
+}
+
+export function rememberOpenRepo(openRepos: string[], name: string): string[] {
+  if (!name || name === "all" || name === INFLIGHT || openRepos.includes(name)) return openRepos;
+  return [...openRepos, name];
+}

--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -4,11 +4,13 @@ import {
   createHashWriter,
   eventsHash,
   hashPath,
+  hashProject,
   hashSearch,
   hashView,
   HASH_WRITE_INTERVAL_MS,
   parseHash,
   shouldReplaceHash,
+  withProject,
 } from "./hash";
 
 describe("parseHash", () => {
@@ -113,6 +115,31 @@ describe("eventsHash", () => {
     expect(eventsHash("web", "evt_1", "factory.ticket.ready")).toBe(
       "events/web/evt_1?type=factory.ticket.ready",
     );
+  });
+});
+
+describe("withProject / hashProject", () => {
+  test("adds, strips, and merges with type=", () => {
+    expect(withProject("runs", "bj29")).toBe("runs?project=bj29");
+    expect(withProject("runs", "inflight")).toBe("runs?project=inflight");
+    expect(withProject("runs?project=bj29", null)).toBe("runs");
+    expect(withProject("events?type=factory.ticket.ready", "bj29")).toBe(
+      "events?type=factory.ticket.ready&project=bj29",
+    );
+    expect(withProject("events?type=x&project=bj29", null)).toBe("events?type=x");
+    expect(withProject("runs/run_01", undefined)).toBe("runs/run_01");
+  });
+
+  test("hashProject reads the context filter off the hash", () => {
+    expect(hashProject("#/runs")).toBeNull();
+    expect(hashProject("#/runs?project=bj29")).toBe("bj29");
+    expect(hashProject("#/events?type=x&project=inflight")).toBe("inflight");
+  });
+
+  test("same-view project query still replaces", () => {
+    expect(shouldReplaceHash("#/runs", "runs?project=bj29")).toBe(true);
+    expect(shouldReplaceHash("#/runs?project=bj29", "runs")).toBe(true);
+    expect(shouldReplaceHash("#/events?project=bj29", "runs?project=bj29")).toBe(false);
   });
 });
 

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -7,6 +7,10 @@
  * full-page run view — distinct first segment so expand/back get push
  * semantics) `#/agents` `#/agents/:ref` `#/workers` `#/workers/:id`
  * `#/graph` `#/graph/:nodeId`
+ *
+ * Optional `?project=` (OPS-356) restores the context-tab filter; `inflight`
+ * is reserved. The path still names the view. A pasted `#/runs/:id` without
+ * that query opens All.
  */
 
 function pathAndQuery(hash: string): { path: string; query: string } {
@@ -163,4 +167,23 @@ export function eventsHash(
 ): string {
   const path = hashPath("events", source, eventId);
   return type ? `${path}?type=${encodeURIComponent(type)}` : path;
+}
+
+/** `?project=` on the hash — the context strip's active filter, not the view. */
+export function hashProject(hash: string): string | null {
+  return hashSearch(hash).get("project");
+}
+
+/**
+ * Set or clear `project` on a hash path, preserving other query keys (`type=`).
+ * `project` null/empty strips it so All has no query of its own.
+ */
+export function withProject(path: string, project: string | null | undefined): string {
+  const i = path.indexOf("?");
+  const pathname = i >= 0 ? path.slice(0, i) : path;
+  const query = new URLSearchParams(i >= 0 ? path.slice(i + 1) : "");
+  if (project) query.set("project", project);
+  else query.delete("project");
+  const qs = query.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
 }

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -47,6 +47,8 @@ export interface Proposal {
   eventSource: string | null;
   agent: string | null;
   spec: RunSpec | null;
+  /** Repos the spec input names. Empty if unscoped. */
+  repos: string[];
 }
 
 export interface AdmittedEvent {
@@ -64,6 +66,8 @@ export interface AdmittedEvent {
   proposalId: string | null;
   runId: string | null;
   envelope: Record<string, unknown>;
+  /** Repos this envelope names (`repoPin.repo` / `repo` / `repos[]`). Empty if unscoped. */
+  repos: string[];
 }
 
 export interface RunListItem {
@@ -78,6 +82,8 @@ export interface RunListItem {
   eventSource: string | null;
   created_at: string;
   updated_at: string;
+  /** Repos the spec input names. Empty if unscoped. */
+  repos: string[];
 }
 
 /** One append-only journal row (GET /journal) — the runtime's activity feed. */

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
 import { useListKeys } from "../hooks";
 import type { AgentDef } from "../types";
+import type { OperatorContext } from "../context";
 import { Button, DetailPane, Disclosure, FilterInput, JsonBlock, KV, ListEmpty, ListPane, Section, copyText, copyLink } from "../components/ui";
+import { ScopeCaption } from "../components/ContextTabs";
 import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
 
@@ -24,9 +26,11 @@ const eventsTypeHref = (type: string) => `#/${eventsHash(null, null, type)}`;
  * the registry has no mutation surface, by design.
  */
 export function Agents({
+  context,
   focusAgentRef,
   onSelectAgent,
 }: {
+  context: OperatorContext;
   focusAgentRef: string | null;
   onSelectAgent: (ref: string | null) => void;
 }) {
@@ -87,6 +91,7 @@ export function Agents({
         chrome={
           <>
         <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
+        <ScopeCaption context={context} surface="registry" />
         <div className="mb-3">
           <FilterInput
             value={filter}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -4,7 +4,10 @@ import { api } from "../api";
 import { retriggerEnvelope } from "../templates";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
+import { ScopeCaption } from "../components/ContextTabs";
 import type { AdmittedEvent, EventFocus } from "../types";
+import type { OperatorContext } from "../context";
+import { matchesRepo } from "../context";
 import {
   Ago,
   Button,
@@ -61,6 +64,7 @@ function rowWash(status: string): string {
  */
 export function Events({
   connected,
+  context,
   focusEvent,
   onFocusConsumed,
   onSelectEvent,
@@ -71,6 +75,7 @@ export function Events({
   onInject,
 }: {
   connected: boolean;
+  context: OperatorContext;
   focusEvent: EventFocus | null;
   onFocusConsumed: () => void;
   onSelectEvent: (source: string | null, eventId?: string) => void;
@@ -96,20 +101,27 @@ export function Events({
     };
   }, []);
 
+  const fetchAll = context.kind === "repo";
   const list = useQuery({
-    queryKey: ["events", tab],
-    queryFn: () => api.events(tab === "all" ? undefined : tab),
+    queryKey: ["events", fetchAll ? "all" : tab],
+    queryFn: () => api.events(fetchAll || tab === "all" ? undefined : tab),
     refetchInterval: 2000,
   });
   const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
   const rows = list.data?.events ?? [];
+  const scoped = useMemo(() => {
+    const focusKey =
+      focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
+    return rows.filter((e) => keyOf(e) === focusKey || matchesRepo(e.repos, context));
+  }, [rows, context, focusEvent?.source, focusEvent?.eventId]);
 
-  const types = useMemo(() => [...new Set(rows.map((e) => e.type))].sort(), [rows]);
-  const sources = useMemo(() => [...new Set(rows.map((e) => e.source))].sort(), [rows]);
+  const types = useMemo(() => [...new Set(scoped.map((e) => e.type))].sort(), [scoped]);
+  const sources = useMemo(() => [...new Set(scoped.map((e) => e.source))].sort(), [scoped]);
 
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    return rows.filter((e) => {
+    return scoped.filter((e) => {
+      if (fetchAll && tab !== "all" && e.status !== tab) return false;
       if (typeFilter && e.type !== typeFilter) return false;
       if (sourceFilter && e.source !== sourceFilter) return false;
       if (!q) return true;
@@ -120,7 +132,7 @@ export function Events({
         (e.subject ?? "").toLowerCase().includes(q)
       );
     });
-  }, [rows, filter, typeFilter, sourceFilter]);
+  }, [scoped, filter, typeFilter, sourceFilter, fetchAll, tab]);
 
   const selectedKey =
     focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
@@ -271,7 +283,14 @@ export function Events({
 
   const eventCounts = statusQ.data?.events ?? {};
   const allCount = Object.values(eventCounts).reduce((n, v) => n + v, 0);
-  const tabCount = (t: StatusTab) => (t === "all" ? allCount : (eventCounts[t] ?? 0));
+  const tabCount = (t: StatusTab) =>
+    fetchAll
+      ? t === "all"
+        ? scoped.length
+        : scoped.filter((e) => e.status === t).length
+      : t === "all"
+        ? allCount
+        : (eventCounts[t] ?? 0);
 
   return (
     <div className="flex h-full min-w-0">
@@ -279,6 +298,7 @@ export function Events({
         chrome={
           <>
         <h1 className="display mb-4 text-lg font-semibold">Events</h1>
+        {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
 
         <div className="mb-3 flex flex-wrap gap-1" role="tablist" aria-label="Event status">
           {STATUS_TABS.map((t) => {
@@ -403,10 +423,12 @@ export function Events({
               <ListEmpty
                 colSpan={6}
                 query={list}
-                filtered={rows.length > 0}
+                filtered={scoped.length > 0}
                 noun="events"
                 empty={
-                  tab === "all"
+                  context.kind === "repo"
+                    ? `No events naming ${context.name}.`
+                    : tab === "all"
                     ? "No events yet."
                     : `No ${TAB_LABEL[tab].toLowerCase()} events.`
                 }

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -14,7 +14,9 @@ import { keyGuard } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
 import type { EventFocus } from "../types";
+import type { OperatorContext } from "../context";
 import { Button, DetailPane, JsonBlock, JumpLink, KV, Section, copyText, copyLink } from "../components/ui";
+import { ScopeCaption } from "../components/ContextTabs";
 
 /**
  * Graph (webui roadmap / OPS-224 phase 1, chrome OPS-230): the capability map
@@ -23,11 +25,13 @@ import { Button, DetailPane, JsonBlock, JumpLink, KV, Section, copyText, copyLin
  * honest empty when /agents is down. Phase 2 overlays live run state.
  */
 export function Graph({
+  context,
   focusNodeId,
   onSelectNode,
   onJumpAgent,
   onJumpEvents,
 }: {
+  context: OperatorContext;
   focusNodeId: string | null;
   onSelectNode: (id: string | null) => void;
   onJumpAgent: (ref: string) => void;
@@ -182,6 +186,7 @@ export function Graph({
           <div className="text-[11px] text-(--text-faint)">
             what this runtime can do — registered routes and recommendation edges
           </div>
+          <ScopeCaption context={context} surface="graph" />
         </div>
         {positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -4,6 +4,8 @@ import { api } from "../api";
 import { hashPath } from "../hash";
 import { useNow } from "../hooks";
 import type { JournalEntry, EventFocus, RunState } from "../types";
+import type { OperatorContext } from "../context";
+import { ScopeCaption } from "../components/ContextTabs";
 import {
   Ago,
   Button,
@@ -60,6 +62,7 @@ function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isErro
  */
 export function Overview({
   connected,
+  context,
   onJumpRun,
   onJumpProposal,
   onJumpEvents,
@@ -70,6 +73,7 @@ export function Overview({
   onInject,
 }: {
   connected: boolean;
+  context: OperatorContext;
   onJumpRun: (runId: string) => void;
   onJumpProposal: (id: string) => void;
   onJumpEvents: (focus: EventFocus) => void;
@@ -212,6 +216,7 @@ export function Overview({
           </button>
         </div>
       </div>
+      <ScopeCaption context={context} surface="overview" />
 
       {/* Promoted Doctor Deck when anomalies exist */}
       {hasAnomalies && (

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -4,6 +4,9 @@ import { api } from "../api";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
 import type { Proposal } from "../types";
+import type { OperatorContext } from "../context";
+import { matchesRepo } from "../context";
+import { ScopeCaption } from "../components/ContextTabs";
 import { SpecDiff } from "../components/SpecDiff";
 import {
   Ago,
@@ -39,6 +42,7 @@ const PROPOSAL_TABS = ["open", "history"] as const;
  */
 export function Proposals({
   connected,
+  context,
   onRunQueued,
   focusProposalId,
   onSelectProposal,
@@ -48,6 +52,7 @@ export function Proposals({
   onJumpEvent,
 }: {
   connected: boolean;
+  context: OperatorContext;
   onRunQueued: (runId: string) => void;
   focusProposalId: string | null;
   onSelectProposal: (id: string | null) => void;
@@ -75,6 +80,10 @@ export function Proposals({
         ? (query.data?.proposals ?? [])
         : (history.data?.proposals ?? []).filter((p) => p.status !== "open"),
     [tab, query.data, history.data],
+  );
+  const scoped = useMemo(
+    () => rows.filter((p) => p.id === focusProposalId || matchesRepo(p.repos, context)),
+    [rows, context, focusProposalId],
   );
 
   // Origin event type, resolved from the shared events cache (cheap: same
@@ -115,24 +124,28 @@ export function Proposals({
   // The expired chip only exists on Open; History rows have no live TTL. Derive
   // the gate once so the row filter and the empty copy can never disagree.
   const expiredFilter = expiredOnly && tab === "open";
+  const expiredCount =
+    context.kind === "repo"
+      ? scoped.filter((p) => p.expired).length
+      : (statusQ.data?.proposals.expired ?? 0);
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    return rows.filter((p) => {
+    return scoped.filter((p) => {
       if (expiredFilter && !p.expired) return false;
       if (!q) return true;
       return [p.id, p.agent, p.decision, p.status, p.eventId, p.reason].some((v) =>
         (v ?? "").toLowerCase().includes(q),
       );
     });
-  }, [rows, filter, expiredFilter]);
+  }, [scoped, filter, expiredFilter]);
 
   // What the list would show without the text filter. An empty list under the
   // expired chip has two causes and needs two messages: no expired opens exist
   // (chip copy, nothing for Esc to clear) or the text filter hid the expired
   // ones (filter copy + the Esc hint).
   const unfilteredCount = useMemo(
-    () => (expiredFilter ? rows.filter((p) => p.expired).length : rows.length),
-    [rows, expiredFilter],
+    () => (expiredFilter ? scoped.filter((p) => p.expired).length : scoped.length),
+    [scoped, expiredFilter],
   );
 
   // Esc clears the text filter and the expired chip together, so the hint is
@@ -292,14 +305,19 @@ export function Proposals({
         chrome={
           <>
         <h1 className="display mb-4 text-lg font-semibold">Proposals</h1>
+        {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <div className="flex gap-1" role="tablist" aria-label="Proposal status">
             {PROPOSAL_TABS.map((t) => {
               const count =
                 t === "open"
-                  ? (statusQ.data?.proposals.open ?? 0)
-                  : (history.data?.proposals.filter((p) => p.status !== "open").length ?? 0);
+                  ? context.kind === "repo"
+                    ? (query.data?.proposals ?? []).filter((p) => matchesRepo(p.repos, context)).length
+                    : (statusQ.data?.proposals.open ?? 0)
+                  : (history.data?.proposals ?? []).filter(
+                      (p) => p.status !== "open" && matchesRepo(p.repos, context),
+                    ).length;
               return (
                 <button
                   key={t}
@@ -335,9 +353,9 @@ export function Proposals({
               }`}
             >
               expired
-              {(statusQ.data?.proposals.expired ?? 0) > 0 && (
+              {expiredCount > 0 && (
                 <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                  {statusQ.data?.proposals.expired}
+                  {expiredCount}
                 </span>
               )}
             </button>
@@ -445,9 +463,11 @@ export function Proposals({
                 empty={
                   expiredFilter
                     ? "No expired open proposals."
-                    : tab === "open"
-                      ? "No open proposals — the operator's work is done, for now."
-                      : "No decided proposals yet."
+                    : context.kind === "repo"
+                      ? `No proposals naming ${context.name}.`
+                      : tab === "open"
+                        ? "No open proposals — the operator's work is done, for now."
+                        : "No decided proposals yet."
                 }
                 action={
                   escClearsFilter ? <span className="text-[11px]">Esc clears the filter</span> : undefined

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -5,6 +5,8 @@ import { hashPath } from "../hash";
 import { useListKeys, useNow, useTabKeys } from "../hooks";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
+import type { OperatorContext } from "../context";
+import { matchesInFlight, matchesRepo } from "../context";
 import type { Attempt, ArtifactRef, RunState } from "../types";
 import {
   Ago,
@@ -302,6 +304,7 @@ function ArtifactRow({ a }: { a: ArtifactRef }) {
 /** Runs (webui spec §4.3): state tabs, lifecycle timeline, guarded verbs. */
 export function Runs({
   connected,
+  context,
   focusRunId,
   onSelectRun,
   onOpenFull,
@@ -311,6 +314,7 @@ export function Runs({
   onJumpEvent,
 }: {
   connected: boolean;
+  context: OperatorContext;
   focusRunId: string | null;
   onSelectRun: (runId: string | null) => void;
   onOpenFull: (runId: string) => void;
@@ -326,22 +330,38 @@ export function Runs({
   const [confirm, setConfirm] = useState<"cancel" | "force-retry" | null>(null);
   const [cancelReason, setCancelReason] = useState("");
 
+  // A project / In-flight filter is client-side; fetching only the active
+  // status tab would make every other tab's badge a factory-wide lie.
+  const fetchAll = context.kind !== "all";
   const list = useQuery({
-    queryKey: ["runs", tab],
-    queryFn: () => api.runs(tab === "ALL" ? undefined : tab),
+    queryKey: ["runs", fetchAll ? "ALL" : tab],
+    queryFn: () => api.runs(fetchAll || tab === "ALL" ? undefined : tab),
     refetchInterval: 2000,
   });
   const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
   const rows = list.data?.runs ?? [];
+  const scoped = useMemo(
+    () =>
+      rows.filter(
+        (r) =>
+          r.runId === focusRunId ||
+          (matchesRepo(r.repos, context) && matchesInFlight(r.state, context)),
+      ),
+    [rows, context, focusRunId],
+  );
+  const byTab = useMemo(
+    () => (!fetchAll || tab === "ALL" ? scoped : scoped.filter((r) => r.state === tab)),
+    [fetchAll, scoped, tab],
+  );
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((r) =>
+    if (!q) return byTab;
+    return byTab.filter((r) =>
       [r.runId, r.state, r.agent, r.adapter, r.reasonCode, r.eventId].some((v) =>
         (v ?? "").toLowerCase().includes(q),
       ),
     );
-  }, [rows, filter]);
+  }, [byTab, filter]);
 
   const selectedId = focusRunId;
   const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
@@ -373,6 +393,12 @@ export function Runs({
       onFocusStateConsumed();
     }
   }, [focusState, onFocusStateConsumed]);
+
+  // In flight is LEASED+RUNNING; a COMPLETED (etc.) status tab would be empty.
+  useEffect(() => {
+    if (context.kind !== "inflight") return;
+    setTab((t) => (t === "LEASED" || t === "RUNNING" || t === "ALL" ? t : "ALL"));
+  }, [context.kind]);
 
   const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
 
@@ -493,8 +519,11 @@ export function Runs({
           <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto" role="tablist" aria-label="Run state">
             {STATE_TABS.map((t) => {
               const byState = statusQ.data?.runs.byState ?? {};
-              const count =
-                t === "ALL"
+              const count = fetchAll
+                ? t === "ALL"
+                  ? scoped.length
+                  : scoped.filter((r) => r.state === t).length
+                : t === "ALL"
                   ? Object.values(byState).reduce((n, v) => n + (v ?? 0), 0)
                   : (byState[t] ?? 0);
               return (
@@ -583,9 +612,17 @@ export function Runs({
               <ListEmpty
                 colSpan={8}
                 query={list}
-                filtered={rows.length > 0}
+                filtered={scoped.length > 0}
                 noun="runs"
-                empty={tab === "ALL" ? "No runs." : `No runs in ${tab}.`}
+                empty={
+                  context.kind === "inflight"
+                    ? "No runs in flight."
+                    : context.kind === "repo"
+                      ? `No runs naming ${context.name}.`
+                      : tab === "ALL"
+                        ? "No runs."
+                        : `No runs in ${tab}.`
+                }
               />
             )}
           </tbody>

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -4,6 +4,8 @@ import { api } from "../api";
 import { useListKeys, useNow } from "../hooks";
 import { setContextActions } from "../palette";
 import type { Worker } from "../types";
+import type { OperatorContext } from "../context";
+import { ScopeCaption } from "../components/ContextTabs";
 import {
   Ago,
   Button,
@@ -177,9 +179,11 @@ const openRun = (runId: string) => {
  * `busy` and still holds a run, and that gap is the whole point of the column.
  */
 export function Workers({
+  context,
   focusWorkerId,
   onSelectWorker,
 }: {
+  context: OperatorContext;
   focusWorkerId: string | null;
   onSelectWorker: (id: string | null) => void;
 }) {
@@ -250,6 +254,7 @@ export function Workers({
         chrome={
           <>
             <h1 className="display mb-4 text-lg font-semibold">Workers</h1>
+            <ScopeCaption context={context} surface="fleet" />
             <div className="mb-3">
               <FilterInput
                 value={filter}


### PR DESCRIPTION
## Summary
- Linear-style context strip above the inverted-L: **All** (home for unscoped work), **factory-repo tabs** (filter Events / Proposals / Runs by `repos: string[]`), and **In flight** (`LEASED`|`RUNNING` across every repo).
- List APIs now expose `repos` extracted from spec input / envelope payload (`repoPin.repo`, `repo`, `repos[]`). Hash still names view + selection; `?project=` + `sessionStorage` keep the strip. Agents / Workers / Graph stay global with a caption when a project filter is on.
- Pin-a-run document tabs are [OPS-357](https://linear.app/watt-mind/issue/OPS-357) (v2, not this PR). Demo seed still uses fake repo names — [OPS-366](https://linear.app/watt-mind/issue/OPS-366).

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build`
- [ ] Open All / a repo from `+` / In flight; confirm Events/Proposals/Runs filter and Agents/Workers/Graph stay unfiltered with a caption
- [ ] Paste `#/runs/:id` without `?project=` — opens All and selects the row; `[` `]` still cycle status tabs
- [ ] Close a repo tab — returns to All; refresh with `?project=` keeps the filter

Fixes OPS-356