### PR TITLE
fix(event-runtime-web): export THEMES from hooks.ts (OPS-353)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -11,7 +11,7 @@ import {
   type OperatorContext,
 } from "./context";
 import { eventsHash, hashPath, hashProject, hashSearch, withProject } from "./hash";
-import { keyGuard, useHashRoute, useTheme, type Theme } from "./hooks";
+import { keyGuard, THEMES, useHashRoute, useTheme } from "./hooks";
 import type { EventFocus } from "./types";
 import { CommandPalette, useGoSequences, type PaletteAction } from "./components/CommandPalette";
 import { InjectDialog } from "./components/InjectDialog";
@@ -41,11 +41,6 @@ const NAV = [
   { key: "workers", label: "Workers", go: "w" },
   { key: "graph", label: "Graph", go: "g" },
 ] as const;
-
-// Display-only mirror of the cycle useTheme() implements: both the footer
-// control and the ⌘K label promise what one click does, so the promise has to
-// name the same order the hook advances in.
-const THEME_ORDER: readonly Theme[] = ["dark", "light", "contrast"];
 
 export function App() {
   const [route, navigateRaw] = useHashRoute();
@@ -252,7 +247,7 @@ export function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, [navigate]);
 
-  const nextTheme = THEME_ORDER[(THEME_ORDER.indexOf(theme) + 1) % THEME_ORDER.length];
+  const nextTheme = THEMES[(THEMES.indexOf(theme) + 1) % THEMES.length];
 
   const paletteActions: PaletteAction[] = [
     ...NAV.map((n) => ({
@@ -276,7 +271,7 @@ export function App() {
     },
     { label: "Copy link to this page", run: copyLink },
     { label: "Keyboard shortcuts", hint: "?", run: () => setHelpOpen(true) },
-    { label: `Cycle theme (${THEME_ORDER.join(" → ")})`, run: cycleTheme },
+    { label: `Cycle theme (${THEMES.join(" → ")})`, run: cycleTheme },
   ];
 
   return (

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -155,7 +155,7 @@ export function useTabKeys<T extends string>(
   }, [current]);
 }
 
-const THEMES = ["dark", "light", "contrast"] as const;
+export const THEMES = ["dark", "light", "contrast"] as const;
 export type Theme = (typeof THEMES)[number];
 
 /** Theme state on <html data-theme>; dark is the default (spec §5.1). */


### PR DESCRIPTION
## Summary
- Export `THEMES` from `hooks.ts` as the single source of truth for theme cycle order
- Remove duplicated `THEME_ORDER` from `App.tsx`; footer label, next-theme aria-label, and ⌘K palette label all import the same constant

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` (320 pass, build green)
- [x] Theme footer shows current theme and promises the correct next theme
- [x] ⌘K "Cycle theme (dark → light → contrast)" label unchanged

Fixes OPS-353