### PR TITLE
fix(event-runtime): stop artifact GC from aborting the serve tick (OPS-412)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -22,7 +22,7 @@ import * as command from "./lib/adapters/command.mjs";
 import * as fake from "./lib/adapters/fake.mjs";
 import { apiClient } from "./lib/client.mjs";
 import {
-  API_HOST, DEFAULT_PORT, dbPath, ensureHome, environmentName, policyVersion, runtimeHome, workspacesRoot,
+  API_HOST, DEFAULT_PORT, artifactsRoot, dbPath, ensureHome, environmentName, policyVersion, runtimeHome, workspacesRoot,
 } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { newWorkerId } from "./lib/ids.mjs";
@@ -95,6 +95,110 @@ async function withClient(fn) {
     }
     fail(err.message);
   }
+}
+
+// Artifact GC interval. Unreferenced bytes older than a week are pruned, but
+// the serve loop only *attempts* that pass once an hour so a large store
+// cannot hitch every 1s tick.
+export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "outbox", "GC", "chains"];
+
+/**
+ * One serve-loop pass (OPS-412). Each named subsystem is caught on its own
+ * so a throw in GC cannot skip chain resolution — or any other step.
+ *
+ * `subsystems` may replace a step by the names in TICK_SUBSYSTEMS; tests use
+ * that to prove isolation. `storeRoot` defaults to `artifactsRoot()`.
+ *
+ * @returns {{ lastPrune: number }}
+ */
+export async function tick({
+  db,
+  registry,
+  now = Date.now(),
+  policyVersion: pv,
+  adapterOverride,
+  withWorker = false,
+  adapters,
+  owner,
+  lastPrune = 0,
+  pruneIntervalMs = PRUNE_INTERVAL_MS,
+  storeRoot,
+  log: logLine = log,
+  announceProposals = () => {},
+  announceTransitions = () => {},
+  subsystems = {},
+} = {}) {
+  const runStep = async (name, fn) => {
+    try {
+      await (subsystems[name] ?? fn)();
+    } catch (err) {
+      logLine(`tick ${name}: ${err.message}`);
+    }
+  };
+
+  await runStep("tick emit", () => {
+    const ticks = emitDueTicks(db, registry, { now });
+    for (const t of ticks.emitted) {
+      logLine(`tick ${t.loop} @ ${t.slot}${t.skipped > 0 ? ` (stands for ${t.skipped} skipped slot(s))` : ""}`);
+    }
+    for (const err of ticks.errors) logLine(`schedule error: ${err}`);
+  });
+
+  await runStep("plan", () => {
+    planAdmittedEvents(db, registry, { now, policyVersion: pv, adapterOverride });
+  });
+
+  await runStep("auto-approve", () => {
+    const auto = autoApproveScheduled(db, registry, approveProposal, { now, policyVersion: pv });
+    for (const a of auto.approved) logLine(`schedule approved ${a.loop} → run ${a.runId} (actor: schedule)`);
+    for (const err of auto.errors) logLine(`schedule approval error: ${err}`);
+  });
+
+  await runStep("announce", () => {
+    announceProposals();
+    announceTransitions();
+  });
+
+  await runStep("reap", () => {
+    reapExpiredLeases(db, { now, policyVersion: pv });
+  });
+
+  if (withWorker) {
+    await runStep("worker", async () => {
+      await runOnce(db, registry, adapters, {
+        workspacesRoot: workspacesRoot(), owner, now, policyVersion: pv,
+      });
+    });
+  }
+
+  await runStep("announce-after", () => {
+    announceTransitions();
+  });
+
+  await runStep("outbox", () => {
+    publishOutbox(db, {
+      sink: (e) => logLine(`result event ${e.type} (${e.eventId}) artifact ${e.payload?.artifactHash ?? "-"}`),
+      now,
+    });
+  });
+
+  let nextPrune = lastPrune;
+  await runStep("GC", () => {
+    if (now - lastPrune <= pruneIntervalMs) return;
+    const pruned = pruneArtifacts(db, storeRoot ?? artifactsRoot(), { now });
+    nextPrune = now;
+    if (pruned.deleted > 0) logLine(`artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`);
+  });
+
+  await runStep("chains", () => {
+    const chains = resolveChains(db, registry, { now });
+    if (chains.emitted > 0) logLine(`chain: emitted ${chains.emitted} follow-up event(s) — planning`);
+    for (const err of chains.errors) logLine(`chain error: ${err}`);
+  });
+
+  return { lastPrune: nextPrune };
 }
 
 // ---------------------------------------------------------------------------
