### PR TITLE
fix(event-runtime-web): do not gap an empty toast live region (OPS-340)

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -320,10 +320,17 @@ export function ToastContainer() {
     };
   }, []);
 
+  const polite = toasts.filter((t) => t.type !== "err");
+  const assertive = toasts.filter((t) => t.type === "err");
+  // An empty region is still a zero-height flex item, so a constant gap would
+  // reserve 8px under the last visible toast and lift the stack off the bottom
+  // inset. Space the two regions apart only while both hold a toast.
+  const gap = polite.length > 0 && assertive.length > 0 ? "gap-2" : "";
+
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
-      <ToastRegion role="status" live="polite" toasts={toasts.filter((t) => t.type !== "err")} />
-      <ToastRegion role="alert" live="assertive" toasts={toasts.filter((t) => t.type === "err")} />
+    <div className={`fixed bottom-4 right-4 z-50 flex flex-col pointer-events-none ${gap}`}>
+      <ToastRegion role="status" live="polite" toasts={polite} />
+      <ToastRegion role="alert" live="assertive" toasts={assertive} />
     </div>
   );
 }


### PR DESCRIPTION
## What

`ToastContainer` wrapped its two always-mounted live regions in `flex flex-col gap-2`. An empty region is still a zero-height flex item, so the gap was reserved even when only one region held a toast — 8px of dead space under the last visible toast, lifting the stack off the `bottom-4` inset.

The gap class is now applied only when both the polite and the assertive region actually hold a toast. Both regions stay mounted and visible in every case: no `display:none`, no conditional unmount, so the a11y tree is unchanged and the first toast still announces.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 290 pass, 0 fail; `tsc --noEmit` + `vite build` clean.

UX critique: skipped — an 8px stacking nit on an internal toast container, no new or materially changed user-completable flow.

Fixes OPS-340