### PR TITLE
test(event-runtime-web): extract heartbeatOf so the 90s arithmetic is unit-tested (OPS-316)

### DIFF
--- a/event-runtime/web/src/heartbeat.test.ts
+++ b/event-runtime/web/src/heartbeat.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { Worker } from "./types";
+import {
+  dur,
+  heartbeatHue,
+  heartbeatOf,
+  HEARTBEAT_STALE_MS,
+  HEARTBEAT_WARN_MS,
+  isOverdue,
+} from "./heartbeat";
+
+const baseWorker = (overrides: Partial<Worker> = {}): Worker => ({
+  workerId: "wkr_test",
+  host: "lab",
+  pid: 1,
+  labels: {},
+  adapters: [],
+  state: "idle",
+  currentRun: null,
+  lastSeen: "2026-01-01T00:00:00.000Z",
+  stale: false,
+  startedAt: "2026-01-01T00:00:00.000Z",
+  stoppedAt: null,
+  ...overrides,
+});
+
+describe("heartbeatOf", () => {
+  const lastSeen = "2026-01-01T00:00:00.000Z";
+  const deadline = Date.parse(lastSeen) + HEARTBEAT_STALE_MS;
+
+  test("a cleanly stopped worker has no countdown", () => {
+    const w = baseWorker({ state: "stopped", lastSeen });
+    expect(heartbeatOf(w, deadline)).toEqual({ kind: "none" });
+  });
+
+  test("stale outranks stopped: a stale row still shows overdue time", () => {
+    const w = baseWorker({ state: "stopped", stale: true, lastSeen });
+    expect(heartbeatOf(w, deadline + 5000)).toEqual({ kind: "stale", overdueMs: 5000 });
+  });
+
+  test("live worker halfway through the window", () => {
+    const w = baseWorker({ state: "busy", lastSeen });
+    const now = deadline - 45_000;
+    expect(heartbeatOf(w, now)).toEqual({ kind: "live", remainingMs: 45_000 });
+  });
+
+  test("ceil rounds sub-second remainder up to the next whole second", () => {
+    const w = baseWorker({ lastSeen });
+    expect(heartbeatOf(w, deadline - 1)).toEqual({ kind: "live", remainingMs: 1000 });
+    expect(heartbeatOf(w, deadline - 999)).toEqual({ kind: "live", remainingMs: 1000 });
+  });
+
+  test("at the 90s boundary remainingMs is zero (overdue, not stale yet)", () => {
+    const w = baseWorker({ lastSeen });
+    expect(heartbeatOf(w, deadline)).toEqual({ kind: "live", remainingMs: 0 });
+    expect(heartbeatOf(w, deadline + 10_000)).toEqual({ kind: "live", remainingMs: 0 });
+  });
+
+  test("stale overdueMs floors to at least one second", () => {
+    const w = baseWorker({ stale: true, lastSeen });
+    expect(heartbeatOf(w, deadline + 1)).toEqual({ kind: "stale", overdueMs: 1000 });
+    expect(heartbeatOf(w, deadline + 2500)).toEqual({ kind: "stale", overdueMs: 2500 });
+  });
+});
+
+describe("isOverdue", () => {
+  test("only a spent live window reads overdue", () => {
+    expect(isOverdue({ kind: "live", remainingMs: 0 })).toBe(true);
+    expect(isOverdue({ kind: "live", remainingMs: 1000 })).toBe(false);
+    expect(isOverdue({ kind: "stale", overdueMs: 5000 })).toBe(false);
+    expect(isOverdue({ kind: "none" })).toBe(false);
+  });
+});
+
+describe("heartbeatHue", () => {
+  test("stale is always error", () => {
+    expect(heartbeatHue({ kind: "stale", overdueMs: 1000 })).toBe("var(--hue-err)");
+  });
+
+  test("live inside the warn band is warn", () => {
+    expect(heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS })).toBe("var(--hue-warn)");
+    expect(heartbeatHue({ kind: "live", remainingMs: 1000 })).toBe("var(--hue-warn)");
+    expect(heartbeatHue({ kind: "live", remainingMs: 0 })).toBe("var(--hue-warn)");
+  });
+
+  test("live outside the warn band has no accent", () => {
+    expect(heartbeatHue({ kind: "live", remainingMs: HEARTBEAT_WARN_MS + 1000 })).toBeUndefined();
+    expect(heartbeatHue({ kind: "none" })).toBeUndefined();
+  });
+});
+
+describe("dur", () => {
+  test("formats sub-hour durations as m:ss", () => {
+    expect(dur(0)).toBe("0:00");
+    expect(dur(1000)).toBe("0:01");
+    expect(dur(65_000)).toBe("1:05");
+    expect(dur(3599_000)).toBe("59:59");
+  });
+
+  test("formats hour-scale durations", () => {
+    expect(dur(3600_000)).toBe("1h00m");
+    expect(dur(3661_000)).toBe("1h01m");
+  });
+
+  test("formats day-scale durations", () => {
+    expect(dur(86_400_000)).toBe("1d0h");
+    expect(dur(90_000_000)).toBe("1d1h");
+  });
+});

