### PR TITLE
fix(event-runtime-web): context-tab close must not steal focus (OPS-399)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -66,11 +66,15 @@ export function ContextTabs({
     activeTab()?.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [activeId]);
 
-  // A closed tab takes its × button — and the focus — with it. Without this,
-  // focus falls to <body> and the next Tab restarts from the top of the page.
+  // A closed tab takes its × button with it. Chromium focuses the button on
+  // click, so unmount drops focus to <body> and the next Tab restarts at the
+  // top of the page. Safari/Firefox leave focus where it was (a list row, a
+  // filter); only recover when it was actually lost.
   const [closes, setCloses] = useState(0);
   useEffect(() => {
-    if (closes) activeTab()?.focus();
+    if (!closes) return;
+    const focused = document.activeElement;
+    if (focused == null || focused === document.body) activeTab()?.focus();
   }, [closes]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Gate the context-tab close-focus effect so the remaining active tab is focused only when `document.activeElement` is `body` or `null`.
- Safari / Firefox-on-macOS keep focus on the list row or filter after ×; Chromium still recovers when the unmounted × drops focus to `<body>`.

## Test plan
- [x] `bun test event-runtime` — 320 pass, 0 fail
- [x] `cd event-runtime/web && bun run build` — green
- [ ] Safari / Firefox-on-macOS: close a repo tab while a list row or filter is focused — focus stays put
- [ ] Chromium: click × on a repo tab — remaining selected tab is focused (body-focus recovery)

UX critique: required — SHIP (live browser skipped: dashboard not running / Chrome profile contention). Residual: the comment names Safari/Firefox; Firefox-on-Linux focuses buttons like Chromium and is covered by the body check. DOM lock-in for the gate is [OPS-446](https://linear.app/watt-mind/issue/OPS-446).

Fixes OPS-399