### PR TITLE
feat(orchestrator): add behavioral escalate_paths for wm-home, watts-mobile, coach-wattz, and legalease

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -137,6 +137,18 @@ repos:
     worktree_warm: bin/worktree-warm.sh
     worktree_root: ~/Develop/.worktrees/coach-wattz
     report_only: true            # Dispatch remains disabled; janitor may use the teardown script.
+    escalate_paths:
+      - server/api/stripe/**
+      - server/api/subscriptions/**
+      - server/api/auth/**
+      - server/api/oauth/**
+      - server/middleware/auth.ts
+      - server/middleware/session-impersonation.ts
+      - prisma/schema.prisma
+      - prisma/migrations/**
+      - docker-compose.yml
+      - Dockerfile
+      - .github/workflows/**
 
   - name: watts-mobile
     path: ~/Develop/watts-mobile

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -147,6 +147,13 @@ repos:
     worktree_root: ~/Develop/.worktrees/watts-mobile
     report_only: true            # No isolated worktree lifecycle yet.
     verify: pnpm typecheck && pnpm lint && pnpm test
+    escalate_paths:
+      - src/features/subscriptions/**
+      - src/auth/**
+      - credentials/**
+      - eas.json
+      - .env.example
+      - .github/workflows/**
 
   - name: legalease
     path: ~/Develop/legalease

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -114,6 +114,17 @@ repos:
     verify: npm run typecheck && npm run lint && npm run format:check
     smoke_workflow: smoke-prod.yml
     smoke_url: https://watt-mind.com
+    escalate_paths:
+      - schema.prisma
+      - migrations/**
+      - src/auth/**
+      - src/admin/**
+      - main.wasp
+      - Dockerfile
+      - Dockerfile.web
+      - docker-compose.yml
+      - nginx.conf
+      - .github/workflows/**
 
   - name: coach-wattz
     path: ~/Develop/coach-wattz

--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -203,6 +203,8 @@ repos:
     # means. mcp/** narrowed to the OAuth boundary itself — the tool
     # implementations under mcp/tools/ are ordinary CRUD behind that boundary.
     escalate_paths:
+      - legalease/legalease/urls.py
+      - legalease/main/decorators.py
       - legalease/main/migrations/**
       - legalease/legalease/settings*.py
       - legalease/main/services/access_control.py

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -19,6 +19,7 @@ const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_p
 const wmHomeGlobs = repos.find((repo) => repo.name === "wm-home")?.escalate_paths;
 const wattsMobileGlobs = repos.find((repo) => repo.name === "watts-mobile")?.escalate_paths;
 const coachWattzGlobs = repos.find((repo) => repo.name === "coach-wattz")?.escalate_paths;
+const legaleaseGlobs = repos.find((repo) => repo.name === "legalease")?.escalate_paths;
 
 test("wm-home config protects its schema, auth, admin, and deployment boundaries", () => {
   expect(wmHomeGlobs).toBeDefined();
@@ -151,6 +152,51 @@ test("coach-wattz config leaves ordinary Vue pages and components unflagged", ()
         "docs/ARCHITECTURE.md",
       ],
       coachWattzGlobs,
+    ),
+  ).toEqual([]);
+});
+
+test("legalease config protects URL routing, auth decorators, migrations, settings, and MCP security boundaries", () => {
+  expect(legaleaseGlobs).toBeDefined();
+
+  const hits = matchEscalations(
+    [
+      "legalease/legalease/urls.py",
+      "legalease/main/decorators.py",
+      "legalease/main/migrations/0001_initial.py",
+      "legalease/legalease/settings_prod.py",
+      "legalease/main/services/access_control.py",
+      "legalease/main/mcp/auth.py",
+      "legalease/main/mcp/scopes.py",
+      "legalease/main/mcp/security.py",
+      "legalease/main/services/google_drive_tokens.py",
+    ],
+    legaleaseGlobs,
+  );
+
+  expect(hits.map((hit) => hit.file)).toEqual([
+    "legalease/legalease/urls.py",
+    "legalease/main/decorators.py",
+    "legalease/main/migrations/0001_initial.py",
+    "legalease/legalease/settings_prod.py",
+    "legalease/main/services/access_control.py",
+    "legalease/main/mcp/auth.py",
+    "legalease/main/mcp/scopes.py",
+    "legalease/main/mcp/security.py",
+    "legalease/main/services/google_drive_tokens.py",
+  ]);
+});
+
+test("legalease config leaves ordinary document generation services and views unflagged", () => {
+  expect(
+    matchEscalations(
+      [
+        "legalease/main/services/document_generation.py",
+        "legalease/main/views/home.py",
+        "README.md",
+        "docs/setup.md",
+      ],
+      legaleaseGlobs,
     ),
   ).toEqual([]);
 });

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -17,6 +17,7 @@ const repos = Bun.YAML.parse(
 ).repos;
 const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_paths;
 const wmHomeGlobs = repos.find((repo) => repo.name === "wm-home")?.escalate_paths;
+const wattsMobileGlobs = repos.find((repo) => repo.name === "watts-mobile")?.escalate_paths;
 
 test("wm-home config protects its schema, auth, admin, and deployment boundaries", () => {
   expect(wmHomeGlobs).toBeDefined();
@@ -61,6 +62,45 @@ test("wm-home config leaves ordinary landing page and docs changes unflagged", (
         "docs/setup.md",
       ],
       wmHomeGlobs,
+    ),
+  ).toEqual([]);
+});
+
+test("watts-mobile config protects subscriptions, auth, credentials, and build configuration", () => {
+  expect(wattsMobileGlobs).toBeDefined();
+
+  const hits = matchEscalations(
+    [
+      "src/features/subscriptions/revenueCat.ts",
+      "src/auth/sessionStore.ts",
+      "credentials/apple/distribution.p12",
+      "eas.json",
+      ".env.example",
+      ".github/workflows/build.yml",
+    ],
+    wattsMobileGlobs,
+  );
+
+  expect(hits.map((hit) => hit.file)).toEqual([
+    "src/features/subscriptions/revenueCat.ts",
+    "src/auth/sessionStore.ts",
+    "credentials/apple/distribution.p12",
+    "eas.json",
+    ".env.example",
+    ".github/workflows/build.yml",
+  ]);
+});
+
+test("watts-mobile config leaves ordinary feature screens and components unflagged", () => {
+  expect(
+    matchEscalations(
+      [
+        "src/features/stats/StatsScreen.tsx",
+        "src/components/Button.tsx",
+        "README.md",
+        "docs/setup.md",
+      ],
+      wattsMobileGlobs,
     ),
   ).toEqual([]);
 });

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -18,6 +18,7 @@ const repos = Bun.YAML.parse(
 const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_paths;
 const wmHomeGlobs = repos.find((repo) => repo.name === "wm-home")?.escalate_paths;
 const wattsMobileGlobs = repos.find((repo) => repo.name === "watts-mobile")?.escalate_paths;
+const coachWattzGlobs = repos.find((repo) => repo.name === "coach-wattz")?.escalate_paths;
 
 test("wm-home config protects its schema, auth, admin, and deployment boundaries", () => {
   expect(wmHomeGlobs).toBeDefined();
@@ -101,6 +102,55 @@ test("watts-mobile config leaves ordinary feature screens and components unflagg
         "docs/setup.md",
       ],
       wattsMobileGlobs,
+    ),
+  ).toEqual([]);
+});
+
+test("coach-wattz config protects stripe, auth, prisma, and deployment boundaries", () => {
+  expect(coachWattzGlobs).toBeDefined();
+
+  const hits = matchEscalations(
+    [
+      "server/api/stripe/webhook.ts",
+      "server/api/subscriptions/sync.ts",
+      "server/api/auth/login.ts",
+      "server/api/oauth/callback.ts",
+      "server/middleware/auth.ts",
+      "server/middleware/session-impersonation.ts",
+      "prisma/schema.prisma",
+      "prisma/migrations/20260223120700_init/migration.sql",
+      "docker-compose.yml",
+      "Dockerfile",
+      ".github/workflows/ci.yml",
+    ],
+    coachWattzGlobs,
+  );
+
+  expect(hits.map((hit) => hit.file)).toEqual([
+    "server/api/stripe/webhook.ts",
+    "server/api/subscriptions/sync.ts",
+    "server/api/auth/login.ts",
+    "server/api/oauth/callback.ts",
+    "server/middleware/auth.ts",
+    "server/middleware/session-impersonation.ts",
+    "prisma/schema.prisma",
+    "prisma/migrations/20260223120700_init/migration.sql",
+    "docker-compose.yml",
+    "Dockerfile",
+    ".github/workflows/ci.yml",
+  ]);
+});
+
+test("coach-wattz config leaves ordinary Vue pages and components unflagged", () => {
+  expect(
+    matchEscalations(
+      [
+        "app/pages/index.vue",
+        "app/components/UserProfile.vue",
+        "README.md",
+        "docs/ARCHITECTURE.md",
+      ],
+      coachWattzGlobs,
     ),
   ).toEqual([]);
 });

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -16,6 +16,54 @@ const repos = Bun.YAML.parse(
   readFileSync(new URL("../config/repos.yaml", import.meta.url), "utf8"),
 ).repos;
 const cashsaasGlobs = repos.find((repo) => repo.name === "cashsaas")?.escalate_paths;
+const wmHomeGlobs = repos.find((repo) => repo.name === "wm-home")?.escalate_paths;
+
+test("wm-home config protects its schema, auth, admin, and deployment boundaries", () => {
+  expect(wmHomeGlobs).toBeDefined();
+
+  const hits = matchEscalations(
+    [
+      "schema.prisma",
+      "migrations/20260519140000_init/migration.sql",
+      "src/auth/email.ts",
+      "src/admin/operations.ts",
+      "main.wasp",
+      "Dockerfile",
+      "Dockerfile.web",
+      "docker-compose.yml",
+      "nginx.conf",
+      ".github/workflows/deploy.yml",
+    ],
+    wmHomeGlobs,
+  );
+
+  expect(hits.map((hit) => hit.file)).toEqual([
+    "schema.prisma",
+    "migrations/20260519140000_init/migration.sql",
+    "src/auth/email.ts",
+    "src/admin/operations.ts",
+    "main.wasp",
+    "Dockerfile",
+    "Dockerfile.web",
+    "docker-compose.yml",
+    "nginx.conf",
+    ".github/workflows/deploy.yml",
+  ]);
+});
+
+test("wm-home config leaves ordinary landing page and docs changes unflagged", () => {
+  expect(
+    matchEscalations(
+      [
+        "src/LandingPage.tsx",
+        "src/components/Header.tsx",
+        "README.md",
+        "docs/setup.md",
+      ],
+      wmHomeGlobs,
+    ),
+  ).toEqual([]);
+});
 
 test("cashsaas config protects its destructive, deployment, credential, and auth boundaries", () => {
   expect(cashsaasGlobs).toBeDefined();


### PR DESCRIPTION
Fixes WM-52
Fixes WM-50
Fixes WM-49
Fixes WM-10

## Changes
- **wm-home (WM-52)**: Added behavioral `escalate_paths` covering `schema.prisma`, `migrations/**`, `src/auth/**`, `src/admin/**`, `main.wasp`, `Dockerfile`, `Dockerfile.web`, `docker-compose.yml`, `nginx.conf`, and `.github/workflows/**`.
- **watts-mobile (WM-50)**: Added behavioral `escalate_paths` covering `src/features/subscriptions/**`, `src/auth/**`, `credentials/**`, `eas.json`, `.env.example`, and `.github/workflows/**`.
- **coach-wattz (WM-49)**: Added behavioral `escalate_paths` covering `server/api/stripe/**`, `server/api/subscriptions/**`, `server/api/auth/**`, `server/api/oauth/**`, `server/middleware/auth.ts`, `server/middleware/session-impersonation.ts`, `prisma/schema.prisma`, `prisma/migrations/**`, `docker-compose.yml`, `Dockerfile`, and `.github/workflows/**`.
- **legalease (WM-10)**: Added `legalease/legalease/urls.py` and `legalease/main/decorators.py` to `escalate_paths` to catch authz / decorator modifications (verified against PR #206).
- **orchestrator/escalate.test.mjs**: Added comprehensive test cases asserting each repo's protected boundaries escalate while ordinary UI/feature/docs files pass cleanly.