### PR TITLE
fix(event-runtime-web): Dialog open effect must not re-run on poll (OPS-262)

### DIFF
--- a/event-runtime/web/src/components/Dialog.test.tsx
+++ b/event-runtime/web/src/components/Dialog.test.tsx
@@ -1,0 +1,111 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { modal } from "../hooks";
+import { Dialog } from "./ui";
+
+function AutofocusChip() {
+  const ref = useRef<HTMLButtonElement>(null);
+  useLayoutEffect(() => {
+    ref.current?.setAttribute("autofocus", "");
+  }, []);
+  return (
+    <button ref={ref} type="button" data-testid="chip">
+      chip
+    </button>
+  );
+}
+
+function OpenDialog({
+  onClose,
+  children,
+}: {
+  onClose: () => void;
+  children?: ReactNode;
+}) {
+  return (
+    <Dialog title="Inject" onClose={onClose}>
+      <textarea data-testid="envelope" />
+      <AutofocusChip />
+      {children}
+    </Dialog>
+  );
+}
+
+beforeEach(() => {
+  modal.depth = 0;
+});
+
+afterEach(() => {
+  modal.depth = 0;
+  cleanup();
+});
+
+describe("Dialog", () => {
+  test("opening focuses the stamped [autofocus] control once", () => {
+    const r = render(<OpenDialog onClose={() => {}} />);
+    expect(document.activeElement).toBe(r.getByTestId("chip"));
+  });
+
+  test("a parent re-render does not steal focus back to [autofocus]", () => {
+    const r = render(<OpenDialog onClose={() => {}} />);
+    const envelope = r.getByTestId("envelope");
+    envelope.focus();
+    expect(document.activeElement).toBe(envelope);
+
+    r.rerender(<OpenDialog onClose={() => {}} />);
+    expect(document.activeElement).toBe(envelope);
+  });
+
+  test("Escape calls the current onClose, not the first-render copy", () => {
+    const closed: string[] = [];
+    function Parent({ tag }: { tag: string }) {
+      return <OpenDialog onClose={() => closed.push(tag)} />;
+    }
+    const r = render(<Parent tag="first" />);
+    r.rerender(<Parent tag="current" />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(closed).toEqual(["current"]);
+  });
+
+  test("modal.depth increments once per open and decrements once on close", () => {
+    expect(modal.depth).toBe(0);
+    const r = render(<OpenDialog onClose={() => {}} />);
+    expect(modal.depth).toBe(1);
+    r.rerender(<OpenDialog onClose={() => {}} />);
+    expect(modal.depth).toBe(1);
+    r.unmount();
+    expect(modal.depth).toBe(0);
+  });
+
+  test("a confirm button mounted later still receives React autoFocus", () => {
+    function Row() {
+      const [confirm, setConfirm] = useState(false);
+      return (
+        <OpenDialog onClose={() => {}}>
+          <button type="button" data-testid="choose" onClick={() => setConfirm(true)}>
+            choose
+          </button>
+          {confirm ? (
+            <button type="button" data-testid="confirm" autoFocus>
+              Confirm inject
+            </button>
+          ) : null}
+        </OpenDialog>
+      );
+    }
+    const r = render(<Row />);
+    fireEvent.click(r.getByTestId("choose"));
+    expect(document.activeElement).toBe(r.getByTestId("confirm"));
+  });
+
+  test("Tab from the last control wraps to the first inside the panel", () => {
+    const r = render(<OpenDialog onClose={() => {}} />);
+    const envelope = r.getByTestId("envelope");
+    const chip = r.getByTestId("chip");
+    chip.focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(envelope);
+  });
+});

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -673,11 +673,13 @@ export function Dialog({
 }) {
   const titleId = useId();
   const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   useEffect(() => {
     modal.depth += 1;
     const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
       else if (e.key === "Tab" && panelRef.current) tabCycle(panelRef.current, e);
     };
     window.addEventListener("keydown", onKey);
@@ -689,7 +691,8 @@ export function Dialog({
       window.removeEventListener("keydown", onKey);
       previous?.focus();
     };
-  }, [onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onClose lives in the ref
+  }, []);
   return (
     <div
       className="fixed inset-0 z-40 flex items-start justify-center bg-black/50 pt-[10vh]"


### PR DESCRIPTION
## Summary
- Hold `onClose` in a ref and run Dialog's open effect with `[]` deps so App/view poll re-renders cannot re-focus `[autofocus]` or restore `previous` while the dialog stays open.
- Escape still reads the current `onClose` (AC 5). `modal.depth` increments/decrements once per open/close (AC 7).
- Companion `Dialog.test.tsx` locks the behaviour now that OPS-384 shipped the happy-dom harness. Owned Paths listed only `ui.tsx`; the test file is the lock-in, not a caller fix.

## Test plan
- [x] `bun test event-runtime && cd event-runtime/web && bun run build` — 379 pass, entry chunk 450.04 kB under the 460 kB budget
- [x] Dialog tests: open focuses stamped `[autofocus]`; parent rerender does not steal focus; Escape uses current `onClose`; `modal.depth` once; late-mounted React `autoFocus` confirm still focuses; Tab wraps

UX critique: skipped — no visual/layout/flow change (effect deps + ref only); focus behaviour is asserted in `Dialog.test.tsx`. Worktree demo daemons were stale (`/health` down), so there was no live UI to walk.

Fixes OPS-262