### PR TITLE
fix(event-runtime-web): reveal hash-selected run/event when context fetchAll hides the status tab (OPS-377)

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -157,9 +157,11 @@ export function Events({
   }, [focusEvent?.status, focusEvent?.type]);
 
   // Reveal a hash-selected row only when current filters hide it. Latch until
-  // the row exists in `rows` (inject / tab switch / poll); decide once so a
+  // the row is on the active tab (inject / tab switch / poll); decide once so a
   // later 2s poll does not wipe a typed filter. j/k/click on a visible row
-  // keeps the chips.
+  // keeps the chips. Under `fetchAll` the row can sit in `rows` while another
+  // status tab is active, so deciding on presence alone would clear the chips
+  // before the tab effect below has made the row renderable.
   const pendingReveal = useRef<string | null>(null);
   const lastKey = useRef<string | null>(null);
   useEffect(() => {
@@ -169,21 +171,27 @@ export function Events({
     }
     const key = pendingReveal.current;
     if (!key || key !== selectedKey) return;
-    if (!rows.some((e) => keyOf(e) === key)) return; // tab switch / poll still pending
+    const row = rows.find((e) => keyOf(e) === key);
+    if (!row) return; // tab switch / poll still pending
+    if (fetchAll && tab !== "all" && row.status !== tab) return; // waiting on the tab switch
     pendingReveal.current = null; // decided once
     if (visible.some((e) => keyOf(e) === key)) return; // visible: keep the filters
     setFilter("");
     setSourceFilter(null);
     if (!focusEvent?.type) setTypeFilter(null);
-  }, [selectedKey, rows, visible, focusEvent?.type]);
+  }, [selectedKey, rows, visible, focusEvent?.type, fetchAll, tab]);
 
   // Hash id: switch to All if the row isn't on this tab. Don't strip the hash.
+  // With a repo context the fetch ignores the tab, so the row's own status —
+  // not its presence in `rows` — decides whether this tab can render it.
   useEffect(() => {
     if (!focusEvent?.source || !focusEvent?.eventId) return;
     const key = `${focusEvent.source}:${focusEvent.eventId}`;
-    if (!rows.some((e) => keyOf(e) === key) && tab !== "all") setTab("all");
+    const row = rows.find((e) => keyOf(e) === key);
+    const onTab = !!row && (!fetchAll || tab === "all" || row.status === tab);
+    if (!onTab && tab !== "all") setTab("all");
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusEvent?.source, focusEvent?.eventId, rows, tab]);
+  }, [focusEvent?.source, focusEvent?.eventId, rows, tab, fetchAll]);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["events"] });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -367,15 +367,21 @@ export function Runs({
   const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
 
   // Deep link / jump: switch to ALL if the run isn't on this tab. Hash stays put.
-  // Reveal (clear filter) once per focus id, after the run is in `rows` so a
+  // Reveal (clear filter) once per focus id, after the run is on the tab so a
   // late arrival still surfaces. Typing a filter does not re-reveal.
+  // Under `fetchAll` the list carries every state, so presence in `rows` says
+  // nothing about the tab — the tab has to be part of the membership test, or
+  // the switch to ALL never fires and the row stays unrendered.
   const revealedFor = useRef<string | null>(null);
   useEffect(() => {
     if (!focusRunId) {
       revealedFor.current = null;
       return;
     }
-    if (rows.some((r) => r.runId === focusRunId)) {
+    const onTab = rows.some(
+      (r) => r.runId === focusRunId && (!fetchAll || tab === "ALL" || r.state === tab),
+    );
+    if (onTab) {
       if (revealedFor.current !== focusRunId) {
         revealedFor.current = focusRunId;
         if (!visible.some((r) => r.runId === focusRunId)) setFilter("");
@@ -383,7 +389,7 @@ export function Runs({
       return;
     }
     if (tab !== "ALL") setTab("ALL");
-  }, [focusRunId, rows, tab, visible]);
+  }, [focusRunId, rows, tab, visible, fetchAll]);
 
   useEffect(() => {
     if (focusState && (STATE_TABS as readonly string[]).includes(focusState)) {


### PR DESCRIPTION
## Summary

Under a repo or In-flight context the Runs/Events lists are fetched unfiltered (`fetchAll`) and the status tab is applied client-side, so the deep-link reveal's `rows.some(focus)` membership test was true on *every* tab and the fallback to ALL never fired. `#/runs/:id?project=bj29` — or a jump from Proposals — while the operator sat on a non-matching tab selected a run the view would not render: the hash named it, the detail pane stayed empty. All-context was unaffected because the server already filtered by tab.

- `Runs.tsx`: membership is now `rows.some(r => r.runId === focus && (!fetchAll || tab === "ALL" || r.state === tab))`, so an off-tab run takes the `setTab("ALL")` branch and then reveals.
- `Events.tsx`: same tab-aware test in the hash-tab effect, and the `pendingReveal` latch now waits until the row is on the tab — otherwise it decided against a stale `visible` and cleared a typed filter that would have shown the row after the switch to All.

## Test plan

- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 290 pass / 0 fail, tsc + vite clean
- [x] Seeded worktree env (`bin/worktree-up.sh OPS-377`) + control API fixtures used to walk the repo-context / non-matching-tab deep links for Runs and Events, plus the all-context and In-flight paths

UX critique: required — SHIP. No blank detail pane in any deep-link scenario, context strip and keyboard nav intact, all-context behaviour unchanged. Two friction findings were out of scope for these two files and are filed rather than fixed here: the tab switch and filter clear are silent (OPS-388), and the views have no component-level test harness so this class of regression ships unguarded (OPS-389). The critique itself ran without browser tooling and so is source + API level, not pixel level (OPS-391); the worktree daemons not surviving the harness shell is OPS-390.

Fixes OPS-377