### PR TITLE
feat(event-runtime): scheduled clock events (OPS-381)

### DIFF
--- a/docs/event-runtime-schedules.md
+++ b/docs/event-runtime-schedules.md
@@ -1,6 +1,6 @@
 # Event runtime: scheduled clock events
 
-Status: **specified; not implemented**. Tracking: OPS-380.
+Status: **implemented** (OPS-381). Tracking: OPS-380 (this spec), OPS-381 (implementation).
 Parent: [event-runtime.md](event-runtime.md) §2 (`clock.tick.<loop>`), §3
 (isolation and capacity), §5.4 (idempotency), §12 (approval).
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -59,7 +59,7 @@ machinery it earns. Anything no listed event type needs stays unbuilt.
 | `keephq.disk-alert.raised` | Keep HQ infra alert webhook / replay CLI | two-node chain (diagnose → remediate) via the discovered-chain machinery, semantic verification recomputing reclaimed bytes from before/after probe evidence, typed remediation plans from a **closed action registry** (`lib/adapters/actions.mjs`), first infra-mutating executor behind watched approval (OPS-208) | shipped (watched) |
 | `github.workflow-run.failed` | GitHub webhook / replay CLI | first discovered chain (OPS-223): typed `ci-doctor` diagnosis → recommendation edges → watched closed-command follow-ups (`gh run rerun`, notify); command adapter and edge registry | shipped |
 | `sentry.issue.created` | Sentry webhook | *(dropped as a slice — Sentry already feeds Linear directly, so classifying here validates nothing operationally new; revisit only if that intake moves)* | — |
-| `clock.tick.<loop>` | scheduler | admitted, audited timer events; per-loop migration of the standing loops — **specified in [event-runtime-schedules.md](event-runtime-schedules.md)** (OPS-380), not yet built | specified |
+| `clock.tick.<loop>` | scheduler | admitted, audited timer events; per-loop migration of the standing loops — **[event-runtime-schedules.md](event-runtime-schedules.md)** (OPS-380/OPS-381) | shipped, loops off by default |
 | repository-mutating events | GitHub / Linear | shared claim, capacity, Owned Paths, and approval authority with the ticket dispatcher (§3) | last |
 
 Clock events are called out deliberately. [architecture.md](architecture.md)

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -27,6 +27,7 @@ bun event-runtime/cli.mjs runs [state]                   # event runs, optionall
 bun event-runtime/cli.mjs proposals                   # open proposals with TTL age
 bun event-runtime/cli.mjs agents                      # registered agents and event routing
 bun event-runtime/cli.mjs workers                     # worker processes: host, labels, state, heartbeat
+bun event-runtime/cli.mjs schedule                    # recurring loops: cadence, last fire, next due
 bun event-runtime/cli.mjs requeue <source> <event-id> # re-plan a dead-lettered/human_needed event
 bun event-runtime/cli.mjs approve <proposal-id>
 bun event-runtime/cli.mjs reject <proposal-id> "<reason>"
@@ -56,6 +57,41 @@ bun event-runtime/web/serve.mjs                        # http://127.0.0.1:7382 (
 Dev loop: `cd event-runtime/web && bunx vite` (proxies /api to the control
 API). Keyboard-first: `⌘K` palette, `g o/p/r` to navigate, `j/k` + `Enter` on
 lists, `a`/`x` to approve/reject the selected proposal.
+
+## Scheduled loops (OPS-381)
+
+A tick is an **event**, not a job (docs/event-runtime-schedules.md). `serve`
+emits `clock.tick.<loop>` on a cadence and the ordinary intake → planner →
+proposal path takes over, so a recurring job gets the same dedup, audit
+trail, and approval gate as a webhook. `config/schedule.yaml`, launchd, and
+the orchestrator are untouched — this is a second, independent mechanism.
+
+```jsonc
+// event-runtime/schedules.json
+"reaper": { "every": "60m", "eventType": "clock.tick.reaper",
+            "catchUp": "none", "singleton": true,
+            "approval": "watched", "enabled": false }
+```
+
+- **Slots, not instants.** `eventId = clock:<loop>:<slot>`, so restarting
+  `serve` three times in one interval admits one tick.
+- **Catch-up** is declared per loop: `none` (default — one reaper now is what
+  six would have achieved, and the tick records how many slots it stands
+  for), `last`, or `all`.
+- **Singleton**: a loop whose previous run is still in flight plans a typed
+  NOOP (`previous_run_in_flight`), never a backlog.
+- **Approval is earned**: `watched` by default; `approval: auto` records
+  `actor: "schedule"` in the journal — never `"operator"`, because a run
+  nobody looked at must not be indistinguishable from one a human approved.
+- **Deterministic commands first** (§3 capacity): the reaper is
+  `orchestrator/reaper.mjs`, not an LLM — a scheduled agent would draw on the
+  same unobservable usage window as interactive sessions.
+
+`cli.mjs schedule` shows cadence, last fire, next due and whether a loop has
+stopped; an enabled loop silent for more than two intervals is a doctor
+anomaly, because silence is the failure mode a scheduler must not have. The
+shipped `reaper` loop is `enabled: false`: switching it on is a deliberate
+act.
 
 ## Artifact inputs (OPS-372)
 
