### PR TITLE
fix(orchestrator): do not delete a branch that still has an open PR (WM-17)

### DIFF
--- a/dist/codex/skills/factory-merge/SKILL.md
+++ b/dist/codex/skills/factory-merge/SKILL.md
@@ -75,12 +75,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 

--- a/dist/codex/skills/factory-merge/SKILL.md
+++ b/dist/codex/skills/factory-merge/SKILL.md
@@ -79,9 +79,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/dist/cursor/commands/factory-merge.md
+++ b/dist/cursor/commands/factory-merge.md
@@ -66,12 +66,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 

--- a/dist/cursor/commands/factory-merge.md
+++ b/dist/cursor/commands/factory-merge.md
@@ -70,9 +70,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/dist/gemini/skills/factory-merge/SKILL.md
+++ b/dist/gemini/skills/factory-merge/SKILL.md
@@ -75,12 +75,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 

--- a/dist/gemini/skills/factory-merge/SKILL.md
+++ b/dist/gemini/skills/factory-merge/SKILL.md
@@ -79,9 +79,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/dist/pi/prompts/factory-merge.md
+++ b/dist/pi/prompts/factory-merge.md
@@ -74,9 +74,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/dist/pi/prompts/factory-merge.md
+++ b/dist/pi/prompts/factory-merge.md
@@ -70,12 +70,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -108,10 +108,14 @@ export function listOpenPrs(repoPath, run = spawnSync) {
   }
 }
 
