### PR TITLE
perf(worktrees): skip unchanged web builds, gate verify on seeding, parallel teardown

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -40,15 +40,35 @@ event_home() { printf '%s/.factory/event-runtime' "$1"; }
 
 pid_alive() { [[ -f "$1" ]] && kill -0 "$(cat "$1")" 2>/dev/null; }
 
-stop_daemon() { # <pidfile> <label>
+# Teardown is two-phase so the waits overlap: term_daemon every pidfile first,
+# then await_daemon each — total cost is the slowest daemon's exit, not the
+# sum of three sequential timeouts.
+term_daemon() { # <pidfile> <label>
   if pid_alive "$1"; then
     info "stopping $2 (pid $(cat "$1"))"
     kill "$(cat "$1")" 2>/dev/null || true
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-      pid_alive "$1" || break
-      sleep 0.3
-    done
-    pid_alive "$1" && kill -9 "$(cat "$1")" 2>/dev/null || true
+  fi
+}
+
+await_daemon() { # <pidfile> <label>
+  for _ in {1..30}; do
+    pid_alive "$1" || break
+    sleep 0.1
+  done
+  if pid_alive "$1"; then
+    warn "$2 ignored SIGTERM — killing"
+    kill -9 "$(cat "$1")" 2>/dev/null || true
   fi
   rm -f "$1"
+}
+
+# Content hash of everything that feeds the web bundle (names + contents, so
+# renames count). The inputs are a handful of source files — well under 0.1s.
+web_build_hash() { # <web-dir>
+  (
+    cd "$1" || exit 1
+    cat package.json bun.lock vite.config.ts tsconfig.json index.html 2>/dev/null
+    find src public -type f 2>/dev/null | LC_ALL=C sort
+    find src public -type f -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 cat 2>/dev/null
+  ) | shasum | cut -d' ' -f1
 }

--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -39,9 +39,12 @@ else
 fi
 
 RUN_DIR="$(run_dir "$WT")"
-stop_daemon "$RUN_DIR/web.pid" "web server"
-stop_daemon "$RUN_DIR/worker.pid" "worker"
-stop_daemon "$RUN_DIR/serve.pid" "event runtime"
+term_daemon "$RUN_DIR/web.pid" "web server"
+term_daemon "$RUN_DIR/worker.pid" "worker"
+term_daemon "$RUN_DIR/serve.pid" "event runtime"
+await_daemon "$RUN_DIR/web.pid" "web server"
+await_daemon "$RUN_DIR/worker.pid" "worker"
+await_daemon "$RUN_DIR/serve.pid" "event runtime"
 
 if [[ "$HERE" -eq 1 ]]; then
   info "removing demo state $(event_home "$WT")"

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -93,8 +93,20 @@ info "installing dependencies (bun install, root + web)"
 (cd "$WT" && bun install --frozen-lockfile >/dev/null) || die "bun install failed in $WT"
 (cd "$WT/event-runtime/web" && bun install --frozen-lockfile >/dev/null) || die "bun install failed in $WT/event-runtime/web"
 
-info "building the web bundle"
-(cd "$WT/event-runtime/web" && bun run build >/dev/null) || die "web build failed — run it manually: cd $WT/event-runtime/web && bun run build"
+# Rebuild only when the build inputs changed since the last successful build.
+# The stamp lives inside dist/, so vite wiping the output dir also wipes the
+# stamp and a half-finished build can never masquerade as current. build:fast
+# skips `tsc --noEmit` — type-checking belongs to verification/CI, not env
+# bring-up (`bun run build` in ci.yml still type-checks).
+WEB_DIR="$WT/event-runtime/web"
+WEB_HASH="$(web_build_hash "$WEB_DIR")"
+if [[ -f "$WEB_DIR/dist/index.html" && "$(cat "$WEB_DIR/dist/.buildstamp" 2>/dev/null)" == "$WEB_HASH" ]]; then
+  info "web bundle up to date — skipping build"
+else
+  info "building the web bundle"
+  (cd "$WEB_DIR" && bun run build:fast >/dev/null) || die "web build failed — run it manually: cd $WEB_DIR && bun run build"
+  printf '%s\n' "$WEB_HASH" >"$WEB_DIR/dist/.buildstamp"
+fi
 
 # ---------------------------------------------------------------- daemons ---
 FRESH=0
@@ -119,6 +131,17 @@ else
   ) &
   echo $! >"$RUN_DIR/serve.pid"
 fi