@@ -222,6 +258,7 @@ spec (§12).
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
 | `lib/adapters/` | adapter registry: `claude` (real), `fake` (tests) (§6) |
 | `lib/artifacts.mjs` | content-addressed store: collect, serve, materialize declared inputs, retention (OPS-372) |
+| `lib/schedules.mjs` `schedules.json` | clock ticks: slots, catch-up, singleton, earned auto-approval (OPS-381) |
 | `lib/workers.mjs` | worker registry, heartbeats, placement predicate (OPS-233) |
 | `lib/repos.mjs` `lib/repository.mjs` | repos.yaml reader; mirror + pinned read-only checkout (OPS-228) |
 | `lib/adapters/actions.mjs` | closed action-list executor: approved action IDs → fixed SSH commands, probe evidence (OPS-208) |

--- a/event-runtime/agents/reaper.json
+++ b/event-runtime/agents/reaper.json
@@ -1,0 +1,35 @@
+{
+  "id": "reaper",
+  "version": 1,
+  "prompt": "agents/reaper.md",
+  "input_schema": "schemas/reaper.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "bun",
+    "{factoryRoot}/orchestrator/reaper.mjs",
+    "--apply"
+  ],
+  "captureStdout": "reaper.log",
+  "captureKind": "log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/reaper.md": "sha256:87836b6d71a90d39c0a27639f3bb959c9a8f1919186bfa0bc2fe11697fc557cb",
+    "schemas/reaper.input.json": "sha256:22a4cc569a8c46cf8f199566f7d432b931ab311547fae41ec3934b454f9074dd",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/reaper.md
+++ b/event-runtime/agents/reaper.md
@@ -1,0 +1,18 @@
+# reaper — closed-registry action
+
+Not a prompt: this definition runs a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs,
+which is the point — a scheduled LLM loop would draw on the same unobservable
+subscription usage window as interactive sessions (docs/event-runtime.md §3),
+and a timer that can starve the operator's own work is not a loop worth
+having yet.
+
+```
+bun {factoryRoot}/orchestrator/reaper.mjs --apply
+```
+
+Reclaims stale agent claims in Linear: tickets left `In Progress` with an
+`ai:in-progress` / `agent:*` marker by an agent that crashed mid-ticket. The
+script is dry-run by default; `--apply` is visible here in the registry
+rather than buried in a plist, and its whole output is captured as an
+artifact.

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -28,9 +28,11 @@ import { openDb } from "./lib/db.mjs";
 import { newWorkerId } from "./lib/ids.mjs";
 import { pruneArtifacts } from "./lib/artifacts.mjs";
 import { publishOutbox } from "./lib/outbox.mjs";
+import { autoApproveScheduled, emitDueTicks, scheduleView } from "./lib/schedules.mjs";
 import { resolveChains } from "./lib/chain.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
+import { approveProposal } from "./lib/proposals.mjs";
 import { startApi } from "./lib/api.mjs";
 import { claimNext, executeClaimed, reapExpiredLeases, runOnce } from "./lib/worker.mjs";
 import { deregisterWorker, heartbeat, registerWorker } from "./lib/workers.mjs";
@@ -53,6 +55,7 @@ usage: bun event-runtime/cli.mjs <command>
   proposals                      open proposals with TTL age
   agents                         registered agent definitions and event routing
   workers                        worker processes: host, labels, state, heartbeat
+  schedule                       recurring loops: cadence, approval, last fire, next due
   repos                          factory repos: team, base, dispatch vs report-only
   approve <proposal-id>          approve an open proposal
   reject <proposal-id> <reason>  reject an open proposal
