### PR TITLE
feat(event-runtime): artifact inputs + CI log-capture chain (OPS-372)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -374,7 +374,7 @@ Every run has an execution directory. It does not necessarily have source code.
 | Workspace type | Use | MVP |
 | :--- | :--- | :---: |
 | `ephemeral` | Empty directory populated only with declared inputs | yes |
-| `artifacts` | New directory materialized from prior accepted artifacts | later |
+| `artifacts` | Declared prior artifacts materialized by content hash, read-only (OPS-372) | yes |
 | `repository` | Read-only checkout pinned to a SHA, from a per-repo bare mirror (tier 1, OPS-228); full worktrees for repo-mutating work are tier 2 and held | tier 1 |
 | `mounted` | Explicit existing directory, normally read-only | later |
 | `container` | Isolated filesystem/volume in Docker or Kubernetes | later |

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -57,6 +57,38 @@ Dev loop: `cd event-runtime/web && bunx vite` (proxies /api to the control
 API). Keyboard-first: `⌘K` palette, `g o/p/r` to navigate, `j/k` + `Enter` on
 lists, `a`/`x` to approve/reject the selected proposal.
 
+## Artifact inputs (OPS-372)
+
+Agents consume prior runs' artifacts **declared and materialized, never
+pulled**: a spec names artifacts by content hash (resolved at plan time, so
+they land in `inputHash` and the receipt), and the `artifacts` workspace
+provider writes those bytes into the workspace before the agent starts. There
+is deliberately no "browse the store" API — that would make `inputHash` a lie
+about what a run read and hand agents ambient access to everything ever
+produced.
+
+```jsonc
+"workspace": { "type": "artifacts", "inputs": [{ "from": "$.input.logArtifact", "as": "failed.log" }] }
+```
+
+A chain passes the **hash**, not the bytes: `$.artifactHash.<kind>` in an edge
+resolves against the upstream result's stored artifacts. Producers declare
+them the usual way; a command-adapter definition can set `captureStdout` to
+keep a command's whole output (a CI log is useless truncated to the 2000-char
+tail the evidence field keeps).
+
+Retention: artifacts referenced by an accepted result are never deleted;
+unreferenced ones are pruned after a week by the serve loop, and store
+size/orphan counts appear in `status`. A run's materialized inputs are capped
+(64 MB) so one agent cannot fill the disk another agent then gets called to
+clean up.
+
+First chain: `github.workflow-run.failed` → `ci-log-capture@1` (stores the
+failed-job log) → `ci-doctor@2` reads `./failed.log` instead of calling
+GitHub — the diagnosis is reproducible against exactly those bytes, and a
+multi-megabyte log lives in the store rather than blowing the inline-evidence
+limit.
+
 ## Discovered chains (OPS-223)
 
 Agents never spawn agents: a completed run whose artifact carries a typed
@@ -180,6 +212,7 @@ spec (§12).
 | `lib/worker.mjs` | single worker: lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
+| `lib/artifacts.mjs` | content-addressed store: collect, serve, materialize declared inputs, retention (OPS-372) |
 | `lib/workers.mjs` | worker registry, heartbeats, placement predicate (OPS-233) |
 | `lib/repos.mjs` `lib/repository.mjs` | repos.yaml reader; mirror + pinned read-only checkout (OPS-228) |
 | `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |

--- a/event-runtime/agents/ci-doctor.json
+++ b/event-runtime/agents/ci-doctor.json
@@ -1,12 +1,18 @@
 {
   "id": "ci-doctor",
-  "version": 1,
+  "version": 2,
   "prompt": "agents/ci-doctor.md",
   "input_schema": "schemas/ci-doctor.input.json",
   "output_schema": "schemas/ci-doctor.output.json",
   "output_contract": "factory.ci-doctor/v1",
   "workspace": {
-    "type": "ephemeral",
+    "type": "artifacts",
+    "inputs": [
+      {
+        "from": "$.input.logArtifact",
+        "as": "failed.log"
+      }
+    ],
     "retainOnFailure": true
   },
   "capabilities": {
@@ -21,8 +27,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/ci-doctor.md": "sha256:08ac4640a8a3c51b13731e23398f21cd448d326b03746d7b6ec570835d519469",
-    "schemas/ci-doctor.input.json": "sha256:c2b79435ab29e8a0f08e262b4ae2d5bac86ae335c86b9fd4e8c210b037319113",
+    "agents/ci-doctor.md": "sha256:e963bd86229798813c627f6381c4fbafdc846c83f708f2b3f5641325d072cbaf",
+    "schemas/ci-doctor.input.json": "sha256:5a3e2c3e0150f0af150af54cd7b3fed002ec5aacc5b42534973d1aa5200d66d5",
     "schemas/ci-doctor.output.json": "sha256:fa0d9eefc2ed4f68b97d5d7b9ec91f36a233bff945bba71b3d9e6e8343167680"
   }
 }

--- a/event-runtime/agents/ci-doctor.md
+++ b/event-runtime/agents/ci-doctor.md
@@ -1,18 +1,19 @@
 # ci-doctor — diagnose one failed GitHub Actions run
 
 You are a CI diagnostician. `./input.json` names one failed GitHub Actions
-run: `{ "repo": "<owner>/<name>", "runId": <id> }`. Diagnose it and write
+run, and **`./failed.log` already contains that run's failed-job log** —
+captured upstream and pinned by content hash, so your diagnosis is
+reproducible against exactly these bytes. Diagnose it and write
 `./result.json`. You are read-only: you never re-run workflows, never push,
 never edit anything. Work only inside this directory.
 
 ## Method
 
-1. `gh run view <runId> --repo <repo>` — identify the failed job(s).
-2. `gh run view <runId> --repo <repo> --log-failed` — find the first real
-   error (not the cascade after it). Quote the smallest set of log lines that
-   prove the diagnosis.
-3. `gh run list --repo <repo> --limit 10 --json conclusion,headSha` — check
-   history: is this failure novel, repeated, or intermittent?
+1. Read `./failed.log`. Find the **first real error**, not the cascade after
+   it. Quote the smallest set of lines that prove the diagnosis.
+2. Only if the log alone is inconclusive, check history:
+   `gh run list --repo <repo> --limit 10 --json conclusion,headSha` — is this
+   failure novel, repeated, or intermittent?
 
 ## Verdict — exactly one
 

--- a/event-runtime/agents/ci-log-capture.json
+++ b/event-runtime/agents/ci-log-capture.json
@@ -1,0 +1,39 @@
+{
+  "id": "ci-log-capture",
+  "version": 1,
+  "prompt": "agents/ci-log-capture.md",
+  "input_schema": "schemas/ci-log-capture.input.json",
+  "output_schema": "schemas/ci-log-captured.output.json",
+  "output_contract": "factory.ci-log/v1",
+  "command": [
+    "gh",
+    "run",
+    "view",
+    "{runId}",
+    "--repo",
+    "{repo}",
+    "--log-failed"
+  ],
+  "captureStdout": "failed.log",
+  "captureKind": "ci-log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 300,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/ci-log-capture.md": "sha256:64e2d368336668dd308376e36cdfd65566171aff3c224282b6c06e6109a3d47a",
+    "schemas/ci-log-capture.input.json": "sha256:ddb6786a6a73a289acbcdf1a76cba48e3e54e33f1bd1212dbb929fd4f6540295",
+    "schemas/ci-log-captured.output.json": "sha256:1f30f70e69a51187565111af202c90d54067dbd38b931459592433c51551788b"
+  }
+}

--- a/event-runtime/agents/ci-log-capture.md
+++ b/event-runtime/agents/ci-log-capture.md
@@ -1,0 +1,14 @@
+# ci-log-capture — closed-registry action
+
+Not a prompt: this definition runs a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+gh run view {runId} --repo {repo} --log-failed
+```
+
+The **whole** stream is captured to `failed.log` and declared as an artifact,
+so the worker stores it content-addressed. Downstream `ci-doctor@2` reads
+those exact bytes instead of calling GitHub again: the diagnosis becomes
+reproducible and re-runnable offline, and a multi-megabyte log lives in the
+artifact store rather than blowing the inline-evidence limit.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -26,6 +26,7 @@ import {
 } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { newWorkerId } from "./lib/ids.mjs";
