### PR TITLE
fix(event-runtime): inject factoryRoot in command adapter (OPS-404)

### DIFF
--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -15,15 +15,24 @@
 import { spawn } from "node:child_process";
 import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
 
 const KILL_GRACE_MS = 10_000;
 const OUTPUT_TAIL_CHARS = 2_000;
 
-/** Substitute `{field}` placeholders in one argv element from spec.input. */
+/**
+ * Substitute `{field}` placeholders in one argv element.
+ *
+ * Bindings come from spec.input, plus `factoryRoot` injected from config
+ * (same pattern as adapters/actions.mjs). The payload must never supply
+ * factoryRoot — `{"factoryRoot":"/tmp/x"}` would otherwise pick which
+ * script `bun` executes.
+ */
 export function resolveTemplate(template, input) {
+  const context = { ...input, factoryRoot: FACTORY_ROOT };
   return template.map((element) =>
     element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
-      const value = input?.[field];
+      const value = context[field];
       if (value === undefined || value === null) {
         throw new Error(`command template references missing input field "${field}"`);
       }

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
+import { openDb } from "../db.mjs";
+import { planAdmittedEvents } from "../planner.mjs";
+import { loadRegistry } from "../registry.mjs";
+import { validate } from "../schema.mjs";
+import { emitDueTicks } from "../schedules.mjs";
 import { execute, resolveTemplate } from "./command.mjs";
 
 const def = (command) => ({ ref: "test-cmd@1", command });
 const spec = (input) => ({ input });
 const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-cmd-"));
+const REAPER_SCRIPT = path.join(FACTORY_ROOT, "orchestrator", "reaper.mjs");
 
 describe("resolveTemplate", () => {
   test("substitutes placeholders inside argv elements", () => {
@@ -24,6 +31,17 @@ describe("resolveTemplate", () => {
   test("hostile input stays a single inert argument — no shell exists", () => {
     const argv = resolveTemplate(["echo", "{msg}"], { msg: "; rm -rf / && echo pwned" });
     expect(argv).toEqual(["echo", "; rm -rf / && echo pwned"]);
+  });
+
+  test("factoryRoot is injected from config, never from input (OPS-404)", () => {
+    expect(resolveTemplate(["bun", "{factoryRoot}/orchestrator/reaper.mjs", "--apply"], {})).toEqual([
+      "bun",
+      REAPER_SCRIPT,
+      "--apply",
+    ]);
+    expect(
+      resolveTemplate(["bun", "{factoryRoot}/orchestrator/reaper.mjs"], { factoryRoot: "/tmp/pwn" }),
+    ).toEqual(["bun", REAPER_SCRIPT]);
   });
 });
 
@@ -71,5 +89,134 @@ describe("execute", () => {
     await expect(
       execute({ spec: spec({}), def: { ref: "x@1" }, workspaceDir: ws(), timeoutMs: 1000 }),
     ).rejects.toThrow("no command template");
+  });
+
+  test("execute injects factoryRoot so a payload cannot pick the script (OPS-404)", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: spec({ factoryRoot: "/tmp/pwn" }),
+      def: def(["test", "-f", "{factoryRoot}/orchestrator/reaper.mjs"]),
+      workspaceDir,
+      timeoutMs: 5000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
+    expect(result.artifact.command.join(" ")).not.toContain("/tmp/pwn");
+  });
+});
+
+/**
+ * A schema-valid sample for a command-adapter input. Required (and declared)
+ * fields only — enough that every `{placeholder}` drawn from input has a
+ * primitive to substitute. `factoryRoot` is not a schema field and must not
+ * appear here.
+ */
+function sampleFromSchema(schema) {
+  if (!schema || typeof schema !== "object") return "x";
+  if (schema.const !== undefined) return schema.const;
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0];
+  const types = schema.type === undefined ? ["object"] : Array.isArray(schema.type) ? schema.type : [schema.type];
+  const type = types.find((t) => t !== "null") ?? "string";
+  switch (type) {
+    case "string": {
+      if (schema.pattern === "^[^/\\s]+/[^/\\s]+$") return "wm/x";
+      if (schema.pattern === "^[0-9a-f]{64}$") return "a".repeat(64);
+      if (schema.pattern === "^[0-9a-f]{40}$") return "b".repeat(40);
+      if (schema.pattern === "^/[A-Za-z0-9/._-]*$") return "/var";
+      if (schema.pattern === "^[A-Z]+-[0-9]+$") return "OPS-1";
+      return "x".repeat(schema.minLength ?? 1);
+    }
+    case "integer":
+    case "number":
+      return schema.minimum ?? 0;
+    case "boolean":
+      return true;
+    case "array": {
+      const n = schema.minItems ?? 0;
+      const item = sampleFromSchema(schema.items ?? { type: "string" });
+      return Array.from({ length: n }, () => structuredClone(item));
+    }
+    case "object": {
+      const obj = {};
+      for (const [key, sub] of Object.entries(schema.properties ?? {})) {
+        obj[key] = sampleFromSchema(sub);
+      }
+      return obj;
+    }
+    default:
+      return "x";
+  }
+}
+
+describe("command-adapter registry (OPS-404)", () => {
+  const registry = loadRegistry();
+  const commandDefs = [...registry.agents.values()].filter(
+    (agent) => Array.isArray(agent.command) && agent.command.length > 0,
+  );
+
+  test("factoryRoot is not an input-schema field — it is injected server-side", () => {
+    const offenders = [];
+    for (const agent of registry.agents.values()) {
+      if (agent.inputSchema?.properties?.factoryRoot) {
+        offenders.push(agent.ref);
+      }
+    }
+    expect(offenders).toEqual([]);
+    const reaper = registry.agents.get("reaper@1");
+    expect(validate(reaper.inputSchema, { loop: "reaper", slot: "2026-08-14T04:00:00.000Z", factoryRoot: "/tmp/pwn" }).valid).toBe(
+      false,
+    );
+  });
+
+  test("every registered command template resolves against a schema-valid input", () => {
+    expect(commandDefs.length).toBeGreaterThan(0);
+    for (const agent of commandDefs) {
+      const input = sampleFromSchema(agent.inputSchema);
+      const checked = validate(agent.inputSchema, input);
+      expect(checked.valid, `${agent.ref} sample is not schema-valid: ${checked.errors?.join("; ")}`).toBe(true);
+      expect(input).not.toHaveProperty("factoryRoot");
+      const argv = resolveTemplate(agent.command, input);
+      expect(argv.every((el) => typeof el === "string")).toBe(true);
+      expect(argv.some((el) => el.includes("{"))).toBe(false);
+    }
+  });
+
+  test("a reaper run planned from a clock tick resolves its argv and executes", async () => {
+    const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-reaper-")), "runtime.db"));
+    const withReaper = {
+      ...registry,
+      schedules: {
+        ...registry.schedules,
+        reaper: { ...registry.schedules.reaper, enabled: true, approval: "auto" },
+      },
+    };
+    emitDueTicks(db, withReaper, { now: Date.parse("2026-08-14T04:30:00Z") });
+    planAdmittedEvents(db, withReaper, { policyVersion: "git:test-pv" });
+
+    const row = db.query(`SELECT spec_json FROM runs`).get();
+    expect(row).toBeTruthy();
+    const planned = JSON.parse(row.spec_json);
+    expect(planned.agent).toBe("reaper@1");
+    expect(planned.adapter).toBe("command");
+    expect(validate(registry.agents.get("reaper@1").inputSchema, planned.input).valid).toBe(true);
+
+    const argv = resolveTemplate(registry.agents.get("reaper@1").command, planned.input);
+    expect(argv).toEqual(["bun", REAPER_SCRIPT, "--apply"]);
+    expect(existsSync(argv[1])).toBe(true);
+
+    // The shipped template includes --apply (Linear writes). Prove execute()
+    // with the planned tick's input actually spawns, using the same
+    // {factoryRoot} placeholder against the real script path.
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: planned,
+      def: { ref: "reaper@1", command: ["test", "-f", "{factoryRoot}/orchestrator/reaper.mjs"] },
+      workspaceDir,
+      timeoutMs: 5000,
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
   });
 });


### PR DESCRIPTION
## Summary
- Inject `factoryRoot` from `lib/config.mjs` in the command adapter's `resolveTemplate`, the same server-side binding `actions.mjs` already had — event input can no longer pick which script `bun` executes.
- A clock-tick-planned `reaper@1` run now resolves `bun {factoryRoot}/orchestrator/reaper.mjs --apply` to the checkout path and the execute path actually spawns.
- Registry-wide test: every command-adapter template resolves against a schema-valid input; adding `factoryRoot` to any input schema fails the suite (that would be arbitrary code execution behind one approval).

## Test plan
- [ ] bun test event-runtime/

Fixes OPS-404
UX critique: skipped — command adapter, no user-visible surface