@@ -186,7 +189,22 @@ async function serve(args) {
     busy = true;
     try {
       const nowMs = Date.now();
+      // Scheduled loops (OPS-381): a tick is an event, admitted through the
+      // same intake as a webhook. The eventId is the slot, so restarting
+      // serve mid-interval cannot double-fire.
+      const ticks = emitDueTicks(db, registry, { now: nowMs });
+      for (const t of ticks.emitted) {
+        log(`tick ${t.loop} @ ${t.slot}${t.skipped > 0 ? ` (stands for ${t.skipped} skipped slot(s))` : ""}`);
+      }
+      for (const err of ticks.errors) log(`schedule error: ${err}`);
+
       planAdmittedEvents(db, registry, { now: nowMs, policyVersion: pv, adapterOverride });
+
+      // Earned automation (§6): only loops that declare approval "auto", and
+      // always recorded with the scheduler as actor.
+      const auto = autoApproveScheduled(db, registry, approveProposal, { now: nowMs, policyVersion: pv });
+      for (const a of auto.approved) log(`schedule approved ${a.loop} → run ${a.runId} (actor: schedule)`);
+      for (const err of auto.errors) log(`schedule approval error: ${err}`);
       announceProposals();
       announceTransitions();
       reapExpiredLeases(db, { now: nowMs, policyVersion: pv });
@@ -581,6 +599,21 @@ async function repos(client) {
   }
 }
 
+async function schedule(client) {
+  const { schedules } = await client.schedules();
+  if (schedules.length === 0) {
+    console.log("no schedules registered (event-runtime/schedules.json)");
+    return;
+  }
+  console.log(`${pad("LOOP", 16)}${pad("EVERY", 8)}${pad("ENABLED", 9)}${pad("APPROVAL", 10)}${pad("CATCHUP", 9)}${pad("LAST SLOT", 26)}${pad("NEXT DUE", 26)}STATE`);
+  for (const s of schedules) {
+    const state = s.error ? `error: ${s.error}` : s.stopped ? `STOPPED (${s.intervalsLate} intervals late)` : s.enabled ? "ok" : "off";
+    console.log(
+      `${pad(s.loop, 16)}${pad(s.every, 8)}${pad(s.enabled ? "yes" : "no", 9)}${pad(s.approval, 10)}${pad(s.catchUp, 9)}${pad(s.lastSlot ?? "-", 26)}${pad(s.nextDue ?? "-", 26)}${state}`,
+    );
+  }
+}
+
 async function agents(client) {
   const { agents: defs } = await client.agents();
   for (const d of defs) {
@@ -637,6 +670,9 @@ async function main() {
 
     case "workers":
       return withClient(workers);
+
+    case "schedule":
+      return withClient(schedule);
 
     case "repos":
       return withClient(repos);

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -96,5 +96,13 @@
       "inputHash"
     ],
     "proposalTtlSeconds": 1800
+  },
+  "clock.tick.reaper": {
+    "agent": "reaper@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "correlationId"
+    ],
+    "proposalTtlSeconds": 3600
   }
 }

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -24,6 +24,7 @@ import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { storeStats } from "./artifacts.mjs";
+import { scheduleView } from "./schedules.mjs";
 import { listWorkers, stalledWorkers } from "./workers.mjs";
 
 /**
@@ -128,7 +129,7 @@ function runCounts(db) {
 }
 
 /** §13 status + doctor view: aggregates plus anomalies, all read-only SQL. */
