### PR TITLE
fix(orchestrator): treat empty PR file list as cannot-evaluate (WM-48)

### DIFF
--- a/orchestrator/escalate.mjs
+++ b/orchestrator/escalate.mjs
@@ -8,14 +8,20 @@
  *           judgment applies
  * Exit 2  — a listed surface is in the diff; NEVER auto-merge, hand to a human
  * Exit 3  — the gate could not be evaluated (unknown repo, no `escalate_paths`
- *           key, `gh pr diff` failed). NOT a pass: treat the PR as escalated
- *           until the check can actually run.
+ *           key, `gh pr diff` failed or named no files at all). NOT a pass:
+ *           treat the PR as escalated until the check can actually run.
  *
- * "Nothing matched" and "there was no list to match against" are different
- * answers and must never share exit 0 — a stale checkout whose config/repos.yaml
- * predates a repo's escalate_paths would otherwise read as a clean gate
- * (WM-15). A repo that deliberately has nothing to check mechanically says so
- * with an explicit `escalate_paths: []`.
+ * "Nothing matched" and "there was nothing to match" are different answers and
+ * must never share exit 0. Two shapes of the second:
+ *
+ *   - no list to match against — a stale checkout whose config/repos.yaml
+ *     predates a repo's escalate_paths would otherwise read as a clean gate
+ *     (WM-15). A repo that deliberately has nothing to check mechanically says
+ *     so with an explicit `escalate_paths: []`.
+ *   - no files to match — a PR always changes at least one file, so an empty
+ *     changed-file list means the diff was never read: wrong PR number, a `gh`
+ *     that failed while still exiting 0, or the test seam exported empty
+ *     (WM-48). Matching zero files against any glob list trivially "passes".
  *
  * This turns the `escalate_paths` lists in config/repos.yaml from documentation
  * into a gate. It is deliberately one-directional: a match here forces
@@ -26,6 +32,8 @@
  * Test seams (tests only; unset in normal use):
  *   FACTORY_ESCALATE_REPOS_YAML  read this config instead of config/repos.yaml
  *   FACTORY_ESCALATE_DIFF_FILES  newline-separated changed files, skips `gh`
+ *                                (only when non-empty — exported-but-empty is
+ *                                not an injected answer)
  */
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -59,6 +67,22 @@ export function resolveEscalateGlobs(repo) {
   if (!Array.isArray(raw) || raw.some((g) => typeof g !== "string" || !g.trim()))
     return { ok: false, reason: `escalate_paths for "${name}" is not a list of path globs` };
   return { ok: true, globs: raw };
+}
+
+/**
+ * The changed files in a `--name-only` list, or why the gate cannot be
+ * evaluated. Unlike `escalate_paths: []`, a zero-length file list is never a
+ * valid answer — no PR changes nothing, so an empty list means the diff was not
+ * read rather than read and found harmless.
+ */
+export function resolveChangedFiles(raw) {
+  const files = String(raw ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!files.length)
+    return { ok: false, reason: "the changed-file list is empty — the diff was never read" };
+  return { ok: true, files };
 }
 
 /** Git facts about the checkout that supplied the config. Never throws. */
@@ -146,9 +170,11 @@ if (import.meta.main) {
   }
   const globs = resolved.globs;
 
+  // Non-empty is the whole test for an injection: an exported-but-empty seam is
+  // an absent answer, not a diff with no files in it.
   const injected = process.env.FACTORY_ESCALATE_DIFF_FILES;
   let raw;
