### PR TITLE
fix(event-runtime): runtime schedules admission and GC retry storm prevention (OPS-452, OPS-437, OPS-436, OPS-468)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -187,9 +187,12 @@ export async function tick({
   let nextPrune = lastPrune;
   await runStep("GC", () => {
     if (now - lastPrune <= pruneIntervalMs) return;
-    const pruned = pruneArtifacts(db, storeRoot ?? artifactsRoot(), { now });
-    nextPrune = now;
-    if (pruned.deleted > 0) logLine(`artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`);
+    try {
+      const pruned = pruneArtifacts(db, storeRoot ?? artifactsRoot(), { now });
+      if (pruned.deleted > 0) logLine(`artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`);
+    } finally {
+      nextPrune = now;
+    }
   });
 
   await runStep("chains", () => {

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -70,10 +70,19 @@ export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
   if (envelope === null || typeof envelope !== "object" || Array.isArray(envelope)) {
     return { admitted: false, duplicate: false, errors: ["$: envelope must be an object"] };
   }
-  const receivedAt = new Date(now).toISOString();
+  const nowMs = typeof now === "number" ? now : (typeof now === "string" ? Date.parse(now) : Date.now());
+  const receivedAt = new Date(nowMs).toISOString();
   const stored = { ...envelope, receivedAt };
   const { valid, errors } = validate(registry.schemas.envelope, stored);
   if (!valid) return { admitted: false, duplicate: false, errors };
+
+  // Refuse clock tick events whose slot is in the future relative to now (OPS-437).
+  if (stored.source === "schedule" || (typeof stored.type === "string" && stored.type.startsWith("clock.tick."))) {
+    const occurredMs = Date.parse(stored.occurredAt);
+    if (!Number.isNaN(occurredMs) && occurredMs > nowMs) {
+      return { admitted: false, duplicate: false, errors: ["occurredAt: clock tick slot cannot be in the future"] };
+    }
+  }
 
   return tx(db, () => {
     const existing = db

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -151,4 +151,24 @@ describe("admitEvent", () => {
     }
     expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
   });
+
+  test("direct admission refuses clock tick events whose slot is in the future relative to now (OPS-437)", () => {
+    const db = openDb(":memory:");
+    const futureTick = {
+      schemaVersion: "factory.event/v1",
+      eventId: "clock:reaper:9999-01-01T00:00:00.000Z",
+      type: "clock.tick.reaper",
+      source: "schedule",
+      subject: "reaper",
+      occurredAt: "9999-01-01T00:00:00.000Z",
+      correlationId: "clock:reaper:9999-01-01T00:00:00.000Z",
+      causationId: null,
+      payload: { loop: "reaper", slot: "9999-01-01T00:00:00.000Z", cadenceSeconds: 3600, skippedSlots: 0 },
+    };
+    const result = admitEvent(db, registry, futureTick, { now: NOW });
+    expect(result.admitted).toBe(false);
+    expect(result.duplicate).toBe(false);
+    expect(result.errors).toContain("occurredAt: clock tick slot cannot be in the future");
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+  });
 });

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -37,6 +37,8 @@ export function slotFor(nowMs, cadenceSeconds) {
 
 export const tickEventId = (loop, slot) => `clock:${loop}:${slot}`;
 
+export const DEFAULT_MAX_CATCH_UP = 24;
+
 /**
  * Which slots to fire, given the last one already admitted (§4 catch-up).
  *
@@ -45,23 +47,36 @@ export const tickEventId = (loop, slot) => `clock:${loop}:${slot}`;
  * while still reporting how many slots it stands for, so a six-hour gap
  * reads as a decision rather than as silence.
  *
+ * Under `all`, at most `maxCatchUp` newest slots are returned in order (default
+ * 24), and any older missed slots are reported in `skipped` (OPS-452).
+ *
  * @returns {{ slots: string[], skipped: number }}
  */
-export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none" }) {
+export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none", maxCatchUp = DEFAULT_MAX_CATCH_UP }) {
   const current = slotFor(nowMs, cadenceSeconds);
   if (!lastSlot) return { slots: [current], skipped: 0 };
   if (Date.parse(lastSlot) >= Date.parse(current)) return { slots: [], skipped: 0 };
 
   const period = cadenceSeconds * 1000;
-  const missed = [];
-  for (let t = Date.parse(lastSlot) + period; t <= Date.parse(current); t += period) {
-    missed.push(new Date(t).toISOString());
+  const totalMissed = Math.round((Date.parse(current) - Date.parse(lastSlot)) / period);
+  if (totalMissed <= 0) return { slots: [], skipped: 0 };
+
+  if (catchUp === "all") {
+    const cap = Math.max(1, maxCatchUp ?? DEFAULT_MAX_CATCH_UP);
+    const count = Math.min(totalMissed, cap);
+    const skipped = totalMissed - count;
+    const slots = [];
+    const startT = Date.parse(current) - (count - 1) * period;
+    for (let t = startT; t <= Date.parse(current); t += period) {
+      slots.push(new Date(t).toISOString());
+    }
+    return { slots, skipped };
   }
-  if (catchUp === "all") return { slots: missed, skipped: 0 };
+
   // "none" and "last" both fire exactly one tick here; they differ only in
   // which slot it claims to be, and therefore in what a replay would mean.
-  const slots = [catchUp === "last" ? missed[missed.length - 1] : current];
-  return { slots, skipped: Math.max(0, missed.length - 1) };
+  const slots = [current];
+  return { slots, skipped: Math.max(0, totalMissed - 1) };
 }
 
 /** The newest slot already admitted for a loop, or null if it never fired. */
@@ -97,6 +112,7 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
         nowMs: now,
         cadenceSeconds,
         catchUp: schedule.catchUp,
+        maxCatchUp: schedule.maxCatchUp,
       });
       for (const slot of slots) {
         const outcome = admitEvent(

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -145,16 +145,30 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
   return { emitted, errors };
 }
 
-/** Is a run for this loop's agent still in flight? (§5 singleton) */
+/** Is a run for this loop's agent still in flight? (§5 singleton; OPS-436 excludes PROPOSED) */
 export function loopInFlight(db, agentRef) {
   const row = db
     .query(
       `SELECT COUNT(*) AS n FROM runs
-       WHERE state NOT IN ('COMPLETED','REFUSED','FAILED','TIMED_OUT','CANCELLED')
+       WHERE state NOT IN ('PROPOSED','COMPLETED','REFUSED','FAILED','TIMED_OUT','CANCELLED')
          AND json_extract(spec_json, '$.agent') = ?`,
     )
     .get(agentRef);
   return row.n > 0;
+}
+
+/** The newest slot that successfully completed for a loop, or null if never completed (OPS-436). */
+export function lastCompletedSlot(db, loop) {
+  const row = db
+    .query(
+      `SELECT e.event_id FROM runs r
+       JOIN proposals p ON p.run_id = r.run_id
+       JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+       WHERE e.source = ? AND (e.type = ? OR e.subject = ?) AND r.state = 'COMPLETED'
+       ORDER BY e.event_id DESC LIMIT 1`,
+    )
+    .get(SCHEDULE_SOURCE, `clock.tick.${loop}`, loop);
+  return row ? row.event_id.slice(`clock:${loop}:`.length) : null;
 }
 
 /**
@@ -171,7 +185,8 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
     } catch (err) {
       error = err.message;
     }
-    const lastSlot = lastAdmittedSlot(db, loop);
+    const lastSlot = lastAdmittedSlot(db, loop, { now });
+    const lastCompleted = lastCompletedSlot(db, loop);
     const nextDue =
       cadenceSeconds && lastSlot
         ? new Date(Date.parse(lastSlot) + cadenceSeconds * 1000).toISOString()
@@ -182,6 +197,7 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
       cadenceSeconds && lastSlot
         ? Math.floor((now - Date.parse(lastSlot)) / (cadenceSeconds * 1000))
         : null;
+    const neverCompleted = Boolean(schedule.enabled) && lastSlot !== null && lastCompleted === null;
     return {
       loop,
       every: schedule.every,
@@ -192,6 +208,8 @@ export function scheduleView(db, registry, { now = Date.now() } = {}) {
       singleton: schedule.singleton !== false,
       enabled: Boolean(schedule.enabled),
       lastSlot,
+      lastCompletedSlot: lastCompleted,
+      neverCompleted,
       nextDue,
       intervalsLate,
       // Enabled, has fired before, and more than two intervals have passed:

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -79,15 +79,17 @@ export function dueSlots({ lastSlot, nowMs, cadenceSeconds, catchUp = "none", ma
   return { slots, skipped: Math.max(0, totalMissed - 1) };
 }
 
-/** The newest slot already admitted for a loop, or null if it never fired. */
-export function lastAdmittedSlot(db, loop) {
+/** The newest slot already admitted for a loop at or before now, or null if it never fired (OPS-437). */
+export function lastAdmittedSlot(db, loop, { now = Date.now() } = {}) {
+  const nowMs = typeof now === "number" ? now : (typeof now === "string" ? Date.parse(now) : Date.now());
+  const maxEventId = tickEventId(loop, new Date(nowMs).toISOString());
   const row = db
     .query(
       `SELECT event_id FROM events
-       WHERE source = ? AND type = ?
+       WHERE source = ? AND type = ? AND event_id <= ?
        ORDER BY event_id DESC LIMIT 1`,
     )
-    .get(SCHEDULE_SOURCE, `clock.tick.${loop}`);
+    .get(SCHEDULE_SOURCE, `clock.tick.${loop}`, maxEventId);
   // eventId is clock:<loop>:<ISO slot>; ISO sorts lexicographically, so the
   // newest row is the newest slot without parsing every payload.
   return row ? row.event_id.slice(`clock:${loop}:`.length) : null;
@@ -108,7 +110,7 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
     try {
       const cadenceSeconds = parseCadence(schedule.every);
       const { slots, skipped } = dueSlots({
-        lastSlot: lastAdmittedSlot(db, loop),
+        lastSlot: lastAdmittedSlot(db, loop, { now }),
         nowMs: now,
         cadenceSeconds,
         catchUp: schedule.catchUp,

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -192,6 +192,39 @@ describe("emitDueTicks (§3)", () => {
     emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
     expect(lastAdmittedSlot(d, "reaper")).toBe("2026-08-13T22:00:00.000Z");
   });
+
+  test("a future-dated schedule row does not halt due-slot emission (OPS-437)", () => {
+    const d = db();
+    const registry = withLoop();
+    // Directly insert a rogue future-dated event row (e.g. year 9999)
+    d.query(
+      `INSERT INTO events
+         (source, event_id, type, subject, occurred_at, received_at,
+          correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'admitted', ?)`,
+    ).run(
+      "schedule",
+      "clock:reaper:9999-01-01T00:00:00.000Z",
+      "clock.tick.reaper",
+      "reaper",
+      "9999-01-01T00:00:00.000Z",
+      "2026-08-13T21:00:00.000Z",
+      null,
+      null,
+      JSON.stringify({}),
+      "sha256:fake",
+      "2026-08-13T21:00:00.000Z",
+    );
+
+    const now = at("2026-08-13T21:00:00Z");
+    // lastAdmittedSlot bounded by now ignores the future-dated row
+    expect(lastAdmittedSlot(d, "reaper", { now })).toBeNull();
+
+    // emitDueTicks fires normally for the current slot
+    const ticks = emitDueTicks(d, registry, { now });
+    expect(ticks.emitted).toHaveLength(1);
+    expect(ticks.emitted[0].slot).toBe("2026-08-13T21:00:00.000Z");
+  });
 });
 
 describe("planning a tick (§5, §6)", () => {

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -301,9 +301,40 @@ describe("planning a tick (§5, §6)", () => {
     planAdmittedEvents(d, registry, { policyVersion: PV });
     expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
   });
+
+  test("unapproved first proposal does not silence subsequent slots on watched loop (OPS-436)", async () => {
+    const d = db();
+    const registry = withLoop({ approval: "watched" });
+
+    // First slot arrives and is planned into an open proposal (PROPOSED run)
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+
+    const props1 = openProposals(d, {}).filter((p) => p.spec?.agent === "reaper@1");
+    expect(props1).toHaveLength(1);
+    expect(props1[0].status).toBe("open");
+
+    // Operator never approves it. Next slot arrives.
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+
+    // Both proposals exist and are open / proposed — NOT silenced into a NOOP!
+    const props2 = openProposals(d, {}).filter((p) => p.spec?.agent === "reaper@1");
+    expect(props2).toHaveLength(2);
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get().n).toBe(2);
+    expect(d.query(`SELECT COUNT(*) AS n FROM proposals WHERE decision = 'noop'`).get().n).toBe(0);
+  });
 });
 
 describe("scheduleView (§9)", () => {
+  const adapters = { command: fake, claude: fake };
+  const workerOpts = () => ({
+    workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-ws-")),
+    artifactStore: mkdtempSync(path.join(os.tmpdir(), "evrt-sched-store-")),
+    owner: "w",
+    policyVersion: PV,
+  });
+
   test("reports cadence, last fire, next due — and a stopped clock", () => {
     const d = db();
     const registry = withLoop();
@@ -318,6 +349,36 @@ describe("scheduleView (§9)", () => {
     const later = scheduleView(d, registry, { now: at("2026-08-14T02:00:00Z") })[0];
     expect(later.stopped).toBe(true);
     expect(later.intervalsLate).toBe(5);
+  });
+
+  test("distinguishes ticking from running and flags neverCompleted loops (OPS-436)", async () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+
+    // Before ticking: no slots, not neverCompleted
+    expect(scheduleView(d, registry, { now: at("2026-08-13T21:00:00Z") })[0]).toMatchObject({
+      lastSlot: null,
+      lastCompletedSlot: null,
+      neverCompleted: false,
+    });
+
+    // Ticked and planned: lastSlot exists, but neverCompleted is true because run hasn't completed
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV });
+
+    const ticking = scheduleView(d, registry, { now: at("2026-08-13T21:10:00Z") })[0];
+    expect(ticking.lastSlot).toBe("2026-08-13T21:00:00.000Z");
+    expect(ticking.lastCompletedSlot).toBeNull();
+    expect(ticking.neverCompleted).toBe(true);
+
+    // Run completes
+    await runOnce(d, registry, adapters, workerOpts());
+
+    const running = scheduleView(d, registry, { now: at("2026-08-13T21:20:00Z") })[0];
+    expect(running.lastSlot).toBe("2026-08-13T21:00:00.000Z");
+    expect(running.lastCompletedSlot).toBe("2026-08-13T21:00:00.000Z");
+    expect(running.neverCompleted).toBe(false);
   });
 
   test("a disabled loop is never reported stopped", () => {

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -112,6 +112,38 @@ describe("dueSlots — catch-up policy (§4)", () => {
     ]);
     expect(outcome.skipped).toBe(0);
   });
+
+  test("all: large downtime gap caps at maxCatchUp (default 24) and reports skipped older slots (OPS-452)", () => {
+    // 30 days downtime on a 60s loop = 30 * 24 * 60 = 43,200 intervals
+    const sixtySec = 60;
+    const monthAgo = at("2026-07-15T04:00:00Z");
+    const outcome = dueSlots({
+      lastSlot: new Date(monthAgo).toISOString(),
+      nowMs: now, // 2026-08-14T04:30:00Z -> slot is 2026-08-14T04:30:00.000Z
+      cadenceSeconds: sixtySec,
+      catchUp: "all",
+    });
+    expect(outcome.slots).toHaveLength(24);
+    // last slot is the current slot
+    expect(outcome.slots[outcome.slots.length - 1]).toBe("2026-08-14T04:30:00.000Z");
+    // slots are strictly in chronological order
+    for (let i = 1; i < outcome.slots.length; i++) {
+      expect(Date.parse(outcome.slots[i])).toBeGreaterThan(Date.parse(outcome.slots[i - 1]));
+    }
+    // Total intervals: (nowMs slot - monthAgo) / 60s = 43230 intervals -> skipped = 43230 - 24 = 43206
+    expect(outcome.skipped).toBe(43206);
+
+    // Custom maxCatchUp configuration
+    const custom = dueSlots({
+      lastSlot: new Date(monthAgo).toISOString(),
+      nowMs: now,
+      cadenceSeconds: sixtySec,
+      catchUp: "all",
+      maxCatchUp: 5,
+    });
+    expect(custom.slots).toHaveLength(5);
+    expect(custom.skipped).toBe(43230 - 5);
+  });
 });
 
 describe("emitDueTicks (§3)", () => {

--- a/event-runtime/lib/tick.test.mjs
+++ b/event-runtime/lib/tick.test.mjs
@@ -61,6 +61,45 @@ describe("tick (OPS-412)", () => {
     expect(logs.some((l) => l.startsWith("artifacts: pruned 1 orphan"))).toBe(true);
   });
 
+  test("a thrown exception in the GC subsystem still advances result.lastPrune to now (OPS-468)", async () => {
+    const { db, storeRoot } = harness();
+    const now = Date.now();
+    const initialPrune = now - PRUNE_INTERVAL_MS - 1;
+    const logs = [];
+
+    // Create a file at storeRoot/invalid so readdirSync fails with ENOTDIR or provide invalid storeRoot
+    const invalidStoreRoot = path.join(storeRoot, "not_a_directory");
+    writeFileSync(invalidStoreRoot, "not a directory");
+
+    const result = await tick({
+      db,
+      registry,
+      now,
+      lastPrune: initialPrune,
+      storeRoot: invalidStoreRoot,
+      policyVersion: "git:test",
+      log: (line) => logs.push(line),
+    });
+
+    expect(result.lastPrune).toBe(now);
+    expect(logs.some((l) => l.startsWith("tick GC:"))).toBe(true);
+
+    // On next 1s tick, GC interval is not elapsed, so pruneArtifacts is not retried
+    const nextLogs = [];
+    const nextTickResult = await tick({
+      db,
+      registry,
+      now: now + 1000,
+      lastPrune: result.lastPrune,
+      storeRoot: invalidStoreRoot,
+      policyVersion: "git:test",
+      log: (line) => nextLogs.push(line),
+    });
+
+    expect(nextLogs.some((l) => l.startsWith("tick GC:"))).toBe(false);
+    expect(nextTickResult.lastPrune).toBe(now);
+  });
+
   for (const failing of TICK_SUBSYSTEMS) {
     test(`a throw in ${failing} does not prevent the others from running`, async () => {
       const { db } = harness();


### PR DESCRIPTION
Fixes OPS-452
Fixes OPS-437
Fixes OPS-436
Fixes OPS-468

## Changes
- **OPS-452 (`event-runtime/lib/schedules.mjs`)**: Enforced `maxCatchUp` cap (default 24) on `dueSlots({ catchUp: "all" })` so large downtime gaps return at most the newest slots in order and record remaining missed intervals in `skipped`.
- **OPS-437 (`event-runtime/lib/schedules.mjs`, `event-runtime/lib/intake.mjs`)**: Bounded `lastAdmittedSlot` by `now` to prevent future-dated schedule rows from wedging scheduler loops, and refused direct admission of clock tick events whose slot is in the future relative to `now`.
- **OPS-436 (`event-runtime/lib/schedules.mjs`)**: Excluded `PROPOSED` state from `loopInFlight` so unapproved proposals on watched loops do not permanently silence subsequent tick proposals, added `lastCompletedSlot` query, and introduced `neverCompleted` status flag in `scheduleView`.
- **OPS-468 (`event-runtime/cli.mjs`)**: Updated GC step using `try ... finally` to advance `nextPrune` to `now` even when artifact GC throws, preventing 1-second tick retry storms on GC failures.

## Verification
- `bun test event-runtime/lib/schedules.test.mjs event-runtime/lib/intake.test.mjs event-runtime/lib/tick.test.mjs event-runtime/cli.test.mjs` (50 passed, 0 failed)
- Full test suite: `bun test` (587 passed across 59 files)
- Floor sync check: `bun build/emit.mjs --check` (clean)