-function statusView(db, nowMs) {
+function statusView(db, registry, nowMs) {
   const open = openProposals(db, { now: nowMs });
   const expiredOpen = open.filter((p) => p.expired);
   const staleLeases = db
@@ -147,6 +148,7 @@ function statusView(db, nowMs) {
     .map((row) => ({ source: row.source, eventId: row.event_id, lastError: row.last_plan_error }));
 
   const workers = listWorkers(db, { now: nowMs });
+  const schedules = scheduleView(db, registry, { now: nowMs });
   const store = storeStats(db, artifactsRoot(), { now: nowMs });
   const stalled = stalledWorkers(db, { now: nowMs });
 
@@ -168,6 +170,11 @@ function statusView(db, nowMs) {
       // A worker holding a run whose heartbeat stopped: its lease may still be
       // valid, so nothing has reclaimed the run yet (OPS-233).
       stalledWorkers: stalled.map((w) => ({ workerId: w.workerId, host: w.host, runId: w.currentRun, lastSeen: w.lastSeen })),
+      // A scheduler's worst failure mode is silence (§9): an enabled loop
+      // that has not ticked for more than two intervals is not running.
+      stoppedSchedules: schedules
+        .filter((s) => s.stopped || s.error)
+        .map((s) => ({ loop: s.loop, every: s.every, lastSlot: s.lastSlot, intervalsLate: s.intervalsLate, error: s.error })),
       noWorkers: workers.filter((w) => w.state !== "stopped" && !w.stale).length === 0 && (runCounts(db).byState.QUEUED ?? 0) > 0,
       // Two or more open proposals on one run: cancel fail-closes and leaves
       // them open (OPS-245). Unreachable on the TTL replan path.
@@ -507,7 +514,7 @@ export function createApi({
       }
 
       if (route === "GET /status") {
-        return send(res, 200, { env, ...statusView(db, nowMs) });
+        return send(res, 200, { env, ...statusView(db, registry, nowMs) });
       }
 
       if (route === "GET /events") {
@@ -518,6 +525,10 @@ export function createApi({
         const status = url.searchParams.get("status");
         if (status) return send(res, 200, { proposals: proposalHistory(db, status === "all" ? null : status) });
         return send(res, 200, { proposals: openProposals(db, { now: nowMs }).map(proposalView) });
+      }
+
+      if (route === "GET /schedules") {
+        return send(res, 200, { schedules: scheduleView(db, registry, { now: nowMs }) });
       }
 
       if (route === "GET /workers") {

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -58,6 +58,7 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
       call("POST", "/events/requeue", { body: JSON.stringify({ source, eventId }) }),
     agents: () => call("GET", "/agents"),
     workers: () => call("GET", "/workers"),
+    schedules: () => call("GET", "/schedules"),
     /** Factory repo registry from config/repos.yaml (OPS-299). */
     repos: () => call("GET", "/repos"),
     /**

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -17,6 +17,7 @@ import { createRun } from "./lifecycle.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
 import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
+import { loopInFlight } from "./schedules.mjs";
 import { resolveInputRef } from "./workspace.mjs";
 
 /**
@@ -123,6 +124,21 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const ttlSeconds = mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS;
 
     const def = getAgent(registry, mapping.agent);
+
+    // §5 singleton: a scheduled loop whose previous run is still in flight
+    // plans a typed NOOP, never a second queued run. A reaper that takes 70
+    // minutes must not accumulate a backlog of reapers.
+    const loop = envelope.payload?.loop;
+    const schedule = loop ? registry.schedules?.[loop] : null;
+    if (schedule && schedule.singleton !== false && loopInFlight(db, mapping.agent)) {
+      const proposal = insertProposal(db, {
+        id: newProposalId(), event, decision: "noop", status: "resolved",
+        reason: "previous_run_in_flight", at, ttlSeconds,
+      });
+      setEventStatus(db, event, "noop");
+      return { decision: "noop", proposal, reason: "previous_run_in_flight" };
+    }
+
     const input = validate(def.inputSchema, envelope.payload);
     if (!input.valid) return humanNeeded(db, event, `invalid_input: ${input.errors[0]}`, at, ttlSeconds);
 

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -11,6 +11,7 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { hashBytes } from "./canonical.mjs";
+import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 
 export class RegistryError extends Error {
@@ -127,7 +128,40 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
     }
   }
 
-  return { root, agents, eventTypes, schemas, edges };
+  // Schedules (OPS-381): validated fail-closed at load — an unparseable
+  // cadence or an unregistered event type must be a startup error, not a
+  // surprise at 03:00 when nothing fires.
+  let schedules = {};
+  const schedulesFile = path.join(root, "schedules.json");
+  if (existsSync(schedulesFile)) {
+    schedules = JSON.parse(readFileSync(schedulesFile, "utf8"));
+    for (const [loop, schedule] of Object.entries(schedules)) {
+      if (!/^[a-z][a-z0-9-]*$/.test(loop)) throw new RegistryError(`schedules.json: bad loop name "${loop}"`);
+      try {
+        parseCadence(schedule.every);
+      } catch (err) {
+        throw new RegistryError(`schedules.json: ${loop}: ${err.message}`);
+      }
+      if (!eventTypes[schedule.eventType]) {
+        throw new RegistryError(`schedules.json: ${loop} fires unregistered event type ${schedule.eventType}`);
+      }
+      const catchUp = schedule.catchUp ?? "none";
+      if (!CATCH_UP_MODES.includes(catchUp)) {
+        throw new RegistryError(`schedules.json: ${loop} has unknown catchUp "${catchUp}" (${CATCH_UP_MODES.join(", ")})`);
+      }
+      const approval = schedule.approval ?? "watched";
+      if (!APPROVAL_MODES.includes(approval)) {
+        throw new RegistryError(`schedules.json: ${loop} has unknown approval "${approval}" (${APPROVAL_MODES.join(", ")})`);
+      }
+      // Unattended approval on a loop that is not even switched on is almost
+      // certainly a half-finished edit; refuse it rather than let it lurk.
+      if (approval === "auto" && !schedule.enabled) {
+        throw new RegistryError(`schedules.json: ${loop} declares approval "auto" but is not enabled — decide one`);
+      }
+    }
+  }
+
+  return { root, agents, eventTypes, schemas, edges, schedules };
 }
 
 export function getAgent(registry, ref) {

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -1,0 +1,225 @@
+/**
+ * Scheduled clock events (docs/event-runtime-schedules.md; OPS-381).
+ *
+ * A tick is an event, not a job: `serve` emits `clock.tick.<loop>` on a
+ * cadence and the ordinary intake → planner → proposal path takes over. The
+ * scheduler knows nothing about agents, and the planner knows nothing about
+ * time.
+ *
+ * Everything here is pure except `dueTicks`'s database read, so slot maths —
+ * the part that decides whether a restart double-fires — is testable without
+ * a clock or a runtime.
+ */
+import { admitEvent } from "./intake.mjs";
+
+export const SCHEDULE_SOURCE = "schedule";
+export const CATCH_UP_MODES = ["none", "last", "all"];
+export const APPROVAL_MODES = ["watched", "auto"];
+
+/** "60m" / "30s" / "2h" / "1d" → seconds. Intervals only: no cron, no timezone. */
+export function parseCadence(every) {
+  const match = /^(\d+)([smhd])$/.exec(String(every ?? "").trim());
+  if (!match) throw new Error(`unparseable cadence "${every}" — use 30s, 15m, 2h or 1d`);
+  const value = Number(match[1]);
+  if (value <= 0) throw new Error(`cadence "${every}" must be positive`);
+  return value * { s: 1, m: 60, h: 3600, d: 86400 }[match[2]];
+}
+
+/**
+ * The slot a moment belongs to: the interval floor from the epoch. Identity
+ * comes from the slot, never from the instant a tick was emitted — that is
+ * what makes a restart mid-interval a no-op instead of a second run.
+ */
+export function slotFor(nowMs, cadenceSeconds) {
+  const period = cadenceSeconds * 1000;
+  return new Date(Math.floor(nowMs / period) * period).toISOString();
+}
+
+export const tickEventId = (loop, slot) => `clock:${loop}:${slot}`;
+
+/**
+ * Which slots to fire, given the last one already admitted (§4 catch-up).
+ *
+ * `none` collapses an outage to a single run — for an idempotent maintenance
+ * loop, reaping once now is what reaping six times would have achieved —
+ * while still reporting how many slots it stands for, so a six-hour gap
+ * reads as a decision rather than as silence.
+ *
+ * @returns {{ slots: string[], skipped: number }}
+ */
+export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none" }) {
+  const current = slotFor(nowMs, cadenceSeconds);
+  if (!lastSlot) return { slots: [current], skipped: 0 };
+  if (Date.parse(lastSlot) >= Date.parse(current)) return { slots: [], skipped: 0 };
+
+  const period = cadenceSeconds * 1000;
+  const missed = [];
+  for (let t = Date.parse(lastSlot) + period; t <= Date.parse(current); t += period) {
+    missed.push(new Date(t).toISOString());
+  }
+  if (catchUp === "all") return { slots: missed, skipped: 0 };
+  // "none" and "last" both fire exactly one tick here; they differ only in
+  // which slot it claims to be, and therefore in what a replay would mean.
+  const slots = [catchUp === "last" ? missed[missed.length - 1] : current];
+  return { slots, skipped: Math.max(0, missed.length - 1) };
+}
+
+/** The newest slot already admitted for a loop, or null if it never fired. */
+export function lastAdmittedSlot(db, loop) {
+  const row = db
+    .query(
+      `SELECT event_id FROM events
+       WHERE source = ? AND type = ?
+       ORDER BY event_id DESC LIMIT 1`,
+    )
+    .get(SCHEDULE_SOURCE, `clock.tick.${loop}`);
+  // eventId is clock:<loop>:<ISO slot>; ISO sorts lexicographically, so the
+  // newest row is the newest slot without parsing every payload.
+  return row ? row.event_id.slice(`clock:${loop}:`.length) : null;
+}
+
+/**
+ * Emit every due tick for every enabled loop. Idempotent by construction:
+ * the eventId is the slot, so a `serve` restarted three times in one interval
+ * admits one tick.
+ *
+ * @returns {{ emitted: Array<{loop: string, slot: string, skipped: number}>, errors: string[] }}
+ */
+export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
+  const emitted = [];
+  const errors = [];
+  for (const [loop, schedule] of Object.entries(registry.schedules ?? {})) {
+    if (!schedule.enabled) continue;
+    try {
+      const cadenceSeconds = parseCadence(schedule.every);
+      const { slots, skipped } = dueSlots({
+        lastSlot: lastAdmittedSlot(db, loop),
+        nowMs: now,
+        cadenceSeconds,
+        catchUp: schedule.catchUp,
+      });
+      for (const slot of slots) {
+        const outcome = admitEvent(
+          db,
+          registry,
+          {
+            schemaVersion: "factory.event/v1",
+            eventId: tickEventId(loop, slot),
+            type: schedule.eventType,
+            source: SCHEDULE_SOURCE,
+            subject: loop,
+            occurredAt: slot,
+            correlationId: tickEventId(loop, slot),
+            causationId: null,
+            // skippedSlots travels on the tick that did fire: the audit trail
+            // says "this run stands for 5 slots nobody was awake for".
+            payload: { loop, slot, cadenceSeconds, skippedSlots: skipped },
+          },
+          { now },
+        );
+        if (outcome.admitted) emitted.push({ loop, slot, skipped });
+        else if (!outcome.duplicate) errors.push(`${loop}@${slot}: ${outcome.errors.join("; ")}`);
+      }
+    } catch (err) {
+      errors.push(`${loop}: ${err.message}`);
+    }
+  }
+  return { emitted, errors };
+}
+
+/** Is a run for this loop's agent still in flight? (§5 singleton) */
+export function loopInFlight(db, agentRef) {
+  const row = db
+    .query(
+      `SELECT COUNT(*) AS n FROM runs
+       WHERE state NOT IN ('COMPLETED','REFUSED','FAILED','TIMED_OUT','CANCELLED')
+         AND json_extract(spec_json, '$.agent') = ?`,
+    )
+    .get(agentRef);
+  return row.n > 0;
+}
+
+/**
+ * Operator view (§9): what is scheduled, when it last fired, when it is due,
+ * and whether the clock has stopped — the question a scheduler must always be
+ * able to answer, and the one a launchd plist cannot.
+ */
+export function scheduleView(db, registry, { now = Date.now() } = {}) {
+  return Object.entries(registry.schedules ?? {}).map(([loop, schedule]) => {
+    let cadenceSeconds = null;
+    let error = null;
+    try {
+      cadenceSeconds = parseCadence(schedule.every);
+    } catch (err) {
+      error = err.message;
+    }
+    const lastSlot = lastAdmittedSlot(db, loop);
+    const nextDue =
+      cadenceSeconds && lastSlot
+        ? new Date(Date.parse(lastSlot) + cadenceSeconds * 1000).toISOString()
+        : cadenceSeconds
+          ? slotFor(now, cadenceSeconds)
+          : null;
+    const intervalsLate =
+      cadenceSeconds && lastSlot
+        ? Math.floor((now - Date.parse(lastSlot)) / (cadenceSeconds * 1000))
+        : null;
+    return {
+      loop,
+      every: schedule.every,
+      cadenceSeconds,
+      eventType: schedule.eventType,
+      approval: schedule.approval ?? "watched",
+      catchUp: schedule.catchUp ?? "none",
+      singleton: schedule.singleton !== false,
+      enabled: Boolean(schedule.enabled),
+      lastSlot,
+      nextDue,
+      intervalsLate,
+      // Enabled, has fired before, and more than two intervals have passed:
+      // the clock is not turning (serve down, machine asleep, bad cadence).
+      stopped: Boolean(schedule.enabled) && intervalsLate !== null && intervalsLate > 2,
+      error,
+    };
+  });
+}
+
+/**
+ * Approve open proposals belonging to loops that declare `approval: auto`
+ * (§6). Separate from planning on purpose: auto-approval is the step that
+ * changes what the runtime may do unattended, so it is one explicit call
+ * that can be read, tested, and turned off.
+ *
+ * The actor is "schedule", never "operator". A run nobody looked at must
+ * never be indistinguishable from one a human approved — that distinction is
+ * the audit trail.
+ */
+export function autoApproveScheduled(db, registry, approve, { now = Date.now(), policyVersion } = {}) {
+  const approved = [];
+  const errors = [];
+  const autoLoops = new Set(
+    Object.entries(registry.schedules ?? {})
+      .filter(([, s]) => s.enabled && (s.approval ?? "watched") === "auto")
+      .map(([loop]) => loop),
+  );
+  if (autoLoops.size === 0) return { approved, errors };
+
+  const rows = db
+    .query(
+      `SELECT p.id, e.envelope_json FROM proposals p
+       JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+       WHERE p.status = 'open' AND p.decision = 'run' AND e.source = ?`,
+    )
+    .all(SCHEDULE_SOURCE);
+  for (const row of rows) {
+    const loop = JSON.parse(row.envelope_json).payload?.loop;
+    if (!autoLoops.has(loop)) continue;
+    try {
+      const outcome = approve(db, registry, row.id, { actor: SCHEDULE_SOURCE, now, policyVersion });
+      if (outcome.approved) approved.push({ loop, proposalId: row.id, runId: outcome.runId });
+    } catch (err) {
+      errors.push(`${loop}: ${err.message}`);
+    }
+  }
+  return { approved, errors };
+}

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./adapters/fake.mjs";
+import { openDb } from "./db.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import {
+  autoApproveScheduled,
+  dueSlots,
+  emitDueTicks,
+  lastAdmittedSlot,
+  parseCadence,
+  scheduleView,
+  slotFor,
+  tickEventId,
+} from "./schedules.mjs";
+import { runOnce } from "./worker.mjs";
+
+const PV = "git:test-pv";
+const base = loadRegistry();
+const db = () => openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-sched-")), "runtime.db"));
+
+/** The real registry with one loop overridden — schedules are just data. */
+const withLoop = (overrides = {}) => ({
+  ...base,
+  schedules: {
+    reaper: {
+      every: "60m",
+      eventType: "clock.tick.reaper",
+      catchUp: "none",
+      singleton: true,
+      approval: "watched",
+      enabled: true,
+      ...overrides,
+    },
+  },
+});
+
+const at = (iso) => Date.parse(iso);
+
+describe("cadence and slots", () => {
+  test("parses the interval forms and rejects everything else", () => {
+    expect(parseCadence("30s")).toBe(30);
+    expect(parseCadence("60m")).toBe(3600);
+    expect(parseCadence("2h")).toBe(7200);
+    expect(parseCadence("1d")).toBe(86400);
+    for (const bad of ["", "60", "0m", "5 minutes", "* * * * *", "-1h", null]) {
+      expect(() => parseCadence(bad)).toThrow();
+    }
+  });
+
+  test("a slot is the interval floor, so every moment inside it maps to one id", () => {
+    const hour = 3600;
+    expect(slotFor(at("2026-08-13T21:00:00Z"), hour)).toBe("2026-08-13T21:00:00.000Z");
+    expect(slotFor(at("2026-08-13T21:59:59Z"), hour)).toBe("2026-08-13T21:00:00.000Z");
+    expect(slotFor(at("2026-08-13T22:00:00Z"), hour)).toBe("2026-08-13T22:00:00.000Z");
+  });
+});
+
+describe("dueSlots — catch-up policy (§4)", () => {
+  const hour = 3600;
+  const now = at("2026-08-14T04:30:00Z");
+
+  test("a loop that never fired fires once, for the current slot", () => {
+    expect(dueSlots({ lastSlot: null, nowMs: now, cadenceSeconds: hour })).toEqual({
+      slots: ["2026-08-14T04:00:00.000Z"],
+      skipped: 0,
+    });
+  });
+
+  test("already fired this slot → nothing due (the restart case)", () => {
+    expect(
+      dueSlots({ lastSlot: "2026-08-14T04:00:00.000Z", nowMs: now, cadenceSeconds: hour }),
+    ).toEqual({ slots: [], skipped: 0 });
+  });
+
+  test("none: six missed slots collapse to one run that says so", () => {
+    const outcome = dueSlots({
+      lastSlot: "2026-08-13T22:00:00.000Z",
+      nowMs: now,
+      cadenceSeconds: hour,
+      catchUp: "none",
+    });
+    expect(outcome.slots).toEqual(["2026-08-14T04:00:00.000Z"]);
+    expect(outcome.skipped).toBe(5);
+  });
+
+  test("last: fires the most recent missed slot rather than the current one", () => {
+    const outcome = dueSlots({
+      lastSlot: "2026-08-13T22:00:00.000Z",
+      nowMs: now,
+      cadenceSeconds: hour,
+      catchUp: "last",
+    });
+    expect(outcome.slots).toEqual(["2026-08-14T04:00:00.000Z"]);
+  });
+
+  test("all: every missed slot fires, in order, nothing skipped", () => {
+    const outcome = dueSlots({
+      lastSlot: "2026-08-14T01:00:00.000Z",
+      nowMs: now,
+      cadenceSeconds: hour,
+      catchUp: "all",
+    });
+    expect(outcome.slots).toEqual([
+      "2026-08-14T02:00:00.000Z",
+      "2026-08-14T03:00:00.000Z",
+      "2026-08-14T04:00:00.000Z",
+    ]);
+    expect(outcome.skipped).toBe(0);
+  });
+});
+
+describe("emitDueTicks (§3)", () => {
+  test("restarting serve inside one interval admits exactly one tick", () => {
+    const d = db();
+    const registry = withLoop();
+    const now = at("2026-08-13T21:10:00Z");
+
+    const first = emitDueTicks(d, registry, { now });
+    expect(first.emitted).toHaveLength(1);
+    expect(first.emitted[0].slot).toBe("2026-08-13T21:00:00.000Z");
+
+    // Three more "restarts" later in the same hour: nothing new.
+    for (const minutes of [20, 40, 59]) {
+      const again = emitDueTicks(d, registry, { now: at(`2026-08-13T21:${minutes}:00Z`) });
+      expect(again.emitted).toEqual([]);
+    }
+    expect(d.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
+
+    // Next hour fires once.
+    expect(emitDueTicks(d, registry, { now: at("2026-08-13T22:05:00Z") }).emitted).toHaveLength(1);
+  });
+
+  test("the tick carries its loop, slot and how many slots it stands for", () => {
+    const d = db();
+    const registry = withLoop();
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    emitDueTicks(d, registry, { now: at("2026-08-14T04:00:00Z") });
+
+    const row = d.query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`).get();
+    const envelope = JSON.parse(row.envelope_json);
+    expect(envelope.payload).toMatchObject({ loop: "reaper", skippedSlots: 5 });
+    expect(envelope.eventId).toBe(tickEventId("reaper", "2026-08-14T04:00:00.000Z"));
+    expect(envelope.source).toBe("schedule");
+  });
+
+  test("a disabled loop never fires", () => {
+    const d = db();
+    expect(emitDueTicks(d, withLoop({ enabled: false }), { now: Date.now() }).emitted).toEqual([]);
+  });
+
+  test("lastAdmittedSlot reads back the newest slot", () => {
+    const d = db();
+    const registry = withLoop();
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    expect(lastAdmittedSlot(d, "reaper")).toBe("2026-08-13T22:00:00.000Z");
+  });
+});
+
+describe("planning a tick (§5, §6)", () => {
+  const adapters = { command: fake, claude: fake };
+  const workerOpts = () => ({
+    workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-ws-")),
+    artifactStore: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-store-")),
+    owner: "w",
+    policyVersion: PV,
+  });
+
+  test("a watched loop proposes and runs nothing until approved", () => {
+    const d = db();
+    const registry = withLoop();
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+
+    const proposal = openProposals(d, {}).find((p) => p.spec?.agent === "reaper@1");
+    expect(proposal).toBeTruthy();
+    expect(proposal.status).toBe("open");
+    expect(d.query(`SELECT state FROM runs`).get().state).toBe("PROPOSED");
+
+    // Auto-approval must not touch a watched loop.
+    expect(autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV }).approved).toEqual([]);
+    expect(openProposals(d, {}).find((p) => p.spec?.agent === "reaper@1").status).toBe("open");
+  });
+
+  test("an auto loop is approved by the scheduler — and the journal says so", () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+
+    const outcome = autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
+    expect(outcome.approved).toHaveLength(1);
+    const runId = outcome.approved[0].runId;
+    expect(d.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId).state).toBe("QUEUED");
+
+    // The distinction that is the whole audit trail: nobody looked at this.
+    const approval = d
+      .query(`SELECT actor FROM lifecycle_events WHERE run_id = ? AND to_state = 'APPROVED'`)
+      .get(runId);
+    expect(approval.actor).toBe("schedule");
+    expect(approval.actor).not.toBe("operator");
+  });
+
+  test("singleton: a loop whose previous run is in flight plans a NOOP, not a queue", async () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
+    // The run is QUEUED — in flight, not terminal.
+
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+
+    const noop = d
+      .query(`SELECT decision, reason FROM proposals WHERE decision = 'noop' ORDER BY rowid DESC LIMIT 1`)
+      .get();
+    expect(noop.reason).toBe("previous_run_in_flight");
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("once the previous run finishes, the next tick plans normally", async () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
+    await runOnce(d, registry, adapters, workerOpts());
+
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+  });
+});
+
+describe("scheduleView (§9)", () => {
+  test("reports cadence, last fire, next due — and a stopped clock", () => {
+    const d = db();
+    const registry = withLoop();
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+
+    const soon = scheduleView(d, registry, { now: at("2026-08-13T21:30:00Z") })[0];
+    expect(soon).toMatchObject({ loop: "reaper", every: "60m", enabled: true, stopped: false });
+    expect(soon.lastSlot).toBe("2026-08-13T21:00:00.000Z");
+    expect(soon.nextDue).toBe("2026-08-13T22:00:00.000Z");
+
+    // Five hours of silence on an hourly loop: the clock is not turning.
+    const later = scheduleView(d, registry, { now: at("2026-08-14T02:00:00Z") })[0];
+    expect(later.stopped).toBe(true);
+    expect(later.intervalsLate).toBe(5);
+  });
+
+  test("a disabled loop is never reported stopped", () => {
+    const d = db();
+    const registry = withLoop({ enabled: false });
+    expect(scheduleView(d, registry, { now: Date.now() })[0].stopped).toBe(false);
+  });
+});
+
+describe("registry validation of schedules.json", () => {
+  test("the shipped reaper loop is registered, watched, and off by default", () => {
+    expect(base.schedules.reaper).toMatchObject({
+      every: "60m",
+      eventType: "clock.tick.reaper",
+      approval: "watched",
+      enabled: false,
+    });
+    // Enabling it must stay a deliberate act, not a default someone inherits.
+    expect(base.schedules.reaper.enabled).toBe(false);
+  });
+
+  test("the reaper agent is a closed command template, not a model", () => {
+    const def = base.agents.get("reaper@1");
+    expect(def.mutating).toBe(true);
+    expect(def.command[0]).toBe("bun");
+    expect(def.command.join(" ")).toContain("orchestrator/reaper.mjs");
+  });
+});

--- a/event-runtime/schedules.json
+++ b/event-runtime/schedules.json
@@ -1,0 +1,10 @@
+{
+  "reaper": {
+    "every": "60m",
+    "eventType": "clock.tick.reaper",
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  }
+}

--- a/event-runtime/schemas/reaper.input.json
+++ b/event-runtime/schemas/reaper.input.json
@@ -1,0 +1,12 @@
+{
+  "title": "reaper input — a clock tick (docs/event-runtime-schedules.md §3)",
+  "type": "object",
+  "required": ["loop", "slot"],
+  "additionalProperties": false,
+  "properties": {
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
+  }
+}


### PR DESCRIPTION
Fixes OPS-381

Implements docs/event-runtime-schedules.md (spec OPS-380). Recurring work — e.g. the reaper every 60 minutes — as admitted, audited events rather than launchd jobs.

- **Slots, not instants**: `eventId = clock:<loop>:<slot>`; restarting `serve` mid-interval admits one tick.
- **Catch-up per loop**: `none` (default) collapses an outage to one run and records `skippedSlots`; `last`; `all`.
- **Singleton**: previous run in flight ⇒ typed NOOP `previous_run_in_flight`, never a backlog.
- **Earned approval**: `watched` default; `approval: auto` approves with `actor: "schedule"` — never `"operator"`.
- **`reaper@1`**: deterministic command over `orchestrator/reaper.mjs` (§3 capacity — no scheduled LLM), shipped `enabled: false`.
- **Visibility**: `GET /schedules`, `cli.mjs schedule`, and a doctor anomaly for an enabled loop silent >2 intervals.
- Registry validation fails closed on bad cadence, unregistered event type, unknown catchUp/approval, or `auto` without `enabled`.

Untouched: `config/schedule.yaml`, `deploy/launchd/`, `orchestrator/`.

Verification: 309 tests green (19 new — cadence parsing, slot floors, all three catch-up modes, restart idempotency, singleton NOOP, auto-approval actor, stopped-clock detection). Live in an isolated worktree with a temporary 30s auto loop: ticks fired one per slot, runs completed, and the lifecycle journal reads `PROPOSED → APPROVED by schedule` — the temporary loop was removed before commit.