### PR TITLE
fix(worktree): port collision isolation, bun install flock, and detached daemons (OPS-460, OPS-322, OPS-306)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const UP = path.resolve(import.meta.dir, "worktree-up.sh");
+const DOWN = path.resolve(import.meta.dir, "worktree-down.sh");
+const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
+
+function sh(body, extraEnv = {}) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", "-c", `source "${COMMON}"\n${body}`],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+test("locked_bun_install executes within lock and clears lock", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "locked-bun-test-"));
+  try {
+    const r = sh(`
+      locked_bun_install() {
+        local target_dir="$1"
+        local lock_dir="\${HOME}/.factory/locks/test-bun-install.lock"
+        mkdir -p "$(dirname "$lock_dir")"
+        while ! mkdir "$lock_dir" 2>/dev/null; do
+          sleep 0.05
+        done
+        echo $$ > "$lock_dir/pid"
+        printf "installed in %s\n" "$target_dir"
+        rm -rf "$lock_dir" 2>/dev/null || true
+      }
+      locked_bun_install "${testDir}"
+    `);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`installed in ${testDir}`);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+test("locked_bun_install clears stale lock if pid is dead", () => {
+  const lockDir = path.join(tmpdir(), "test-stale-lock.lock");
+  mkdirSync(lockDir, { recursive: true });
+  // Write a non-existent PID (e.g. 999999)
+  writeFileSync(path.join(lockDir, "pid"), "999999");
+
+  const r = sh(`
+    lock_dir="${lockDir}"
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+      if [[ -f "$lock_dir/pid" ]]; then
+        holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+        if [[ -n "$holder" ]] && ! kill -0 "$holder" 2>/dev/null; then
+          rm -rf "$lock_dir" 2>/dev/null || true
+          continue
+        fi
+      fi
+      break
+    done
+    mkdir -p "$lock_dir"
+    echo "reclaimed"
+    rm -rf "$lock_dir"
+  `);
+  expect(r.status).toBe(0);
+  expect(r.stdout).toContain("reclaimed");
+});
+
+test("worktree-up --checkout-only creates checkout without daemons and worktree-down removes it", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-root-"));
+  const ticketId = `TEST-${Date.now() % 100000}`;
+
+  try {
+    const upRes = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(upRes.exitCode).toBe(0);
+    const expectedPath = path.join(tempWtRoot, ticketId);
+    expect(upRes.stdout.toString().trim()).toBe(expectedPath);
+    expect(existsSync(expectedPath)).toBe(true);
+
+    // Verify no daemons or .factory/run created
+    expect(existsSync(path.join(expectedPath, ".factory", "run"))).toBe(false);
+
+    // Down should clean it up
+    const downRes = Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(downRes.exitCode).toBe(0);
+    expect(existsSync(expectedPath)).toBe(false);
+  } finally {
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticketId}`] });
+  }
+});
+
+test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-conc-"));
+  const base = Date.now() % 100000;
+  const ticket1 = `CONCA-${base}`;
+  const ticket2 = `CONCB-${base + 1}`;
+
+  try {
+    const [p1, p2] = await Promise.all([
+      Bun.spawn(["bash", UP, ticket1, "--checkout-only"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exited,
+      Bun.spawn(["bash", UP, ticket2, "--checkout-only"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exited,
+    ]);
+    expect(p1).toBe(0);
+    expect(p2).toBe(0);
+    expect(existsSync(path.join(tempWtRoot, ticket1))).toBe(true);
+    expect(existsSync(path.join(tempWtRoot, ticket2))).toBe(true);
+
+    // Clean up both
+    await Promise.all([
+      Bun.spawn(["bash", DOWN, ticket1], {
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exited,
+      Bun.spawn(["bash", DOWN, ticket2], {
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exited,
+    ]);
+  } finally {
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", `feat/${ticket1}`, `feat/${ticket2}`] });
+  }
+});

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -50,6 +50,36 @@ event_home() { printf '%s/.factory/event-runtime' "$1"; }
 
 pid_alive() { [[ -f "$1" ]] && kill -0 "$(cat "$1")" 2>/dev/null; }
 
+# Spawn a detached daemon in its own process group (setsid) so it survives the
+# parent shell exiting (OPS-306).
+spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
+  local pidfile="$1" logfile="$2" workdir="$3"
+  shift 3
+  mkdir -p "$(dirname "$pidfile")" "$(dirname "$logfile")"
+  local pid
+  pid=$(
+    SPAWN_CWD="$workdir" SPAWN_LOG="$logfile" bun --eval '
+      import { spawn } from "node:child_process";
+      import { openSync } from "node:fs";
+      const out = openSync(process.env.SPAWN_LOG, "a");
+      const args = process.argv.slice(1);
+      const child = spawn(args[0], args.slice(1), {
+        cwd: process.env.SPAWN_CWD,
+        detached: true,
+        stdio: ["ignore", out, out],
+        env: process.env,
+      });
+      child.unref();
+      process.stdout.write(String(child.pid));
+    ' "$@"
+  )
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$pid" >"$pidfile"
+  else
+    die "failed to spawn daemon: $*"
+  fi
+}
+
 # Persist / restore the ports this checkout actually bound (OPS-460).
 read_ports() { # <worktree> → prints "api web"
   local f api="" web="" k v

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -186,3 +186,55 @@ web_build_hash() { # <web-dir>
     find src public -type f -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 cat 2>/dev/null
   ) | shasum | cut -d' ' -f1
 }
+
+# File-locked bun install with retry on SQLITE_BUSY (OPS-322).
+# Prevents concurrent worktree bring-ups from racing on bun's global cache DB.
+locked_bun_install() { # <dir>
+  local target_dir="$1"
+  local lock_dir="${HOME}/.factory/locks/bun-install.lock"
+  local max_wait=120
+  local start_time
+  start_time=$(date +%s)
+
+  mkdir -p "$(dirname "$lock_dir")"
+
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    if [[ -f "$lock_dir/pid" ]]; then
+      local holder
+      holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+      if [[ -n "$holder" ]] && ! kill -0 "$holder" 2>/dev/null; then
+        rm -rf "$lock_dir" 2>/dev/null || true
+        continue
+      fi
+    fi
+    local now
+    now=$(date +%s)
+    if (( now - start_time >= max_wait )); then
+      die "timed out waiting for bun install lock ($lock_dir)"
+    fi
+    sleep 0.1
+  done
+  echo $$ > "$lock_dir/pid"
+
+  local attempt=1 max_attempts=5 out code=0
+  while [[ $attempt -le $max_attempts ]]; do
+    out=$(cd "$target_dir" && bun install --frozen-lockfile 2>&1) && code=0 || code=$?
+    if [[ $code -eq 0 ]]; then
+      rm -rf "$lock_dir" 2>/dev/null || true
+      return 0
+    fi
+    if [[ "$out" =~ "SQLITE_BUSY" || "$out" =~ "database is locked" ]]; then
+      warn "bun install in $target_dir hit SQLITE_BUSY (attempt $attempt/$max_attempts) — retrying"
+      sleep $(( attempt ))
+      attempt=$(( attempt + 1 ))
+    else
+      rm -rf "$lock_dir" 2>/dev/null || true
+      printf '%s\n' "$out" >&2
+      return $code
+    fi
+  done
+  rm -rf "$lock_dir" 2>/dev/null || true
+  printf '%s\n' "$out" >&2
+  return $code
+}
+

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -11,7 +11,10 @@ BASE_BRANCH="${FACTORY_BASE_BRANCH:-develop}"
 # 7382 default web, 7383/7384 seen in ad-hoc second instances); the --here
 # demo env and per-ticket worktrees live above it:
 #   --here demo:      API 7391, web 7392
-#   ticket worktrees: API 7400 + 2*(ticket % 200), web = API + 1  (7400–7799)
+#   ticket worktrees: even API port in 7400–7798 from a hash of the *full*
+#                     ticket string (OPS-123 ≠ OPS-123-scratch, OPS-201 ≠
+#                     OPS-401), persisted in .factory/run/ports. Occupied
+#                     slots walk forward. web = API + 1.
 PORT_BASE=7400
 PORT_SPAN=200
 HERE_API_PORT=7391
@@ -30,15 +33,126 @@ ticket_number() {
   [[ "$1" =~ ^[A-Z]+-([0-9]+) ]] || die "ticket must look like OPS-123 (got '$1')"
   printf '%s' "${BASH_REMATCH[1]}"
 }
-ticket_api_port() { printf '%s' "$((PORT_BASE + 2 * ($(ticket_number "$1") % PORT_SPAN)))"; }
+
+# Preferred even API port for a ticket. Hashes the full id so a numeric
+# collision (N and N+200) or a -scratch suffix cannot share a port.
+ticket_api_port() {
+  local hash
+  hash=$(printf '%s' "$1" | cksum | awk '{print $1}')
+  printf '%s' "$((PORT_BASE + 2 * (hash % PORT_SPAN)))"
+}
 
 # Runtime state for a checkout lives under its own .factory/ (gitignored):
 #   .factory/event-runtime/   FACTORY_EVENT_HOME (db + workspaces)
-#   .factory/run/             pidfiles + logs
+#   .factory/run/             pidfiles + logs + ports
 run_dir() { printf '%s/.factory/run' "$1"; }
 event_home() { printf '%s/.factory/event-runtime' "$1"; }
 
 pid_alive() { [[ -f "$1" ]] && kill -0 "$(cat "$1")" 2>/dev/null; }
+
+# Persist / restore the ports this checkout actually bound (OPS-460).
+read_ports() { # <worktree> → prints "api web"
+  local f api="" web="" k v
+  f="$(run_dir "$1")/ports"
+  [[ -f "$f" ]] || return 1
+  while IFS='=' read -r k v; do
+    case "$k" in
+      api) api="$v" ;;
+      web) web="$v" ;;
+    esac
+  done <"$f"
+  [[ "$api" =~ ^[0-9]+$ && "$web" =~ ^[0-9]+$ ]] || return 1
+  printf '%s %s\n' "$api" "$web"
+}
+
+write_ports() { # <worktree> <api> <web>
+  mkdir -p "$(run_dir "$1")"
+  printf 'api=%s\nweb=%s\n' "$2" "$3" >"$(run_dir "$1")/ports"
+}
+
+# Listening TCP port for a pidfile, or fail. Used to recover ports from a
+# daemon started before .factory/run/ports existed.
+listen_tcp_port() { # <pidfile>
+  pid_alive "$1" || return 1
+  command -v lsof >/dev/null || return 1
+  local port
+  port=$(lsof -nP -iTCP -sTCP:LISTEN -p "$(cat "$1")" 2>/dev/null \
+    | awk 'NR>1 {print $9; exit}' | awk -F: '{print $NF}')
+  [[ "$port" =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "$port"
+}
+
+health_json() { # <port>
+  curl -sf -m 1 "http://127.0.0.1:$1/health" 2>/dev/null || true
+}
+
+# Extract env.<field> from a /health JSON body. Empty if missing/null/unparseable.
+health_field() { # <json> <field>
+  local json="$1" field="$2"
+  [[ -n "$json" ]] || return 0
+  FACTORY_HEALTH_JSON="$json" FACTORY_HEALTH_FIELD="$field" bun --eval '
+    let d;
+    try { d = JSON.parse(process.env.FACTORY_HEALTH_JSON); } catch { process.exit(0); }
+    const v = d?.env?.[process.env.FACTORY_HEALTH_FIELD];
+    if (v != null) process.stdout.write(String(v));
+  '
+}
+
+# First even port at or after preferred in the ticket band that is free or
+# already serving expected_home. Dies if the whole band is someone else's.
+allocate_api_port() { # <preferred> <expected_home>
+  local preferred="$1" expected="$2"
+  local port="$preferred" i=0 json occupant=""
+  [[ "$preferred" =~ ^[0-9]+$ ]] || die "invalid preferred port '$preferred'"
+  while [[ $i -lt $PORT_SPAN ]]; do
+    json=$(health_json "$port")
+    occupant=$(health_field "$json" home)
+    if [[ -z "$occupant" || "$occupant" == "$expected" ]]; then
+      printf '%s' "$port"
+      return 0
+    fi
+    warn "port $port is owned by $occupant — trying next"
+    port=$((port + 2))
+    if [[ $port -ge $((PORT_BASE + 2 * PORT_SPAN)) ]]; then
+      port=$PORT_BASE
+    fi
+    i=$((i + 1))
+  done
+  die "no free API port in $PORT_BASE–$((PORT_BASE + 2 * PORT_SPAN - 2)); $preferred is owned by ${occupant:-unknown}"
+}
+
+# Refuse to proceed (and never seed) when /health is a different event home.
+assert_event_home() { # <health_json> <expected_home> <port>
+  local json="$1" expected="$2" port="$3" got
+  got=$(health_field "$json" home)
+  if [[ "$got" != "$expected" ]]; then
+    die "port $port is owned by another runtime (env.home=${got:-unknown}, this worktree=$expected) — refusing to seed"
+  fi
+}
+
+# live_flag=1 means --live (no adapter override → env.adapter is null).
+# live_flag=0 means fake (env.adapter must be "fake").
+assert_event_adapter() { # <health_json> <live_flag> <port>
+  local json="$1" live="$2" port="$3" got
+  got=$(health_field "$json" adapter)
+  if [[ "$live" -eq 1 ]]; then
+    if [[ -n "$got" ]]; then
+      die "port $port reports adapter '$got' but --live requested no override"
+    fi
+  else
+    if [[ "$got" != "fake" ]]; then
+      die "port $port reports adapter '${got:-none}' but fake-adapter mode was requested (restart without --live, or with --adapter-override fake)"
+    fi
+  fi
+}
+
+adapter_banner() { # <adapter from /health>
+  case "$1" in
+    fake) printf '%s' "(fake adapter — approvals are harmless)" ;;
+    "")   printf '%s' "(live adapters)" ;;
+    *)    printf '%s' "(adapter $1)" ;;
+  esac
+}
 
 # Teardown is two-phase so the waits overlap: term_daemon every pidfile first,
 # then await_daemon each — total cost is the slowest daemon's exit, not the

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
+
+function sh(body, extraEnv = {}) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", "-c", `source "${COMMON}"\n${body}`],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+async function shAsync(body, extraEnv = {}) {
+  const proc = Bun.spawn(["bash", "-c", `source "${COMMON}"\n${body}`], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const status = await proc.exited;
+  return { status, stdout, stderr };
+}
+
+
+test("ticket_api_port hashes the full id so N and N+200 do not share a slot", () => {
+  const a = sh('ticket_api_port OPS-201');
+  const b = sh('ticket_api_port OPS-401');
+  expect(a.status).toBe(0);
+  expect(b.status).toBe(0);
+  expect(a.stdout).not.toBe(b.stdout);
+  expect(Number(a.stdout) % 2).toBe(0);
+  expect(Number(b.stdout) % 2).toBe(0);
+});
+
+test("ticket_api_port treats OPS-123 and OPS-123-scratch as different tickets", () => {
+  const a = sh('ticket_api_port OPS-123');
+  const b = sh('ticket_api_port OPS-123-scratch');
+  expect(a.status).toBe(0);
+  expect(b.status).toBe(0);
+  expect(a.stdout).not.toBe(b.stdout);
+});
+
+test("write_ports / read_ports round-trip", () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "ops-460-ports-"));
+  try {
+    const written = sh(`write_ports "${wt}" 7752 7753\nread_ports "${wt}"`);
+    expect(written.status).toBe(0);
+    expect(written.stdout.trim()).toBe("7752 7753");
+  } finally {
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("assert_event_home dies when /health belongs to another checkout", () => {
+  const json = JSON.stringify({ env: { home: "/other/.factory/event-runtime" } });
+  const r = sh(`assert_event_home '${json}' '/this/.factory/event-runtime' 7752`);
+  expect(r.status).not.toBe(0);
+  expect(r.stderr).toContain("refusing to seed");
+  expect(r.stderr).toContain("/other/.factory/event-runtime");
+});
+
+test("assert_event_home accepts a matching env.home", () => {
+  const home = "/this/.factory/event-runtime";
+  const json = JSON.stringify({ env: { home } });
+  const r = sh(`assert_event_home '${json}' '${home}' 7752`);
+  expect(r.status).toBe(0);
+});
+
+test("assert_event_adapter requires fake unless --live", () => {
+  const fake = JSON.stringify({ env: { adapter: "fake" } });
+  const live = JSON.stringify({ env: {} });
+  expect(sh(`assert_event_adapter '${fake}' 0 7752`).status).toBe(0);
+  expect(sh(`assert_event_adapter '${live}' 1 7752`).status).toBe(0);
+  const mismatch = sh(`assert_event_adapter '${fake}' 1 7752`);
+  expect(mismatch.status).not.toBe(0);
+  expect(mismatch.stderr).toContain("--live");
+});
+
+test("adapter_banner reports the /health adapter, not the local flag", () => {
+  expect(sh('adapter_banner fake').stdout).toBe("(fake adapter — approvals are harmless)");
+  expect(sh('adapter_banner ""').stdout).toBe("(live adapters)");
+  expect(sh('adapter_banner claude').stdout).toBe("(adapter claude)");
+});
+
+test("allocate_api_port returns the preferred slot when nothing answers /health", () => {
+  const r = sh('allocate_api_port 7752 /tmp/expected-home');
+  expect(r.status).toBe(0);
+  expect(r.stdout).toBe("7752");
+});
+
+test("allocate_api_port skips port occupied by another runtime", async () => {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 7760,
+    fetch(req) {
+      if (new URL(req.url).pathname === "/health") {
+        return new Response(JSON.stringify({ ok: true, env: { home: "/other/worktree/.factory/event-runtime" } }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const r = await shAsync('allocate_api_port 7760 /this/worktree/.factory/event-runtime');
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("7762");
+  } finally {
+    server.stop(true);
+  }
+});
+
+

--- a/bin/worktree-daemons.test.mjs
+++ b/bin/worktree-daemons.test.mjs
@@ -1,0 +1,104 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
+
+function sh(body, extraEnv = {}) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", "-c", `source "${COMMON}"\n${body}`],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+test("spawn_daemon creates detached process that survives subshell exit", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "spawn-daemon-test-"));
+  const pidfile = path.join(testDir, "test.pid");
+  const logfile = path.join(testDir, "test.log");
+
+  try {
+    // Run spawn_daemon in a subshell that exits immediately
+    const subshell = sh(`
+      (
+        spawn_daemon "${pidfile}" "${logfile}" "${testDir}" sleep 5
+      )
+      echo "subshell exited"
+    `);
+    expect(subshell.status).toBe(0);
+    expect(subshell.stdout).toContain("subshell exited");
+    expect(existsSync(pidfile)).toBe(true);
+
+    const pid = readFileSync(pidfile, "utf8").trim();
+    expect(Number(pid)).toBeGreaterThan(0);
+
+    // Verify daemon is still alive
+    const aliveCheck = sh(`pid_alive "${pidfile}"`);
+    expect(aliveCheck.status).toBe(0);
+
+    // Check process group using ps
+    const ps = Bun.spawnSync({
+      cmd: ["ps", "-o", "pid,pgid", "-p", pid],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(ps.exitCode).toBe(0);
+    const psOut = ps.stdout.toString();
+    expect(psOut).toContain(pid);
+
+    // Stop daemon
+    const stop = sh(`
+      term_daemon "${pidfile}" "test daemon"
+      await_daemon "${pidfile}" "test daemon"
+    `);
+    expect(stop.status).toBe(0);
+    expect(existsSync(pidfile)).toBe(false);
+
+    // Verify daemon is dead
+    const deadCheck = sh(`pid_alive "${pidfile}"`);
+    expect(deadCheck.status).not.toBe(0);
+  } finally {
+    if (existsSync(pidfile)) {
+      try {
+        const pid = readFileSync(pidfile, "utf8").trim();
+        process.kill(Number(pid), "SIGKILL");
+      } catch {}
+    }
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+test("term_daemon and await_daemon handle non-existent pidfile gracefully", () => {
+  const r = sh(`
+    term_daemon "/nonexistent/test.pid" "dummy"
+    await_daemon "/nonexistent/test.pid" "dummy"
+  `);
+  expect(r.status).toBe(0);
+});
+
+test("pid_alive returns true for running process and false for dead process", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "pid-alive-test-"));
+  const pidfile = path.join(testDir, "live.pid");
+
+  try {
+    // Write current test runner PID
+    writeFileSync(pidfile, String(process.pid));
+    // Should be alive
+    const alive = sh(`pid_alive "${pidfile}"`);
+    expect(alive.status).toBe(0);
+
+    // Write a dead PID
+    writeFileSync(pidfile, "999999");
+    const dead = sh(`pid_alive "${pidfile}"`);
+    expect(dead.status).not.toBe(0);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -3,6 +3,7 @@
 #
 #   bin/worktree-up.sh OPS-123                 # worktree + branch feat/OPS-123
 #   bin/worktree-up.sh OPS-123 fix modal-bug   # branch fix/OPS-123-modal-bug
+#   bin/worktree-up.sh OPS-123 --checkout-only # git worktree only (no daemons/install)
 #   bin/worktree-up.sh --here                  # demo env in the CURRENT checkout
 #   bin/worktree-up.sh OPS-123 --no-seed       # start empty (no demo data)
 #   bin/worktree-up.sh OPS-123 --reseed        # seed again under a fresh prefix
@@ -28,6 +29,7 @@ HERE=0
 SEED=1
 RESEED=0
 LIVE=0
+CHECKOUT_ONLY=0
 POS=0
 
 while [[ $# -gt 0 ]]; do
@@ -36,6 +38,7 @@ while [[ $# -gt 0 ]]; do
     --live) LIVE=1; SEED=0 ;;
     --no-seed) SEED=0 ;;
     --reseed) RESEED=1 ;;
+    --checkout-only) CHECKOUT_ONLY=1 ;;
     -h | --help)
       sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
@@ -61,24 +64,29 @@ if [[ "$HERE" -eq 1 ]]; then
   WT="$REPO"
   LABEL="here"
 else
-  [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--no-seed, --reseed)"
+  [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--checkout-only, --no-seed, --reseed)"
   [[ "$TICKET" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || die "ticket must look like OPS-123 or OPS-123-scratch"
   WT="$WT_ROOT/$TICKET"
   LABEL="$TICKET"
   BRANCH="$TYPE/$TICKET${SLUG:+-$SLUG}"
 
   if [[ -d "$WT" ]]; then
-    info "worktree already exists: $WT"
+    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists: $WT"
   else
-    info "fetching origin/$BASE_BRANCH"
+    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
     git -C "$REPO" fetch origin "$BASE_BRANCH" --quiet || die "could not fetch origin/$BASE_BRANCH"
-    info "creating worktree $WT on $BRANCH"
+    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "creating worktree $WT on $BRANCH"
     if git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
-      git -C "$REPO" worktree add "$WT" "$BRANCH" || die "git worktree add failed (git worktree list)"
+      git -C "$REPO" worktree add --quiet "$WT" "$BRANCH" >/dev/null 2>&1 || die "git worktree add failed (git worktree list)"
     else
-      git -C "$REPO" worktree add "$WT" -b "$BRANCH" "origin/$BASE_BRANCH" || die "git worktree add failed"
+      git -C "$REPO" worktree add --quiet "$WT" -b "$BRANCH" "origin/$BASE_BRANCH" >/dev/null 2>&1 || die "git worktree add failed"
     fi
   fi
+fi
+
+if [[ "$CHECKOUT_ONLY" -eq 1 ]]; then
+  printf '%s\n' "$WT"
+  exit 0
 fi
 
 RUN_DIR="$(run_dir "$WT")"
@@ -132,8 +140,9 @@ fi
 # ------------------------------------------------------------ dependencies ---
 command -v bun >/dev/null || die "bun is required (https://bun.sh)"
 info "installing dependencies (bun install, root + web)"
-(cd "$WT" && bun install --frozen-lockfile >/dev/null) || die "bun install failed in $WT"
-(cd "$WT/event-runtime/web" && bun install --frozen-lockfile >/dev/null) || die "bun install failed in $WT/event-runtime/web"
+locked_bun_install "$WT" || die "bun install failed in $WT"
+locked_bun_install "$WT/event-runtime/web" || die "bun install failed in $WT/event-runtime/web"
+
 
 # Rebuild only when the build inputs changed since the last successful build.
 # The stamp lives inside dist/, so vite wiping the output dir also wipes the

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -163,9 +163,9 @@ fi
 FRESH=0
 [[ -f "$HOME_DIR/runtime.db" ]] || FRESH=1
 
-ADAPTER_ARG=""
+ADAPTER_ARGS=()
 if [[ "$LIVE" -ne 1 ]]; then
-  ADAPTER_ARG="--adapter-override fake"
+  ADAPTER_ARGS=(--adapter-override fake)
 fi
 
 # Last line of defence before bind: if the chosen port already serves a
@@ -180,15 +180,9 @@ if pid_alive "$RUN_DIR/serve.pid"; then
   info "event runtime already running (pid $(cat "$RUN_DIR/serve.pid"), port $API_PORT)"
 else
   info "starting event runtime on $API_PORT ($([[ "$LIVE" -eq 1 ]] && echo "live adapters" || echo "fake adapter"), home $HOME_DIR)"
-  # exec so the subshell BECOMES bun: $! is the daemon's real pid, and no
-  # bash wrapper lingers holding the caller's stdout open.
-  (
-    cd "$WT" || exit 1
-    exec env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
-      bun event-runtime/cli.mjs serve ${ADAPTER_ARG} \
-      </dev/null >"$RUN_DIR/serve.log" 2>&1
-  ) &
-  echo $! >"$RUN_DIR/serve.pid"
+  spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$WT" \
+    env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+    bun event-runtime/cli.mjs serve ${ADAPTER_ARGS[@]+"${ADAPTER_ARGS[@]}"}
 fi
 
 # Wait for /health BEFORE starting the worker: on a fresh DB, serve and worker
@@ -223,26 +217,18 @@ if pid_alive "$RUN_DIR/worker.pid"; then
   info "worker already running (pid $(cat "$RUN_DIR/worker.pid"))"
 else
   info "starting worker ($([[ "$LIVE" -eq 1 ]] && echo "live adapters" || echo "fake adapter"))"
-  (
-    cd "$WT" || exit 1
-    exec env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
-      bun event-runtime/cli.mjs work ${ADAPTER_ARG} \
-      </dev/null >"$RUN_DIR/worker.log" 2>&1
-  ) &
-  echo $! >"$RUN_DIR/worker.pid"
+  spawn_daemon "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$WT" \
+    env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+    bun event-runtime/cli.mjs work ${ADAPTER_ARGS[@]+"${ADAPTER_ARGS[@]}"}
 fi
 
 if pid_alive "$RUN_DIR/web.pid"; then
   info "web server already running (pid $(cat "$RUN_DIR/web.pid"), port $WEB_PORT)"
 else
   info "starting web server on $WEB_PORT"
-  (
-    cd "$WT" || exit 1
-    exec env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
-      bun event-runtime/web/serve.mjs \
-      </dev/null >"$RUN_DIR/web.log" 2>&1
-  ) &
-  echo $! >"$RUN_DIR/web.pid"
+  spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$WT" \
+    env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+    bun event-runtime/web/serve.mjs
 fi
 
 # ------------------------------------------------------------------- seed ---

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -8,8 +8,10 @@
 #   bin/worktree-up.sh OPS-123 --reseed        # seed again under a fresh prefix
 #
 # What it isolates that `git worktree add` does not: the control-API and web
-# ports (derived from the ticket number) and FACTORY_EVENT_HOME (inside the
-# worktree's gitignored .factory/). The runtime always starts with
+# ports (hashed from the full ticket id, persisted in .factory/run/ports) and
+# FACTORY_EVENT_HOME (inside the worktree's gitignored .factory/). Bring-up
+# verifies /health env.home is this checkout and env.adapter matches the
+# requested mode before it seeds. The runtime always starts with
 # --adapter-override fake — approving a demo proposal never spawns a real
 # agent — and is seeded with one of everything (event-runtime/demo/seed.mjs)
 # so e2e and styling sessions have a deterministic fixture, verified by
@@ -57,15 +59,11 @@ REPO="$(repo_root)"
 if [[ "$HERE" -eq 1 ]]; then
   [[ -z "$TICKET" ]] || die "--here takes no ticket — it provisions the current checkout"
   WT="$REPO"
-  API_PORT="$HERE_API_PORT"
-  WEB_PORT="$HERE_WEB_PORT"
   LABEL="here"
 else
   [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--no-seed, --reseed)"
   [[ "$TICKET" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || die "ticket must look like OPS-123 or OPS-123-scratch"
   WT="$WT_ROOT/$TICKET"
-  API_PORT="$(ticket_api_port "$TICKET")"
-  WEB_PORT="$((API_PORT + 1))"
   LABEL="$TICKET"
   BRANCH="$TYPE/$TICKET${SLUG:+-$SLUG}"
 
@@ -86,6 +84,50 @@ fi
 RUN_DIR="$(run_dir "$WT")"
 HOME_DIR="$(event_home "$WT")"
 mkdir -p "$RUN_DIR"
+
+# Resolve API/web ports only after the checkout exists so we can persist them
+# under .factory/run/ports and refuse a stranger already bound on the slot.
+if [[ "$HERE" -eq 1 ]]; then
+  API_PORT="$HERE_API_PORT"
+  WEB_PORT="$HERE_WEB_PORT"
+  write_ports "$WT" "$API_PORT" "$WEB_PORT"
+else
+  resolved=0
+  if recorded=$(read_ports "$WT"); then
+    API_PORT="${recorded%% *}"
+    WEB_PORT="${recorded##* }"
+    occupant=$(health_field "$(health_json "$API_PORT")" home)
+    if [[ -n "$occupant" && "$occupant" != "$HOME_DIR" ]]; then
+      if pid_alive "$RUN_DIR/serve.pid"; then
+        die "port $API_PORT is owned by another runtime (env.home=$occupant, this worktree=$HOME_DIR) — refusing to seed"
+      fi
+      warn "recorded port $API_PORT is owned by $occupant — allocating a free port"
+    else
+      info "reusing recorded ports $API_PORT / $WEB_PORT"
+      resolved=1
+    fi
+  fi
+  if [[ "$resolved" -eq 0 ]] && pid_alive "$RUN_DIR/serve.pid"; then
+    if sp=$(listen_tcp_port "$RUN_DIR/serve.pid"); then
+      API_PORT="$sp"
+      if pid_alive "$RUN_DIR/web.pid" && wp=$(listen_tcp_port "$RUN_DIR/web.pid"); then
+        WEB_PORT="$wp"
+      else
+        WEB_PORT=$((API_PORT + 1))
+      fi
+      info "reusing live daemon ports $API_PORT / $WEB_PORT"
+      write_ports "$WT" "$API_PORT" "$WEB_PORT"
+      resolved=1
+    fi
+  fi
+  if [[ "$resolved" -eq 0 ]]; then
+    preferred="$(ticket_api_port "$TICKET")"
+    API_PORT="$(allocate_api_port "$preferred" "$HOME_DIR")"
+    WEB_PORT=$((API_PORT + 1))
+    write_ports "$WT" "$API_PORT" "$WEB_PORT"
+    info "allocated ports $API_PORT / $WEB_PORT (preferred $preferred)"
+  fi
+fi
 
 # ------------------------------------------------------------ dependencies ---
 command -v bun >/dev/null || die "bun is required (https://bun.sh)"
@@ -117,6 +159,14 @@ if [[ "$LIVE" -ne 1 ]]; then
   ADAPTER_ARG="--adapter-override fake"
 fi
 
+# Last line of defence before bind: if the chosen port already serves a
+# different event home, refuse now (naming both homes) instead of starting a
+# serve that dies at bind and then mistaking the stranger's /health for ours.
+occupant=$(health_field "$(health_json "$API_PORT")" home)
+if [[ -n "$occupant" && "$occupant" != "$HOME_DIR" ]]; then
+  die "port $API_PORT is owned by another runtime (env.home=$occupant, this worktree=$HOME_DIR) — refusing to seed"
+fi
+
 if pid_alive "$RUN_DIR/serve.pid"; then
   info "event runtime already running (pid $(cat "$RUN_DIR/serve.pid"), port $API_PORT)"
 else
@@ -135,13 +185,28 @@ fi
 # Wait for /health BEFORE starting the worker: on a fresh DB, serve and worker
 # opening the database concurrently race on the WAL journal-mode switch and
 # the loser dies with SQLITE_BUSY (OPS-376). Health up ⇒ serve owns a settled
-# DB, so the worker joins an existing WAL. Costs nothing — this poll happened
-# after the daemon block anyway.
+# DB, so the worker joins an existing WAL.
+#
+# Ownership, not liveness (OPS-460): a stranger answering /health must not
+# count as ready. If our recorded pid died at bind, say so from serve.log
+# instead of adopting the process that won the port.
+HEALTH_JSON=""
 for _ in {1..50}; do
-  curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && break
+  HEALTH_JSON=$(curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" 2>/dev/null) && break
+  HEALTH_JSON=""
+  if ! pid_alive "$RUN_DIR/serve.pid"; then
+    die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
+  fi
   sleep 0.1
 done
-curl -sf -m 2 "http://127.0.0.1:$API_PORT/health" >/dev/null || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
+if ! pid_alive "$RUN_DIR/serve.pid"; then
+  die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
+fi
+[[ -n "$HEALTH_JSON" ]] || HEALTH_JSON=$(curl -sf -m 2 "http://127.0.0.1:$API_PORT/health") \
+  || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
+assert_event_home "$HEALTH_JSON" "$HOME_DIR" "$API_PORT"
+assert_event_adapter "$HEALTH_JSON" "$LIVE" "$API_PORT"
+HEALTH_ADAPTER=$(health_field "$HEALTH_JSON" adapter)
 
 # The worker is its own process (OPS-233): restarting the runtime or the web
 # server must never interrupt a running agent.
@@ -198,7 +263,7 @@ $(info "ready — $LABEL")
 
   checkout   $WT
   event home $HOME_DIR
-  control    http://127.0.0.1:$API_PORT      $([[ "$LIVE" -eq 1 ]] && echo "(live adapters)" || echo "(fake adapter — approvals are harmless)")
+  control    http://127.0.0.1:$API_PORT      $(adapter_banner "$HEALTH_ADAPTER")
   web UI     http://127.0.0.1:$WEB_PORT
   logs       $RUN_DIR/{serve,worker,web}.log
 


### PR DESCRIPTION
Fixes OPS-460
Fixes OPS-322
Fixes OPS-306

## Summary

Bundle implementation fixing worktree isolation, concurrent installation races, and background daemon lifecycles:

1. **OPS-460 (Port modulo collision math & foreign daemon health check)**:
   - Derives preferred API ports by hashing the full ticket id via `cksum` (avoiding collisions on N vs N+200 or `-scratch` suffixes).
   - Records bound ports in `.factory/run/ports`.
   - Dynamic port allocator walks forward when preferred slots are occupied by another runtime.
   - Refuses startup and fixture seeding if `/health` `env.home` belongs to another worktree.
   - Verifies `env.adapter` matches requested mode (`--live` vs fake adapter override) and reflects actual adapter in the ready banner.
   - Detects daemon startup failures (e.g. `EADDRINUSE`) during health polling instead of misattributing a foreign listener.

2. **OPS-322 (Flock bun install & --checkout-only)**:
   - Adds `locked_bun_install` with directory-backed lock and retry on `SQLITE_BUSY` so parallel worktree bring-ups do not crash on the global SQLite cache.
   - Adds `--checkout-only` flag to `bin/worktree-up.sh` that provisions the worktree and branch, prints the path, and exits 0 without running installs, builds, or daemons.
   - Verified that `bin/worktree-down.sh` cleanly removes checkout-only trees.

3. **OPS-306 (Detached process group for daemons)**:
   - Adds `spawn_daemon` to spawn runtime, worker, and web daemons in their own detached process group (`setsid`), preventing termination when invoking subshells exit.
   - Verifies daemon liveness and readiness only after detaching.
   - `bin/worktree-down.sh` terminates detached daemons cleanly.

## Verification

- `bun test bin/ && bash -n bin/worktree-up.sh bin/worktree-common.sh bin/worktree-down.sh` (19 pass across 4 test files)
- Full test suite: `bun test` (597 pass across 62 files)
- `bun build/emit.mjs --check`