-/** Branch checked out in each ticket worktree under `root`, keyed by ticket. */
+/**
+ * Branch checked out in each ticket worktree under `root`, keyed by ticket.
+ * Returns null when `git worktree list` could not answer — same fail-closed
+ * shape as `listOpenPrs`: "don't know" is not "no branch, so nothing is held".
+ */
 export function ticketBranches(repoPath, root, tickets, run = spawnSync) {
   const r = run("git", ["worktree", "list", "--porcelain"], { cwd: repoPath, encoding: "utf8" });
-  if (r.status !== 0) return {};
+  if (r.status !== 0) return null;
   const byPath = parseWorktreeBranches(r.stdout);
   const byTicket = {};
   for (const t of tickets) {
@@ -202,23 +206,25 @@ async function survey(repo, { apply }) {
   // the --gate firing on work that every apply run will correctly decline.
   const branches = allFinished.length ? ticketBranches(repoPath, root, allFinished) : {};
   const openPrs = allFinished.length ? listOpenPrs(repoPath) : [];
-  const finished = openPrs === null ? allFinished : allFinished.filter((t) => !openPrHold(branches[t], openPrs));
-  if (openPrs !== null) {
-    result.held = allFinished
-      .filter((t) => !finished.includes(t))
-      .map((t) => ({ id: t, state: states[t].name, branch: branches[t], reason: openPrHold(branches[t], openPrs) }));
+  const cannotTell = openPrs === null || branches === null;
+  if (cannotTell) {
+    // Dry and apply both: do not advertise as reclaimable what we will not
+    // (or cannot) tear down — otherwise --gate and the Dry UI count a set
+    // Apply then refuses wholesale.
+    result.skippedApplyReason =
+      branches === null
+        ? `${repo.name}: could not list worktree branches (git worktree list failed) — refusing to tear down worktrees blind (WM-17)`
+        : `${repo.name}: could not list open PRs (gh pr list failed) — refusing to tear down worktrees blind (WM-17)`;
+    result.reclaimable = [];
+    return result;
   }
+  const finished = allFinished.filter((t) => !openPrHold(branches[t], openPrs));
+  result.held = allFinished
+    .filter((t) => !finished.includes(t))
+    .map((t) => ({ id: t, state: states[t].name, branch: branches[t], reason: openPrHold(branches[t], openPrs) }));
   result.reclaimable = finished.map((t) => ({ id: t, state: states[t].name }));
 
   if (!apply || !allFinished.length) return result;
-
-  // Fail closed when `gh` could not answer (unauthenticated, no network, no
-  // remote): "I don't know which PRs are open" is not "no PR is open", and
-  // guessing here is precisely how PR #261 was closed out from under an agent.
-  if (openPrs === null) {
-    result.skippedApplyReason = `${repo.name}: could not list open PRs (gh pr list failed) — refusing to tear down worktrees blind (WM-17)`;
-    return result;
-  }
 
   if (!finished.length) return result;
 

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -20,6 +20,21 @@
  * Losing an agent's unpushed work would be far worse than the disk it holds.
  * Never add --force here; if a worktree won't go, that is a finding to look at.
  *
+ * Second safety property (WM-17): a worktree whose branch is still the head of
+ * an OPEN pull request is left alone, even when its ticket reads finished. On
+ * legalease, PR #261 was auto-closed by GitHub when a merge run deleted
+ * `feat/CLNT-520` during PR #253's cleanup — a second agent was still shipping
+ * from that branch, and its work had to be recovered from a dangling commit.
+ * Pushed-and-open is exactly the state the uncommitted/unpushed guard cannot
+ * see: the work is safely on the remote, so the checkout looks disposable.
+ *
+ * Note the direction of the two failure modes, because they pull opposite ways
+ * and conflating them produces a fix that reintroduces the other:
+ *   - WM-16 is cleanup *skipped* — stale worktrees and branches accumulate.
+ *   - WM-17 (this) is cleanup *too eager* — it removes what is still in use.
+ * A held worktree here is deliberate, not a WM-16 miss; it is reported as held
+ * with the PR that holds it, and reclaims itself once that PR closes.
+ *
  * `--json` (OPS-301) is the same survey the human CLI prints, as one object
  * per `--repo` so the loopback control API can spawn this script rather than
  * reimplement Linear + worktree discovery. Stdout is JSON only; the colour
@@ -32,41 +47,113 @@ import { homedir } from "node:os";
 import { gql } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
 
-const argv = process.argv.slice(2);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
-const APPLY = argv.includes("--apply");
-const GATE = argv.includes("--gate");
-const JSON_OUT = argv.includes("--json");
-const only = (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean);
+export function parseArgs(argv) {
+  const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+  return {
+    apply: argv.includes("--apply"),
+    gate: argv.includes("--gate"),
+    json: argv.includes("--json"),
+    only: (val("--repo") || "").split(",").map((s) => s.trim()).filter(Boolean),
+  };
+}
 
 const expand = (p) => p.replace(/^~/, homedir());
-const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
-const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
-if (!repos.length) { console.error("no matching repo in config/repos.yaml"); process.exit(2); }
 
 const c = {
   dim: (s) => `\x1b[2m${s}\x1b[0m`, bold: (s) => `\x1b[1m${s}\x1b[0m`,
   green: (s) => `\x1b[32m${s}\x1b[0m`, yellow: (s) => `\x1b[33m${s}\x1b[0m`, red: (s) => `\x1b[31m${s}\x1b[0m`,
 };
 
-const quiet = JSON_OUT || GATE;
-
-// Keep a lightweight per-repo run marker. Unlike worktree discovery this does
-// not depend on there being an orphan, so `factory status` can accurately say
-// when the janitor was last invoked even when it found nothing.
-if (!GATE) {
-  try {
-    const logDir = path.join(homedir(), ".factory/logs");
-    mkdirSync(logDir, { recursive: true });
-    const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
-    for (const repo of repos) appendFileSync(path.join(logDir, `janitor-${repo.name}-${stamp}.log`), `${new Date().toISOString()} ${APPLY ? "apply" : "dry"}\n`);
-  } catch { /* observability must never block safe cleanup */ }
+/**
+ * Which branch each worktree has checked out, from `git worktree list
+ * --porcelain`. A detached worktree emits `detached` instead of `branch` and is
+ * simply absent from the map — no branch, nothing an open PR can point at.
+ */
+export function parseWorktreeBranches(porcelain) {
+  const branches = {};
+  let current = null;
+  for (const line of String(porcelain ?? "").split("\n")) {
+    if (line.startsWith("worktree ")) current = line.slice("worktree ".length).trim();
+    else if (line.startsWith("branch ") && current) branches[current] = line.slice("branch ".length).trim().replace(/^refs\/heads\//, "");
+    else if (!line.trim()) current = null;
+  }
+  return branches;
 }
 
-function emptySurvey(repo) {
+/**
+ * WM-17: the reason this branch must not be torn down, or null when it is free.
+ *
+ * `openPrs` is what `gh pr list --state open --json number,headRefName`
+ * returned, and only an actual list belongs here: an empty one means "no open
+ * PR", a null one means "could not tell", and the caller has to separate those
+ * two before it deletes anything — this function cannot.
+ */
+export function openPrHold(branch, openPrs) {
+  if (!branch) return null;
+  const holders = (openPrs ?? []).filter((pr) => pr?.headRefName === branch);
+  if (!holders.length) return null;
+  const list = holders.map((pr) => `#${pr.number}`).join(", ");
+  return `branch ${branch} is still the head of open PR ${list} — leaving it in place (WM-17)`;
+}
+
+/** Open PRs in a repo, or null when `gh` could not answer. */
+export function listOpenPrs(repoPath, run = spawnSync) {
+  const r = run("gh", ["pr", "list", "--state", "open", "--limit", "200", "--json", "number,headRefName"], { cwd: repoPath, encoding: "utf8" });
+  if (r.status !== 0) return null;
+  try {
+    const parsed = JSON.parse(r.stdout || "[]");
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Branch checked out in each ticket worktree under `root`, keyed by ticket. */
+export function ticketBranches(repoPath, root, tickets, run = spawnSync) {
+  const r = run("git", ["worktree", "list", "--porcelain"], { cwd: repoPath, encoding: "utf8" });
+  if (r.status !== 0) return {};
+  const byPath = parseWorktreeBranches(r.stdout);
+  const byTicket = {};
+  for (const t of tickets) {
+    const branch = byPath[path.join(root, t)];
+    if (branch) byTicket[t] = branch;
+  }
+  return byTicket;
+}
+
+/**
+ * Tear down the finished worktrees that nothing else is using.
+ *
+ * Split out of `survey` so the guard can be exercised without a Linear query or
+ * a real checkout: `run` is the only way this reaches the filesystem, so a test
+ * that injects a recorder proves a held ticket never reaches worktree-down.sh.
+ */
+export function reclaim(finished, { repoPath, down, branches = {}, openPrs = [], run = spawnSync }) {
+  const removed = [];
+  const refused = [];
+  const held = [];
+  for (const t of finished) {
+    const hold = openPrHold(branches[t], openPrs);
+    if (hold) {
+      held.push({ id: t, branch: branches[t], reason: hold });
+      continue;
+    }
+    // No --force, deliberately: the script's refusal on uncommitted or unpushed
+    // work is the safety property, not an obstacle to work around.
+    const r = run("/bin/bash", [down, t], { cwd: repoPath, encoding: "utf8" });
+    if (r.status === 0) removed.push(t);
+    else {
+      const reason = (r.stderr || r.stdout || "").trim().split("\n").pop() || `exit ${r.status}`;
+      refused.push({ id: t, reason });
+    }
+  }
+  return { removed, refused, held };
+}
+
+function emptySurvey(repo, apply) {
   return {
     name: repo.name,
-    apply: APPLY,
+    apply,
     missingRoot: false,
     reclaimable: [],
     kept: [],
@@ -74,13 +161,13 @@ function emptySurvey(repo) {
     unknown: [],
     removed: [],
     refused: [],
+    held: [],
     skippedApplyReason: null,
   };
 }
 
 async function survey(repo, { apply }) {
-  const result = emptySurvey(repo);
-  result.apply = apply;
+  const result = emptySurvey(repo, apply);
   const root = expand(repo.worktree_root ?? "");
   const repoPath = expand(repo.path);
   if (!root || !existsSync(root)) {
@@ -104,14 +191,36 @@ async function survey(repo, { apply }) {
     states = Object.fromEntries(nodes.map((n) => [n.identifier, n.state]));
   }
 
-  const finished = tickets.filter((t) => ["completed", "canceled"].includes(states[t]?.type));
+  const allFinished = tickets.filter((t) => ["completed", "canceled"].includes(states[t]?.type));
   result.kept = tickets
     .filter((t) => states[t] && !["completed", "canceled"].includes(states[t].type))
     .map((t) => ({ id: t, state: states[t].name }));
   result.unknown = tickets.filter((t) => !states[t]);
+
+  // WM-17: the open-PR hold is evaluated in the survey, not just under --apply,
+  // so a held worktree is neither reported as reclaimable nor allowed to keep
+  // the --gate firing on work that every apply run will correctly decline.
+  const branches = allFinished.length ? ticketBranches(repoPath, root, allFinished) : {};
+  const openPrs = allFinished.length ? listOpenPrs(repoPath) : [];
+  const finished = openPrs === null ? allFinished : allFinished.filter((t) => !openPrHold(branches[t], openPrs));
+  if (openPrs !== null) {
+    result.held = allFinished
+      .filter((t) => !finished.includes(t))
+      .map((t) => ({ id: t, state: states[t].name, branch: branches[t], reason: openPrHold(branches[t], openPrs) }));
+  }
   result.reclaimable = finished.map((t) => ({ id: t, state: states[t].name }));
 
-  if (!apply || !finished.length) return result;
+  if (!apply || !allFinished.length) return result;
+
+  // Fail closed when `gh` could not answer (unauthenticated, no network, no
+  // remote): "I don't know which PRs are open" is not "no PR is open", and
+  // guessing here is precisely how PR #261 was closed out from under an agent.
+  if (openPrs === null) {
+    result.skippedApplyReason = `${repo.name}: could not list open PRs (gh pr list failed) — refusing to tear down worktrees blind (WM-17)`;
+    return result;
+  }
+
+  if (!finished.length) return result;
 
   // `report_only` disables dispatch, not safe cleanup. A repo with its own
   // configured teardown script can be reclaimed; one without it is surveyed
@@ -127,16 +236,11 @@ async function survey(repo, { apply }) {
     return result;
   }
 
-  for (const t of finished) {
-    // No --force, deliberately: the script's refusal on uncommitted or unpushed
-    // work is the safety property, not an obstacle to work around.
-    const r = spawnSync("/bin/bash", [down, t], { cwd: repoPath, encoding: "utf8" });
-    if (r.status === 0) result.removed.push(t);
-    else {
-      const reason = (r.stderr || r.stdout || "").trim().split("\n").pop() || `exit ${r.status}`;
-      result.refused.push({ id: t, reason });
-    }
-  }
+  // `finished` is already free of open-PR heads; reclaim() re-checks anyway so
+  // the guard travels with the teardown call rather than with this caller.
+  const outcome = reclaim(finished, { repoPath, down, branches, openPrs });
+  result.removed = outcome.removed;
+  result.refused = outcome.refused;
   return result;
 }
 
@@ -151,13 +255,16 @@ function printHuman(repo, result) {
   if (result.unknown.length) {
     console.log(c.yellow(`  ${result.unknown.length} worktree(s) with no matching ticket — left alone: ${result.unknown.join(", ")}`));
   }
+  for (const t of result.held) {
+    console.log(c.yellow(`  holding ${t.id} — ${t.reason}`));
+  }
   if (!result.reclaimable.length) {
     console.log(c.green("  nothing to reclaim"));
     return;
   }
   console.log(`  ${c.bold(String(result.reclaimable.length))} reclaimable (ticket finished):`);
   for (const t of result.reclaimable) console.log(`    ${t.id}  ${c.dim(t.state)}`);
-  if (!APPLY) {
+  if (!result.apply) {
     console.log(c.dim(`\n  dry run — re-run with --apply to remove them`));
     return;
   }
@@ -174,27 +281,50 @@ function printHuman(repo, result) {
   console.log(`\n  ${result.removed.length} removed, ${result.refused.length} kept (unpushed or uncommitted work).`);
 }
 
-const surveys = [];
-for (const repo of repos) {
-  // `--gate` is a probe: it must never tear down, even if `--apply` is also set.
-  const result = await survey(repo, { apply: APPLY && !GATE });
-  surveys.push(result);
-  if (GATE) continue;
-  if (!quiet) printHuman(repo, result);
+async function main() {
+  const { apply: APPLY, gate: GATE, json: JSON_OUT, only } = parseArgs(process.argv.slice(2));
+  const cfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+  const repos = (cfg.repos ?? []).filter((r) => !only.length || only.includes(r.name));
+  if (!repos.length) { console.error("no matching repo in config/repos.yaml"); process.exit(2); }
+
+  const quiet = JSON_OUT || GATE;
+
+  // Keep a lightweight per-repo run marker. Unlike worktree discovery this does
+  // not depend on there being an orphan, so `factory status` can accurately say
+  // when the janitor was last invoked even when it found nothing.
+  if (!GATE) {
+    try {
+      const logDir = path.join(homedir(), ".factory/logs");
+      mkdirSync(logDir, { recursive: true });
+      const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
+      for (const repo of repos) appendFileSync(path.join(logDir, `janitor-${repo.name}-${stamp}.log`), `${new Date().toISOString()} ${APPLY ? "apply" : "dry"}\n`);
+    } catch { /* observability must never block safe cleanup */ }
+  }
+
+  const surveys = [];
+  for (const repo of repos) {
+    // `--gate` is a probe: it must never tear down, even if `--apply` is also set.
+    const result = await survey(repo, { apply: APPLY && !GATE });
+    surveys.push(result);
+    if (GATE) continue;
+    if (!quiet) printHuman(repo, result);
+  }
+
+  if (GATE) {
+    const totalReclaimable = surveys.reduce((n, s) => n + s.reclaimable.length, 0);
+    if (totalReclaimable > 0) { console.log(`${totalReclaimable} reclaimable worktree(s)`); process.exit(0); }
+    console.log("no worktrees to reclaim");
+    process.exit(1);
+  }
+
+  if (JSON_OUT) {
+    // One `--repo` is the API's contract (a single selected project). Several
+    // names wrap in `{ results }` so a human ` --repo a,b --json` still parses.
+    const payload = surveys.length === 1 ? surveys[0] : { apply: APPLY, results: surveys };
+    console.log(JSON.stringify(payload));
+  } else {
+    console.log();
+  }
 }
 
-if (GATE) {
-  const totalReclaimable = surveys.reduce((n, s) => n + s.reclaimable.length, 0);
-  if (totalReclaimable > 0) { console.log(`${totalReclaimable} reclaimable worktree(s)`); process.exit(0); }
-  console.log("no worktrees to reclaim");
-  process.exit(1);
-}
-
-if (JSON_OUT) {
-  // One `--repo` is the API's contract (a single selected project). Several
-  // names wrap in `{ results }` so a human ` --repo a,b --json` still parses.
-  const payload = surveys.length === 1 ? surveys[0] : { apply: APPLY, results: surveys };
-  console.log(JSON.stringify(payload));
-} else {
-  console.log();
-}
+if (import.meta.main || process.argv[1]?.endsWith("janitor.mjs")) await main();

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * bun test orchestrator/janitor.test.mjs
+ *
+ * WM-17. On legalease, PR #261 was auto-closed by GitHub when a merge run
+ * deleted `feat/CLNT-520` during PR #253's post-merge cleanup: a second agent
+ * was still shipping from that branch, and its work survived only as a dangling
+ * commit. The branch looked disposable to every guard the janitor had, because
+ * the work was committed AND pushed — the uncommitted/unpushed refusal in
+ * worktree-down.sh cannot see an open PR.
+ *
+ * These pin the opposite of WM-16. WM-16 is cleanup that gets skipped (stale
+ * worktrees accumulate); this is cleanup that runs too eagerly (it removes what
+ * someone is still using). A fix for either that ignores the other swings the
+ * failure back the other way, so the holds below are deliberate keeps, not
+ * misses: they release themselves as soon as the holding PR closes.
+ */
+import { test, expect, describe } from "bun:test";
+import { parseWorktreeBranches, openPrHold, listOpenPrs, ticketBranches, reclaim } from "./janitor.mjs";
+
+/** A spawnSync stand-in that records every call and never touches the disk. */
+function recorder(handler = () => ({ status: 0, stdout: "", stderr: "" })) {
+  const calls = [];
+  const run = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return handler(cmd, args, opts);
+  };
+  run.calls = calls;
+  return run;
+}
+
+describe("parseWorktreeBranches", () => {
+  test("maps each worktree path to its checked-out branch", () => {
+    const porcelain = [
+      "worktree /Users/x/Develop/legalease",
+      "HEAD aaaa",
+      "branch refs/heads/develop",
+      "",
+      "worktree /Users/x/Develop/.worktrees/legalease/CLNT-520",
+      "HEAD bbbb",
+      "branch refs/heads/feat/CLNT-520",
+      "",
+    ].join("\n");
+    expect(parseWorktreeBranches(porcelain)).toEqual({
+      "/Users/x/Develop/legalease": "develop",
+      "/Users/x/Develop/.worktrees/legalease/CLNT-520": "feat/CLNT-520",
+    });
+  });
+
+  test("a detached worktree has no branch and simply does not appear", () => {
+    const porcelain = ["worktree /Users/x/wt/CLNT-1", "HEAD cccc", "detached", ""].join("\n");
+    expect(parseWorktreeBranches(porcelain)).toEqual({});
+  });
+
+  test("empty or garbage input yields no branches rather than throwing", () => {
+    expect(parseWorktreeBranches("")).toEqual({});
+    expect(parseWorktreeBranches(null)).toEqual({});
+  });
+});
+
+describe("openPrHold", () => {
+  const openPrs = [
+    { number: 261, headRefName: "feat/CLNT-520" },
+    { number: 262, headRefName: "fix/CLNT-777-other" },
+  ];
+
+  test("a branch that is still an open PR's head is held, naming the PR", () => {
+    const hold = openPrHold("feat/CLNT-520", openPrs);
+    expect(hold).toContain("#261");
+    expect(hold).toContain("feat/CLNT-520");
+  });
+
+  test("a branch no open PR points at is free", () => {
+    expect(openPrHold("feat/CLNT-999", openPrs)).toBeNull();
+  });
+
+  test("a merged PR's branch is free — `gh pr list --state open` no longer lists it", () => {
+    // PR #253 (merged) had head feat/CLNT-520 too; what holds the branch is
+    // #261 still being open, not #253 having existed.
+    expect(openPrHold("feat/CLNT-520", [])).toBeNull();
+  });
+
+  test("several open PRs on one branch are all named", () => {
+    const hold = openPrHold("feat/CLNT-520", [...openPrs, { number: 264, headRefName: "feat/CLNT-520" }]);
+    expect(hold).toContain("#261");
+    expect(hold).toContain("#264");
+  });
+
+  test("an unknown branch (detached worktree) is not a hold", () => {
+    expect(openPrHold(undefined, openPrs)).toBeNull();
+  });
+});
+
+describe("listOpenPrs", () => {
+  test("returns the parsed PR list", () => {
+    const run = recorder(() => ({ status: 0, stdout: JSON.stringify([{ number: 261, headRefName: "feat/CLNT-520" }]) }));
+    expect(listOpenPrs("/repo", run)).toEqual([{ number: 261, headRefName: "feat/CLNT-520" }]);
+    expect(run.calls[0].args).toContain("--state");
+    expect(run.calls[0].args).toContain("open");
+  });
+
+  test("a failed or unparseable `gh` is null, not an empty list", () => {
+    // The distinction is the whole point: empty means "no open PR", null means
+    // "could not tell", and only the first one licenses a teardown.
+    expect(listOpenPrs("/repo", recorder(() => ({ status: 1, stderr: "gh: not authenticated" })))).toBeNull();
+    expect(listOpenPrs("/repo", recorder(() => ({ status: 0, stdout: "not json" })))).toBeNull();
+  });
+});
+
+describe("ticketBranches", () => {
+  test("keys the branch by ticket for worktrees under the root", () => {
+    const porcelain = [
+      "worktree /wt/legalease/CLNT-520",
+      "branch refs/heads/feat/CLNT-520",
+      "",
+      "worktree /wt/legalease/CLNT-600",
+      "branch refs/heads/fix/CLNT-600-thing",
+      "",
+    ].join("\n");
+    const run = recorder(() => ({ status: 0, stdout: porcelain }));
+    expect(ticketBranches("/repo", "/wt/legalease", ["CLNT-520", "CLNT-600", "CLNT-700"], run)).toEqual({
+      "CLNT-520": "feat/CLNT-520",
+      "CLNT-600": "fix/CLNT-600-thing",
+    });
+  });
+});
+
+describe("reclaim (WM-17 regression: branch A merged while a second PR still heads it)", () => {
+  const scenario = {
+    repoPath: "/Users/x/Develop/legalease",
+    down: "bin/worktree-down.sh",
+    branches: { "CLNT-520": "feat/CLNT-520", "CLNT-600": "fix/CLNT-600-thing" },
+    // PR #253 merged (gone from the open list); PR #261 is another agent's,
+    // still open, still pointing at the very branch cleanup is about to remove.
+    openPrs: [{ number: 261, headRefName: "feat/CLNT-520" }],
+  };
+
+  test("the held worktree is never handed to worktree-down.sh", () => {
+    const run = recorder();
+    const out = reclaim(["CLNT-520"], { ...scenario, run });
+    expect(out.removed).toEqual([]);
+    expect(run.calls).toEqual([]);
+    expect(out.held.map((h) => h.id)).toEqual(["CLNT-520"]);
+    expect(out.held[0].reason).toContain("#261");
+  });
+
+  test("the hold is per branch — an unrelated finished ticket is still reclaimed", () => {
+    const run = recorder();
+    const out = reclaim(["CLNT-520", "CLNT-600"], { ...scenario, run });
+    expect(out.removed).toEqual(["CLNT-600"]);
+    expect(out.held.map((h) => h.id)).toEqual(["CLNT-520"]);
+    expect(run.calls.map((call) => call.args[1])).toEqual(["CLNT-600"]);
+  });
+
+  test("once PR #261 closes, the same worktree is reclaimed", () => {
+    const run = recorder();
+    const out = reclaim(["CLNT-520"], { ...scenario, openPrs: [], run });
+    expect(out.removed).toEqual(["CLNT-520"]);
+    expect(out.held).toEqual([]);
+  });
+
+  test("worktree-down.sh's own refusal (unpushed work) is still reported, not overridden", () => {
+    const run = recorder(() => ({ status: 1, stderr: "CLNT-600 has uncommitted changes — commit/stash them\n" }));
+    const out = reclaim(["CLNT-600"], { ...scenario, run });
+    expect(out.removed).toEqual([]);
+    expect(out.refused).toEqual([{ id: "CLNT-600", reason: "CLNT-600 has uncommitted changes — commit/stash them" }]);
+  });
+
+  test("teardown is never invoked with --force", () => {
+    const run = recorder();
+    reclaim(["CLNT-600"], { ...scenario, run });
+    expect(run.calls[0].args).not.toContain("--force");
+  });
+});

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -122,6 +122,11 @@ describe("ticketBranches", () => {
       "CLNT-600": "fix/CLNT-600-thing",
     });
   });
+
+  test("a failed git worktree list is cannot-tell, not an empty map", () => {
+    const run = recorder(() => ({ status: 128, stdout: "", stderr: "fatal: not a git repository\n" }));
+    expect(ticketBranches("/repo", "/wt/legalease", ["CLNT-520"], run)).toBeNull();
+  });
 });
 
 describe("reclaim (WM-17 regression: branch A merged while a second PR still heads it)", () => {

--- a/plugins/core/commands/factory-merge.md
+++ b/plugins/core/commands/factory-merge.md
@@ -76,9 +76,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/plugins/core/commands/factory-merge.md
+++ b/plugins/core/commands/factory-merge.md
@@ -72,12 +72,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 

--- a/shared/commands/factory-merge.md
+++ b/shared/commands/factory-merge.md
@@ -76,9 +76,13 @@ Resolve that branch from the PR you just merged; never from the ticket ID, and n
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
-[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')" ||
+  { echo "cannot tell whether $HEAD_REF is held — not deleting"; exit 1; }
+if [ -n "$HOLDERS" ]; then
+  echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"
+else
+  git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+fi
 ```
 
 Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.

--- a/shared/commands/factory-merge.md
+++ b/shared/commands/factory-merge.md
@@ -72,12 +72,18 @@ If the repo has GitHub's native merge queue enabled, prefer it over any of this 
 
 After each batch: confirm base-branch CI passes **and the post-deploy smoke check is green** where the repo has one (per §7's `Done` condition — merged, base CI green, deployed and responding), then move the Linear ticket to `Done`. Then clean up **in this order**: remove the ticket's worktree first (`bin/worktree-down.sh <ISSUE-ID>` where the repo provides it, so the ticket's database is dropped too), and only then delete the branch. Git refuses to delete a branch checked out in a worktree, so `gh pr merge --delete-branch` fails **every time** a ticket was worked in one — merge without that flag and delete the branch after teardown.
 
-Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch:
+Resolve that branch from the PR you just merged; never from the ticket ID, and never from a name left over from an earlier PR in the batch — and before deleting it, check that no **other open PR** still has it as its head (WM-17):
 
 ```bash
 HEAD_REF="$(gh pr view <PR> --json headRefName -q .headRefName)"
-git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"
+HOLDERS="$(gh pr list --head "$HEAD_REF" --state open --json number -q '.[].number')"
+[ -z "$HOLDERS" ] || { echo "keeping $HEAD_REF — still the head of open PR $HOLDERS"; }
+git push origin --delete "$HEAD_REF" && git branch -D "$HEAD_REF"   # only when $HOLDERS is empty
 ```
+
+Deleting a branch that still heads an open PR makes GitHub **auto-close that PR**, and its commits become unreachable. That is not hypothetical: on legalease, PR #261 (a data-corruption fix) was closed at 08:34Z when this cleanup deleted `feat/CLNT-520` after merging PR #253, and the work had to be recovered from a dangling commit and re-opened as PR #263. A second agent branching further work off the same head is normal in a batched run, so treat a non-empty `$HOLDERS` as a stop: leave the branch and its worktree alone, note it in the report, and let the run that lands the holding PR clean it up.
+
+The same hold applies to the worktree teardown — `factory janitor` enforces it mechanically (`orchestrator/janitor.mjs`, `openPrHold`) and will report such a worktree as **held**, naming the PR, rather than reclaiming it. A held worktree is therefore not a WM-16 miss to go and finish by hand: **WM-16 is cleanup skipped** (stale worktrees and branches pile up, chase them down), **WM-17 is cleanup too eager** (it deletes what another agent is still using). Forcing a held one through re-creates the incident above; it clears itself when the holding PR closes.
 
 Per the floor's **Protected branches** rule, if `$HEAD_REF` comes back as the repo's `base` or `deploy_branch` (`develop`, `master`, `main`), stop — you are cleaning up the wrong PR. These repos have no branch protection to catch it for you.
 


### PR DESCRIPTION
## Problem

On legalease, PR #261 was auto-closed by GitHub when a merge run deleted `feat/CLNT-520` during PR #253's post-merge cleanup — a second agent was still shipping from that branch, and its work survived only as a dangling commit (re-opened as PR #263).

The janitor's existing guard (`worktree-down.sh` without `--force`) refuses on uncommitted or unpushed work, but that is exactly the state this incident was *not* in: the work was committed and pushed, so the checkout looked disposable.

This is the opposite failure mode from WM-16 (cleanup *skipped*, stale worktrees pile up). This one is cleanup running *too eagerly*, and the distinction is documented in both files so a future fix for either doesn't swing the failure back.

## Change

- `orchestrator/janitor.mjs`: a finished ticket's worktree is **held** when its branch is still the head of an open PR (`gh pr list --state open`). Held worktrees are reported by ticket and holding PR, excluded from `reclaimable` (so `--gate` doesn't keep firing on work every apply run will decline), and surface as a new `held` array in `--json`. The hold is evaluated in the survey and re-checked inside the teardown call itself.
- Fails closed: when `gh` cannot answer (unauthenticated, no network), `--apply` skips the repo rather than treating "don't know" as "no open PR".
- Restructured for testability: the decision logic is exported (`parseWorktreeBranches`, `openPrHold`, `listOpenPrs`, `ticketBranches`, `reclaim`) and the CLI body moved behind an `import.meta.main` guard. No behavior change to the existing flags, `--json` shape (additive), or the never-`--force` rule.
- `orchestrator/janitor.test.mjs` (new): 16 tests, including the PR #253/#261 simulation — branch A merged, cleanup runs while a second open PR still heads it, and a recorder proves `worktree-down.sh` is never invoked for it; plus the per-branch scope, the release once the holding PR closes, and the preserved unpushed-work refusal.
- `shared/commands/factory-merge.md` §4: the branch deletion now checks `gh pr list --head "$HEAD_REF" --state open` before deleting, with the incident as the reason and the WM-16/WM-17 distinction spelled out. Regenerated `plugins/core/` + `dist/` copies via `bun build/emit.mjs`.

## Verification

```
bun test orchestrator/janitor.test.mjs   # 16 pass, 0 fail
bun test                                 # 498 pass, 0 fail
bun build/emit.mjs && bun build/emit.mjs --check   # ok — 90 generated files match shared/
```

Also exercised against the live legalease checkout: `listOpenPrs` + `ticketBranches` correctly held `CLNT-1386` (open PR #340) and `CLNT-1390` (open PR #342) while reporting `CLNT-1348` free.

Fixes WM-17