### PR TITLE
test(event-runtime-demo): assert, document, and serve-source project tags (OPS-385)

### DIFF
--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -212,6 +212,16 @@ run approved last (it occupies the single worker until the 600 s spec timeout,
 then TIMED_OUT — or cancel it from the UI). The seed refuses to run against a
 real-adapter runtime.
 
+Some of those rows additionally carry a real `config/repos.yaml` name so the
+project tabs are not empty on a fresh worktree. The tag is appended after the
+mode — `repos[0]` is still what selects the fake adapter's behaviour. The
+tagged fixtures are the completed `ok` run, the rejected proposal, the open
+approvable proposal, and the `hang` run; `refuse`, `crash`,
+`invalid-artifact`, and the `human_needed` proposal stay untagged because a
+tab that matches every row proves nothing about filtering. Names come from
+the reader's own registry, not a hardcoded pair; a checkout without one
+seeds the full set untagged and logs `project tags: none`.
+
 `event-runtime/demo/verify.mjs --port <api>` asserts the whole fixture via
 the API — the e2e smoke. `worktree-up.sh` runs it before reporting ready, so
 "ready" means a browser test or styling session can rely on every state

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -22,15 +22,16 @@
  * Plus two open proposals: one approvable (`run`) and one `human_needed`
  * (empty repos fails the input schema's minItems).
  *
- * Some fixtures carry a second repo — a real config/repos.yaml name appended
- * after the mode (`["ok", "bj29"]`). The web UI's project tabs filter on
- * `repos[]`, so without it every tab on a freshly seeded runtime reads empty
- * (OPS-366). Only appended, never substituted: repos[0] stays the mode.
+ * Some fixtures carry a second repo — a real project name from the serve
+ * process's GET /repos (the same list the UI's project tabs use), appended
+ * after the mode. Names come from the server on purpose, not from the
+ * seeder's local config/repos.yaml, so a seed aimed at a runtime serving a
+ * different checkout still tags with names the tabs can offer (OPS-387).
+ * Only appended, never substituted: repos[0] stays the mode.
  *
  *   bun event-runtime/demo/seed.mjs [--port 7381] [--prefix demo]
  */
 import { apiClient } from "../lib/client.mjs";