+import { pruneArtifacts } from "./lib/artifacts.mjs";
 import { publishOutbox } from "./lib/outbox.mjs";
 import { resolveChains } from "./lib/chain.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
@@ -178,6 +179,7 @@ async function serve(args) {
   // all-in-one behaviour for a quick single-process demo.
   const withWorker = args.includes("--with-worker");
 
+  let lastPrune = Date.now();
   let busy = false;
   async function tick() {
     if (busy) return; // never overlap: planning and (optional) execution share this tick
@@ -202,6 +204,14 @@ async function serve(args) {
       // Discovered chains (OPS-223): a completed run with a registered
       // recommendation edge emits an internal event through the same intake;
       // the next planning pass proposes the follow-up, watched like anything.
+      // Artifact GC (OPS-372): unreferenced bytes older than the window go;
+      // anything an accepted result points at is never touched, because a
+      // receipt aiming at a deleted file turns the audit trail into a lie.
+      if (Date.now() - lastPrune > 60 * 60 * 1000) {
+        lastPrune = Date.now();
+        const pruned = pruneArtifacts(db, artifactsRoot(), { now: Date.now() });
+        if (pruned.deleted > 0) log(`artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`);
+      }
       const chains = resolveChains(db, registry, { now: Date.now() });
       if (chains.emitted > 0) log(`chain: emitted ${chains.emitted} follow-up event(s) — planning`);
       for (const err of chains.errors) log(`chain error: ${err}`);

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -1,5 +1,43 @@
 {
-  "ci-doctor@1": {
+  "disk-diagnose@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "REMEDIATE": {
+        "eventType": "keephq.disk-remediate.requested",
+        "input": {
+          "host": "$.input.host",
+          "mount": "$.artifact.mount",
+          "actions": "$.artifact.plan"
+        }
+      }
+    }
+  },
+  "triage-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "TRIAGE": {
+        "eventType": "factory.triage-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "plan": "$.artifact.plan"
+        }
+      }
+    }
+  },
+  "ci-log-capture@1": {
+    "recommendationField": "exitCode",
+    "edges": {
+      "0": {
+        "eventType": "factory.ci-diagnose.requested",
+        "input": {
+          "repo": "$.input.repo",
+          "runId": "$.input.runId",
+          "logArtifact": "$.artifactHash.ci-log"
+        }
+      }
+    }
+  },
+  "ci-doctor@2": {
     "recommendationField": "verdict",
     "edges": {
       "FLAKE": {
@@ -22,31 +60,6 @@
           "repo": "$.input.repo",
           "runId": "$.input.runId",
           "summary": "$.artifact.summary"
-        }
-      }
-    }
-  },
-  "disk-diagnose@1": {
-    "recommendationField": "recommendation",
-    "edges": {
-      "REMEDIATE": {
-        "eventType": "keephq.disk-remediate.requested",
-        "input": {
-          "host": "$.input.host",
-          "mount": "$.artifact.mount",
-          "actions": "$.artifact.plan"
-        }
-      }
-    }
-  },
-  "triage-scan@1": {
-    "recommendationField": "recommendation",
-    "edges": {
-      "TRIAGE": {
-        "eventType": "factory.triage-apply.requested",
-        "input": {
-          "repo": "$.artifact.repo",
-          "plan": "$.artifact.plan"
         }
       }
     }

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -9,8 +9,8 @@
     "proposalTtlSeconds": 1800
   },
   "github.workflow-run.failed": {
-    "agent": "ci-doctor@1",
-    "adapter": "claude",
+    "agent": "ci-log-capture@1",
+    "adapter": "command",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -76,6 +76,14 @@
   "factory.janitor-apply.requested": {
     "agent": "janitor-apply@1",
     "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.ci-diagnose.requested": {
+    "agent": "ci-doctor@2",
+    "adapter": "claude",
     "idempotencyScope": [
       "inputHash"
     ],

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -13,7 +13,7 @@
  * the worker records FAILED with `agent_exit_<code>` as usual.
  */
 import { spawn } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const KILL_GRACE_MS = 10_000;
@@ -55,6 +55,14 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
     const collect = (chunk) => {
       output = (output + chunk.toString()).slice(-OUTPUT_TAIL_CHARS);
     };
+    // `captureStdout` keeps the WHOLE stream as a declared artifact (OPS-372).
+    // The tail above is a preview for the artifact body; a CI log truncated to
+    // 2000 chars is useless to a downstream agent, which is the entire reason
+    // artifact inputs exist.
+    const capture = def.captureStdout
+      ? createWriteStream(path.join(workspaceDir, def.captureStdout))
+      : null;
+    if (capture) child.stdout.pipe(capture);
     child.stdout.on("data", collect);
     child.stderr.on("data", collect);
 
@@ -77,22 +85,39 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
       clearTimeout(termTimer);
       clearTimeout(killTimer);
       if (exitCode === 0 && !timedOut) {
-        writeFileSync(
-          path.join(workspaceDir, "result.json"),
-          `${JSON.stringify(
-            {
-              schemaVersion: "factory.agent-result/v1",
-              terminalState: "completed",
-              reasonCode: "ok",
-              artifact: { command: argv, exitCode: 0, outputTail: output },
-              evidence: { command: argv, outputTail: output },
-            },
-            null,
-            2,
-          )}\n`,
-          "utf8",
-        );
+        const write = () => {
+          const captured = def.captureStdout
+            ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }]
+            : [];
+          writeFileSync(
+            path.join(workspaceDir, "result.json"),
+            `${JSON.stringify(
+              {
+                schemaVersion: "factory.agent-result/v1",
+                terminalState: "completed",
+                reasonCode: "ok",
+                artifact: {
+                  command: argv,
+                  exitCode: 0,
+                  outputTail: output,
+                  ...(def.captureStdout ? { captured: def.captureStdout } : {}),
+                },
+                evidence: { command: argv, outputTail: output },
+                ...(captured.length ? { artifacts: captured } : {}),
+              },
+              null,
+              2,
+            )}\n`,
+            "utf8",
+          );
+          resolve({ exitCode, timedOut });
+        };
+        // The capture stream must be flushed before the verifier hashes it.
+        if (capture) capture.end(write);
+        else write();
+        return;
       }
+      capture?.end();
       resolve({ exitCode, timedOut });
     });
   });

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -7,7 +7,7 @@
  * validates against the real factory-status-report input schema and the rest
  * of the pipeline (planner, verifier, lifecycle) runs unmodified.
  */