+
+# Wait for /health BEFORE starting the worker: on a fresh DB, serve and worker
+# opening the database concurrently race on the WAL journal-mode switch and
+# the loser dies with SQLITE_BUSY (OPS-376). Health up ⇒ serve owns a settled
+# DB, so the worker joins an existing WAL. Costs nothing — this poll happened
+# after the daemon block anyway.
+for _ in {1..50}; do
+  curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+curl -sf -m 2 "http://127.0.0.1:$API_PORT/health" >/dev/null || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
 
 # The worker is its own process (OPS-233): restarting the runtime or the web
 # server must never interrupt a running agent.
@@ -148,12 +171,6 @@ else
   echo $! >"$RUN_DIR/web.pid"
 fi
 
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && break
-  sleep 0.5
-done
-curl -sf -m 2 "http://127.0.0.1:$API_PORT/health" >/dev/null || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
-
 # ------------------------------------------------------------------- seed ---
 if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
   PREFIX="demo"
@@ -166,7 +183,10 @@ else
   warn "skipping demo seed (--no-seed)"
 fi
 
-if [[ "$SEED" -eq 1 ]]; then
+# Verify only when this run actually (re)seeded — on an idempotent re-run the
+# fixture was already verified when it was created, and /health above is the
+# liveness signal. `bun ... verify.mjs` stays in the report for on-demand use.
+if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
   info "verifying the e2e fixture"
   (cd "$WT" && bun event-runtime/demo/verify.mjs --port "$API_PORT") || die "fixture verification failed"
 fi

--- a/event-runtime/web/package.json
+++ b/event-runtime/web/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build"
+    "build": "tsc --noEmit && vite build",
+    "build:fast": "vite build"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.5",


### PR DESCRIPTION
Fixes OPS-379

Profiled `bin/worktree-up.sh`: bun installs are ~0.1s (global-cache clonefile), but `tsc --noEmit` (~1.8s) + `vite build` (~6.2s) + `verify.mjs` (~1s) ran on **every** invocation, so an idempotent re-run burned ~10s producing nothing.

## Changes
- **Stamp-gated build**: content hash of web build inputs (src/, public/, index.html, configs, lockfile) stored in `dist/.buildstamp`; rebuild only on mismatch or missing dist. Stamp lives inside dist/ so vite wiping the output dir also invalidates it.
- **`build:fast`** (vite only) for provisioning; CI's `bun run build` still type-checks.
- **Worker starts after `/health`**: on a fresh DB, serve+worker racing on the WAL journal-mode switch killed the worker with SQLITE_BUSY (reproduced 2/3 fresh provisions; script-level mitigation for OPS-376, which still owns the db.mjs fix). Costs nothing — the poll ran anyway, just later.
- **Verify gated on seeding**: `demo/verify.mjs` runs only when this invocation seeded (fresh/--reseed).
- **Parallel teardown**: SIGTERM all three daemons, then await together; polls at 0.1s.

## Measured
| scenario | before | after |
|---|---|---|
| idempotent re-run | ~10s | **0.15s** |
| fresh daemons+seed+verify (warm build) | ~16s | **3.0s** |
| teardown | up to ~9s | **~3.9s** (slowest daemon) |

## Verification
- 3× fresh down/up cycles green (seed + fixture verify pass, no SQLITE errors in worker.log)
- content change under `web/src/` → rebuilds; mtime-only touch → skips
- `bun test`: 447 pass, 0 fail