### PR TITLE
fix(event-runtime): runtime execution lifecycle, cancel, recovery, and timeout containment

### DIFF
--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -44,10 +44,24 @@ export function resolveTemplate(template, input) {
   );
 }
 
+function killProcessGroup(child, signal = "SIGTERM") {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
 /**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
-export async function execute({ spec, def, workspaceDir, timeoutMs }) {
+export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal, signal }) {
   if (!Array.isArray(def.command) || def.command.length === 0) {
     throw new Error(`definition ${def.ref} has no command template — not a command-adapter agent`);
   }
@@ -58,6 +72,7 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
       cwd: workspaceDir,
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     let output = "";
@@ -76,23 +91,39 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
     child.stderr.on("data", collect);
 
     let timedOut = false;
-    let killTimer;
+    let killTimer = null;
     const termTimer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS);
-      killTimer.unref?.();
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), KILL_GRACE_MS);
     }, timeoutMs);
+
+    const onAbort = () => {
+      killProcessGroup(child, "SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), KILL_GRACE_MS);
+      }
+    };
+    const abortSig = abortSignal ?? signal;
+    if (abortSig) {
+      if (abortSig.aborted) {
+        onAbort();
+      } else {
+        abortSig.addEventListener("abort", onAbort, { once: true });
+      }
+    }
 
     child.on("error", (err) => {
       clearTimeout(termTimer);
-      clearTimeout(killTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       reject(err);
     });
 
     child.on("close", (exitCode) => {
       clearTimeout(termTimer);
-      clearTimeout(killTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       if (exitCode === 0 && !timedOut) {
         const write = () => {
           const captured = def.captureStdout

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -104,6 +104,67 @@ describe("execute", () => {
     expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
     expect(result.artifact.command.join(" ")).not.toContain("/tmp/pwn");
   });
+
+  test("timeout kills the whole process group, leaving no orphaned grandchildren (OPS-411)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    // sh spawns background sleep and writes its pid, then waits
+    const script = `sh -c 'sleep 30 & echo $! > "${pidFile}"; wait'`;
+    const outcome = await execute({
+      spec: spec({}),
+      def: def(["sh", "-c", script]),
+      workspaceDir,
+      timeoutMs: 200,
+    });
+    expect(outcome.timedOut).toBe(true);
+
+    // Give the kernel a brief moment to finish reaping signals
+    await new Promise((r) => setTimeout(r, 100));
+
+    if (existsSync(pidFile)) {
+      const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+      let alive = true;
+      try {
+        process.kill(grandchildPid, 0);
+      } catch {
+        alive = false;
+      }
+      expect(alive).toBe(false);
+    }
+  }, 10_000);
+
+  test("abortSignal terminates process group immediately (OPS-411)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild_abort.pid");
+    const script = `sh -c 'sleep 30 & echo $! > "${pidFile}"; wait'`;
+    const ac = new AbortController();
+
+    const runPromise = execute({
+      spec: spec({}),
+      def: def(["sh", "-c", script]),
+      workspaceDir,
+      timeoutMs: 10_000,
+      abortSignal: ac.signal,
+    });
+
+    // Abort after 200ms
+    setTimeout(() => ac.abort(), 200);
+
+    const outcome = await runPromise;
+    expect(outcome.timedOut).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 100));
+    if (existsSync(pidFile)) {
+      const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+      let alive = true;
+      try {
+        process.kill(grandchildPid, 0);
+      } catch {
+        alive = false;
+      }
+      expect(alive).toBe(false);
+    }
+  }, 10_000);
 });
 
 /**

--- a/event-runtime/lib/reaper.mjs
+++ b/event-runtime/lib/reaper.mjs
@@ -1,0 +1,8 @@
+/**
+ * Lease reaper for the event runtime (docs/event-runtime.md §8; OPS-416).
+ *
+ * Sweeps LEASED, RUNNING, and VERIFYING attempts whose lease has expired.
+ * Recovers stranded attempts by re-queuing (if attempts < maxAttempts)
+ * or dead-lettering to FAILED (if maxAttempts exhausted).
+ */
+export { reapExpiredLeases } from "./worker.mjs";

--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import * as fake from "./adapters/fake.mjs";
+import { canonicalJson, hashJson } from "./canonical.mjs";
+import { openDb } from "./db.mjs";
+import { createRun, runState, transition } from "./lifecycle.mjs";
+import { reapExpiredLeases } from "./reaper.mjs";
+import { cancelRun, claimNext, forceFailRun, retryRun } from "./worker.mjs";
+
+const T0 = Date.parse("2026-08-12T10:00:00Z");
+
+let seq = 0;
+function makeSpec(overrides = {}) {
+  const runId = overrides.runId ?? `run_reaper_${++seq}_${Math.random().toString(36).slice(2)}`;
+  const input = overrides.input ?? { repos: ["ok"] };
+  return {
+    schemaVersion: "factory.run-spec/v1",
+    runId,
+    agent: "factory-status-report@1",
+    input,
+    inputHash: hashJson(input),
+    workspace: { type: "ephemeral", retainOnFailure: false },
+    adapter: "fake",
+    promptVersion: "git:test",
+    policyVersion: "git:test",
+    outputContract: "factory.status-report/v1",
+    capabilities: ["linear:read"],
+    timeoutSeconds: 5,
+    maxAttempts: 1,
+    idempotencyKey: `idem-${runId}`,
+    ...overrides,
+  };
+}
+
+function setupVerifyingRun(db, spec, { now = T0, expired = false } = {}) {
+  createRun(db, {
+    runId: spec.runId,
+    idempotencyKey: spec.idempotencyKey,
+    spec,
+    specJson: canonicalJson(spec),
+    specHash: hashJson(spec),
+    actor: "test",
+    policyVersion: "test",
+    now,
+  });
+  transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now });
+  transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now });
+  transition(db, { runId: spec.runId, to: "LEASED", actor: "test", attempt: 1, now });
+  transition(db, { runId: spec.runId, to: "RUNNING", actor: "test", attempt: 1, now });
+  transition(db, { runId: spec.runId, to: "VERIFYING", actor: "test", attempt: 1, now });
+
+  const leaseExpiresAt = new Date(
+    expired ? now - 1000 : now + (spec.timeoutSeconds + 120) * 1000,
+  ).toISOString();
+
+  db.query(`UPDATE runs SET attempts = 1 WHERE run_id = ?`).run(spec.runId);
+  db.query(
+    `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, lease_expires_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(spec.runId, 1, 1, "worker-1", leaseExpiresAt);
+}
+
+describe("reaper (OPS-416)", () => {
+  test("reaps stranded VERIFYING run and re-queues when attempts remain", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec({ maxAttempts: 2 });
+    setupVerifyingRun(db, spec, { now: T0, expired: true });
+
+    expect(runState(db, spec.runId)).toBe("VERIFYING");
+
+    const reaped = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
+    expect(reaped).toBe(1);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+
+    const events = db
+      .query(`SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
+      .all(spec.runId);
+    const lastTwo = events.slice(-2);
+    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "lease_expired" });
+    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "retry" });
+  });
+
+  test("reaps stranded VERIFYING run and dead-letters to FAILED when maxAttempts reached", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec({ maxAttempts: 1 });
+    setupVerifyingRun(db, spec, { now: T0, expired: true });
+
+    expect(runState(db, spec.runId)).toBe("VERIFYING");
+
+    const reaped = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
+    expect(reaped).toBe(1);
+    expect(runState(db, spec.runId)).toBe("FAILED");
+
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("FAILED");
+    expect(attempt.reason_code).toBe("lease_expired");
+  });
+
+  test("cancelRun from VERIFYING transitions cleanly to FAILED without 409", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec();
+    setupVerifyingRun(db, spec, { now: T0, expired: false });
+
+    expect(runState(db, spec.runId)).toBe("VERIFYING");
+    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("FAILED");
+    expect(attempt.reason_code).toBe("cancelled");
+  });
+
+  test("forceFailRun on VERIFYING transitions to FAILED with audited journal entry", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec();
+    setupVerifyingRun(db, spec, { now: T0, expired: false });
+
+    forceFailRun(db, spec.runId, { actor: "operator", reason: "stuck_in_verification", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+
+    const events = db
+      .query(`SELECT from_state, to_state, reason, actor FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`)
+      .get(spec.runId);
+    expect(events.from_state).toBe("VERIFYING");
+    expect(events.to_state).toBe("FAILED");
+    expect(events.reason).toBe("stuck_in_verification");
+    expect(events.actor).toBe("operator");
+  });
+
+  test("retryRun from VERIFYING moves to FAILED then QUEUED", () => {
+    const db = openDb(":memory:");
+    const spec = makeSpec({ maxAttempts: 2 });
+    setupVerifyingRun(db, spec, { now: T0, expired: false });
+
+    retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+
+    const events = db
+      .query(`SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
+      .all(spec.runId);
+    const lastTwo = events.slice(-2);
+    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "operator_retry_verifying" });
+    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "operator_retry" });
+  });
+});

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -316,29 +316,54 @@ export async function executeClaimed(db, registry, adapters, claim, {
       if (workspaceDir) destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
       return { cancelled: true };
     }
-    throw err;
+    const reasonCode = "adapter_error";
+    const journalReason = `adapter_error: ${err?.message ?? String(err)}`;
+    try {
+      failTerminal("FAILED", journalReason, reasonCode, { requeue: true });
+    } catch {
+      // if failTerminal could not transition, continue
+    }
+    if (workspaceDir) {
+      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+    }
+    return { runId, attempt, terminalState: "FAILED", reasonCode, error: err?.message };
   }
 }
 
 /**
  * Re-queue LEASED/RUNNING runs whose current attempt's lease expired. The
  * stale attempt keeps its (now lower) fencing token, so a late publish from
- * it is fenced out.
+ * it is fenced out. Respects maxAttempts and dead-letters beyond it.
  */
 export function reapExpiredLeases(db, { now = Date.now(), policyVersion = "unknown" } = {}) {
   return tx(db, () => {
     const rows = db
       .query(
-        `SELECT r.run_id, r.attempts FROM runs r
+        `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
          JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
          WHERE r.state IN ('LEASED', 'RUNNING') AND a.lease_expires_at < ?`,
       )
       .all(iso(now));
     for (const row of rows) {
-      transition(db, {
-        runId: row.run_id, to: "QUEUED",
-        actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now,
-      });
+      const spec = JSON.parse(row.spec_json);
+      if (row.attempts < spec.maxAttempts) {
+        transition(db, {
+          runId: row.run_id, to: "QUEUED",
+          actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now,
+        });
+      } else {
+        if (row.state === "LEASED") {
+          transition(db, {
+            runId: row.run_id, to: "RUNNING",
+            actor: "reaper", reason: "lease_expired_attempts_exhausted", attempt: row.attempts, policyVersion, now,
+          });
+        }
+        transition(db, {
+          runId: row.run_id, to: "FAILED",
+          actor: "reaper", reason: "lease_expired_attempts_exhausted", attempt: row.attempts, policyVersion, now,
+        });
+        finishAttempt(db, row.run_id, row.attempts, "FAILED", "lease_expired", now);
+      }
     }
     return rows.length;
   });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -331,8 +331,8 @@ export async function executeClaimed(db, registry, adapters, claim, {
 }
 
 /**
- * Re-queue LEASED/RUNNING runs whose current attempt's lease expired. The
- * stale attempt keeps its (now lower) fencing token, so a late publish from
+ * Re-queue LEASED/RUNNING/VERIFYING runs whose current attempt's lease expired.
+ * The stale attempt keeps its (now lower) fencing token, so a late publish from
  * it is fenced out. Respects maxAttempts and dead-letters beyond it.
  */
 export function reapExpiredLeases(db, { now = Date.now(), policyVersion = "unknown" } = {}) {
@@ -341,16 +341,27 @@ export function reapExpiredLeases(db, { now = Date.now(), policyVersion = "unkno
       .query(
         `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
          JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-         WHERE r.state IN ('LEASED', 'RUNNING') AND a.lease_expires_at < ?`,
+         WHERE r.state IN ('LEASED', 'RUNNING', 'VERIFYING') AND a.lease_expires_at < ?`,
       )
       .all(iso(now));
     for (const row of rows) {
       const spec = JSON.parse(row.spec_json);
       if (row.attempts < spec.maxAttempts) {
-        transition(db, {
-          runId: row.run_id, to: "QUEUED",
-          actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now,
-        });
+        if (row.state === "VERIFYING") {
+          transition(db, {
+            runId: row.run_id, to: "FAILED",
+            actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now,
+          });
+          transition(db, {
+            runId: row.run_id, to: "QUEUED",
+            actor: "reaper", reason: "retry", attempt: row.attempts, policyVersion, now,
+          });
+        } else {
+          transition(db, {
+            runId: row.run_id, to: "QUEUED",
+            actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now,
+          });
+        }
       } else {
         if (row.state === "LEASED") {
           transition(db, {
@@ -377,28 +388,73 @@ export async function runOnce(db, registry, adapters, opts = {}) {
 }
 
 /**
- * Operator cancel (§13): legal from any state before VERIFYING; a VERIFYING
- * or terminal run throws IllegalTransition to the caller. A still-open
- * proposal for the run is closed in the same transaction (reason
- * `run_cancelled`); none, or more than one, is left untouched.
+ * Operator cancel (§13): cancels runs in pre-terminal states.
+ * For VERIFYING, transitions to FAILED with reason operator_cancel.
+ * A still-open proposal for the run is closed in the same transaction.
  */
 export function cancelRun(db, runId, { actor, reason = "operator_cancel", now = Date.now(), policyVersion } = {}) {
   return tx(db, () => {
-    const result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now });
+    const run = db.query(`SELECT state, attempts FROM runs WHERE run_id = ?`).get(runId);
+    if (!run) throw new Error(`unknown run ${runId}`);
+    let result;
+    if (run.state === "VERIFYING") {
+      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now });
+      finishAttempt(db, runId, run.attempts, "FAILED", "cancelled", now);
+    } else {
+      result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now });
+      if (run.state === "RUNNING" || run.state === "LEASED") {
+        finishAttempt(db, runId, run.attempts, "CANCELLED", "cancelled", now);
+      }
+    }
     closeOpenProposalForRun(db, runId, { actor, now });
     return result;
   });
 }
 
 /**
- * Operator retry (§13): FAILED → QUEUED. Retrying past maxAttempts requires
+ * Force-fail a stranded or non-terminal run with a journaled transition.
+ */
+export function forceFailRun(db, runId, { actor = "operator", reason = "operator_force_fail", now = Date.now(), policyVersion = "unknown" } = {}) {
+  return tx(db, () => {
+    const run = db.query(`SELECT state, attempts FROM runs WHERE run_id = ?`).get(runId);
+    if (!run) throw new Error(`unknown run ${runId}`);
+    let result;
+    if (run.state === "VERIFYING" || run.state === "RUNNING") {
+      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now });
+      finishAttempt(db, runId, run.attempts, "FAILED", reason, now);
+    } else if (run.state === "LEASED") {
+      transition(db, { runId, to: "RUNNING", actor, reason: "force_fail_start", attempt: run.attempts, policyVersion, now });
+      result = transition(db, { runId, to: "FAILED", actor, reason, policyVersion, now });
+      finishAttempt(db, runId, run.attempts, "FAILED", reason, now);
+    } else if (run.state === "QUEUED" || run.state === "APPROVED" || run.state === "PROPOSED") {
+      result = transition(db, { runId, to: "CANCELLED", actor, reason, policyVersion, now });
+    } else {
+      throw new Error(`cannot force-fail run in terminal state ${run.state}`);
+    }
+    closeOpenProposalForRun(db, runId, { actor, now });
+    return result;
+  });
+}
+
+/**
+ * Operator retry (§13): FAILED → QUEUED, or recovery from VERIFYING. Retrying past maxAttempts requires
  * the explicit force override, which is recorded in the journal reason.
  */
 export function retryRun(db, runId, { actor, force = false, now = Date.now(), policyVersion } = {}) {
-  const row = db.query(`SELECT spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
+  const row = db.query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
   if (!row) throw new Error(`unknown run ${runId}`);
   const spec = JSON.parse(row.spec_json);
   if (!force && row.attempts >= spec.maxAttempts) throw new Error("attempts_exhausted");
+  if (row.state === "VERIFYING") {
+    return tx(db, () => {
+      transition(db, { runId, to: "FAILED", actor, reason: "operator_retry_verifying", policyVersion, now });
+      finishAttempt(db, runId, row.attempts, "FAILED", "operator_retry", now);
+      return transition(db, {
+        runId, to: "QUEUED", actor,
+        reason: force ? "operator_retry_forced" : "operator_retry", policyVersion, now,
+      });
+    });
+  }
   return transition(db, {
     runId, to: "QUEUED", actor,
     reason: force ? "operator_retry_forced" : "operator_retry", policyVersion, now,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -111,6 +111,9 @@ export function claimNext(db, { owner, now = Date.now(), policyVersion = "unknow
   });
 }
 
+/** Active executions by runId for cooperative cancellation. */
+const ACTIVE_EXECUTIONS = new Map();
+
 /**
  * Execute one claimed attempt to a terminal state. Returns a summary
  * { runId, attempt, terminalState, reasonCode, receipt? }, or
@@ -128,6 +131,25 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let workspaceDir = null;
   let checkoutPath = null;
   const repoName = spec.input?.repoPin?.repo ?? spec.input?.repo ?? null;
+
+  const abortController = new AbortController();
+  ACTIVE_EXECUTIONS.set(runId, {
+    abort: (reason) => abortController.abort(reason),
+    controller: abortController,
+    runId,
+    attempt,
+  });
+  let cancelPoll = setInterval(() => {
+    try {
+      const state = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
+      if (state === "CANCELLED" && !abortController.signal.aborted) {
+        abortController.abort("db_cancelled");
+      }
+    } catch {
+      // ignore
+    }
+  }, 250);
+  cancelPoll?.unref?.();
 
   /** Terminal failure-shaped write: transition + attempts row, one tx. */
   const failTerminal = (to, journalReason, reasonCode, { requeue = false } = {}) =>
@@ -187,9 +209,28 @@ export async function executeClaimed(db, registry, adapters, claim, {
       }
     };
 
-    const { exitCode, timedOut } = await adapter.execute({
-      spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env: {}, onTrace,
-    });
+    let outcome;
+    try {
+      outcome = await adapter.execute({
+        spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env: {}, onTrace,
+        abortSignal: abortController.signal, signal: abortController.signal,
+      });
+    } finally {
+      clearInterval(cancelPoll);
+      ACTIVE_EXECUTIONS.delete(runId);
+    }
+
+    if (abortController.signal.aborted) {
+      if (workspaceDir) destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      try {
+        finishAttempt(db, runId, attempt, "CANCELLED", "cancelled", now);
+      } catch {
+        // ignore
+      }
+      return { cancelled: true };
+    }
+
+    const { exitCode, timedOut } = outcome ?? {};
 
     if (timedOut) {
       failTerminal("TIMED_OUT", "timeout", "timeout");
@@ -407,6 +448,10 @@ export function cancelRun(db, runId, { actor, reason = "operator_cancel", now = 
       }
     }
     closeOpenProposalForRun(db, runId, { actor, now });
+    const active = ACTIVE_EXECUTIONS.get(runId);
+    if (active) {
+      active.abort(reason);
+    }
     return result;
   });
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -404,6 +404,44 @@ describe("worker", () => {
     expect(claimNext(db, opts())).toBeNull();
   });
 
+  test("cancelRun on a RUNNING attempt aborts adapter immediately and records attempt (OPS-417)", async () => {
+    const db = openDb(":memory:");
+    let aborted = false;
+    const longRunningAdapter = {
+      execute: ({ abortSignal }) => {
+        return new Promise((resolve) => {
+          const timer = setTimeout(() => resolve({ exitCode: 0, timedOut: false }), 5000);
+          abortSignal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            aborted = true;
+            resolve({ exitCode: null, timedOut: false });
+          });
+        });
+      },
+    };
+    const customAdapters = { long: longRunningAdapter };
+    const spec = queueRun(db, makeSpec({ adapter: "long", timeoutSeconds: 30 }));
+    const o = opts();
+
+    const claim = claimNext(db, o);
+    const execPromise = executeClaimed(db, registry, customAdapters, claim, o);
+
+    // Cancel while RUNNING
+    expect(runState(db, spec.runId)).toBe("RUNNING");
+    cancelRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+
+    const summary = await execPromise;
+    expect(summary.cancelled).toBe(true);
+    expect(aborted).toBe(true);
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("CANCELLED");
+    expect(attempt.reason_code).toBe("cancelled");
+    expect(attempt.finished_at).toBeTruthy();
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+  });
+
   test("runOnce returns null when nothing is QUEUED", async () => {
     const db = openDb(":memory:");
     expect(await runOnce(db, registry, adapters, opts())).toBeNull();

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -195,7 +195,7 @@ describe("worker", () => {
 
   test("fencing: a stale claim can never publish over a newer attempt", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec());
+    const spec = queueRun(db, makeSpec({ maxAttempts: 2 }));
     linkEvent(db, spec.runId);
     const o = opts();
 
@@ -345,8 +345,68 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("QUEUED");
   });
 
+  test("adapter exception: FAILED/adapter_error, workspace destroyed, not wedged in RUNNING (OPS-405)", async () => {
+    const db = openDb(":memory:");
+    const throwingAdapter = {
+      execute: async () => {
+        throw new Error("simulated adapter explosion");
+      },
+    };
+    const throwingAdapters = { throwing: throwingAdapter };
+    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 1, workspace: { type: "ephemeral", retainOnFailure: false } }));
+    const o = opts();
+
+    const summary = await runOnce(db, registry, throwingAdapters, o);
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("adapter_error");
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("FAILED");
+    expect(attempt.reason_code).toBe("adapter_error");
+    expect(attempt.finished_at).toBeTruthy();
+  });
+
+  test("adapter exception with retries: auto re-QUEUED, workspace cleaned (OPS-405)", async () => {
+    const db = openDb(":memory:");
+    const throwingAdapter = {
+      execute: async () => {
+        throw new Error("simulated adapter explosion");
+      },
+    };
+    const throwingAdapters = { throwing: throwingAdapter };
+    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 2, workspace: { type: "ephemeral", retainOnFailure: false } }));
+    const o = opts();
+
+    const summary = await runOnce(db, registry, throwingAdapters, o);
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("adapter_error");
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+  });
+
+  test("reapExpiredLeases dead-letters when maxAttempts is reached (OPS-405)", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ maxAttempts: 1 }));
+    const o = opts();
+    const claim = claimNext(db, o);
+    expect(runState(db, spec.runId)).toBe("LEASED");
+
+    const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    expect(runState(db, spec.runId)).toBe("FAILED");
+
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("FAILED");
+    expect(attempt.reason_code).toBe("lease_expired");
+    // Does not re-queue again
+    expect(reapExpiredLeases(db, { now: afterExpiry + 1000, policyVersion: "test" })).toBe(0);
+    expect(claimNext(db, opts())).toBeNull();
+  });
+
   test("runOnce returns null when nothing is QUEUED", async () => {
     const db = openDb(":memory:");
     expect(await runOnce(db, registry, adapters, opts())).toBeNull();
   });
 });
+


### PR DESCRIPTION
Fixes OPS-417
Fixes OPS-416
Fixes OPS-411
Fixes OPS-405

## Changes
- **OPS-405**: Wrap adapter execution in `executeClaimed` to transition thrown exceptions to `FAILED` with reason `adapter_error` and clean workspace; ensure `reapExpiredLeases` respects `maxAttempts` and dead-letters exhausted runs.
- **OPS-411**: Spawn child processes in `command.mjs` with `detached: true`, signal the process group (`process.kill(-child.pid)`) on timeout and abort, and keep the SIGKILL escalation timer referenced.
- **OPS-416**: Include `VERIFYING` state in `reapExpiredLeases` lease sweep, enable `cancelRun` and `retryRun` recovery from `VERIFYING`, provide `forceFailRun`, and export `reaper.mjs`.
- **OPS-417**: Maintain `ACTIVE_EXECUTIONS` in worker, wire `abortSignal` to `adapter.execute`, abort active execution and record terminal attempt row on `cancelRun`.

## Verification
- `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/reaper.test.mjs event-runtime/lib/adapters/command.test.mjs` (41 pass, 0 fail)
- `bun test` (592 pass, 0 fail)
- `bun build/emit.mjs --check` (ok — 90 generated files match shared/)