@@ -184,55 +288,24 @@ async function serve(args) {
 
   let lastPrune = Date.now();
   let busy = false;
-  async function tick() {
+  async function loopTick() {
     if (busy) return; // never overlap: planning and (optional) execution share this tick
     busy = true;
     try {
-      const nowMs = Date.now();
-      // Scheduled loops (OPS-381): a tick is an event, admitted through the
-      // same intake as a webhook. The eventId is the slot, so restarting
-      // serve mid-interval cannot double-fire.
-      const ticks = emitDueTicks(db, registry, { now: nowMs });
-      for (const t of ticks.emitted) {
-        log(`tick ${t.loop} @ ${t.slot}${t.skipped > 0 ? ` (stands for ${t.skipped} skipped slot(s))` : ""}`);
-      }
-      for (const err of ticks.errors) log(`schedule error: ${err}`);
-
-      planAdmittedEvents(db, registry, { now: nowMs, policyVersion: pv, adapterOverride });
-
-      // Earned automation (§6): only loops that declare approval "auto", and
-      // always recorded with the scheduler as actor.
-      const auto = autoApproveScheduled(db, registry, approveProposal, { now: nowMs, policyVersion: pv });
-      for (const a of auto.approved) log(`schedule approved ${a.loop} → run ${a.runId} (actor: schedule)`);
-      for (const err of auto.errors) log(`schedule approval error: ${err}`);
-      announceProposals();
-      announceTransitions();
-      reapExpiredLeases(db, { now: nowMs, policyVersion: pv });
-      if (withWorker) {
-        await runOnce(db, registry, adapters, {
-          workspacesRoot: workspacesRoot(), owner, now: Date.now(), policyVersion: pv,
-        });
-      }
-      announceTransitions();
-      // Watched-mode outbox sink (§15): display the result event, stamp it published.
-      publishOutbox(db, {
-        sink: (e) => log(`result event ${e.type} (${e.eventId}) artifact ${e.payload?.artifactHash ?? "-"}`),
-        now: Date.now(),
+      const result = await tick({
+        db,
+        registry,
+        policyVersion: pv,
+        adapterOverride,
+        withWorker,
+        adapters,
+        owner,
+        lastPrune,
+        log,
+        announceProposals,
+        announceTransitions,
       });
-      // Discovered chains (OPS-223): a completed run with a registered
-      // recommendation edge emits an internal event through the same intake;
-      // the next planning pass proposes the follow-up, watched like anything.
-      // Artifact GC (OPS-372): unreferenced bytes older than the window go;
-      // anything an accepted result points at is never touched, because a
-      // receipt aiming at a deleted file turns the audit trail into a lie.
-      if (Date.now() - lastPrune > 60 * 60 * 1000) {
-        lastPrune = Date.now();
-        const pruned = pruneArtifacts(db, artifactsRoot(), { now: Date.now() });
-        if (pruned.deleted > 0) log(`artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`);
-      }
-      const chains = resolveChains(db, registry, { now: Date.now() });
-      if (chains.emitted > 0) log(`chain: emitted ${chains.emitted} follow-up event(s) — planning`);
-      for (const err of chains.errors) log(`chain error: ${err}`);
+      lastPrune = result.lastPrune;
     } catch (err) {
       log(`tick error: ${err.message}`);
     } finally {
@@ -245,7 +318,7 @@ async function serve(args) {
     db, registry, policyVersion: pv, port, env,
     onEvent: (kind) => {
       log(`event ${kind} — planning`);
-      tick();
+      loopTick();
     },
   });
   server.on("listening", () => {
@@ -267,7 +340,7 @@ async function serve(args) {
   let timer = null;
   server.on("listening", () => {
     announceProposals();
-    timer = setInterval(tick, 1000);
+    timer = setInterval(loopTick, 1000);
   });
 
   // SIGTERM is what `bun --watch` sends on reload; without a close the next
@@ -745,4 +818,6 @@ async function main() {
   }
 }
 
-await main();
+if (import.meta.main || process.argv[1]?.endsWith("cli.mjs")) {
+  await main();
+}

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -78,4 +78,35 @@ describe("cli", () => {
     expect(out).toContain("serve --watch: restarting on event-runtime/ changes");
     expect(out).toContain("control API on");
   });
+
+  test("serve binds the control API, starts the loop, and answers /health", async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-serve-"));
+    const port = String(59800 + (process.pid % 100));
+    const child = spawn("bun", [CLI, "serve", "--port", port], {
+      env: { ...process.env, FACTORY_EVENT_HOME: home },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    child.stdout.on("data", (b) => {
+      out += b;
+    });
+    child.stderr.on("data", (b) => {
+      out += b;
+    });
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline && !out.includes("control API on")) {
+      await Bun.sleep(100);
+    }
+    let health;
+    try {
+      expect(out).toContain("control API on");
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(res.ok).toBe(true);
+      health = await res.json();
+    } finally {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    expect(health.ok).toBe(true);
+  });
 });

--- a/event-runtime/lib/repository.test.mjs
+++ b/event-runtime/lib/repository.test.mjs
@@ -21,7 +21,10 @@ const tmp = (prefix) => {
 };
 afterAll(() => {
   for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
-});
+}, 20_000);
+
+/** Real git init/commit is already ~3–4s in isolation; 5s flakes under parallel load. */
+const GIT_MS = 20_000;
 
 const git = (args, cwd) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
@@ -65,12 +68,12 @@ describe("repos.yaml is read, not owned", () => {
       verify: "echo ok",
     });
     expect(expandHome("~/x")).toBe(path.join(process.env.HOME ?? "", "x"));
-  });
+  }, { timeout: GIT_MS });
 
   test("an unknown repo names what is configured instead of failing vaguely", () => {
     const repos = loadRepos({ root: makeFactoryRoot(makeRepo().dir) });
     expect(() => getRepo(repos, "nope")).toThrow(/not in config\/repos\.yaml \(have: testrepo\)/);
-  });
+  }, { timeout: GIT_MS });
 
   test("a missing config fails closed", () => {
     expect(() => loadRepos({ root: tmp("evrt-empty-") })).toThrow(RepoError);
@@ -96,7 +99,7 @@ describe("mirror + pinned checkout", () => {
     git(["commit", "--quiet", "-m", "third"], src.dir);
     syncMirror(repo, { root: mirrors });
     expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(git(["rev-parse", "HEAD"], src.dir));
-  });
+  }, { timeout: GIT_MS });
 
   test("resolves a ref to an immutable sha — the pin a run is reproducible against", () => {
     const src = makeRepo();
@@ -104,7 +107,7 @@ describe("mirror + pinned checkout", () => {
     const repo = getRepo(loadRepos({ root: makeFactoryRoot(src.dir) }), "testrepo");
     expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
     expect(resolveRef(repo, src.first, { root: mirrors }).sha).toBe(src.first);
-  });
+  }, { timeout: GIT_MS });
 
   test("materializes the pinned tree inside the workspace, then releases it", () => {
     const src = makeRepo();
@@ -128,7 +131,7 @@ describe("mirror + pinned checkout", () => {
     // The mirror survives as cache, with no stale worktree registration.
     expect(existsSync(mirrorPath("testrepo", mirrors))).toBe(true);
     expect(git(["worktree", "list"], mirrorPath("testrepo", mirrors))).not.toContain(workspaceDir);
-  });
+  }, { timeout: GIT_MS });
 
   test("a checkout may not escape its workspace", () => {
     const src = makeRepo();
@@ -144,7 +147,7 @@ describe("mirror + pinned checkout", () => {
         reposRoot,
       }),
     ).toThrow(RepositoryWorkspaceError);
-  });
+  }, { timeout: GIT_MS });
 
   test("an unpinned run refuses rather than guessing a ref", () => {
     expect(() =>

--- a/event-runtime/lib/tick.test.mjs
+++ b/event-runtime/lib/tick.test.mjs
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PRUNE_INTERVAL_MS, TICK_SUBSYSTEMS, tick } from "../cli.mjs";
+import { sha256Hex } from "./canonical.mjs";
+import { openDb } from "./db.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const registry = loadRegistry();
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+function harness() {
+  const dir = tmp("evrt-tick-");
+  const db = openDb(path.join(dir, "runtime.db"));
+  const storeRoot = path.join(dir, "artifacts");
+  mkdirSync(storeRoot, { recursive: true });
+  return { db, storeRoot };
+}
+
+function storeFile(storeRoot, bytes) {
+  const hash = sha256Hex(Buffer.from(bytes));
+  const file = path.join(storeRoot, hash);
+  writeFileSync(file, bytes);
+  return { hash, file };
+}
+
+describe("tick (OPS-412)", () => {
+  test("pruneArtifacts runs when the clock is past the prune window and deletes aged orphans", async () => {
+    const { db, storeRoot } = harness();
+    const orphan = storeFile(storeRoot, "orphan bytes");
+    const kept = storeFile(storeRoot, "kept bytes");
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
+    ).run(
+      "run_kept",
+      JSON.stringify({ artifacts: [{ kind: "ci-log", sha256: kept.hash, uri: "file:///x" }] }),
+      new Date().toISOString(),
+    );
+
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    utimesSync(orphan.file, old, old);
+    utimesSync(kept.file, old, old);
+
+    const now = Date.now();
+    const logs = [];
+    const result = await tick({
+      db,
+      registry,
+      now,
+      lastPrune: now - PRUNE_INTERVAL_MS - 1,
+      storeRoot,
+      policyVersion: "git:test",
+      log: (line) => logs.push(line),
+    });
+
+    expect(existsSync(orphan.file)).toBe(false);
+    expect(existsSync(kept.file)).toBe(true);
+    expect(result.lastPrune).toBe(now);
+    expect(logs.some((l) => l.startsWith("artifacts: pruned 1 orphan"))).toBe(true);
+  });
+
+  for (const failing of TICK_SUBSYSTEMS) {
+    test(`a throw in ${failing} does not prevent the others from running`, async () => {
+      const { db } = harness();
+      const ran = [];
+      const logs = [];
+      const subsystems = Object.fromEntries(
+        TICK_SUBSYSTEMS.map((name) => [
+          name,
+          () => {
+            ran.push(name);
+            if (name === failing) throw new Error(`${name} boom`);
+          },
+        ]),
+      );
+
+      await tick({
+        db,
+        registry,
+        now: Date.now(),
+        lastPrune: Date.now(),
+        policyVersion: "git:test",
+        log: (line) => logs.push(line),
+        subsystems,
+      });
+
+      expect(ran).toEqual(TICK_SUBSYSTEMS);
+      expect(logs).toContain(`tick ${failing}: ${failing} boom`);
+      for (const name of TICK_SUBSYSTEMS) {
+        if (name === failing) continue;
+        expect(logs.some((l) => l.startsWith(`tick ${name}:`))).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Import `artifactsRoot` so the hourly `pruneArtifacts` call no longer throws `ReferenceError` and abort the whole tick.
- Catch each serve-loop subsystem on its own (`tick emit`, `plan`, `auto-approve`, `outbox`, `GC`, `chains`) so a throw in GC cannot skip chain resolution.
- Tests: one `tick()` with the clock past the prune window deletes aged orphans; a throw in any of the six subsystems still runs the others; `cli.test.mjs` boots `serve` and hits `/health`.

## Test plan
- [x] `bun test event-runtime/` — 328 pass, 0 fail
- Git-mirror tests in `repository.test.mjs` were already at the 5s ceiling under parallel load; timeout raised to 20s so this gate is honest. Assertions unchanged.

UX critique: skipped — serve-loop backend, not a user-facing web flow.

Fixes OPS-412