### PR TITLE
feat(event-runtime-web): keyed filter chips (OPS-382)

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,6 +1,14 @@
 import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
 import { modal, useNow } from "../hooks";
 import { tokenizeJson, TOKEN_CLASSES } from "../highlight";
+import {
+  type FilterChipToken,
+  type FilterQuery,
+  chipHelp,
+  chipLabel,
+  filterHint,
+  removeFilterToken,
+} from "../filterQuery";
 
 /** One fixed hue map for the closed §8 lifecycle — identical in every view. */
 export const STATE_HUES: Record<string, string> = {
@@ -51,42 +59,164 @@ export function copyLink() {
   copyText(window.location.href, "link");
 }
 
+/**
+ * One active token, as a dismissible chip (UX doc Proposal 4). The whole chip
+ * is the remove target: a token is one word in the query box, so there is
+ * nothing else to click it for, and one tab stop per token keeps the bar
+ * traversable when a query has four of them.
+ */
+function FilterToken({
+  token,
+  query,
+  onRemove,
+}: {
+  token: FilterChipToken;
+  query: FilterQuery;
+  onRemove: () => void;
+}) {
+  const label = chipLabel(token);
+  const help = chipHelp(token, query);
+  return (
+    <button
+      type="button"
+      onClick={onRemove}
+      title={help}
+      aria-label={`Remove ${label}. ${help}`}
+      className={`group inline-flex cursor-pointer items-center gap-1 rounded-md border bg-(--surface-2) px-1.5 py-0.5 text-[11px] hover:bg-(--surface-3) ${
+        token.supported
+          ? "border-(--border) hover:border-(--border-strong)"
+          : "border-dashed text-(--hue-warn)"
+      }`}
+    >
+      <span className={`mono ${token.supported ? "" : "line-through"}`}>{label}</span>
+      <span aria-hidden className="text-(--text-faint) group-hover:text-(--text)">
+        ×
+      </span>
+    </button>
+  );
+}
+
+/**
+ * The list filter box. Pass `query` (parsed by the view, which is the only
+ * thing that knows its own facets) to get the keyed syntax: the text stays
+ * authoritative and the chips are what it parsed to, so editing the box and
+ * dismissing a chip can never disagree about the current filter.
+ */
 export function FilterInput({
   value,
   onChange,
   placeholder,
   label,
+  query,
 }: {
   value: string;
   onChange: (value: string) => void;
   placeholder: string;
   label: string;
+  query?: FilterQuery;
 }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hintId = useId();
+  const [hint, setHint] = useState(false);
+  const chips = query?.chips ?? [];
+  const hintText = query ? filterHint(query) : "";
+  // Dismissal rewrites the query text, so focus returns to the box: the next
+  // keystroke — or Esc — lands where the operator thinks it is.
+  const rewrite = (next: string) => {
+    onChange(next);
+    inputRef.current?.focus();
+  };
   return (
-    <span className="relative inline-flex w-56 shrink-0">
-      <input
-        data-view-filter
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key !== "Escape") return;
-          e.preventDefault();
-          if (value) onChange("");
-          else e.currentTarget.blur();
-        }}
-        placeholder={placeholder}
-        aria-label={label}
-        className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 pr-7 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
-      />
-      {!value && (
-        <kbd
-          aria-hidden
-          className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-(--border) px-1 font-sans text-[10px] text-(--text-faint)"
+    <>
+      <span className="relative inline-flex w-56 shrink-0">
+        <input
+          ref={inputRef}
+          data-view-filter
+          value={value}
+          title={hintText || undefined}
+          aria-describedby={query ? hintId : undefined}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setHint(true)}
+          onBlur={() => setHint(false)}
+          onKeyDown={(e) => {
+            if (e.key !== "Escape") return;
+            e.preventDefault();
+            if (value) onChange("");
+            else e.currentTarget.blur();
+          }}
+          placeholder={placeholder}
+          aria-label={label}
+          className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 pr-7 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+        />
+        {!value && (
+          <kbd
+            aria-hidden
+            className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-(--border) px-1 font-sans text-[10px] text-(--text-faint)"
+          >
+            /
+          </kbd>
+        )}
+        {/* Syntax on `/`, not on hover — the operators who need it reached
+            this box with a keystroke. It floats over the table rather than
+            taking a row, so focusing the filter never moves the rows. Right-
+            aligned and wider than the box: Runs parks the input at the far
+            end of the tab row, and a box-width column of wrapping text is
+            unreadable. */}
+        {query && (
+          <span
+            id={hintId}
+            role="tooltip"
+            className={
+              hint && !value
+                ? "absolute top-full right-0 z-20 mt-1 w-72 rounded-md border border-(--border-strong) bg-(--surface-2) px-2 py-1 text-[11px] text-(--text-faint)"
+                : "sr-only"
+            }
+          >
+            {hintText}
+          </span>
+        )}
+      </span>
+      {query && chips.length > 0 && (
+        <div
+          role="group"
+          aria-label={`${label} tokens`}
+          // A focused chip is a button, and `keyGuard` (hooks.ts) only stands
+          // the global list verbs down inside a text field — so Enter here
+          // would open the selected row instead of dismissing the chip, and `x`
+          // would open a cancel dialog. Contain those. Esc is the one list
+          // verb that belongs here too, but list Esc deselects first: from
+          // the chip bar it must clear the query, same as from the box.
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              e.stopPropagation();
+              rewrite("");
+              return;
+            }
+            e.stopPropagation();
+          }}
+          className="flex basis-full flex-wrap items-center gap-1.5"
         >