-import { loadRepos } from "../lib/repos.mjs";
 
 const args = process.argv.slice(2);
 const flag = (name) => {
@@ -45,20 +46,22 @@ const log = (line) => console.log(`seed: ${line}`);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Real repos.yaml names for the project tags. Optional by design: a checkout
- * without config/repos.yaml (or with no entries) must still seed a full demo
- * set, so a missing registry costs the tags, not the run.
+ * Real project names for the tags, from the serve process's GET /repos — the
+ * same list the UI's project tabs offer. Optional by design: a missing or
+ * unreadable registry (HTTP 500) must still seed a full demo set, so it
+ * costs the tags, not the run. Resolved after the health check; calling the
+ * API at module scope would surface a connection error instead of the
+ * "no control API" message.
  */
-function projectNames() {
+async function projectNames() {
   try {
-    return [...loadRepos().keys()];
+    const { repos: registry } = await client.repos();
+    return (registry ?? []).map((row) => row.name).filter(Boolean);
   } catch (err) {
     log(`no repo registry (${err.message}) — seeding without project tags`);
     return [];
   }
 }
-
-const [projectA, projectB = projectA] = projectNames();
 
 /** repos[0] must stay the fake adapter's mode — the project name only trails it. */
 const tag = (mode, project) => (project ? [mode, project] : [mode]);
@@ -140,6 +143,7 @@ if (probe.spec?.adapter !== "fake") {
 }
 await client.reject(probe.id, "adapter probe — not part of the demo set");
 
+const [projectA, projectB = projectA] = await projectNames();
 log(projectA ? `project tags: ${[...new Set([projectA, projectB])].join(", ")}` : "project tags: none");
 
 // Quick terminals first: the single worker handles them one per tick. The

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -51,6 +51,32 @@ if (completed) {
 const events = await client.events();
 check("≥8 admitted events", events.events.length >= 8);
 
+// Project tags (OPS-385 / OPS-366). ≥-shaped because --reseed accumulates
+// fixtures under a fresh prefix rather than wiping: one old tagged row keeps
+// this check green on an accumulated database.
+const FAKE_ADAPTER_MODES = new Set(["ok", "refuse", "crash", "invalid-artifact", "hang"]);
+let registryNames = null;
+try {
+  const { repos: registry } = await client.repos();
+  registryNames = (registry ?? []).map((row) => row.name).filter(Boolean);
+} catch (err) {
+  if (err.status === 500) {
+    console.log("skip ≥1 run carries a project tag (GET /repos 500 — registry missing or unreadable)");
+  } else {
+    check(`GET /repos (${err.status ?? "no status"})`, false);
+  }
+}
+if (registryNames !== null) {
+  const tagged = runs.filter((r) => {
+    const repos = r.repos ?? [];
+    return FAKE_ADAPTER_MODES.has(repos[0]) && registryNames.includes(repos[1]);
+  });
+  check(
+    "≥1 run carries a project tag (repos[1] from GET /repos, repos[0] still a fake-adapter mode)",
+    tagged.length >= 1,
+  );
+}
+
 if (failures.length) {
   console.error(`\nverify: ${failures.length} check(s) failed — reseed with: bun event-runtime/demo/seed.mjs --port ${port}`);
   process.exit(1);


### PR DESCRIPTION
## Summary

Human-authorized bundle (lead OPS-385). One commit per ticket.

- **OPS-385** — `verify.mjs` now fails when no seeded run carries a project tag. Names come from `client.repos()` (`GET /repos`), `repos[0]` must still be a fake-adapter mode, and a missing registry (`GET /repos` 500) prints an explicit skip line without changing the exit code.
- **OPS-386** — the fixture paragraph in `event-runtime/README.md` now says some rows append a real `config/repos.yaml` name (which four, that it is appended, why the others stay untagged, and that a registry-less checkout logs `project tags: none`).
- **OPS-387** — `seed.mjs` resolves `projectA`/`projectB` from the serve process `GET /repos` after the health check + adapter probe, not from `loadRepos()` on the seeder's filesystem. A 500 degrades to `project tags: none` and still seeds the full set.

## Test plan

- [x] `bin/worktree-up.sh OPS-385 --reseed` — pass. New check: `ok ≥1 run carries a project tag (repos[1] from GET /repos, repos[0] still a fake-adapter mode)`. Seed log: `project tags: bj29, wm-home`. Tagged rows: `completed`/`open` → `[ok, bj29]`; `rejected`/`running` → `[ok|hang, wm-home]`; `refuse`/`crash`/`invalid-artifact`/`human_needed` untagged.
- [x] OPS-385 skip: serve with empty `FACTORY_REPOS_ROOT`, seed + verify. Exit **0**. Line: `skip ≥1 run carries a project tag (GET /repos 500 — registry missing or unreadable)`. Other checks still `ok`.
- [x] OPS-385 bite: seed against an empty-registry server (untagged fixtures), restart serve with the real registry on the same DB, verify. Exit **1**. Line: `FAIL ≥1 run carries a project tag …`. (After OPS-387, hiding `FACTORY_REPOS_ROOT` from the *seeder only* no longer drops tags — that is the point of 387 — so the bite proof seeds against a server with no registry, then points serve at the real one.)
- [x] OPS-387 coupling: server `FACTORY_REPOS_ROOT=/tmp/altroot` (`name: alt-demo`), seeder checkout unchanged. Log: `seed: project tags: alt-demo`. Fixtures tagged `alt-demo`.
- [x] OPS-387 empty registry: server pointed at an empty directory. Log: `seed: project tags: none`. Seed completed (not a crash).
- [x] `bun test event-runtime` — 320 pass, 0 fail (OPS-386 no-regression).

## OPS-386 before / after

Before:

> The seed (`event-runtime/demo/seed.mjs`) drives one of everything through the real intake/approval surfaces, using the fake adapter's input modes (`payload.repos[0]`): `ok` → COMPLETED, `refuse` → REFUSED, `crash` and `invalid-artifact` → FAILED, a rejected proposal → CANCELLED, `[]` → an open `human_needed` proposal, one open approvable proposal, and `hang` → a RUNNING run approved last (it occupies the single worker until the 600 s spec timeout, then TIMED_OUT — or cancel it from the UI). The seed refuses to run against a real-adapter runtime.

After: same paragraph, plus:

> Some of those rows additionally carry a real `config/repos.yaml` name so the project tabs are not empty on a fresh worktree. The tag is appended after the mode — `repos[0]` is still what selects the fake adapter's behaviour. The tagged fixtures are the completed `ok` run, the rejected proposal, the open approvable proposal, and the `hang` run; `refuse`, `crash`, `invalid-artifact`, and the `human_needed` proposal stay untagged because a tab that matches every row proves nothing about filtering. Names come from the reader's own registry, not a hardcoded pair; a checkout without one seeds the full set untagged and logs `project tags: none`.

Cross-checked against the four `tag(...)` call sites in `seed.mjs` (`completed`, `rejected`, `open`, `running`).

## UX critique

skipped — demo seed/verify/docs, not a user-facing app flow.

Fixes OPS-385
Fixes OPS-386
Fixes OPS-387