### PR TITLE
feat(event-runtime-web): show the armed g navigation prefix on screen (OPS-311)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -205,7 +205,7 @@ export function App() {
         : env.name
       : "…";
 
-  useGoSequences(
+  const goArmed = useGoSequences(
     useMemo(
       () => Object.fromEntries(NAV.map((n) => [n.go, () => navigate(n.key)])),
       [navigate],
@@ -416,8 +416,12 @@ export function App() {
           </div>
           <div className="mt-1.5 text-(--text-faint)">
             <span className="mono">⌘K</span> commands · <span className="mono">g</span>+
-            <span className="mono">o/e/p/r/t/w/g</span> · <span className="mono">/</span> filter ·{" "}
-            <span className="mono">i</span> inject · <span className="mono">?</span> keys
+            {/* Read off NAV, not typed out: hand-listed it had already lost `f`
+                (Projects), so the footer promised a shorter chord set than the
+                pill and the `?` list. */}
+            <span className="mono">{NAV.map((n) => n.go).join("/")}</span> ·{" "}
+            <span className="mono">/</span> filter · <span className="mono">i</span> inject ·{" "}
+            <span className="mono">?</span> keys
           </div>
           {/* Named, not just toggled: "contrast" is the accessibility theme, and
               an operator who lands in it by accident needs to read where they
@@ -589,7 +593,57 @@ export function App() {
         />
       )}
       {helpOpen && <ShortcutsDialog onClose={() => setHelpOpen(false)} />}
+      <GoPrefixHint armed={goArmed} />
       <ToastContainer />
+    </div>
+  );
+}
+
+/**
+ * The armed `g` prefix, on screen for as long as the chord window is open.
+ * Without it a `g` plus any hesitation reads as a dropped keystroke, and the
+ * suffix pressed after the window lapsed fires as a bare list verb instead.
+ *
+ * `fixed` and `pointer-events-none` on purpose: the indicator appears mid-key
+ * and must not reflow the nav/list/detail layout under it, or reading the row
+ * it is about to leave becomes impossible. The region itself stays mounted
+ * while empty — a screen reader only announces nodes inserted into a live
+ * region that already existed (see ToastContainer).
+ */
+function GoPrefixHint({ armed }: { armed: boolean }) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-4 left-1/2 z-30 -translate-x-1/2"
+    >
+      {armed && (
+        <>
+          <span className="sr-only">Navigation prefix g armed — press a second key</span>
+          {/* The legend is the point for a sighted operator and noise read
+              aloud: the sentence above says the same thing in one breath. */}
+          <div
+            aria-hidden="true"
+            className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-full border border-(--border-strong) bg-(--surface-2) px-3 py-1.5 text-[11px] shadow-lg"
+          >
+            <span
+              className="mono rounded px-1.5 font-semibold"
+              style={{
+                color: "var(--accent)",
+                background: "color-mix(in oklch, var(--accent) 16%, transparent)",
+              }}
+            >
+              g
+            </span>
+            <span className="text-(--text-dim)">then</span>
+            {NAV.map((n) => (
+              <span key={n.key} className="whitespace-nowrap text-(--text-faint)">
+                <span className="mono text-(--text)">{n.go}</span> {n.label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Command } from "cmdk";
 import { useEffect, useState } from "react";
 import { api } from "../api";
-import { goPrefix, goSequence } from "../goSequence";
+import { GO_CHORD_MS, goPrefix, goSequence } from "../goSequence";
 import { keyGuard, modal } from "../hooks";
 import { useContextActions } from "../palette";
 
@@ -280,10 +280,21 @@ export function CommandPalette({
   );
 }
 
-/** g-then-letter navigation sequences (spec §5): g g, g o, g p, g r, g e. */
-export function useGoSequences(map: Record<string, () => void>) {
+/**
+ * g-then-letter navigation sequences (spec §5): g g, g o, g p, g r, g e.
+ *
+ * Returns whether a `g` is currently waiting for its suffix, so the caller can
+ * show that the chord is armed — without it, a `g` plus any hesitation looks
+ * like a dropped keystroke, and the suffix that follows a lapsed window fires
+ * as a bare list verb instead.
+ */
+export function useGoSequences(map: Record<string, () => void>): boolean {
+  const [armed, setArmed] = useState(false);
   useEffect(() => {
-    const press = goSequence((key) => key in map);
+    const chord = goSequence((key) => key in map);
+    // The window closes on its own, with nothing to press: the only way the
+    // affordance can follow it is a timer of the same length.
+    let lapse: ReturnType<typeof setTimeout> | undefined;
     function onKey(e: KeyboardEvent) {
       if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey) return;
       // A held `g` auto-repeats: without this, resting on the key would arm
@@ -291,11 +302,22 @@ export function useGoSequences(map: Record<string, () => void>) {
       if (e.repeat) return;
       // Arm the shared flag so list verbs (o, w, …) stand down (goSequence.ts).
       if (e.key === "g") goPrefix.armedAt = Date.now();
-      if (!press(e.key)) return;
+      const fired = chord.press(e.key);
+      clearTimeout(lapse);
+      setArmed(chord.armed());
+      if (chord.armed()) lapse = setTimeout(() => setArmed(false), GO_CHORD_MS);
+      if (!fired) return;
       e.preventDefault();
       map[e.key]();
     }
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      clearTimeout(lapse);
+      // This listener carried the chord; a remount mid-window would otherwise
+      // leave the indicator on with nothing left to resolve it.
+      setArmed(false);
+    };
   }, [map]);
+  return armed;
 }

--- a/event-runtime/web/src/goSequence.test.ts
+++ b/event-runtime/web/src/goSequence.test.ts
@@ -4,8 +4,8 @@ import { goSequence } from "./goSequence";
 /** A stepper over the real nav suffixes, with a clock the test drives. */
 function chord(targets = ["g", "o", "e", "p", "r", "t", "w"]) {
   let now = 1_000;
-  const press = goSequence((k) => targets.includes(k), () => now);
-  return { press, at: (t: number) => (now = t) };
+  const seq = goSequence((k) => targets.includes(k), () => now);
+  return { press: seq.press, armed: seq.armed, at: (t: number) => (now = t) };
 }
 
 describe("goSequence", () => {
@@ -52,6 +52,45 @@ describe("goSequence", () => {
     c.press("g");
     expect(c.press("x")).toBe(false);
     expect(c.press("w")).toBe(false);
+  });
+
+  test("nothing is armed before the first key", () => {
+    expect(chord().armed()).toBe(false);
+  });
+
+  test("a bare g reads as armed for the whole window and not past it", () => {
+    const c = chord();
+    c.press("g");
+    expect(c.armed()).toBe(true);
+    c.at(1_799);
+    expect(c.armed()).toBe(true);
+    c.at(1_800);
+    expect(c.armed()).toBe(false);
+  });
+
+  test("a resolved chord is no longer armed", () => {
+    for (const suffix of ["g", "o", "w"]) {
+      const c = chord();
+      c.press("g");
+      expect(c.press(suffix)).toBe(true);
+      expect(c.armed()).toBe(false);
+    }
+  });
+
+  test("a key that breaks the chord clears the armed state", () => {
+    const c = chord();
+    c.press("g");
+    c.press("x");
+    expect(c.armed()).toBe(false);
+  });
+
+  test("a lapsed g re-arms for a fresh window", () => {
+    const c = chord();
+    c.press("g");
+    c.at(2_000);
+    expect(c.armed()).toBe(false);
+    c.press("g");
+    expect(c.armed()).toBe(true);
   });
 
   test("with no Graph target, the second g re-arms instead of matching", () => {

--- a/event-runtime/web/src/goSequence.ts
+++ b/event-runtime/web/src/goSequence.ts
@@ -20,21 +20,32 @@ export function goPrefixActive(now: number = Date.now()): boolean {
  * `g r`, `g t`, `g w`. Kept free of React and the DOM so it is testable —
  * `useGoSequences` owns the listener, the key guard and `preventDefault`.
  *
- * Returns a stepper: feed it key names, and it answers whether this key
- * completed a chord. `g` is both the prefix and the Graph suffix, so a key
- * is matched against the map *before* it is considered as a new prefix.
+ * Returns a stepper: feed it key names through `press`, and it answers whether
+ * this key completed a chord. `g` is both the prefix and the Graph suffix, so a
+ * key is matched against the map *before* it is considered as a new prefix.
+ *
+ * `armed` reports whether a `g` is still waiting for its suffix. That is the
+ * same pending state `press` already keeps, exposed so the on-screen
+ * affordance renders from it instead of re-deriving the chord rules — and it is
+ * deliberately not `goPrefixActive()`, which stays true for the rest of the
+ * window after a chord resolves so the list verbs keep standing down.
  */
 export function goSequence(
   hasTarget: (key: string) => boolean,
   now: () => number = Date.now,
 ) {
   let pendingG = 0;
-  return function press(key: string): boolean {
-    if (pendingG && now() - pendingG < GO_CHORD_MS && hasTarget(key)) {
-      pendingG = 0;
-      return true;
-    }
-    pendingG = key === "g" ? now() : 0;
-    return false;
+  return {
+    press(key: string): boolean {
+      if (pendingG && now() - pendingG < GO_CHORD_MS && hasTarget(key)) {
+        pendingG = 0;
+        return true;
+      }
+      pendingG = key === "g" ? now() : 0;
+      return false;
+    },
+    armed(): boolean {
+      return pendingG > 0 && now() - pendingG < GO_CHORD_MS;
+    },
   };
 }


### PR DESCRIPTION
Fixes OPS-311

## Why

Pressing `g` left no trace on screen. Inside the 800 ms chord window the app is
in a real mode — the suffix keys navigate and the single-key list verbs (`o`,
`w`, …) stand down — but nothing said so. Any hesitation read as a dropped
keystroke, and a suffix typed one beat too late fired as a bare list verb
instead of navigating, which on a list view means opening a row you did not
mean to open.

## What

- `goSequence` returns `{ press, armed }`. `armed()` reports the pending `g`
  the state machine already tracked, so the indicator renders from the chord
  rules rather than re-deriving them. Deliberately not `goPrefixActive()`: that
  stays true for the rest of the window after a chord resolves, which is what
  keeps the list verbs standing down, and is the wrong signal for a light that
  must go out the instant you have navigated.
- `useGoSequences` mirrors `armed()` into React state and returns it. The window
  can also close with nothing pressed, so a timer of the same length clears the
  state on lapse; it is cleared on unmount too, or a remount mid-window would
  leave the indicator on with nothing left to resolve it.
- `App` renders a bottom-center pill with the `g`-then-suffix legend. `fixed`
  and `pointer-events-none`: it appears mid-keystroke and must not reflow the
  nav/list/detail layout under it. The live region stays mounted while empty so
  the `sr-only` announcement is actually announced.
- The nav footer's chord hint is now read off `NAV` instead of hand-listed. It
  had already drifted and lost `f` (Projects), advertising a shorter chord set
  than both the new pill and the `?` cheatsheet.

The chord key map is untouched — same suffixes, same window, same precedence of
map lookup before re-arming.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 314 pass /
0 fail, `tsc --noEmit` and `vite build` clean. Five new `goSequence` cases pin
the armed state: nothing armed before the first key, armed for the whole window
and not one tick past it, cleared on a resolved chord, cleared by a key that
breaks the chord, re-armed by a lapsed `g`.

## Reviewer notes

- The pill lists all eight suffixes. That is a judgement call — it teaches the
  chord at the moment it is relevant, at the cost of ~40 characters of 11px
  text on screen for under a second. A minimal `g …` dot is the alternative.
- Not visually verified in a browser: the UX critique could not run (no browser
  tooling in the session), so the no-reflow and narrow-width claims rest on the
  CSS — the root is `h-screen`, the pill is `fixed` with
  `max-w-[calc(100vw-2rem)]` and `flex-wrap`. Worth a look at ~420px and in the
  contrast theme.
- Toasts are `fixed bottom-4 right-4 z-50`; the pill is bottom-center `z-30`, so
  they can share the bottom strip at narrow widths. Filed separately rather than
  reaching into `ui.tsx`.