-  if (injected !== undefined) {
+  if (injected?.trim()) {
     raw = injected;
   } else {
     const repoPath = String(repo.path).replace(/^~/, homedir());
@@ -161,7 +187,15 @@ if (import.meta.main) {
     raw = diff.stdout;
   }
 
-  const files = raw.split("\n").map((s) => s.trim()).filter(Boolean);
+  const changed = resolveChangedFiles(raw);
+  if (!changed.ok) {
+    console.error(`CANNOT EVALUATE — PR #${pr}: ${changed.reason}`);
+    console.error(`zero files match every glob list => treat PR #${pr} as ESCALATED, not as clean`);
+    console.error(`Check: \`gh pr diff ${pr} --name-only\` in ${repo.name} — an empty result usually means the wrong PR number, a closed or cross-fork PR, or a \`gh\` auth failure.`);
+    process.exit(EXIT.CANNOT_EVALUATE);
+  }
+  const files = changed.files;
+
   const hits = matchEscalations(files, globs);
   if (hits.length) {
     console.log(`ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`);

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -7,6 +7,7 @@ import {
   checkoutFreshness,
   freshnessWarnings,
   matchEscalations,
+  resolveChangedFiles,
   resolveEscalateGlobs,
 } from "./escalate.mjs";
 
@@ -96,6 +97,17 @@ test("a missing escalate_paths key is not an empty list", () => {
   expect(resolveEscalateGlobs({ name: "declared", escalate_paths: [] })).toEqual({ ok: true, globs: [] });
 });
 
+test("a changed-file list only answers the question when it names a file", () => {
+  expect(resolveChangedFiles("src/auth/session.ts\ndocs/notes.md\n")).toEqual({
+    ok: true,
+    files: ["src/auth/session.ts", "docs/notes.md"],
+  });
+  // No PR changes nothing, so these are all "the diff was not read".
+  expect(resolveChangedFiles("").ok).toBe(false);
+  expect(resolveChangedFiles("\n  \n").ok).toBe(false);
+  expect(resolveChangedFiles(undefined).ok).toBe(false);
+});
+
 test("freshness warns when behind, when dirty, and when it cannot tell", () => {
   expect(freshnessWarnings({ upstream: "origin/main", behind: 0, dirtyConfig: false })).toEqual([]);
 
@@ -130,8 +142,21 @@ writeFileSync(
     escalate_paths: []
   - name: unguarded
     path: ~/Develop/unguarded
+  - name: stubbed
+    path: ${tmp}
+    escalate_paths:
+      - src/auth/**
 `,
 );
+
+// A `gh` that prints exactly what the test tells it to, so the CLI's real diff
+// path can be exercised without the network — including the case that matters
+// most here: exit 0 with no files named.
+const stubBin = path.join(tmp, "stub-bin");
+mkdirSync(stubBin, { recursive: true });
+writeFileSync(path.join(stubBin, "gh"), `#!/bin/sh\nprintf '%s' "$FACTORY_TEST_GH_FILES"\n`, {
+  mode: 0o755,
+});
 
 test("checkoutFreshness sees a locally modified config wherever it sits in the checkout", () => {
   const repo = mkdtempSync(path.join(tmp, "checkout-"));
@@ -153,13 +178,14 @@ test("checkoutFreshness sees a locally modified config wherever it sits in the c
 
 const CLI = path.join(import.meta.dir, "escalate.mjs");
 
-function runCli(repo, files = []) {
+function runCli(repo, files, env = {}) {
   const result = Bun.spawnSync({
     cmd: ["bun", CLI, "--repo", repo, "--pr", "123"],
     env: {
       ...process.env,
       FACTORY_ESCALATE_REPOS_YAML: configPath,
       FACTORY_ESCALATE_DIFF_FILES: files.join("\n"),
+      ...env,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -196,6 +222,35 @@ test("an explicitly empty escalate_paths list is a real answer => exit 0", () =>
   const result = runCli("declared-empty", ["src/auth/session.ts"]);
   expect(result.exitCode).toBe(EXIT.CLEAN);
   expect(result.stdout).toContain("explicitly empty");
+});
+
+// The seam is empty in both, so these run the CLI's real `gh pr diff` branch
+// against the stub — which is the point: an exported-but-empty seam must not
+// short-circuit as "a diff with no files".
+const withStubGh = (ghFiles) => ({
+  PATH: `${stubBin}${path.delimiter}${process.env.PATH}`,
+  FACTORY_TEST_GH_FILES: ghFiles,
+});
+
+test("a gh pr diff that names no files cannot be evaluated, never exit 0", () => {
+  const result = runCli("stubbed", [], withStubGh(""));
+  expect(result.exitCode).not.toBe(EXIT.CLEAN);
+  expect(result.exitCode).toBe(EXIT.CANNOT_EVALUATE);
+  expect(result.stderr).toContain("CANNOT EVALUATE");
+  expect(result.stderr).toContain("changed-file list is empty");
+  expect(result.stderr).toContain("ESCALATED");
+});
+
+test("an empty diff seam falls through to gh rather than passing as zero files", () => {
+  const result = runCli("stubbed", [], withStubGh("src/dashboard/Page.tsx\n"));
+  expect(result.exitCode).toBe(EXIT.CLEAN);
+  expect(result.stdout).toContain("none of 1 changed file(s)");
+});
+
+test("a whitespace-only diff seam is not an injected answer either", () => {
+  const result = runCli("stubbed", ["  ", ""], withStubGh(""));
+  expect(result.exitCode).toBe(EXIT.CANNOT_EVALUATE);
+  expect(result.stderr).toContain("changed-file list is empty");
 });
 
 test("an unknown repo cannot be evaluated either", () => {


### PR DESCRIPTION
## Summary

WM-15 closed the "there was no list to match against" fail-open, but the escalation gate still exited 0 when it had no *files* to match. Zero changed files trivially match no glob, so the check printed "mechanical check clean" for a diff it had never actually read:

```
FACTORY_ESCALATE_DIFF_FILES="" bun orchestrator/escalate.mjs --repo bj29 --pr 1
PR #1: none of 0 changed file(s) hit 23 escalate_paths glob(s) — mechanical check clean
exit:0
```

Both routes into that state are closed:

- **`gh pr diff --name-only` returns nothing while exiting 0** (wrong PR number, closed or cross-fork PR, auth failure) — now `EXIT.CANNOT_EVALUATE` (3) with the `gh` command to re-run by hand.
- **`FACTORY_ESCALATE_DIFF_FILES` exported but empty** — the seam is now an injection only when it is non-empty (`if (injected?.trim())`, not `!== undefined`), so an empty export no longer short-circuits `gh` and then reads as a clean gate.

A new pure `resolveChangedFiles()` mirrors `resolveEscalateGlobs()`: an explicit `escalate_paths: []` stays a real answer (exit 0), but a zero-length file list never is, because no PR changes nothing.

Same command now:

```
CANNOT EVALUATE — PR #1: the changed-file list is empty — the diff was never read
zero files match every glob list => treat PR #1 as ESCALATED, not as clean
exit:3
```

No behaviour change for a PR that does name files: match still exits 2, clean still exits 0.

## Test plan

- [x] `bun test orchestrator/escalate.test.mjs` — 19 pass / 0 fail
- [x] `bun test` (whole repo, what CI runs) — 486 pass / 0 fail
- [x] New coverage: `resolveChangedFiles` unit cases (populated, empty, whitespace-only, undefined); and three CLI cases driven through a stub `gh` on `PATH` so the real diff branch is exercised without the network — empty stdout → exit 3, empty seam falling through to a `gh` that *does* name a file → exit 0 (proves the seam no longer short-circuits), whitespace-only seam → exit 3
- [x] Ticket's original repro re-run against a stub `gh` that prints nothing: exit 3

Fixes WM-48