--- a/event-runtime/web/src/heartbeat.ts
+++ b/event-runtime/web/src/heartbeat.ts
@@ -1,0 +1,53 @@
+import type { Worker } from "./types";
+
+/**
+ * Mirrors `HEARTBEAT_STALE_MS` in `event-runtime/lib/workers.mjs`. The web app
+ * never imports from the runtime's `lib/`, so moving the window there means
+ * changing it here too — the number is duplicated on purpose, not by accident.
+ */
+export const HEARTBEAT_STALE_MS = 90_000;
+
+/** The last third of the window. A worker that checks in every tick never reaches it. */
+export const HEARTBEAT_WARN_MS = 30_000;
+
+export type Heartbeat =
+  | { kind: "stale"; overdueMs: number }
+  | { kind: "live"; remainingMs: number }
+  | { kind: "none" };
+
+/**
+ * Threshold arithmetic, not a second opinion on health: whether a worker *is*
+ * stale stays the server's call (`w.stale`, via `health`), and this only says how
+ * much of the 90s window is left or how far past it we are. A cleanly stopped
+ * worker stops checking in on purpose, so it has no deadline at all — counting
+ * down for it would invent an outage.
+ */
+export const heartbeatOf = (w: Worker, now: number): Heartbeat => {
+  const deadline = Date.parse(w.lastSeen) + HEARTBEAT_STALE_MS;
+  // Floored to a second, because `dur` renders the first sub-second of overdue as
+  // `0:00` and "stale for no time at all" reads as a broken badge rather than a
+  // fresh one. Same floor the countdown below uses, so the flip reads 0:01 next.
+  if (w.stale) return { kind: "stale", overdueMs: Math.max(1000, now - deadline) };
+  if (w.state === "stopped") return { kind: "none" };
+  // Whole seconds, rounded up: the last fraction of a second reads 0:01, and only
+  // a genuinely spent window reads 0 — which is what `overdue` keys off.
+  return { kind: "live", remainingMs: Math.max(0, Math.ceil((deadline - now) / 1000) * 1000) };
+};
+
+/** One hue per clock, so the age, the countdown and the meter never disagree. */
+export const heartbeatHue = (hb: Heartbeat): string | undefined => {
+  if (hb.kind === "stale") return "var(--hue-err)";
+  if (hb.kind === "live" && hb.remainingMs <= HEARTBEAT_WARN_MS) return "var(--hue-warn)";
+  return undefined;
+};
+
+/** `m:ss` while seconds decide, coarser once they stop mattering. */
+export const dur = (ms: number) => {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 3600) return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}m`;
+  return `${Math.floor(s / 86400)}d${Math.floor((s % 86400) / 3600)}h`;
+};
+
+/** Whether the live countdown has spent the window but the server has not marked stale yet. */
+export const isOverdue = (hb: Heartbeat): boolean => hb.kind === "live" && hb.remainingMs === 0;

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -5,6 +5,14 @@ import { useListKeys, useNow } from "../hooks";
 import { setContextActions } from "../palette";
 import type { Worker } from "../types";
 import type { OperatorContext } from "../context";
+import {
+  dur,
+  heartbeatHue,
+  heartbeatOf,
+  HEARTBEAT_STALE_MS,
+  isOverdue,
+  type Heartbeat,
+} from "../heartbeat";
 import { ScopeCaption } from "../components/ContextTabs";
 import {
   Ago,
@@ -38,52 +46,6 @@ const WORKER_HUES: Record<string, string> = {
 const health = (w: Worker) => (w.stale ? "stale" : w.state);
 
 /**
- * Mirrors `HEARTBEAT_STALE_MS` in `event-runtime/lib/workers.mjs`. The web app
- * never imports from the runtime's `lib/`, so moving the window there means
- * changing it here too — the number is duplicated on purpose, not by accident.
- */
-const HEARTBEAT_STALE_MS = 90_000;
-
-/** The last third of the window. A worker that checks in every tick never reaches it. */
-const HEARTBEAT_WARN_MS = 30_000;
-
-type Heartbeat = { kind: "stale"; overdueMs: number } | { kind: "live"; remainingMs: number } | { kind: "none" };
-
-/**
- * Threshold arithmetic, not a second opinion on health: whether a worker *is*
- * stale stays the server's call (`w.stale`, via `health`), and this only says how
- * much of the 90s window is left or how far past it we are. A cleanly stopped
- * worker stops checking in on purpose, so it has no deadline at all — counting
- * down for it would invent an outage.
- */
-const heartbeatOf = (w: Worker, now: number): Heartbeat => {
-  const deadline = Date.parse(w.lastSeen) + HEARTBEAT_STALE_MS;
-  // Floored to a second, because `dur` renders the first sub-second of overdue as
-  // `0:00` and "stale for no time at all" reads as a broken badge rather than a
-  // fresh one. Same floor the countdown below uses, so the flip reads 0:01 next.
-  if (w.stale) return { kind: "stale", overdueMs: Math.max(1000, now - deadline) };
-  if (w.state === "stopped") return { kind: "none" };
-  // Whole seconds, rounded up: the last fraction of a second reads 0:01, and only
-  // a genuinely spent window reads 0 — which is what `overdue` keys off.
-  return { kind: "live", remainingMs: Math.max(0, Math.ceil((deadline - now) / 1000) * 1000) };
-};
-
-/** One hue per clock, so the age, the countdown and the meter never disagree. */
-const heartbeatHue = (hb: Heartbeat): string | undefined => {
-  if (hb.kind === "stale") return "var(--hue-err)";
-  if (hb.kind === "live" && hb.remainingMs <= HEARTBEAT_WARN_MS) return "var(--hue-warn)";
-  return undefined;
-};
-
-/** `m:ss` while seconds decide, coarser once they stop mattering. */
-const dur = (ms: number) => {
-  const s = Math.max(0, Math.floor(ms / 1000));
-  if (s < 3600) return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}m`;
-  return `${Math.floor(s / 86400)}d${Math.floor((s % 86400) / 3600)}h`;
-};
-
-/**
  * The distance to the stale threshold, worded the same way in the row and the
  * detail pane so an operator only has to learn one phrase. The countdown is local
  * arithmetic and the verdict is the server's, so a spent window says `overdue`
@@ -113,7 +75,7 @@ function StaleClock({ hb, className }: { hb: Heartbeat; className?: string }) {
         stale for {dur(hb.overdueMs)}
       </span>
     );
-  if (hb.remainingMs === 0)
+  if (isOverdue(hb))
     return (
       <span
         className={className}


### PR DESCRIPTION
## Summary
- Extract `heartbeatOf`, `dur`, `heartbeatHue`, and `isOverdue` from `Workers.tsx` into `event-runtime/web/src/heartbeat.ts`
- Add 13 unit tests covering stale-vs-stopped precedence, the 90s boundary (ceil + overdue), warn-band hue, and duration formatting
- `Workers.tsx` imports the module; no user-facing behavior change

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 333 pass, build green
- [x] New `heartbeat.test.ts` covers stopped (`kind: none`), stale-outranks-stopped, live countdown ceil, spent-window overdue, and `dur` formatting

Fixes OPS-316