### PR TITLE
fix(event-runtime-web): re-baseline entry chunk budget (OPS-469)

### DIFF
--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -55,12 +55,13 @@ function vendorChunk(id: string): string | undefined {
 // are fetched on demand, and are deliberately over the limit. kB is 1000 bytes
 // here to match how Vite reports sizes.
 //
-// The budget tracks the measured entry (391 kB as of OPS-303) with ~7% of slack,
-// not a round number well above it: at 500 kB, dropping @xyflow/react alone —
-// the exact regression this guards — landed at 479 kB and still passed. Slack
-// this thin means ordinary feature work will eventually trip it; that is the
-// trade, and re-baselining is a normal move (see the error message below).
-const ENTRY_CHUNK_BUDGET_BYTES = 450 * 1000;
+// The budget tracks the measured entry (450.01 kB as of OPS-382 keyed filters)
+// with a little slack, not a round number well above it: at 500 kB, dropping
+// @xyflow/react alone — the exact regression this guards — landed at 479 kB
+// and still passed. Slack this thin means ordinary feature work will eventually
+// trip it; that is the trade, and re-baselining is a normal move (see the
+// error message below). Raised in OPS-469 after develop Verify went red.
+const ENTRY_CHUNK_BUDGET_BYTES = 460 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
## Summary
- Raise `ENTRY_CHUNK_BUDGET_BYTES` from 450 kB to 460 kB after OPS-382 keyed filters measured 450.01 kB.
- Vendor splits unchanged (xyflow 197 kB, elk 1441 kB). Genuine app growth, not a missing split.

## Test plan
- [x] `cd event-runtime/web && bun run build` — pass (entry 450.01 kB)
- [ ] develop Verify green after merge

Fixes OPS-469