-          /
-        </kbd>
+          {chips.map((token) => (
+            <FilterToken
+              key={`${token.start}-${token.raw}`}
+              token={token}
+              query={query}
+              onRemove={() => rewrite(removeFilterToken(value, token))}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => rewrite("")}
+            title="Clear query (Esc)"
+            aria-label="Clear query"
+            className="cursor-pointer rounded-md px-1.5 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+          >
+            clear
+          </button>
+        </div>
       )}
-    </span>
+    </>
   );
 }
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -133,7 +133,6 @@ export function FilterInput({
           ref={inputRef}
           data-view-filter
           value={value}
-          title={hintText || undefined}
           aria-describedby={query ? hintId : undefined}
           onChange={(e) => onChange(e.target.value)}
           onFocus={() => setHint(true)}
@@ -165,7 +164,6 @@ export function FilterInput({
         {query && (
           <span
             id={hintId}
-            role="tooltip"
             className={
               hint && !value
                 ? "absolute top-full right-0 z-20 mt-1 w-72 rounded-md border border-(--border-strong) bg-(--surface-2) px-2 py-1 text-[11px] text-(--text-faint)"

--- a/event-runtime/web/src/filterQuery.test.ts
+++ b/event-runtime/web/src/filterQuery.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EVENT_FACETS,
+  PROPOSAL_FACETS,
+  RUN_FACETS,
+  chipHelp,
+  chipLabel,
+  filterHint,
+  matchesFilterQuery,
+  parseFilterQuery,
+  proposalRunState,
+  removeFilterToken,
+} from "./filterQuery";
+import type { AdmittedEvent, Proposal, RunListItem } from "./types";
+
+const run = (over: Partial<RunListItem> = {}): RunListItem => ({
+  runId: "run_48ac91",
+  state: "FAILED",
+  attempts: 1,
+  maxAttempts: 3,
+  agent: "factory/ci-doctor@2",
+  adapter: "claude",
+  reasonCode: "verify_failed",
+  eventId: "evt_7719",
+  eventSource: "keephq",
+  created_at: "2026-08-14T09:00:00.000Z",
+  updated_at: "2026-08-14T09:05:00.000Z",
+  repos: ["watt-mind/factory"],
+  ...over,
+});
+
+const event = (over: Partial<AdmittedEvent> = {}): AdmittedEvent => ({
+  source: "keephq",
+  eventId: "evt_7719",
+  type: "alert.disk_pressure",
+  subject: "shadow / var full",
+  status: "planned",
+  occurredAt: "2026-08-14T09:00:00.000Z",
+  receivedAt: "2026-08-14T09:00:01.000Z",
+  correlationId: null,
+  planFailures: 0,
+  lastPlanError: null,
+  admittedAt: "2026-08-14T09:00:02.000Z",
+  proposalId: "prop_8f12",
+  runId: "run_48ac91",
+  envelope: {},
+  repos: ["watt-mind/factory"],
+  ...over,
+});
+
+const proposal = (over: Partial<Proposal> = {}): Proposal => ({
+  id: "prop_8f12",
+  decision: "run",
+  status: "open",
+  expired: false,
+  created_at: "2026-08-14T09:00:00.000Z",
+  ttl_seconds: 900,
+  decided_at: null,
+  decided_by: null,
+  reason: "disk pressure on shadow",
+  runId: "run_48ac91",
+  eventId: "evt_7719",
+  eventSource: "keephq",
+  agent: "factory/ci-doctor@2",
+  spec: null,
+  repos: ["watt-mind/factory"],
+  ...over,
+});
+
+const noStale = { staleRuns: new Set<string>() };
+const matchRun = (input: string, row = run(), ctx = noStale) =>
+  matchesFilterQuery(row, parseFilterQuery(input, RUN_FACETS), RUN_FACETS, ctx);
+const matchEvent = (input: string, row = event()) =>
+  matchesFilterQuery(row, parseFilterQuery(input, EVENT_FACETS), EVENT_FACETS, undefined);
+const matchProposal = (input: string, row = proposal(), runStates = new Map<string, string>()) =>
+  matchesFilterQuery(row, parseFilterQuery(input, PROPOSAL_FACETS), PROPOSAL_FACETS, { runStates });
+
+describe("parseFilterQuery", () => {
+  test("keyed tokens, flags and leftover words, each keeping its offsets", () => {
+    const q = parseFilterQuery("agent:ci-doctor is:stale 48ac", RUN_FACETS);
+    expect(q.tokens).toEqual([
+      {
+        kind: "field",
+        key: "agent",
+        typedKey: "agent",
+        value: "ci-doctor",
+        supported: true,
+        raw: "agent:ci-doctor",
+        start: 0,
+        end: 15,
+      },
+      {
+        kind: "flag",
+        flag: "stale",
+        help: RUN_FACETS.flags.stale.help,
+        supported: true,
+        raw: "is:stale",
+        start: 16,
+        end: 24,
+      },
+      { kind: "text", value: "48ac", raw: "48ac", start: 25, end: 29 },
+    ]);
+    expect(q.chips.map(chipLabel)).toEqual(["agent:ci-doctor", "is:stale"]);
+    expect(q.isEmpty).toBe(false);
+  });
+
+  test("an empty query has no tokens and nothing to render", () => {
+    const q = parseFilterQuery("   ", RUN_FACETS);
+    expect(q.isEmpty).toBe(true);
+    expect(q.chips).toEqual([]);
+  });
+
+  test("aliases resolve to the canonical key; the chip still reads as typed", () => {
+    const q = parseFilterQuery("STATUS:Failed", RUN_FACETS);
+    expect(q.tokens[0]).toMatchObject({ kind: "field", key: "state", typedKey: "status", value: "failed" });
+    expect(chipLabel(q.chips[0])).toBe("status:failed");
+  });
+
+  test("a half-typed key is not yet a filter", () => {
+    expect(parseFilterQuery("agent:", RUN_FACETS).isEmpty).toBe(true);
+    expect(parseFilterQuery("is:", RUN_FACETS).isEmpty).toBe(true);
+    expect(matchRun("agent:")).toBe(true);
+  });
+
+  test("quotes hold a value together and are not part of it", () => {
+    const q = parseFilterQuery('subject:"var full" plain', EVENT_FACETS);
+    expect(q.tokens[0]).toMatchObject({ kind: "field", key: "subject", value: "var full" });
+    expect(q.tokens[1]).toMatchObject({ kind: "text", value: "plain" });
+  });
+
+  test("a colon that was never a filter key stays free text", () => {
+    const q = parseFilterQuery("https://linear.app/watt-mind", RUN_FACETS);
+    expect(q.tokens).toHaveLength(1);
+    expect(q.tokens[0]).toMatchObject({ kind: "text", value: "https://linear.app/watt-mind" });
+  });
+
+  test("a known key this list has no field for is flagged, not silently dropped", () => {
+    const q = parseFilterQuery("agent:ci-doctor", EVENT_FACETS);
+    expect(q.chips[0]).toMatchObject({ kind: "field", key: "agent", supported: false });
+    expect(matchEvent("agent:ci-doctor")).toBe(false);
+  });
+
+  test("an is: flag this list cannot answer is flagged the same way", () => {
+    const q = parseFilterQuery("is:expired", RUN_FACETS);
+    expect(q.chips[0]).toMatchObject({ kind: "flag", flag: "expired", supported: false });
+    expect(matchRun("is:expired")).toBe(false);
+  });
+});
+
+describe("matchesFilterQuery", () => {
+  test("a keyed token only ever sees its own field", () => {
+    // Every needle here does occur on the row — in a different column. The old
+    // substring filter said yes to all of them.
+    expect(matchRun("agent:keephq")).toBe(false);
+    expect(matchRun("source:ci-doctor")).toBe(false);
+    expect(matchRun("reason:48ac")).toBe(false);
+    expect(matchRun("state:claude")).toBe(false);
+    expect(matchRun("agent:ci-doctor")).toBe(true);
+    expect(matchRun("run:48ac")).toBe(true);
+  });
+
+  test("values match whole, or at a word start — never mid-word", () => {
+    expect(matchRun("agent:factory/ci-doctor@2")).toBe(true);
+    expect(matchRun("agent:ci-doctor@2")).toBe(true);
+    expect(matchRun("agent:doctor")).toBe(true);
+    expect(matchRun("agent:octor")).toBe(false);
+    expect(matchRun("state:fail")).toBe(true);
+    expect(matchRun("state:ail")).toBe(false);
+    expect(matchEvent("status:human", event({ status: "human_needed" }))).toBe(true);
+    expect(matchEvent("status:needed", event({ status: "human_needed" }))).toBe(true);
+  });
+
+  test("case never matters", () => {
+    expect(matchRun("STATE:failed")).toBe(true);
+    expect(matchRun("state:FAILED")).toBe(true);
+  });
+
+  test("the same key twice is an either/or; different keys narrow", () => {
+    expect(matchRun("state:failed state:refused")).toBe(true);
+    expect(matchRun("state:refused state:cancelled")).toBe(false);
+    expect(matchRun("state:failed adapter:claude")).toBe(true);
+    expect(matchRun("state:failed adapter:codex")).toBe(false);
+  });
+
+  test("leftover words stay the substring search the lists always had", () => {
+    expect(matchRun("48ac")).toBe(true);
+    expect(matchRun("erify_fail")).toBe(true);
+    expect(matchRun("keephq")).toBe(false); // eventSource is not a text column
+    expect(matchRun("source:keephq")).toBe(true);
+    expect(matchRun("48ac nothing")).toBe(false);
+  });
+
+  test("an empty field can never be matched by a keyed token", () => {
+    expect(matchRun("reason:verify", run({ reasonCode: null }))).toBe(false);
+    expect(matchRun("source:keephq", run({ eventSource: null }))).toBe(false);
+  });
+
+  test("repo: reads the whole repos list", () => {
+    expect(matchRun("repo:watt-mind/factory")).toBe(true);
+    expect(matchRun("repo:factory")).toBe(true);
+    expect(matchRun("repo:bj29")).toBe(false);
+  });
+
+  test("Runs is:stale is the stalled-worker projection, not a guess", () => {
+    expect(matchRun("is:stale")).toBe(false);
+    expect(matchRun("is:stale", run(), { staleRuns: new Set(["run_48ac91"]) })).toBe(true);
+    expect(matchRun("is:stale state:completed", run({ state: "COMPLETED" }), {
+      staleRuns: new Set(["run_48ac91"]),
+    })).toBe(true);
+  });
+
+  test("Events is:stale is an admitted event with nothing behind it", () => {
+    expect(matchEvent("is:stale")).toBe(false);
+    expect(
+      matchEvent("is:stale", event({ status: "admitted", proposalId: null, runId: null })),
+    ).toBe(true);
+    expect(matchEvent("is:stale", event({ status: "admitted" }))).toBe(false);
+  });
+
+  test("Proposals is:stale and is:expired answer the two ways an open row is dead", () => {
+    expect(matchProposal("is:stale")).toBe(false);
+    expect(matchProposal("is:stale", proposal(), new Map([["run_48ac91", "CANCELLED"]]))).toBe(true);
+    expect(matchProposal("is:stale", proposal(), new Map([["run_48ac91", "PROPOSED"]]))).toBe(false);
+    expect(matchProposal("is:expired")).toBe(false);
+    expect(matchProposal("is:expired", proposal({ expired: true }))).toBe(true);
+  });
+
+  test("Proposals keyed fields cover the columns the list shows", () => {
+    expect(matchProposal("agent:ci-doctor decision:run status:open")).toBe(true);
+    expect(matchProposal("decision:human_needed")).toBe(false);
+    expect(matchProposal("source:keephq event:evt_7719")).toBe(true);
+    expect(matchProposal("proposal:prop_8f12")).toBe(true);
+  });
+
+  test("Events keyed fields cover the columns the inbox shows", () => {
+    expect(matchEvent("source:keephq type:alert status:planned")).toBe(true);
+    expect(matchEvent("type:disk_pressure")).toBe(true);
+    expect(matchEvent("id:evt_7719")).toBe(true);
+    expect(matchEvent("subject:shadow")).toBe(true);
+    expect(matchEvent("subject:full")).toBe(true);
+    expect(matchEvent("subject:hadow")).toBe(false);
+  });
+});
+
+describe("removeFilterToken", () => {
+  test("cuts exactly the word the chip came from", () => {
+    const input = "agent:ci-doctor is:stale 48ac";
+    const q = parseFilterQuery(input, RUN_FACETS);
+    expect(removeFilterToken(input, q.tokens[0])).toBe("is:stale 48ac");
+    expect(removeFilterToken(input, q.tokens[1])).toBe("agent:ci-doctor 48ac");
+    expect(removeFilterToken(input, q.tokens[2])).toBe("agent:ci-doctor is:stale");
+  });
+
+  test("a quoted value is one word, and removal leaves no double space", () => {
+    const input = 'a subject:"var full" b';
+    const q = parseFilterQuery(input, EVENT_FACETS);
+    expect(removeFilterToken(input, q.chips[0])).toBe("a b");
+  });
+
+  test("removing the only token empties the query", () => {
+    const q = parseFilterQuery("  is:stale  ", RUN_FACETS);
+    expect(removeFilterToken("  is:stale  ", q.chips[0])).toBe("");
+  });
+});
+
+describe("chip and input copy", () => {
+  test("a supported chip explains what it narrows", () => {
+    const q = parseFilterQuery("agent:ci-doctor is:stale", RUN_FACETS);
+    expect(chipHelp(q.chips[0], q)).toBe("Matches agent at a word start.");
+    expect(chipHelp(q.chips[1], q)).toBe(RUN_FACETS.flags.stale.help);
+  });
+
+  test("an impossible chip says so and names what this list does have", () => {
+    const q = parseFilterQuery("agent:ci-doctor is:expired", EVENT_FACETS);
+    expect(chipHelp(q.chips[0], q)).toBe(
+      "No agent field. event, source, type, subject, status, proposal, run, repo.",
+    );
+    expect(chipHelp(q.chips[1], q)).toBe("Unknown is:expired. is:stale.");
+  });
+
+  test("the input hint names every key this list answers", () => {
+    const hint = filterHint(parseFilterQuery("", PROPOSAL_FACETS));
+    expect(hint).toContain("agent:");
+    expect(hint).toContain("is:stale");
+    expect(hint).toContain("is:expired");
+    expect(hint).toContain("Esc clears");
+  });
+});
+
+describe("proposalRunState", () => {
+  test("only a run that left PROPOSED is stale; an unknown run is not", () => {
+    expect(proposalRunState({ runId: "r1" }, new Map([["r1", "PROPOSED"]]))).toBeNull();
+    expect(proposalRunState({ runId: "r1" }, new Map([["r1", "RUNNING"]]))).toBe("RUNNING");
+    expect(proposalRunState({ runId: "r1" }, new Map())).toBeNull();
+    expect(proposalRunState({ runId: null }, new Map([["r1", "RUNNING"]]))).toBeNull();
+  });
+});

--- a/event-runtime/web/src/filterQuery.ts
+++ b/event-runtime/web/src/filterQuery.ts
@@ -1,0 +1,339 @@
+/**
+ * Keyed list filters (webui UX doc Proposal 4) — `agent:ci-doctor`,
+ * `state:failed`, `source:keephq`, `is:stale`, plus whatever bare words are
+ * left over.
+ *
+ * One parser and one matcher, shared by Runs, Events and Proposals. Each view
+ * hands in a facet table naming the fields its rows actually carry, and that is
+ * what makes a keyed token honest: `agent:run` is only ever tested against the
+ * agent field, so a run id that happens to contain "run" can never satisfy it.
+ * Bare words keep the old behaviour — a plain substring over the columns the
+ * view already searched — because that is what pasting an id expects to do.
+ */
+
+import type { AdmittedEvent, Proposal, RunListItem } from "./types";
+
+/** What a field accessor may return: one value, several, or nothing. */
+export type FieldValue = string | null | undefined | readonly (string | null | undefined)[];
+
+export interface FilterFacets<T, C = undefined> {
+  /**
+   * `key:value` fields these rows have, by canonical key — the row property to
+   * read, or a function when the value is not one property.
+   */
+  fields: Record<string, Extract<keyof T, string> | ((row: T) => FieldValue)>;
+  /** `is:flag` questions these rows can answer, with the copy that explains them. */
+  flags: Record<string, { help: string; test: (row: T, ctx: C) => boolean }>;
+  /** What a bare word searches. */
+  text: (row: T) => FieldValue;
+  /** Spellings that mean a canonical key — an operator reaches for both. */
+  aliases?: Record<string, string>;
+}
+
+/**
+ * Every key any list understands. A word whose key is in here was meant as a
+ * filter, so a view without that field says so — an "impossible" chip that
+ * matches nothing — instead of quietly searching for the literal text. A key
+ * outside the set (`linear:OPS-1`, `https://…`) was never a filter and stays
+ * free text, which is why this list is closed rather than "anything with a colon".
+ */
+const FILTER_KEYS = new Set([
+  "is",
+  "id",
+  "run",
+  "state",
+  "status",
+  "agent",
+  "adapter",
+  "reason",
+  "source",
+  "event",
+  "type",
+  "subject",
+  "proposal",
+  "decision",
+  "repo",
+]);
+
+interface Span {
+  /** The word as typed, including any quotes — what dismissal cuts back out. */
+  raw: string;
+  start: number;
+  end: number;
+}
+
+export type FilterToken =
+  | ({ kind: "text"; value: string } & Span)
+  | ({ kind: "field"; key: string; typedKey: string; value: string; supported: boolean } & Span)
+  | ({ kind: "flag"; flag: string; help: string; supported: boolean } & Span);
+
+/** The tokens that get a chip: everything the operator spelled as a filter. */
+export type FilterChipToken = Extract<FilterToken, { kind: "field" } | { kind: "flag" }>;
+
+export interface FilterQuery {
+  tokens: FilterToken[];
+  /** Keyed tokens and flags, in the order typed — what the chip bar renders. */
+  chips: FilterChipToken[];
+  isEmpty: boolean;
+  /** Canonical field keys this list supports, for the chip and input help. */
+  fields: string[];
+  /** `is:` flags this list supports. */
+  flags: string[];
+}
+
+const KEYED = /^([A-Za-z][A-Za-z0-9_-]*):([\s\S]*)$/;
+
+/** Quotes group a value with spaces (`subject:"deploy failed"`); they are not data. */
+const unquote = (text: string) => text.replace(/"/g, "");
+
+/**
+ * Split on whitespace, but not inside quotes, keeping each word's offsets — a
+ * chip can only be dismissed by cutting exactly the word it came from back out
+ * of the raw query, which stays the single source of truth.
+ */
+function splitWords(input: string): Span[] {
+  const words: Span[] = [];
+  let start = -1;
+  let quoted = false;
+  for (let i = 0; i <= input.length; i++) {
+    const ch: string | undefined = input[i];
+    if (start < 0) {
+      if (ch === undefined || /\s/.test(ch)) continue;
+      start = i;
+      quoted = false;
+    }
+    if (ch === '"') quoted = !quoted;
+    if (ch === undefined || (!quoted && /\s/.test(ch))) {
+      words.push({ raw: input.slice(start, i), start, end: i });
+      start = -1;
+    }
+  }
+  return words;
+}
+
+export function parseFilterQuery<T, C>(input: string, facets: FilterFacets<T, C>): FilterQuery {
+  const tokens: FilterToken[] = [];
+  for (const span of splitWords(input)) {
+    const keyed = KEYED.exec(span.raw);
+    const typedKey = keyed ? keyed[1].toLowerCase() : "";
+    const key = facets.aliases?.[typedKey] ?? typedKey;
+    const value = keyed ? unquote(keyed[2]).trim() : "";
+
+    if (keyed && (key === "is" || FILTER_KEYS.has(key) || key in facets.fields)) {
+      // `agent:` with nothing after it is half-typed, not a filter that matches
+      // nothing: the list must not blank out between `agent:` and `agent:c`.
+      if (!value) continue;
+      if (key === "is") {
+        const flag = value.toLowerCase();
+        const known = facets.flags[flag];
+        tokens.push({
+          kind: "flag",
+          flag,
+          help: known?.help ?? "",
+          supported: !!known,
+          ...span,
+        });
+      } else {
+        tokens.push({
+          kind: "field",
+          key,
+          typedKey,
+          value: value.toLowerCase(),
+          supported: key in facets.fields,
+          ...span,
+        });
+      }
+      continue;
+    }
+
+    const text = unquote(span.raw).trim();
+    if (text) tokens.push({ kind: "text", value: text.toLowerCase(), ...span });
+  }
+
+  return {
+    tokens,
+    chips: tokens.filter((t): t is FilterChipToken => t.kind !== "text"),
+    isEmpty: tokens.length === 0,
+    fields: Object.keys(facets.fields),
+    flags: Object.keys(facets.flags),
+  };
+}
+
+const read = <T,>(field: Extract<keyof T, string> | ((row: T) => FieldValue), row: T): FieldValue =>
+  typeof field === "function" ? field(row) : (row[field] as FieldValue);
+
+const asList = (value: FieldValue): string[] =>
+  (Array.isArray(value) ? value : [value]).filter((v): v is string => typeof v === "string" && v !== "");
+
+/**
+ * A keyed value matches its field whole or at a word start inside it:
+ * `agent:ci-doctor` finds `factory/ci-doctor@2`, `status:human` finds
+ * `human_needed`, `state:fail` finds `FAILED` — and `state:ail` finds nothing.
+ * An anywhere-substring is what makes a filter feel haunted.
+ */
+function valueMatches(value: string, needle: string): boolean {
+  for (let i = 0; i + needle.length <= value.length; i++) {
+    if (i > 0 && /[a-z0-9]/.test(value[i - 1])) continue;
+    if (value.startsWith(needle, i)) return true;
+  }
+  return false;
+}
+
+const fieldMatches = (value: FieldValue, needle: string) =>
+  asList(value).some((v) => valueMatches(v.toLowerCase(), needle));
+
+const textMatches = (value: FieldValue, needle: string) =>
+  asList(value).some((v) => v.toLowerCase().includes(needle));
+
+/**
+ * Same key twice is an either/or (`state:failed state:refused`); different keys
+ * narrow. A token this list cannot answer matches nothing at all, so an
+ * impossible query reads as an empty list next to a flagged chip rather than
+ * silently filtering on less than the operator asked for.
+ */
+export function matchesFilterQuery<T, C = undefined>(
+  row: T,
+  query: FilterQuery,
+  facets: FilterFacets<T, C>,
+  ctx: C,
+): boolean {
+  if (query.isEmpty) return true;
+  const byKey = new Map<string, string[]>();
+  for (const token of query.tokens) {
+    if (token.kind === "text") {
+      if (!textMatches(facets.text(row), token.value)) return false;
+    } else if (token.kind === "flag") {
+      const flag = facets.flags[token.flag];
+      if (!flag || !flag.test(row, ctx)) return false;
+    } else {
+      const group = byKey.get(token.key);
+      if (group) group.push(token.value);
+      else byKey.set(token.key, [token.value]);
+    }
+  }
+  for (const [key, needles] of byKey) {
+    const field = facets.fields[key];
+    if (!field) return false;
+    const value = read(field, row);
+    if (!needles.some((needle) => fieldMatches(value, needle))) return false;
+  }
+  return true;
+}
+
+/** Dismiss one chip by cutting its word back out of the raw query. */
+export function removeFilterToken(input: string, token: FilterToken): string {
+  return `${input.slice(0, token.start)} ${input.slice(token.end)}`.replace(/\s+/g, " ").trim();
+}
+
+/** What the chip says — the key as typed, so chip and input never disagree. */
+export const chipLabel = (token: FilterChipToken): string =>
+  token.kind === "flag" ? `is:${token.flag}` : `${token.typedKey}:${token.value}`;
+
+/** Why this chip does (or cannot) narrow anything, on hover and for screen readers. */
+export function chipHelp(token: FilterChipToken, query: FilterQuery): string {
+  if (token.kind === "flag") {
+    if (token.supported) return token.help;
+    const flags = query.flags.map((f) => `is:${f}`).join(", ");
+    return `Unknown is:${token.flag}. ${flags || "none"}.`;
+  }
+  if (token.supported) return `Matches ${token.key} at a word start.`;
+  return `No ${token.key} field. ${query.fields.join(", ")}.`;
+}
+
+/** The syntax, on the input itself — cheaper than a help dialog nobody opens. */
+export function filterHint(query: FilterQuery): string {
+  const keys = query.fields.map((f) => `${f}:`).join(" ");
+  const flags = query.flags.map((f) => `is:${f}`).join(" ");
+  return `${keys}${flags ? ` ${flags}` : ""}. Esc clears.`;
+}
+
+/**
+ * An open proposal whose run already left PROPOSED was raced (cancelled from
+ * Runs, say) and can never be approved — the list calls that stale, and the
+ * `is:stale` facet has to agree with the row wash that shows it.
+ */
+export function proposalRunState(
+  proposal: { runId: string | null },
+  runStates: ReadonlyMap<string, string>,
+): string | null {
+  const state = proposal.runId ? runStates.get(proposal.runId) : undefined;
+  return state && state !== "PROPOSED" ? state : null;
+}
+
+/** Runs: which runs a stale worker is still holding (GET /status anomalies). */
+export interface RunFilterContext {
+  staleRuns: ReadonlySet<string>;
+}
+
+export const RUN_FACETS: FilterFacets<RunListItem, RunFilterContext> = {
+  fields: {
+    run: (r) => r.runId,
+    state: (r) => r.state,
+    agent: (r) => r.agent,
+    adapter: (r) => r.adapter,
+    reason: (r) => r.reasonCode,
+    source: (r) => r.eventSource,
+    event: (r) => r.eventId,
+    repo: (r) => r.repos,
+  },
+  flags: {
+    stale: {
+      help: "Stale worker heartbeat.",
+      test: (r, ctx) => ctx.staleRuns.has(r.runId),
+    },
+  },
+  text: (r) => [r.runId, r.state, r.agent, r.adapter, r.reasonCode, r.eventId],
+  aliases: { id: "run", status: "state" },
+};
+
+export const EVENT_FACETS: FilterFacets<AdmittedEvent, undefined> = {
+  fields: {
+    event: (e) => e.eventId,
+    source: (e) => e.source,
+    type: (e) => e.type,
+    subject: (e) => e.subject,
+    status: (e) => e.status,
+    proposal: (e) => e.proposalId,
+    run: (e) => e.runId,
+    repo: (e) => e.repos,
+  },
+  flags: {
+    stale: {
+      help: "Admitted, no proposal or run.",
+      test: (e) => e.status === "admitted" && !e.proposalId && !e.runId,
+    },
+  },
+  text: (e) => [e.eventId, e.source, e.type, e.subject],
+  aliases: { id: "event", state: "status" },
+};
+
+/** Proposals: the run states the open list is watching, for `is:stale`. */
+export interface ProposalFilterContext {
+  runStates: ReadonlyMap<string, string>;
+}
+
+export const PROPOSAL_FACETS: FilterFacets<Proposal, ProposalFilterContext> = {
+  fields: {
+    id: (p) => p.id,
+    agent: (p) => p.agent,
+    decision: (p) => p.decision,
+    status: (p) => p.status,
+    reason: (p) => p.reason,
+    source: (p) => p.eventSource,
+    event: (p) => p.eventId,
+    run: (p) => p.runId,
+    repo: (p) => p.repos,
+  },
+  flags: {
+    stale: {
+      help: "Run left PROPOSED.",
+      test: (p, ctx) => proposalRunState(p, ctx.runStates) !== null,
+    },
+    expired: {
+      help: "TTL expired.",
+      test: (p) => p.expired,
+    },
+  },
+  text: (p) => [p.id, p.agent, p.decision, p.status, p.eventId, p.reason],
+  aliases: { proposal: "id", state: "status" },
+};

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -8,6 +8,7 @@ import { ScopeCaption } from "../components/ContextTabs";
 import type { AdmittedEvent, EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
+import { EVENT_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import {
   Ago,
   Button,
@@ -118,21 +119,15 @@ export function Events({
   const types = useMemo(() => [...new Set(scoped.map((e) => e.type))].sort(), [scoped]);
   const sources = useMemo(() => [...new Set(scoped.map((e) => e.source))].sort(), [scoped]);
 
+  const parsed = useMemo(() => parseFilterQuery(filter, EVENT_FACETS), [filter]);
   const visible = useMemo(() => {
-    const q = filter.trim().toLowerCase();
     return scoped.filter((e) => {
       if (fetchAll && tab !== "all" && e.status !== tab) return false;
       if (typeFilter && e.type !== typeFilter) return false;
       if (sourceFilter && e.source !== sourceFilter) return false;
-      if (!q) return true;
-      return (
-        e.eventId.toLowerCase().includes(q) ||
-        e.source.toLowerCase().includes(q) ||
-        e.type.toLowerCase().includes(q) ||
-        (e.subject ?? "").toLowerCase().includes(q)
-      );
+      return matchesFilterQuery(e, parsed, EVENT_FACETS, undefined);
     });
-  }, [scoped, filter, typeFilter, sourceFilter, fetchAll, tab]);
+  }, [scoped, parsed, typeFilter, sourceFilter, fetchAll, tab]);
 
   const selectedKey =
     focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
@@ -329,13 +324,11 @@ export function Events({
           })}
         </div>
 
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="Filter type, source, id…"
-            label="Filter events"
-          />
+        {/* Type / source facets get their own line, above the query box: the
+            token chips below the box are full-width, so a facet chip beside it
+            would jump a line the moment a token appeared. */}
+        {(types.length > 1 || sources.length > 1) && (
+        <div className="mb-2 flex flex-wrap items-center gap-2">
           {types.length > 1 &&
             types.map((t) => (
               <button
@@ -372,6 +365,17 @@ export function Events({
                 {s}
               </button>
             ))}
+        </div>
+        )}
+
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <FilterInput
+            value={filter}
+            onChange={setFilter}
+            placeholder="source:… type:… is:stale"
+            label="Filter events"
+            query={parsed}
+          />
         </div>
           </>
         }

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -6,6 +6,7 @@ import { setContextActions } from "../palette";
 import type { Proposal } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
+import { PROPOSAL_FACETS, matchesFilterQuery, parseFilterQuery, proposalRunState } from "../filterQuery";
 import { ScopeCaption } from "../components/ContextTabs";
 import { SpecDiff } from "../components/SpecDiff";
 import {
@@ -107,10 +108,9 @@ export function Proposals({
     () => new Map((runsQuery.data?.runs ?? []).map((r) => [r.runId, r.state])),
     [runsQuery.data],
   );
-  const staleState = (p: Proposal) => {
-    const state = p.runId ? runStates.get(p.runId) : undefined;
-    return state && state !== "PROPOSED" ? state : null;
-  };
+  // Shared with the `is:stale` facet, so the chip and the red row wash can never
+  // disagree about which open proposals are already dead.
+  const staleState = (p: Proposal) => proposalRunState(p, runStates);
 
   const [filter, setFilter] = useState("");
   const [expiredOnly, setExpiredOnly] = useState(false);
@@ -128,16 +128,13 @@ export function Proposals({
     context.kind === "repo"
       ? scoped.filter((p) => p.expired).length
       : (statusQ.data?.proposals.expired ?? 0);
+  const parsed = useMemo(() => parseFilterQuery(filter, PROPOSAL_FACETS), [filter]);
   const visible = useMemo(() => {
-    const q = filter.trim().toLowerCase();
     return scoped.filter((p) => {
       if (expiredFilter && !p.expired) return false;
-      if (!q) return true;
-      return [p.id, p.agent, p.decision, p.status, p.eventId, p.reason].some((v) =>
-        (v ?? "").toLowerCase().includes(q),
-      );
+      return matchesFilterQuery(p, parsed, PROPOSAL_FACETS, { runStates });
     });
-  }, [scoped, filter, expiredFilter]);
+  }, [scoped, parsed, expiredFilter, runStates]);
 
   // What the list would show without the text filter. An empty list under the
   // expired chip has two causes and needs two messages: no expired opens exist
@@ -335,12 +332,6 @@ export function Proposals({
               );
             })}
           </div>
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="Filter agent, id, origin…"
-            label="Filter proposals"
-          />
           {tab === "open" && (
             <button
               type="button"
@@ -360,6 +351,16 @@ export function Proposals({
               )}
             </button>
           )}
+          {/* Last in the row: the token chips are a full-width item, so anything
+              after the filter box would be pushed onto a third line the moment
+              a chip appears. */}
+          <FilterInput
+            value={filter}
+            onChange={setFilter}
+            placeholder="agent:… is:stale is:expired"
+            label="Filter proposals"
+            query={parsed}
+          />
         </div>
           </>
         }

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -7,6 +7,7 @@ import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import type { OperatorContext } from "../context";
 import { matchesInFlight, matchesRepo } from "../context";
+import { RUN_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import type { Attempt, ArtifactRef, RunState } from "../types";
 import {
   Ago,
@@ -353,15 +354,17 @@ export function Runs({
     () => (!fetchAll || tab === "ALL" ? scoped : scoped.filter((r) => r.state === tab)),
     [fetchAll, scoped, tab],
   );
-  const visible = useMemo(() => {
-    const q = filter.trim().toLowerCase();
-    if (!q) return byTab;
-    return byTab.filter((r) =>
-      [r.runId, r.state, r.agent, r.adapter, r.reasonCode, r.eventId].some((v) =>
-        (v ?? "").toLowerCase().includes(q),
-      ),
-    );
-  }, [byTab, filter]);
+  // `is:stale` is the doctor's projection, not a guess this view makes: a run
+  // held by a worker whose heartbeat has gone (lib/workers.mjs stalledWorkers).
+  const staleRuns = useMemo(
+    () => new Set((statusQ.data?.anomalies.stalledWorkers ?? []).map((w) => w.runId)),
+    [statusQ.data],
+  );
+  const parsed = useMemo(() => parseFilterQuery(filter, RUN_FACETS), [filter]);
+  const visible = useMemo(
+    () => byTab.filter((r) => matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns })),
+    [byTab, parsed, staleRuns],
+  );
 
   const selectedId = focusRunId;
   const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
@@ -521,7 +524,9 @@ export function Runs({
           <>
         <h1 className="display mb-4 text-lg font-semibold">Runs</h1>
 
-        <div className="mb-3 flex items-center gap-2">
+        {/* `flex-wrap`: the token chips are a full-width item, so they take
+            their own line under the tabs and the box instead of squeezing them. */}
+        <div className="mb-3 flex flex-wrap items-center gap-2">
           <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto" role="tablist" aria-label="Run state">
             {STATE_TABS.map((t) => {
               const byState = statusQ.data?.runs.byState ?? {};
@@ -552,8 +557,9 @@ export function Runs({
           <FilterInput
             value={filter}
             onChange={setFilter}
-            placeholder="Filter agent, id, origin…"
+            placeholder="agent:… state:… is:stale"
             label="Filter runs"
+            query={parsed}
           />
         </div>
           </>


### PR DESCRIPTION
Fixes OPS-382

## What

List search on Runs, Events and Proposals was one substring over whichever columns the view happened to look at, so `keephq` matched a run id and `failed` matched a reason code. The filter box now accepts keyed tokens from UX doc Proposal 4 — `agent:`, `state:`/`status:`, `source:`, `is:stale`, plus each list's own remaining fields — and the leftover bare words still do the old substring pass, so pasting an id keeps working.

- `filterQuery.ts` owns the grammar, the matching, and the per-view facet tables. A view declares the fields its rows actually carry, which is what makes a keyed token honest: `agent:` is only ever tested against the agent field.
- Values match whole or at a word start: `state:fail` finds `FAILED`, `status:human` finds `human_needed`, `state:ail` finds nothing. Case never matters.
- The same key twice is an either/or (`state:failed state:refused`); different keys narrow.
- A token the list cannot answer (`agent:` on Events, `is:bogus` anywhere) matches nothing and says so — dashed warn chip, struck-through label, hover/screen-reader copy naming the fields that do exist — instead of being silently ignored.
- Chips are a reflection of the query text, which stays the single source of truth. Dismissing a chip cuts exactly that word back out and refocuses the box; clear and Esc both clear everything; a second Esc blurs. Esc from a focused chip also clears the query (list Esc still deselects first).
- `is:stale` reads real state per list: Runs uses the doctor's stalled-worker projection off `/status`, Proposals reuses the same "its run already left PROPOSED" predicate that paints the red row wash, Events means admitted with no proposal or run behind it.

Agents / Workers / Projects keep the plain substring filter — `FilterInput` only grows chips when a view passes a parsed query.

## Verification

`bun test event-runtime && cd event-runtime/web && bun run build` — pass after merging current `origin/develop` (347 tests; 27 new in `filterQuery.test.ts`). Entry chunk 449.98 kB against a 450 kB budget.

UX critique: required — FIX-FIRST resolved in 1 round (chip-bar key containment so Enter/`x` do not fire list verbs; syntax help on `/` focus; token row last in chrome so nothing jumps). A later factory-ux-critic re-run from this session could not exercise the live app (workspace mismatch, [OPS-459](https://linear.app/watt-mind/issue/OPS-459)); residual risks below, not blocking.

## What a reviewer should look at first

1. **Entry chunk is 449.98 kB / 450 kB (~20 bytes of slack).** Next app-shell change will trip `entry-chunk-budget`. Re-baseline is [OPS-448](https://linear.app/watt-mind/issue/OPS-448/event-runtime-web-entry-chunk-sits-30-bytes-under-the-450-kb-budget), not this PR.
2. The `is:stale` definition on Events (admitted with nothing downstream) is the one facet not lifted from an existing projection.
3. Esc on a focused chip clears the whole query (ticket: "Esc still clears the whole query"). Tab-to-chip then Esc is a high-cost accident if the operator expected "defocus".