### PR TITLE
fix(event-runtime-web): scroll the view's status tab, not the context strip (OPS-378)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { OperatorContext } from "../context";
 import { INFLIGHT } from "../context";
+import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
 
 export function ScopeCaption({
@@ -49,11 +50,28 @@ export function ContextTabs({
 }) {
   const [picker, setPicker] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
   const available = useMemo(
     () => repos.filter((r) => !openRepos.includes(r.name)),
     [repos, openRepos],
   );
   const activeId = active.kind === "repo" ? active.name : active.kind;
+  const activeTab = () =>
+    stripRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ?? null;
+
+  // The strip scrolls its own active tab: `[` / `]` scroll-into-view belongs to
+  // the view's status tabs, and a repo tab can go active without being clicked
+  // (opening a project, the command palette), so it may sit past the overflow.
+  useEffect(() => {
+    activeTab()?.scrollIntoView({ inline: "nearest", block: "nearest" });
+  }, [activeId]);
+
+  // A closed tab takes its × button — and the focus — with it. Without this,
+  // focus falls to <body> and the next Tab restarts from the top of the page.
+  const [closes, setCloses] = useState(0);
+  useEffect(() => {
+    if (closes) activeTab()?.focus();
+  }, [closes]);
 
   useEffect(() => {
     if (!picker) return;
@@ -81,55 +99,63 @@ export function ContextTabs({
 
   return (
     <div className="flex h-9 shrink-0 items-stretch gap-0.5 border-b border-(--border) bg-(--surface-1) px-2">
-      <button
-        type="button"
-        role="tab"
-        aria-selected={active.kind === "all"}
-        className={tabClass("all")}
-        onClick={() => onSelect({ kind: "all" })}
-      >
-        All
-      </button>
       <div
-        className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+        ref={stripRef}
+        className="flex min-w-0 flex-1 items-stretch gap-0.5"
         role="tablist"
-        aria-label="Open repo contexts"
+        aria-label="Context"
+        {...{ [CONTEXT_TABS_ATTR]: "" }}
       >
-        {openRepos.map((name) => (
-          <div key={name} className="flex shrink-0 items-center">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={active.kind === "repo" && active.name === name}
-              className={tabClass(name)}
-              onClick={() => onSelect({ kind: "repo", name })}
-            >
-              {name}
-            </button>
-            <button
-              type="button"
-              aria-label={`Close ${name}`}
-              title={`Close ${name}`}
-              className="rounded px-1 text-[11px] text-(--text-faint) hover:text-(--text)"
-              onClick={(e) => {
-                e.stopPropagation();
-                onClose(name);
-              }}
-            >
-              ×
-            </button>
-          </div>
-        ))}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={active.kind === "all"}
+          className={tabClass("all")}
+          onClick={() => onSelect({ kind: "all" })}
+        >
+          All
+        </button>
+        <div
+          role="presentation"
+          className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+        >
+          {openRepos.map((name) => (
+            <div key={name} role="presentation" className="flex shrink-0 items-center">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={active.kind === "repo" && active.name === name}
+                className={tabClass(name)}
+                onClick={() => onSelect({ kind: "repo", name })}
+              >
+                {name}
+              </button>
+              <button
+                type="button"
+                aria-label={`Close ${name}`}
+                title={`Close ${name}`}
+                className="rounded px-1 text-[11px] text-(--text-faint) hover:text-(--text)"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(name);
+                  setCloses((n) => n + 1);
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={active.kind === "inflight"}
+          className={tabClass(INFLIGHT)}
+          onClick={() => onSelect({ kind: "inflight" })}
+        >
+          In flight
+        </button>
       </div>
-      <button
-        type="button"
-        role="tab"
-        aria-selected={active.kind === "inflight"}
-        className={tabClass(INFLIGHT)}
-        onClick={() => onSelect({ kind: "inflight" })}
-      >
-        In flight
-      </button>
       <div className="relative flex shrink-0 items-center" ref={pickerRef}>
         <button
           type="button"

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -116,6 +116,21 @@ export function useListKeys(opts: {
   }, [count, selected, onSelect, onOpen, onClose, keys]);
 }
 
+/**
+ * Marks the context strip's tablist. The strip renders above every view and its
+ * tabs are `role="tab"` too, so `[` / `]` scroll-into-view has to skip them to
+ * reach the view's own status tabs.
+ */
+export const CONTEXT_TABS_ATTR = "data-context-tabs";
+
+/** The selected status tab of the current view — never a context-strip tab. */
+function selectedStatusTab(): HTMLElement | null {
+  const strip = document.querySelector(`[${CONTEXT_TABS_ATTR}]`);
+  const selected = document.querySelectorAll<HTMLElement>('[role="tab"][aria-selected="true"]');
+  for (const tab of selected) if (!strip?.contains(tab)) return tab;
+  return null;
+}
+
 /** `[` / `]` cycle a view's status tabs (Linear's issue-state keys). */
 export function useTabKeys<T extends string>(
   tabs: readonly T[],
@@ -136,9 +151,7 @@ export function useTabKeys<T extends string>(
     return () => window.removeEventListener("keydown", onKey);
   }, [tabs, current, onSelect]);
   useEffect(() => {
-    document
-      .querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')
-      ?.scrollIntoView({ inline: "nearest", block: "nearest" });
+    selectedStatusTab()?.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [current]);
 }
 


### PR DESCRIPTION
Fixes OPS-378

## The bug

`useTabKeys` scrolled `document.querySelector('[role="tab"][aria-selected="true"]')` into view on every `[` / `]` cycle. The context strip renders above every view and always has exactly one selected `role="tab"` (All, a repo, or In flight), so in document order that selector *always* matched a context tab. The status tab the operator was actually cycling never scrolled — on a narrow window the active Runs state tab could sit permanently past the overflow while the strip scrolled instead.

## The fix

- `hooks.ts` — the strip is marked `data-context-tabs` (`CONTEXT_TABS_ATTR`), and `selectedStatusTab()` returns the first selected tab *outside* it, so `[` / `]` targets the view's own status tab on Runs, Events and Proposals.
- `ContextTabs.tsx` — the strip was two tablists with All and In flight loose outside both. It is now one `role="tablist"` labelled **Context** owning All, the open repo tabs and In flight; the overflow wrapper and each repo/close pair are `role="presentation"` so the tabs stay owned by the tablist.

Two smaller things that follow from the above, both inside the same file:

- The strip now scrolls **its own** active tab, since it can no longer piggyback on the hook's scroll. This is not cosmetic: a repo tab goes active without ever being clicked (opening a project, the command palette), so it could otherwise sit past the horizontal overflow.
- Closing a tab returns focus to the active tab. The `×` unmounts with its tab and focus fell to `<body>`, so the next Tab restarted from the top of the page.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — 309 pass / 0 fail, `tsc --noEmit` and `vite build` clean.

No test covers this change: `event-runtime/web` has no DOM test harness at all (no happy-dom/jsdom/testing-library, no browser runner), so component and keyboard behaviour is unverifiable in CI. Filed as OPS-398. The UX critique for this ticket also had no working browser path, so the keyboard/a11y review was code-level.

## What to look at first

1. `selectedStatusTab()` assumes at most one selected `role="tab"` lives outside the strip. That holds today — only Runs, Events and Proposals call `useTabKeys` and only one view mounts at a time — and it would degrade to scrolling the wrong tab, not throwing, if a second tablist ever appeared in a view.
2. The `role="presentation"` wrappers: they are what keeps All / repos / In flight owned by the one tablist. Removing them silently breaks the acceptance criterion.
3. The focus-on-close effect fires for any close, so closing a non-active tab moves focus to the active tab rather than to the neighbouring one. Deliberate — anywhere is better than `<body>` — but it is a choice.

## Out of scope, filed

- OPS-397 — the strip still is not a conforming ARIA tabs widget: the `×` buttons are focusable non-tab children of the tablist, there is no roving tabindex or arrow-key movement, no tabpanel association, and no keyboard close. Pre-existing, and the fix needs new keyboard vocabulary plus a spec update.
- OPS-398 — `event-runtime/web` has no DOM test harness.