### PR TITLE
feat(event-runtime): run-postmortem + cross-run artifact pinning (OPS-373, OPS-376)

### DIFF
--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -89,6 +89,15 @@ GitHub — the diagnosis is reproducible against exactly those bytes, and a
 multi-megabyte log lives in the store rather than blowing the inline-evidence
 limit.
 
+**Cross-run references (OPS-373).** An artifact need not come from the same
+chain. `factory.run-postmortem.requested {runId}` → `run-postmortem@1` reads
+`./transcript.json`, the *earlier* run's captured transcript: the planner
+resolves that run's stored artifact into `input.runPin` at plan time, so the
+operator approves a run pinned to specific bytes rather than "whatever that
+run's transcript is by the time this executes". A run that never stored a
+transcript, or an unknown run id, parks `human_needed` with that exact reason
+instead of proposing a run over nothing.
+
 ## Discovered chains (OPS-223)
 
 Agents never spawn agents: a completed run whose artifact carries a typed

--- a/event-runtime/agents/run-postmortem.json
+++ b/event-runtime/agents/run-postmortem.json
@@ -1,0 +1,32 @@
+{
+  "id": "run-postmortem",
+  "version": 1,
+  "prompt": "agents/run-postmortem.md",
+  "input_schema": "schemas/run-postmortem.input.json",
+  "output_schema": "schemas/run-postmortem.output.json",
+  "output_contract": "factory.run-postmortem/v1",
+  "workspace": {
+    "type": "artifacts",
+    "inputs": [
+      {
+        "from": "$.input.runPin.transcript",
+        "as": "transcript.json"
+      }
+    ],
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": []
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/run-postmortem.md": "sha256:7564db016c3de24dec763f873d4e70cb7ca201da6a19d0efd6a6734c5cc850e5",
+    "schemas/run-postmortem.input.json": "sha256:c0127cbec0af57ee98f6eaa4a65cc5de7ceef9e5c004aef62bc85d18d53d6bfa",
+    "schemas/run-postmortem.output.json": "sha256:41de372ab6513cbbc2065fb7ca7367005d9a5cc0268dc02bb4d53e94cc07e644"
+  }
+}

