### PR TITLE
chore(event-runtime-web): re-baseline entry chunk budget to 480 kB (OPS-448)

### DIFF
--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -55,12 +55,13 @@ function vendorChunk(id: string): string | undefined {
 // are fetched on demand, and are deliberately over the limit. kB is 1000 bytes
 // here to match how Vite reports sizes.
 //
-// The budget tracks the measured entry (391 kB as of OPS-303) with ~7% of slack,
-// not a round number well above it: at 500 kB, dropping @xyflow/react alone —
-// the exact regression this guards — landed at 479 kB and still passed. Slack
-// this thin means ordinary feature work will eventually trip it; that is the
-// trade, and re-baselining is a normal move (see the error message below).
-const ENTRY_CHUNK_BUDGET_BYTES = 450 * 1000;
+// The budget tracks the measured entry (450 kB as of OPS-382 on develop) with
+// ~7% of slack, not a round number well above it: at 500 kB, dropping
+// @xyflow/react alone — the exact regression this guards — landed at 479 kB
+// and still passed. Slack this thin means ordinary feature work will
+// eventually trip it; that is the trade, and re-baselining is a normal move
+// (see the error message below). 480 kB is 450 + ~7%.
+const ENTRY_CHUNK_BUDGET_BYTES = 480 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
## Summary
- Develop CI went red after merging OPS-382: entry chunk 450.00 kB vs 450 kB budget, vendor split still intact (`xyflow` 197 kB / `elk` 1441 kB).
- Re-baselines `ENTRY_CHUNK_BUDGET_BYTES` to 480 kB (~7% slack over the measured 450 kB).

PR #124 accidentally targeted `main` and was reverted (`192819a`). This PR is the same commit against `develop`.

UX critique: skipped — build-config constant only.

## Test plan
- [x] `cd event-runtime/web && bun run build` green locally (entry 450.01 kB, budget 480 kB)

Fixes OPS-448