-import { writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { TRACE_EVENTS_CAP } from "../trace.mjs";
 
@@ -57,13 +57,37 @@ function ciDoctorArtifact(input) {
 export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace }) {
   // Contract-shaped fakes for the chain slice (OPS-223) — behavior keyed on
   // the spec's output contract so planner/verifier/chain run unmodified.
-  if (spec.outputContract === "factory.ci-doctor/v1") {
+  if (spec.outputContract === "factory.ci-log/v1") {
+    writeFileSync(path.join(workspaceDir, "failed.log"), `fake CI log for run ${spec.input?.runId}\nsocket hang up\n`, "utf8");
     writeResult(workspaceDir, {
       schemaVersion: "factory.agent-result/v1",
       terminalState: "completed",
       reasonCode: "ok",
-      artifact: ciDoctorArtifact(spec.input),
-      evidence: { commands: ["fake"] },
+      artifact: { command: ["fake"], exitCode: 0, outputTail: "", captured: "failed.log" },
+      evidence: { command: ["fake"] },
+      artifacts: [{ kind: "ci-log", path: "failed.log" }],
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.ci-doctor/v1") {
+    // Prove the artifact was materialized: the fake reads the file the
+    // workspace provider was supposed to write, and refuses if it is absent.
+    const logPath = path.join(workspaceDir, "failed.log");
+    if (!existsSync(logPath)) {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "refused",
+        reasonCode: "missing_input",
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    const logText = readFileSync(logPath, "utf8");
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: { ...ciDoctorArtifact(spec.input), evidenceLines: [logText.trim().split("\n").at(-1) ?? "empty"] },
+      evidence: { commands: ["fake"], logBytes: logText.length },
     });
     return { exitCode: 0, timedOut: false };
   }

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -23,6 +23,7 @@ import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectPropos
 import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
+import { storeStats } from "./artifacts.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
 
 /**
@@ -146,6 +147,7 @@ function statusView(db, nowMs) {
     .map((row) => ({ source: row.source, eventId: row.event_id, lastError: row.last_plan_error }));
 
   const workers = listWorkers(db, { now: nowMs });
+  const store = storeStats(db, artifactsRoot(), { now: nowMs });
   const stalled = stalledWorkers(db, { now: nowMs });
 
   return {
@@ -157,6 +159,7 @@ function statusView(db, nowMs) {
       busy: workers.filter((w) => w.state === "busy" && !w.stale).length,
       stale: workers.filter((w) => w.stale).length,
     },
+    artifacts: { files: store.files, bytes: store.bytes, orphans: store.orphans, orphanBytes: store.orphanBytes },
     anomalies: {
       expiredOpenProposals: expiredOpen.map((p) => p.id),
       staleLeases,

--- a/event-runtime/lib/artifact-inputs.test.mjs
+++ b/event-runtime/lib/artifact-inputs.test.mjs
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  materializeArtifact,
+  pruneArtifacts,
+  referencedHashes,
+  storeStats,
+} from "./artifacts.mjs";
+import { sha256Hex } from "./canonical.mjs";
+import * as fake from "./adapters/fake.mjs";
+import { resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+import { createWorkspace, resolveInputRef } from "./workspace.mjs";
+
+const registry = loadRegistry();
+
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+/** Put bytes in a store the way the worker does: keyed by their own hash. */
+function store(bytes, storeRoot = tmp("evrt-store-")) {
+  mkdirSync(storeRoot, { recursive: true });
+  const hash = sha256Hex(Buffer.from(bytes));
+  writeFileSync(path.join(storeRoot, hash), bytes);
+  return { storeRoot, hash };
+}
+
+/** A results row referencing an artifact, so GC can see it as live. */
+function recordResult(db, { runId, sha256, kind = "ci-log" }) {
+  db.query(
+    `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+     VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
+  ).run(
+    runId,
+    JSON.stringify({ artifacts: [{ kind, sha256, uri: "file:///x" }] }),
+    new Date().toISOString(),
+  );
+}
+
+describe("materializeArtifact (OPS-372)", () => {
+  test("writes the stored bytes into the workspace under the declared name", () => {
+    const { storeRoot, hash } = store("first line\nsecond line\n");
+    const workspaceDir = tmp("evrt-ws-");
+    const out = materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "failed.log" });
+    expect(out.sha256).toBe(hash);
+    expect(readFileSync(path.join(workspaceDir, "failed.log"), "utf8")).toBe("first line\nsecond line\n");
+  });
+
+  test("a hash that is not in the store fails closed", () => {
+    const { storeRoot } = store("x");
+    expect(() =>
+      materializeArtifact({ storeRoot, sha256hex: "a".repeat(64), workspaceDir: tmp("evrt-ws-"), as: "x.log" }),
+    ).toThrow(/not in the store/);
+  });
+
+  test("a malformed hash is rejected before touching the filesystem", () => {
+    const { storeRoot } = store("x");
+    expect(() =>
+      materializeArtifact({ storeRoot, sha256hex: "../../etc/passwd", workspaceDir: tmp("evrt-ws-"), as: "x" }),
+    ).toThrow();
+  });
+
+  test("the target name may not escape the workspace", () => {
+    const { storeRoot, hash } = store("x");
+    const workspaceDir = tmp("evrt-ws-");
+    for (const as of ["../escaped.log", "/etc/passwd", ""]) {
+      expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as })).toThrow();
+    }
+  });
+});
+
+describe("resolveInputRef", () => {
+  test("resolves $.input.* paths and passes literals through", () => {
+    const input = { logArtifact: "abc", nested: { hash: "def" } };
+    expect(resolveInputRef(input, "$.input.logArtifact")).toBe("abc");
+    expect(resolveInputRef(input, "$.input.nested.hash")).toBe("def");
+    expect(resolveInputRef(input, "literal")).toBe("literal");
+  });
+
+  test("a ref that resolves to nothing fails loudly", () => {
+    expect(() => resolveInputRef({}, "$.input.missing")).toThrow(/resolves to nothing/);
+  });
+});
+
+describe("artifacts workspace provider (OPS-372)", () => {
+  test("materializes every declared input and reports what it wrote", () => {
+    const { storeRoot, hash } = store("ci log bytes\n");
+    const created = createWorkspace({
+      root: tmp("evrt-root-"),
+      runId: "run_1",
+      attempt: 1,
+      input: { logArtifact: hash },
+      workspace: { type: "artifacts", inputs: [{ from: "$.input.logArtifact", as: "failed.log" }] },
+      artifactStore: storeRoot,
+    });
+    expect(created.materialized).toEqual([{ as: "failed.log", sha256: hash, sizeBytes: 13 }]);
+    expect(readFileSync(path.join(created.dir, "failed.log"), "utf8")).toBe("ci log bytes\n");
+    // input.json is still written: declared inputs and declared bytes coexist.
+    expect(JSON.parse(readFileSync(path.join(created.dir, "input.json"), "utf8"))).toEqual({
+      logArtifact: hash,
+    });
+  });
+
+  test("an ephemeral workspace materializes nothing", () => {
+    const created = createWorkspace({
+      root: tmp("evrt-root-"),
+      runId: "run_2",
+      attempt: 1,
+      input: {},
+      workspace: { type: "ephemeral" },
+      artifactStore: tmp("evrt-store-"),
+    });
+    expect(created.materialized).toEqual([]);
+  });
+});
+
+describe("retention (OPS-372)", () => {
+  const db = () => openDb(path.join(tmp("evrt-db-"), "runtime.db"));
+
+  test("referencedHashes finds every hash an accepted result points at", () => {
+    const d = db();
+    const { hash } = store("kept");
+    recordResult(d, { runId: "run_1", sha256: hash });
+    expect([...referencedHashes(d)]).toEqual([hash]);
+  });
+
+  test("storeStats separates referenced bytes from orphans", () => {
+    const d = db();
+    const kept = store("kept bytes");
+    const orphan = store("orphan bytes", kept.storeRoot);
+    recordResult(d, { runId: "run_1", sha256: kept.hash });
+
+    const stats = storeStats(d, kept.storeRoot);
+    expect(stats.files).toBe(2);
+    expect(stats.orphans).toBe(1);
+    expect(stats.orphanBytes).toBe("orphan bytes".length);
+  });
+
+  test("pruning deletes only old orphans — a referenced artifact is never touched", () => {
+    const d = db();
+    const kept = store("kept bytes");
+    const orphan = store("orphan bytes", kept.storeRoot);
+    recordResult(d, { runId: "run_1", sha256: kept.hash });
+
+    // Age both files past the window; only the unreferenced one may go.
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    utimesSync(path.join(kept.storeRoot, kept.hash), old, old);
+    utimesSync(path.join(kept.storeRoot, orphan.hash), old, old);
+
+    const outcome = pruneArtifacts(d, kept.storeRoot, { olderThanMs: 7 * 24 * 60 * 60 * 1000 });
+    expect(outcome.deleted).toBe(1);
+    expect(readFileSync(path.join(kept.storeRoot, kept.hash), "utf8")).toBe("kept bytes");
+    expect(storeStats(d, kept.storeRoot).orphans).toBe(0);
+  });
+
+  test("a fresh orphan survives — bytes may be referenced by a run still in flight", () => {
+    const d = db();
+    const { storeRoot } = store("just written");
+    expect(pruneArtifacts(d, storeRoot, { olderThanMs: 7 * 24 * 60 * 60 * 1000 }).deleted).toBe(0);
+  });
+});
+
+describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)", () => {
+  test("the log becomes an artifact, chains by hash, and is materialized for the doctor", async () => {
+    const dir = tmp("evrt-poc-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const workspaces = tmp("evrt-poc-ws-");
+    const artifactStore = tmp("evrt-poc-store-");
+    const adapters = { claude: fake, command: fake };
+    const opts = { workspacesRoot: workspaces, artifactStore, owner: "w", policyVersion: "git:test" };
+
+    admitEvent(db, registry, {
+      schemaVersion: "factory.event/v1",
+      eventId: "gh-poc-1",
+      type: "github.workflow-run.failed",
+      source: "github",
+      occurredAt: "2026-08-13T10:00:00Z",
+      correlationId: "gh-poc-1",
+      payload: { repo: "wm/factory", runId: 4242 },
+    });
+
+    // Node 1: capture. The whole log is stored content-addressed.
+    planAdmittedEvents(db, registry, opts);
+    const capture = openProposals(db, {}).find((p) => p.spec?.agent === "ci-log-capture@1");
+    expect(capture).toBeTruthy();
+    const captureRun = approveProposal(db, registry, capture.id, { actor: "operator", policyVersion: "git:test" });
+    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe("COMPLETED");
+
+    const captured = JSON.parse(
+      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(captureRun.runId).result_json,
+    );
+    const logEntry = captured.artifacts.find((a) => a.kind === "ci-log");
+    expect(logEntry.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(readFileSync(path.join(artifactStore, logEntry.sha256), "utf8")).toContain("socket hang up");
+
+    // The chain passes the HASH, not the bytes.
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, opts);
+    const diagnose = openProposals(db, {}).find((p) => p.spec?.agent === "ci-doctor@2");
+    expect(diagnose.spec.input.logArtifact).toBe(logEntry.sha256);
+
+    // Node 2: the doctor reads ./failed.log, proving materialization happened.
+    const diagnoseRun = approveProposal(db, registry, diagnose.id, { actor: "operator", policyVersion: "git:test" });
+    expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe("COMPLETED");
+    const diagnosis = JSON.parse(
+      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(diagnoseRun.runId).result_json,
+    );
+    expect(diagnosis.artifact.evidenceLines).toEqual(["socket hang up"]);
+    expect(diagnosis.evidence.logBytes).toBeGreaterThan(0);
+  });
+
+  test("a run whose declared artifact is missing parks for a human instead of proposing", () => {
+    const db = openDb(path.join(tmp("evrt-poc-"), "runtime.db"));
+    admitEvent(db, registry, {
+      schemaVersion: "factory.event/v1",
+      eventId: "diag-orphan",
+      type: "factory.ci-diagnose.requested",
+      source: "chain",
+      occurredAt: "2026-08-13T10:00:00Z",
+      correlationId: "diag-orphan",
+      payload: { repo: "wm/factory", runId: 1, logArtifact: "b".repeat(64) },
+    });
+    planAdmittedEvents(db, registry, { policyVersion: "git:test" });
+    const parked = openProposals(db, {}).find((p) => p.decision === "human_needed");
+    expect(parked.reason).toContain("artifact_missing");
+  });
+});

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -8,7 +8,7 @@
  * so identical bytes are stored once and a result row never references a file
  * that no longer exists.
  */
-import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,4 +43,84 @@ export function findArtifact(storeRoot, sha256hex) {
   const file = path.join(storeRoot, sha256hex);
   if (!existsSync(file)) return null;
   return { file, sizeBytes: statSync(file).size };
+}
+
+/**
+ * Materialize a stored artifact into a run workspace (OPS-372).
+ *
+ * Declared inputs only: the spec names hashes, the provider writes bytes,
+ * and the agent reads a file. There is deliberately no way for an agent to
+ * ask the store for something it did not declare — that would make the run's
+ * inputHash a lie about what it actually read.
+ */
+export function materializeArtifact({ storeRoot, sha256hex, workspaceDir, as }) {
+  const found = findArtifact(storeRoot, sha256hex);
+  if (!found) throw new Error(`artifact ${sha256hex} is not in the store`);
+  if (typeof as !== "string" || !as || path.isAbsolute(as)) {
+    throw new Error(`artifact target "${as}" must be a relative filename`);
+  }
+  const root = path.resolve(workspaceDir);
+  const dest = path.resolve(root, as);
+  if (!dest.startsWith(root + path.sep)) throw new Error(`artifact target "${as}" escapes the workspace`);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  copyFileSync(found.file, dest);
+  return { path: dest, sha256: sha256hex, sizeBytes: found.sizeBytes };
+}
+
+/** Every artifact hash any accepted result still points at. */
+export function referencedHashes(db) {
+  const hashes = new Set();
+  for (const row of db.query(`SELECT result_json FROM results`).all()) {
+    for (const entry of JSON.parse(row.result_json).artifacts ?? []) {
+      if (entry.sha256) hashes.add(entry.sha256);
+    }
+  }
+  return hashes;
+}
+
+/**
+ * Store inventory: total bytes, and the orphans — files no accepted result
+ * references. Orphans are normal (a failed attempt stores nothing, but a
+ * superseded one can leave bytes behind); they are only a problem unattended.
+ */
+export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
+  if (!existsSync(storeRoot)) return { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 };
+  const referenced = referencedHashes(db);
+  let files = 0;
+  let bytes = 0;
+  let orphans = 0;
+  let orphanBytes = 0;
+  for (const name of readdirSync(storeRoot)) {
+    if (!HEX64.test(name)) continue;
+    const size = statSync(path.join(storeRoot, name)).size;
+    files += 1;
+    bytes += size;
+    if (!referenced.has(name)) {
+      orphans += 1;
+      orphanBytes += size;
+    }
+  }
+  return { files, bytes, orphans, orphanBytes, at: new Date(now).toISOString() };
+}
+
+/**
+ * Delete unreferenced artifacts older than `olderThanMs`. Referenced bytes are
+ * never touched: a receipt that points at a deleted file is worse than a full
+ * disk, because it turns the audit trail into a lie.
+ */
+export function pruneArtifacts(db, storeRoot, { olderThanMs = 7 * 24 * 60 * 60 * 1000, now = Date.now() } = {}) {
+  if (!existsSync(storeRoot)) return { deleted: 0, freedBytes: 0 };
+  const referenced = referencedHashes(db);
+  let deleted = 0;
+  let freedBytes = 0;
+  for (const name of readdirSync(storeRoot)) {
+    if (!HEX64.test(name) || referenced.has(name)) continue;
+    const file = path.join(storeRoot, name);
+    const stat = statSync(file);
+    if (now - stat.mtimeMs < olderThanMs) continue;
+    freedBytes += stat.size;
+    rmSync(file, { force: true });
+    deleted += 1;
+  }
+  return { deleted, freedBytes };
 }

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -90,6 +90,16 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
         outcome.skipped += 1;
         continue;
       }
+      // A chain may pass an artifact by content hash — `$.artifactHash.<kind>`
+      // resolves against the accepted result's stored artifacts (OPS-372).
+      // Values, not bytes, travel through events; the downstream workspace
+      // materializes the bytes from the store.
+      const artifactHash = {};
+      for (const entry of result.artifacts ?? []) {
+        if (entry.kind && entry.sha256 && artifactHash[entry.kind] === undefined) {
+          artifactHash[entry.kind] = entry.sha256;
+        }
+      }
       const envelope = {
         schemaVersion: "factory.event/v1",
         eventId: `chain-${row.run_id}`,
@@ -99,7 +109,11 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
         occurredAt: new Date(now).toISOString(),
         correlationId: row.correlation_id ?? row.origin_event_id,
         causationId: row.run_id,
-        payload: buildChainInput(edge.input, { input: spec.input, artifact: result.artifact ?? {} }),
+        payload: buildChainInput(edge.input, {
+          input: spec.input,
+          artifact: result.artifact ?? {},
+          artifactHash,
+        }),
       };
       const admitted = admitEvent(db, registry, envelope, { now });
       if (admitted.admitted) outcome.emitted += 1;

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -69,12 +69,30 @@ describe("buildChainInput", () => {
   });
 });
 
+/**
+ * github.workflow-run.failed now lands on ci-log-capture@1, which stores the
+ * log as an artifact and chains to ci-doctor@2 (OPS-372). Run that first hop
+ * so these tests stay about the *verdict* edges they were written for.
+ */
+async function throughCapture(h, eventId) {
+  const capture = await h.runToCompletion(eventId);
+  expect(resolveChains(h.db, registry).emitted).toBe(1);
+  planAdmittedEvents(h.db, registry, { policyVersion: PV });
+  const diagnose = openProposals(h.db, {}).find((p) => p.spec?.agent === "ci-doctor@2");
+  expect(diagnose).toBeTruthy();
+  const approved = approveProposal(h.db, registry, diagnose.id, { actor: "operator", policyVersion: PV });
+  const summary = await runOnce(h.db, registry, h.adapters, h.workerOpts);
+  expect(summary.terminalState).toBe("COMPLETED");
+  return { capture, diagnoseRunId: approved.runId, diagnoseProposal: diagnose };
+}
+
 describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
   test("FLAKE verdict chains to a watched ci-rerun proposal with inherited correlation", async () => {
-    const { db, runToCompletion } = harness();
+    const h = harness();
+    const { db, runToCompletion } = h;
     const envelope = failedRunEnvelope({ eventId: "gh-flake-1" });
     expect(admitEvent(db, registry, envelope).admitted).toBe(true);
-    const { runId } = await runToCompletion("gh-flake-1");
+    const { diagnoseRunId: runId } = await throughCapture(h, "gh-flake-1");
 
     const outcome = resolveChains(db, registry);
     expect(outcome).toEqual({ emitted: 1, skipped: 0, errors: [] });
@@ -101,12 +119,13 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
   });
 
   test("TICKET verdict chains to ci-notify with the diagnosis summary mapped in", async () => {
-    const { db, runToCompletion } = harness();
+    const h = harness();
+    const { db, runToCompletion } = h;
     admitEvent(db, registry, failedRunEnvelope({
       eventId: "gh-ticket-1",
       payload: { repo: "wm/factory-ticket", runId: 777 },
     }));
-    await runToCompletion("gh-ticket-1");
+    await throughCapture(h, "gh-ticket-1");
 
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, { policyVersion: PV });
@@ -116,9 +135,10 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
   });
 
   test("full chain executes after approval: rerun completes under the command contract", async () => {
-    const { db, runToCompletion, adapters, workerOpts } = harness();
+    const h = harness();
+    const { db, adapters, workerOpts } = h;
     admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-flake-2", payload: { repo: "wm/f2", runId: 2 } }));
-    await runToCompletion("gh-flake-2");
+    await throughCapture(h, "gh-flake-2");
     resolveChains(db, registry);
     planAdmittedEvents(db, registry, { policyVersion: PV });
 
@@ -133,13 +153,14 @@ describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
   });
 
   test("duplicate failed-run delivery converges: one doctor run, one chain event", async () => {
-    const { db, runToCompletion } = harness();
+    const h = harness();
+    const { db, runToCompletion } = h;
     admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
     const dup = admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-dup-1", payload: { repo: "wm/d", runId: 9 } }));
     expect(dup.duplicate).toBe(true);
     await runToCompletion("gh-dup-1");
-    expect(resolveChains(db, registry).emitted).toBe(1);
-    expect(resolveChains(db, registry).emitted).toBe(0);
+    expect(resolveChains(db, registry).emitted).toBe(1); // capture → diagnose
+    expect(resolveChains(db, registry).emitted).toBe(0); // one chain event per run, ever
   });
 });
 
@@ -157,14 +178,14 @@ describe("registry gates (OPS-223)", () => {
 
     writeFileSync(
       path.join(root, "edges.json"),
-      JSON.stringify({ "ci-doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "not.registered", input: {} } } } }),
+      JSON.stringify({ "ci-doctor@2": { recommendationField: "verdict", edges: { FLAKE: { eventType: "not.registered", input: {} } } } }),
     );
     expect(() => loadRegistry({ root })).toThrow(RegistryError);
 
     writeFileSync(
       path.join(root, "edges.json"),
-      JSON.stringify({ "ci-doctor@1": { recommendationField: "verdict", edges: { FLAKE: { eventType: "factory.ci-rerun.requested", input: { x: "$.secrets.key" } } } } }),
+      JSON.stringify({ "ci-doctor@2": { recommendationField: "verdict", edges: { FLAKE: { eventType: "factory.ci-rerun.requested", input: { x: "$.secrets.key" } } } } }),
     );
-    expect(() => loadRegistry({ root })).toThrow("only $.input.* and $.artifact.*");
+    expect(() => loadRegistry({ root })).toThrow("only $.input.*, $.artifact.* and $.artifactHash.*");
   });
 });

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -8,14 +8,16 @@
  * returns the recorded outcome — and a poison event that keeps throwing is
  * dead-lettered instead of wedging the sweep or silently vanishing.
  */
+import { findArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
-import { DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
+import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
 import { tx } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun } from "./lifecycle.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
 import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
+import { resolveInputRef } from "./workspace.mjs";
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -107,7 +109,7 @@ function existingOutcome(db, event) {
  *
  * @returns {{ decision: string, proposal?: object, runId?: string, reason?: string }}
  */
-export function planEvent(db, registry, { source, eventId }, { now = Date.now(), policyVersion = "unknown", adapterOverride } = {}) {
+export function planEvent(db, registry, { source, eventId }, { now = Date.now(), policyVersion = "unknown", adapterOverride, artifactStore = artifactsRoot() } = {}) {
   return tx(db, () => {
     const event = db.query(`SELECT * FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
     if (!event) throw new Error(`no admitted event (${source}, ${eventId})`);
@@ -129,6 +131,21 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // inputHash, and the receipt). A run therefore names the exact tree it
     // read, and dedup distinguishes "same repo, new commit".
     let payload = envelope.payload;
+    // Declared artifact inputs must exist in the store at plan time (OPS-372):
+    // proposing a run whose bytes are missing wastes an approval, and the
+    // operator should see the failure before deciding, not after.
+    if (def.workspace?.type === "artifacts") {
+      for (const entry of def.workspace.inputs ?? []) {
+        try {
+          const sha = resolveInputRef(payload, entry.from);
+          if (!findArtifact(artifactStore, sha)) {
+            return humanNeeded(db, event, `artifact_missing: ${entry.as} (${sha})`, at, ttlSeconds);
+          }
+        } catch (err) {
+          return humanNeeded(db, event, `artifact_ref_failed: ${err.message}`, at, ttlSeconds);
+        }
+      }
+    }
     if (def.workspace?.type === "repository") {
       try {
         payload = { ...payload, repoPin: pinRepo(payload.repo, payload.ref ?? undefined) };

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -119,8 +119,8 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
           throw new RegistryError(`edges.json: ${agentRef}.${value} targets unregistered event type ${edge.eventType}`);
         }
         for (const expr of Object.values(edge.input ?? {})) {
-          if (typeof expr === "string" && expr.startsWith("$.") && !/^\$\.(input|artifact)(\.|$)/.test(expr)) {
-            throw new RegistryError(`edges.json: ${agentRef}.${value} input path "${expr}" — only $.input.* and $.artifact.* are allowed`);
+          if (typeof expr === "string" && expr.startsWith("$.") && !/^\$\.(input|artifact|artifactHash)(\.|$)/.test(expr)) {
+            throw new RegistryError(`edges.json: ${agentRef}.${value} input path "${expr}" — only $.input.*, $.artifact.* and $.artifactHash.* are allowed`);
           }
         }
       }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -157,6 +157,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     const created = createWorkspace({
       root: workspacesRoot, runId, attempt, input: spec.input, workspace: spec.workspace,
+      artifactStore,
     });
     workspaceDir = created.dir;
     checkoutPath = created.checkout?.path ?? null;

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -11,6 +11,8 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson } from "./canonical.mjs";
+import { materializeArtifact } from "./artifacts.mjs";
+import { artifactsRoot } from "./config.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 
 export class PathViolation extends Error {
@@ -47,10 +49,44 @@ export function safeJoin(workspaceDir, relPath) {
  * checkout lives inside this directory, so teardown is still one rm — plus a
  * `git worktree remove` so the mirror does not accumulate stale registrations.
  */
-export function createWorkspace({ root, runId, attempt, input, workspace = {} }) {
+/** One run's declared artifact inputs may not exceed this in total. */
+export const MAX_MATERIALIZED_BYTES = 64 * 1024 * 1024;
+
+/** Resolve "$.input.logArtifact" against the run input; literals pass through. */
+export function resolveInputRef(input, expr) {
+  if (typeof expr !== "string") throw new Error(`artifact input ref must be a string, got ${typeof expr}`);
+  if (!expr.startsWith("$.input.")) return expr;
+  const value = expr
+    .slice("$.input.".length)
+    .split(".")
+    .reduce((acc, key) => (acc === null || acc === undefined ? acc : acc[key]), input);
+  if (typeof value !== "string" || !value) throw new Error(`artifact input ref "${expr}" resolves to nothing`);
+  return value;
+}
+
+export function createWorkspace({ root, runId, attempt, input, workspace = {}, artifactStore = artifactsRoot() }) {
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "input.json"), `${canonicalJson(input)}\n`, "utf8");
+
+  // Declared artifact inputs (§7 `artifacts`, OPS-372): the spec names hashes,
+  // the provider writes bytes, the agent reads files. An agent can never ask
+  // the store for something the spec did not declare.
+  const materialized = [];
+  if (workspace.type === "artifacts") {
+    let total = 0;
+    for (const entry of workspace.inputs ?? []) {
+      const sha256 = resolveInputRef(input, entry.from);
+      const out = materializeArtifact({
+        storeRoot: artifactStore, sha256hex: sha256, workspaceDir: dir, as: entry.as,
+      });
+      total += out.sizeBytes;
+      if (total > MAX_MATERIALIZED_BYTES) {
+        throw new Error(`artifact inputs exceed ${MAX_MATERIALIZED_BYTES} bytes for this run`);
+      }
+      materialized.push({ as: entry.as, sha256, sizeBytes: out.sizeBytes });
+    }
+  }
 
   let checkout = null;
   if (workspace.type === "repository") {
@@ -62,7 +98,7 @@ export function createWorkspace({ root, runId, attempt, input, workspace = {} })
       subdir,
     });
   }
-  return { dir, checkout };
+  return { dir, checkout, materialized };
 }
 
 /**

--- a/event-runtime/schemas/ci-doctor.input.json
+++ b/event-runtime/schemas/ci-doctor.input.json
@@ -1,12 +1,32 @@
 {
-  "title": "ci-doctor input — one failed GitHub Actions run",
+  "title": "ci-doctor input \u2014 one failed GitHub Actions run",
   "type": "object",
-  "required": ["repo", "runId"],
+  "required": [
+    "repo",
+    "runId",
+    "logArtifact"
+  ],
   "additionalProperties": false,
   "properties": {
-    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
-    "runId": { "type": ["string", "integer"] },
-    "headSha": { "type": "string" },
-    "workflowName": { "type": "string" }
+    "repo": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "runId": {
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "headSha": {
+      "type": "string"
+    },
+    "workflowName": {
+      "type": "string"
+    },
+    "logArtifact": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
   }
 }

--- a/event-runtime/schemas/ci-log-capture.input.json
+++ b/event-runtime/schemas/ci-log-capture.input.json
@@ -1,0 +1,10 @@
+{
+  "title": "ci-log-capture input — the failed run whose log to capture",
+  "type": "object",
+  "required": ["repo", "runId"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
+    "runId": { "type": ["string", "integer"] }
+  }
+}

--- a/event-runtime/schemas/ci-log-captured.output.json
+++ b/event-runtime/schemas/ci-log-captured.output.json
@@ -1,0 +1,12 @@
+{
+  "title": "factory.ci-log/v1 output artifact — a captured CI log",
+  "type": "object",
+  "required": ["command", "exitCode", "captured"],
+  "additionalProperties": false,
+  "properties": {
+    "command": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "exitCode": { "const": 0 },
+    "outputTail": { "type": "string" },
+    "captured": { "type": "string", "minLength": 1 }
+  }
+}


### PR DESCRIPTION
Fixes OPS-372

Agents consume prior runs' artifacts — **declared and materialized, never pulled**.

- **`artifacts` workspace provider**: `inputs: [{ from: "$.input.logArtifact", as: "failed.log" }]`, path-confined, failing closed on missing/malformed hashes, 64 MB per-run cap.
- **Plan-time verification**: declared hashes must exist in the store or the event parks `human_needed` — the operator sees it before spending an approval, and the hash is inside `inputHash`/receipt.
- **Chains pass hashes**: `$.artifactHash.<kind>` resolves against the upstream result's stored artifacts.
- **`captureStdout`** on command definitions keeps a command's whole output as a declared artifact (the evidence field keeps only a 2000-char tail).
- **Retention**: referenced artifacts never pruned; orphans pruned after a week by the serve loop; store size/orphans in `status`.
- **POC chain**: `github.workflow-run.failed` → `ci-log-capture@1` → `ci-doctor@2` reading `./failed.log`. Reproducible against exact bytes, offline, and no longer bounded by the inline-evidence cap.

Verification: 282 tests green (14 new: materialization, confinement, malformed/missing hashes, GC keeping referenced bytes, full capture→chain→consume loop, and missing-artifact parking). Live in an isolated worktree: injected a failed-run event, approved capture, the chain carried the hash into a `ci-doctor@2` proposal with the artifacts workspace, and approving it diagnosed from the materialized log.