--- a/event-runtime/agents/run-postmortem.md
+++ b/event-runtime/agents/run-postmortem.md
@@ -1,0 +1,48 @@
+# run-postmortem — explain why one run failed, from its own transcript
+
+`./input.json` names a run of this runtime:
+
+```json
+{ "runId": "run_...", "runPin": { "runId": "run_...", "transcript": "<40+ hex>", "state": "FAILED", "agent": "ci-doctor@2" } }
+```
+
+`./transcript.json` is **that run's captured agent transcript**, materialized
+from the artifact store by content hash — the exact bytes the agent produced,
+not a summary. Read it and write `./result.json`. You are read-only: you never
+retry, cancel, or modify anything. Work only inside this directory.
+
+## Method
+
+1. Read `./transcript.json`. It is the adapter's structured capture of the
+   agent's session.
+2. Find where the run actually went wrong — the first real failure, not the
+   symptoms after it. Distinguish these plainly:
+   - the **agent misunderstood its task** (prompt or contract problem),
+   - the **agent did its job and the world refused** (a tool errored, a
+     service was down, permissions),
+   - the **output violated its contract** (schema, hashes, evidence),
+   - the run was **cut short** (timeout, cancellation).
+3. Say what an operator should do about it, in one actionable sentence. If the
+   right answer is "nothing, retry it", say that.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "runId": "run_...",
+    "category": "agent_error | environment | contract_violation | cut_short | unclear",
+    "whatHappened": "one plain sentence",
+    "operatorAction": "one actionable sentence",
+    "evidenceLines": ["the transcript lines this rests on"]
+  },
+  "evidence": { "transcriptBytes": 12345 }
+}
+```
+
+If the transcript is empty, unreadable, or shows nothing conclusive, use
+`category: "unclear"` and say so — a confident wrong story about a failure is
+worse than admitting the transcript does not explain it.

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -88,5 +88,13 @@
       "inputHash"
     ],
     "proposalTtlSeconds": 1800
+  },
+  "factory.run-postmortem.requested": {
+    "agent": "run-postmortem@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -55,8 +55,47 @@ function ciDoctorArtifact(input) {
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace }) {
+  // Every real adapter captures the agent's output as a runtime artifact
+  // (worker.mjs RUNTIME_ARTIFACTS). The fake must too, or it models a world
+  // where transcripts do not exist — which is exactly what run-postmortem
+  // consumes (OPS-373).
+  writeFileSync(
+    path.join(workspaceDir, ".transcript.json"),
+    `${JSON.stringify(
+      { adapter: "fake", agent: spec.agent, contract: spec.outputContract, input: spec.input },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
   // Contract-shaped fakes for the chain slice (OPS-223) — behavior keyed on
   // the spec's output contract so planner/verifier/chain run unmodified.
+  if (spec.outputContract === "factory.run-postmortem/v1") {
+    const transcript = path.join(workspaceDir, "transcript.json");
+    if (!existsSync(transcript)) {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "refused",
+        reasonCode: "missing_input",
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    const text = readFileSync(transcript, "utf8");
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        runId: spec.input.runId,
+        category: "environment",
+        whatHappened: `fake postmortem of ${spec.input.runId}`,
+        operatorAction: "retry it",
+        evidenceLines: [text.trim().split("\n").at(-1) ?? "empty"],
+      },
+      evidence: { transcriptBytes: text.length },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
   if (spec.outputContract === "factory.ci-log/v1") {
     writeFileSync(path.join(workspaceDir, "failed.log"), `fake CI log for run ${spec.input?.runId}\nsocket hang up\n`, "utf8");
     writeResult(workspaceDir, {

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -124,3 +124,29 @@ export function pruneArtifacts(db, storeRoot, { olderThanMs = 7 * 24 * 60 * 60 *
   }
   return { deleted, freedBytes };
 }
+
+/**
+ * Resolve a prior run's stored artifact of a given kind (OPS-373).
+ *
+ * The cross-run case: a postmortem consumes a transcript produced by a run it
+ * has no chain relationship with. Resolved at PLAN time so the hash lands in
+ * the spec input, the inputHash, and the receipt — the operator approves a run
+ * pinned to specific bytes, not "whatever that run's transcript happens to be
+ * by the time it executes".
+ */
+export function pinRunArtifact(db, runId, { kind = "transcript" } = {}) {
+  const run = db.query(`SELECT run_id, state, spec_json FROM runs WHERE run_id = ?`).get(runId);
+  if (!run) throw new Error(`unknown run ${runId}`);
+  const row = db
+    .query(`SELECT result_json FROM results WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`)
+    .get(runId);
+  if (!row) throw new Error(`run ${runId} has no accepted result — nothing was captured`);
+  const entry = (JSON.parse(row.result_json).artifacts ?? []).find((a) => a.kind === kind);
+  if (!entry?.sha256) throw new Error(`run ${runId} stored no "${kind}" artifact`);
+  return {
+    runId,
+    transcript: entry.sha256,
+    state: run.state,
+    agent: JSON.parse(run.spec_json).agent,
+  };
+}

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -142,6 +142,34 @@ CREATE INDEX IF NOT EXISTS idx_workers_last_seen ON workers (last_seen);
 CREATE INDEX IF NOT EXISTS idx_attempt_trace_run ON attempt_trace (run_id, seq);
 `;
 
+/**
+ * Put the database in WAL, tolerating a cold-start race (OPS-376).
+ *
+ * Journal mode is persistent, so the steady state needs no lock at all — read
+ * it first and skip the switch when it is already `wal`. Only the genuine
+ * first-time switch needs momentary exclusive access, which `busy_timeout`
+ * does NOT cover: two processes starting together against a brand-new file
+ * (serve and work, as worktree-up.sh launches them) had one win and the other
+ * die with SQLITE_BUSY. A bounded retry converges instead.
+ */
+function enableWal(db, { attempts = 20, waitMs = 50 } = {}) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (db.query("PRAGMA journal_mode").get()?.journal_mode === "wal") return;
+    try {
+      db.exec("PRAGMA journal_mode = WAL;");
+      return;
+    } catch (err) {
+      // Someone else is mid-switch; they will finish and the read above wins.
+      if (i === attempts - 1) {
+        throw new Error(
+          `could not switch the database to WAL after ${attempts} attempts: ${err.message}`,
+        );
+      }
+      Bun.sleepSync(waitMs);
+    }
+  }
+}
+
 export function openDb(file = dbPath()) {
   if (file !== ":memory:") mkdirSync(path.dirname(file), { recursive: true });
   const db = new Database(file, { create: true });
@@ -150,7 +178,7 @@ export function openDb(file = dbPath()) {
   // rather than failing with SQLITE_BUSY_RECOVERY. Ordering matters here —
   // observed live the moment serve and work became separate processes.
   db.exec("PRAGMA busy_timeout = 5000;");
-  db.exec("PRAGMA journal_mode = WAL;");
+  enableWal(db);
   db.exec("PRAGMA foreign_keys = ON;");
   db.exec(SCHEMA);
   return db;

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openDb, txImmediate } from "./db.mjs";
+
+const freshFile = () => path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-db-")), "runtime.db");
+
+describe("cold start (OPS-376)", () => {
+  test("a second connection to a brand-new database does not fight for the WAL switch", () => {
+    const file = freshFile();
+    // The first open performs the switch; the second must find it already
+    // done. Before OPS-376 the second raced for an exclusive lock that
+    // busy_timeout does not cover, and one process died with SQLITE_BUSY —
+    // exactly what serve and work did when worktree-up.sh started them together.
+    const first = openDb(file);
+    const second = openDb(file);
+    expect(first.query("PRAGMA journal_mode").get().journal_mode).toBe("wal");
+    expect(second.query("PRAGMA journal_mode").get().journal_mode).toBe("wal");
+    // Both are usable, which is the property that actually matters.
+    expect(second.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+    first.close();
+    second.close();
+  });
+
+  test("many connections to one fresh database all open cleanly", () => {
+    const file = freshFile();
+    const connections = Array.from({ length: 8 }, () => openDb(file));
+    for (const db of connections) {
+      expect(db.query("PRAGMA journal_mode").get().journal_mode).toBe("wal");
+    }
+    for (const db of connections) db.close();
+  });
+
+  test("reopening an existing WAL database takes no exclusive lock", () => {
+    const file = freshFile();
+    const held = openDb(file); // stays open, holding the database
+    const second = openDb(file); // would block on an exclusive switch
+    expect(second.query("PRAGMA journal_mode").get().journal_mode).toBe("wal");
+    held.close();
+    second.close();
+  });
+});
+
+describe("txImmediate (OPS-233)", () => {
+  test("commits like a normal transaction and rolls back on throw", () => {
+    const db = openDb(freshFile());
+    txImmediate(db, () => {
+      db.query(`INSERT INTO counters (name, value) VALUES ('x', 1)`).run();
+    });
+    expect(db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value).toBe(1);
+
+    expect(() =>
+      txImmediate(db, () => {
+        db.query(`UPDATE counters SET value = 99 WHERE name = 'x'`).run();
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(db.query(`SELECT value FROM counters WHERE name = 'x'`).get().value).toBe(1);
+    db.close();
+  });
+});

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -8,7 +8,7 @@
  * returns the recorded outcome — and a poison event that keeps throwing is
  * dead-lettered instead of wedging the sweep or silently vanishing.
  */
-import { findArtifact } from "./artifacts.mjs";
+import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
 import { tx } from "./db.mjs";
@@ -131,6 +131,19 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // inputHash, and the receipt). A run therefore names the exact tree it
     // read, and dedup distinguishes "same repo, new commit".
     let payload = envelope.payload;
+    // A run reference resolves to that run's stored transcript at plan time
+    // (OPS-373): the cross-run case, where the bytes come from a run this one
+    // has no chain relationship with.
+    if (
+      def.workspace?.type === "artifacts" &&
+      (def.workspace.inputs ?? []).some((i) => typeof i.from === "string" && i.from.startsWith("$.input.runPin."))
+    ) {
+      try {
+        payload = { ...payload, runPin: pinRunArtifact(db, payload.runId) };
+      } catch (err) {
+        return humanNeeded(db, event, `run_pin_failed: ${err.message}`, at, ttlSeconds);
+      }
+    }
     // Declared artifact inputs must exist in the store at plan time (OPS-372):
     // proposing a run whose bytes are missing wastes an approval, and the
     // operator should see the failure before deciding, not after.

--- a/event-runtime/lib/postmortem.test.mjs
+++ b/event-runtime/lib/postmortem.test.mjs
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./adapters/fake.mjs";
+import { pinRunArtifact } from "./artifacts.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+function harness() {
+  const db = openDb(path.join(tmp("evrt-pm-"), "runtime.db"));
+  const opts = {
+    workspacesRoot: tmp("evrt-pm-ws-"),
+    artifactStore: tmp("evrt-pm-store-"),
+    owner: "w",
+    policyVersion: PV,
+  };
+  const adapters = { claude: fake, command: fake };
+
+  async function runOne(envelope, agentRef) {
+    expect(admitEvent(db, registry, envelope).admitted).toBe(true);
+    planAdmittedEvents(db, registry, opts);
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, opts);
+    return { runId: approved.runId, summary, proposal };
+  }
+  return { db, opts, adapters, runOne };
+}
+
+const statusEnvelope = (eventId, repos = ["ok"]) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.status-report.requested",
+  source: "test",
+  occurredAt: "2026-08-13T10:00:00Z",
+  correlationId: eventId,
+  payload: { repos },
+});
+
+const postmortemEnvelope = (eventId, runId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.run-postmortem.requested",
+  source: "operator",
+  occurredAt: "2026-08-13T11:00:00Z",
+  correlationId: eventId,
+  payload: { runId },
+});
+
+describe("run-postmortem: consuming an artifact across runs (OPS-373)", () => {
+  test("the planner pins the earlier run's transcript, and the agent reads those bytes", async () => {
+    const h = harness();
+
+    // An ordinary run, unrelated to any postmortem — its transcript is captured
+    // by the adapter as a matter of course.
+    const subject = await h.runOne(statusEnvelope("subject-1"), "factory-status-report@1");
+    expect(subject.summary.terminalState).toBe("COMPLETED");
+
+    // Later, and with no chain between them, the operator asks why.
+    const pm = await h.runOne(postmortemEnvelope("pm-1", subject.runId), "run-postmortem@1");
+    expect(pm.summary.terminalState).toBe("COMPLETED");
+
+    // The pin is in the approved spec: the operator approved specific bytes.
+    expect(pm.proposal.spec.input.runPin).toMatchObject({ runId: subject.runId, state: "COMPLETED" });
+    expect(pm.proposal.spec.input.runPin.transcript).toMatch(/^[0-9a-f]{64}$/);
+
+    // And the agent actually read the materialized transcript.
+    const result = JSON.parse(
+      h.db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(pm.runId).result_json,
+    );
+    expect(result.artifact.runId).toBe(subject.runId);
+    expect(result.evidence.transcriptBytes).toBeGreaterThan(0);
+  });
+
+  test("the pin names the exact stored bytes the subject run produced", async () => {
+    const h = harness();
+    const subject = await h.runOne(statusEnvelope("subject-2"), "factory-status-report@1");
+    const pin = pinRunArtifact(h.db, subject.runId);
+    const stored = JSON.parse(
+      h.db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(subject.runId).result_json,
+    ).artifacts.find((a) => a.kind === "transcript");
+    expect(pin.transcript).toBe(stored.sha256);
+    expect(readFileSync(path.join(h.opts.artifactStore, pin.transcript), "utf8").length).toBeGreaterThan(0);
+  });
+
+  test("an unknown run parks for a human instead of proposing a run over nothing", async () => {
+    const h = harness();
+    admitEvent(h.db, registry, postmortemEnvelope("pm-unknown", "run_does_not_exist"));
+    planAdmittedEvents(h.db, registry, h.opts);
+    const parked = openProposals(h.db, {}).find((p) => p.decision === "human_needed");
+    expect(parked.reason).toContain("run_pin_failed");
+    expect(parked.reason).toContain("unknown run");
+  });
+
+  test("a run that never produced a transcript parks with that reason, not a crash", async () => {
+    const h = harness();
+    // A run with an accepted result but no transcript artifact.
+    h.db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES ('run_bare', 'k', '{"agent":"x@1"}', 'sha256:x', 'FAILED', 1, ?, ?)`,
+    ).run(new Date().toISOString(), new Date().toISOString());
+    h.db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('run_bare', 1, '{"artifacts":[]}', 'sha256:x', '{}', '{}', ?)`,
+    ).run(new Date().toISOString());
+
+    admitEvent(h.db, registry, postmortemEnvelope("pm-bare", "run_bare"));
+    planAdmittedEvents(h.db, registry, h.opts);
+    const parked = openProposals(h.db, {}).find((p) => p.decision === "human_needed");
+    expect(parked.reason).toContain('stored no "transcript" artifact');
+  });
+});

--- a/event-runtime/schemas/run-postmortem.input.json
+++ b/event-runtime/schemas/run-postmortem.input.json
@@ -1,0 +1,20 @@
+{
+  "title": "run-postmortem input — one run of this runtime; runPin is resolved by the planner",
+  "type": "object",
+  "required": ["runId"],
+  "additionalProperties": false,
+  "properties": {
+    "runId": { "type": "string", "minLength": 1 },
+    "runPin": {
+      "type": "object",
+      "required": ["runId", "transcript"],
+      "additionalProperties": false,
+      "properties": {
+        "runId": { "type": "string", "minLength": 1 },
+        "transcript": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "state": { "type": "string" },
+        "agent": { "type": "string" }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/run-postmortem.output.json
+++ b/event-runtime/schemas/run-postmortem.output.json
@@ -1,0 +1,13 @@
+{
+  "title": "factory.run-postmortem/v1 output artifact — why a run failed",
+  "type": "object",
+  "required": ["runId", "category", "whatHappened", "operatorAction"],
+  "additionalProperties": false,
+  "properties": {
+    "runId": { "type": "string", "minLength": 1 },
+    "category": { "enum": ["agent_error", "environment", "contract_violation", "cut_short", "unclear"] },
+    "whatHappened": { "type": "string", "minLength": 1 },
+    "operatorAction": { "type": "string", "minLength": 1 },
+    "evidenceLines": { "type": "array", "items": { "type": "string" } }
+  }
+}


### PR DESCRIPTION
Fixes OPS-373
Fixes OPS-376

**POC 2 — cross-run artifact consumption.** `factory.run-postmortem.requested {runId}` → `run-postmortem@1` reads `./transcript.json`, an artifact produced by a run it has no chain relationship with. The planner resolves it into `input.runPin` at plan time (hash in `inputHash` + receipt), so approval pins specific bytes. Unknown run / no stored transcript ⇒ `human_needed` with that exact reason.

Also: the fake adapter now writes `.transcript.json` like every real adapter — it was modelling a world where transcripts don't exist, which is what this agent consumes.

**OPS-376 — cold-start race**, introduced by OPS-233 and hit while provisioning this very worktree: `serve` and `work` start together, and against a brand-new database both run the initial WAL switch, which needs momentary exclusive access `busy_timeout` does not cover. One process died with `SQLITE_BUSY`. `openDb` now reads `journal_mode` first (steady state takes no lock) and retries the first-time switch.

Verification: 290 tests green (8 new — cross-run pinning, missing-run and missing-transcript parking, plus cold-start/immediate-transaction coverage). Live: fresh run → postmortem proposal carrying its transcript hash → approved → COMPLETED citing the transcript; a run predating the transcript fix correctly parked with "stored no transcript artifact"; a wiped worktree re-provisioned cleanly.