### PR TITLE
fix(event-runtime): runtime security confinement for artifact store, ssh arguments, loopback api, and claude adapter

### DIFF
--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -1,5 +1,5 @@
 /**
- * Closed action-list executor (docs/event-runtime.md §11, §14; OPS-208).
+ * Closed action-list executor (docs/event-runtime.md §11, §14; OPS-208, OPS-410).
  *
  * Slice 2's remediation node: executes an *approved list of action IDs*, each
  * resolved to a fixed remote command from the definition's action registry —
@@ -25,8 +25,48 @@ import { FACTORY_ROOT } from "../config.mjs";
 
 const OUTPUT_TAIL_CHARS = 2_000;
 
+/**
+ * Validate that every placeholder in a remote template or probeRemote corresponds
+ * to an input-schema property constrained by an enum or an anchored pattern (OPS-410).
+ */
+export function validateRemotePlaceholders(def, inputSchema) {
+  const templates = [];
+  if (typeof def?.probeRemote === "string") templates.push(def.probeRemote);
+  if (Array.isArray(def?.probeRemote)) templates.push(...def.probeRemote);
+  if (def?.actionRegistry && typeof def.actionRegistry === "object") {
+    for (const action of Object.values(def.actionRegistry)) {
+      if (typeof action?.remote === "string") templates.push(action.remote);
+      if (Array.isArray(action?.remote)) templates.push(...action.remote);
+    }
+  }
+  const properties = inputSchema?.properties ?? {};
+  for (const tpl of templates) {
+    const matches = typeof tpl === "string" ? tpl.matchAll(/\{([A-Za-z0-9_]+)\}/g) : [];
+    for (const match of matches) {
+      const field = match[1];
+      const prop = properties[field];
+      if (!prop) {
+        throw new Error(`unconstrained placeholder "{${field}}" in remote template: field is missing from input schema`);
+      }
+      const hasEnum = Array.isArray(prop.enum) && prop.enum.length > 0;
+      const hasPattern = typeof prop.pattern === "string" && prop.pattern.startsWith("^") && prop.pattern.endsWith("$");
+      if (!hasEnum && !hasPattern) {
+        throw new Error(
+          `unconstrained placeholder "{${field}}" in remote template: input schema property must declare an enum or anchored pattern`,
+        );
+      }
+    }
+  }
+}
+
 /** {mount}-style substitution in a remote command string; fields are schema-validated at plan time. */
-function substituteRemote(remote, input) {
+export function substituteRemote(remote, input) {
+  if (Array.isArray(remote)) {
+    return remote.map((item) => substituteRemote(item, input));
+  }
+  if (typeof remote !== "string") {
+    throw new Error(`remote template must be a string or array of strings, got ${typeof remote}`);
+  }
   return remote.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
     const value = input?.[field];
     if (value === undefined || value === null || !["string", "number"].includes(typeof value)) {
@@ -36,19 +76,36 @@ function substituteRemote(remote, input) {
   });
 }
 
-function buildArgv(exec, target, remote) {
-  return exec.map((element) => element.replace("{target}", target).replace("{remote}", remote));
+/**
+ * Build argv array safely using function replacers to prevent $ patterns from being interpreted (OPS-410).
+ */
+export function buildArgv(exec, target, remote) {
+  const targetStr = String(target);
+  const result = [];
+  for (const element of exec) {
+    if (element === "{remote}" && Array.isArray(remote)) {
+      result.push(...remote);
+    } else {
+      const remoteStr = Array.isArray(remote) ? remote.join(" ") : String(remote);
+      result.push(
+        element
+          .replace(/\{target\}/g, () => targetStr)
+          .replace(/\{remote\}/g, () => remoteStr),
+      );
+    }
+  }
+  return result;
 }
 
 /** Last integer in probe output — `df --output=used -B1 <mount> | tail -1`. */
-function probeBytes(raw) {
+export function probeBytes(raw) {
   const match = String(raw ?? "").trim().match(/(\d+)\s*$/);
   if (!match) throw new Error(`probe output has no byte count: "${String(raw).slice(0, 120)}"`);
   return Number(match[1]);
 }
 
 /** Substitute {field} placeholders across an argv template (item-list mode). */
-function substituteArgv(argv, context) {
+export function substituteArgv(argv, context) {
   return argv.map((element) =>
     element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
       const value = context?.[field];
@@ -154,6 +211,15 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
   const target = def.hosts?.[input.host];
   if (!target) return fail(`host "${input.host}" is not in the definition's host allowlist`);
 
+  const schema = def.inputSchema ?? spec.inputSchema;
+  if (schema) {
+    try {
+      validateRemotePlaceholders(def, schema);
+    } catch (err) {
+      return fail(err.message);
+    }
+  }
+
   // Resolve EVERYTHING before executing ANYTHING — an unregistered action ID
   // in the approved plan is a refusal, not a partial execution (OPS-208 AC).
   let probeRemote;
@@ -174,13 +240,15 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
   const outputs = {};
   const run = (label, remote) => {
     const budget = Math.max(1000, deadline - Date.now());
-    const proc = spawnSync(buildArgv(exec, target, remote)[0], buildArgv(exec, target, remote).slice(1), {
+    const argv = buildArgv(exec, target, remote);
+    const proc = spawnSync(argv[0], argv.slice(1), {
       encoding: "utf8",
       timeout: budget,
     });
     const raw = `${proc.stdout ?? ""}${proc.stderr ?? ""}`;
     outputs[label] = raw.slice(-OUTPUT_TAIL_CHARS);
-    appendFileSync(log, `$ ${label}: ${remote}\n${outputs[label]}\n`, "utf8");
+    const cmdStr = Array.isArray(remote) ? remote.join(" ") : remote;
+    appendFileSync(log, `$ ${label}: ${cmdStr}\n${outputs[label]}\n`, "utf8");
     if (proc.error?.code === "ETIMEDOUT") throw Object.assign(new Error(`${label} timed out`), { timedOut: true });
     if (proc.status !== 0) throw new Error(`${label} exited ${proc.status}`);
     return proc.stdout ?? "";
@@ -211,7 +279,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs }) {
           evidence: {
             probeBefore,
             probeAfter,
-            commands: [probeRemote, ...actionCommands.map((a) => a.remote)],
+            commands: [
+              Array.isArray(probeRemote) ? probeRemote.join(" ") : probeRemote,
+              ...actionCommands.map((a) => (Array.isArray(a.remote) ? a.remote.join(" ") : a.remote)),
+            ],
             outputs,
           },
           artifacts: [{ kind: "log", path: ".actions.log" }],

--- a/event-runtime/lib/adapters/actions.test.mjs
+++ b/event-runtime/lib/adapters/actions.test.mjs
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildArgv,
+  execute,
+  probeBytes,
+  substituteArgv,
+  substituteRemote,
+  validateRemotePlaceholders,
+} from "./actions.mjs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+describe("buildArgv (OPS-410)", () => {
+  test("replaces {target} and {remote} in exec template", () => {
+    const exec = ["ssh", "-o", "BatchMode=yes", "{target}", "{remote}"];
+    const argv = buildArgv(exec, "root@10.0.0.1", "df -h");
+    expect(argv).toEqual(["ssh", "-o", "BatchMode=yes", "root@10.0.0.1", "df -h"]);
+  });
+
+  test("handles multiple occurrences of {target} or {remote}", () => {
+    const exec = ["echo", "{target}", "and", "{target}", "running", "{remote}"];
+    const argv = buildArgv(exec, "host1", "cmd1");
+    expect(argv).toEqual(["echo", "host1", "and", "host1", "running", "cmd1"]);
+  });
+
+  test("safely handles special $ patterns in remote without regex backreference corruption", () => {
+    const exec = ["ssh", "{target}", "{remote}"];
+    const remoteWithDollar = "awk '{print $1}' /var/log/syslog | grep $& | sed 's/$//'";
+    const argv = buildArgv(exec, "user@host", remoteWithDollar);
+    expect(argv).toEqual(["ssh", "user@host", remoteWithDollar]);
+  });
+
+  test("expands array remote into argv elements when element is exact {remote}", () => {
+    const exec = ["ssh", "{target}", "{remote}"];
+    const argv = buildArgv(exec, "user@host", ["df", "--output=used", "-B1", "/var"]);
+    expect(argv).toEqual(["ssh", "user@host", "df", "--output=used", "-B1", "/var"]);
+  });
+});
+
+describe("validateRemotePlaceholders (OPS-410)", () => {
+  test("accepts placeholders with anchored pattern in inputSchema", () => {
+    const def = {
+      probeRemote: "df --output=used -B1 {mount} | tail -1",
+      actionRegistry: {
+        clean: { remote: "rm -rf {mount}/tmp" },
+      },
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
+      },
+    };
+    expect(() => validateRemotePlaceholders(def, schema)).not.toThrow();
+  });
+
+  test("accepts placeholders with enum in inputSchema", () => {
+    const def = {
+      probeRemote: "check {service}",
+      actionRegistry: {
+        restart: { remote: "systemctl restart {service}" },
+      },
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        service: { type: "string", enum: ["nginx", "redis"] },
+      },
+    };
+    expect(() => validateRemotePlaceholders(def, schema)).not.toThrow();
+  });
+
+  test("throws when placeholder has unanchored pattern", () => {
+    const def = {
+      probeRemote: "cat {path}",
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        path: { type: "string", pattern: "[a-z]+" },
+      },
+    };
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/unconstrained placeholder/);
+  });
+
+  test("throws when placeholder property lacks both enum and anchored pattern", () => {
+    const def = {
+      probeRemote: "df -h {mount}",
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        mount: { type: "string" },
+      },
+    };
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/unconstrained placeholder/);
+  });
+
+  test("throws when placeholder is completely missing from inputSchema", () => {
+    const def = {
+      probeRemote: "df -h {missing}",
+    };
+    const schema = {
+      type: "object",
+      properties: {},
+    };
+    expect(() => validateRemotePlaceholders(def, schema)).toThrow(/missing from input schema/);
+  });
+});
+
+describe("substituteRemote", () => {
+  test("substitutes placeholders from input", () => {
+    const res = substituteRemote("df -h {mount}", { mount: "/data" });
+    expect(res).toBe("df -h /data");
+  });
+
+  test("substitutes placeholders in array", () => {
+    const res = substituteRemote(["df", "-h", "{mount}"], { mount: "/data" });
+    expect(res).toEqual(["df", "-h", "/data"]);
+  });
+
+  test("throws on missing or non-primitive input field", () => {
+    expect(() => substituteRemote("df -h {mount}", {})).toThrow(/missing\/non-primitive/);
+    expect(() => substituteRemote("df -h {mount}", { mount: { nested: true } })).toThrow(/missing\/non-primitive/);
+  });
+});
+
+describe("substituteArgv", () => {
+  test("substitutes fields in argv elements", () => {
+    const argv = ["echo", "{issueId}", "--action", "{action}"];
+    const out = substituteArgv(argv, { issueId: "OPS-123", action: "close" });
+    expect(out).toEqual(["echo", "OPS-123", "--action", "close"]);
+  });
+
+  test("throws on missing or non-primitive fields", () => {
+    expect(() => substituteArgv(["echo", "{missing}"], {})).toThrow(/missing\/non-primitive/);
+  });
+});
+
+describe("probeBytes", () => {
+  test("parses last integer in probe output", () => {
+    expect(probeBytes("Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/sda1 10000 456789\n")).toBe(456789);
+    expect(probeBytes("   12345   \n")).toBe(12345);
+  });
+
+  test("throws on invalid probe output without numbers", () => {
+    expect(() => probeBytes("no numbers here")).toThrow(/probe output has no byte count/);
+    expect(() => probeBytes("")).toThrow(/probe output has no byte count/);
+  });
+});
+
+describe("execute refutations", () => {
+  test("refuses execution when placeholder is unconstrained in input schema", async () => {
+    const ws = tmp("evrt-ws-");
+    const def = {
+      ref: "test@1",
+      exec: ["ssh", "{target}", "{remote}"],
+      hosts: { lab: "root@10.0.0.1" },
+      probeRemote: "df {unconstrained}",
+      actionRegistry: { a: { remote: "echo 1" } },
+      inputSchema: {
+        type: "object",
+        properties: {
+          host: { type: "string", enum: ["lab"] },
+          unconstrained: { type: "string" },
+          actions: { type: "array" },
+        },
+      },
+    };
+    const spec = {
+      input: { host: "lab", unconstrained: "; rm -rf /", actions: [{ action: "a" }] },
+    };
+    const res = await execute({ spec, def, workspaceDir: ws, timeoutMs: 5000 });
+    expect(res.exitCode).toBe(1);
+    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain("unconstrained placeholder");
+  });
+
+  test("refuses execution on unknown host", async () => {
+    const ws = tmp("evrt-ws-");
+    const def = {
+      ref: "test@1",
+      exec: ["ssh", "{target}", "{remote}"],
+      hosts: { lab: "root@10.0.0.1" },
+      probeRemote: "df /",
+      actionRegistry: { a: { remote: "echo 1" } },
+    };
+    const spec = {
+      input: { host: "unknown-host", actions: [{ action: "a" }] },
+    };
+    const res = await execute({ spec, def, workspaceDir: ws, timeoutMs: 5000 });
+    expect(res.exitCode).toBe(1);
+    expect(readFileSync(path.join(ws, ".actions.log"), "utf8")).toContain("not in the definition's host allowlist");
+  });
+});

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -1,10 +1,13 @@
 /**
- * Claude Code adapter (docs/event-runtime.md §6) — the one real registry
- * entry. Spawns a bounded `claude -p` process with the workspace as its cwd,
- * enforces the run spec's timeout with the factory's shutdown discipline
- * (TERM, then KILL after 30s), and strips ANTHROPIC_API_KEY so the CLI uses
- * subscription auth (docs/architecture.md §2.9) — an event run must never
- * silently bill an API key that happens to be in the environment.
+ * Claude Code adapter (docs/event-runtime.md §6, §14; OPS-407) — the one real
+ * registry entry. Spawns a bounded `claude -p` process with the workspace as
+ * its cwd, enforces the run spec's timeout with the factory's shutdown discipline
+ * (TERM, then KILL after 30s), strips ANTHROPIC_API_KEY so the CLI uses
+ * subscription auth (docs/architecture.md §2.9), and confines tool access:
+ *   - passes `--allowedTools` derived from `def.capabilities`, denying write tools
+ *     when `mutating: false`
+ *   - passes `--strict-mcp-config` and sets `CLAUDE_CONFIG_DIR` to an isolated
+ *     runtime directory with no ambient MCP servers or global memory
  *
  * Output is `--output-format stream-json` (NDJSON; the CLI requires
  * `--verbose` with it in -p mode): the full raw stream is captured to
@@ -14,7 +17,7 @@
  * best-effort — an unparseable or unrecognized line is ignored, never fatal.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, readFileSync } from "node:fs";
+import { createWriteStream, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 
@@ -25,6 +28,48 @@ const TEXT_PREVIEW_CHARS = 4000;
 
 const PROMPT_SUFFIX =
   "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
+
+export const READ_ONLY_TOOLS = ["Read", "Grep", "Glob"];
+export const WRITE_TOOLS = new Set([
+  "Write",
+  "Edit",
+  "Replace",
+  "NotebookEdit",
+  "Bash",
+  "Kill",
+  "DeleteFile",
+  "CreateFile",
+]);
+
+/**
+ * Derive allowed tools from definition capabilities and mutating flag (OPS-407).
+ * When mutating is false, write tools are strictly forbidden.
+ */
+export function deriveAllowedTools(def) {
+  if (def?.mutating === false) {
+    if (Array.isArray(def?.capabilities?.tools)) {
+      return def.capabilities.tools.filter((t) => !WRITE_TOOLS.has(t));
+    }
+    return [...READ_ONLY_TOOLS];
+  }
+  if (Array.isArray(def?.capabilities?.tools)) {
+    return [...def.capabilities.tools];
+  }
+  return [...READ_ONLY_TOOLS];
+}
+
+/**
+ * Build argv for spawning claude (OPS-407).
+ * Enforces --allowedTools and --strict-mcp-config.
+ */
+export function buildClaudeArgv({ prompt, def, allowedTools = deriveAllowedTools(def) }) {
+  const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
+  if (allowedTools && allowedTools.length > 0) {
+    args.push("--allowedTools", allowedTools.join(","));
+  }
+  args.push("--strict-mcp-config");
+  return args;
+}
 
 function clip(text) {
   const s = String(text ?? "");
@@ -86,15 +131,17 @@ export function mapStreamEvent(msg) {
     for (const key of ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]) {
       if (typeof msg.usage?.[key] === "number") usage[key] = msg.usage[key];
     }
-    return [{
-      kind: "usage",
-      payload: {
-        durationMs: msg.duration_ms ?? null,
-        numTurns: msg.num_turns ?? null,
-        costUSD: msg.total_cost_usd ?? null,
-        usage,
+    return [
+      {
+        kind: "usage",
+        payload: {
+          durationMs: msg.duration_ms ?? null,
+          numTurns: msg.num_turns ?? null,
+          costUSD: msg.total_cost_usd ?? null,
+          usage,
+        },
       },
-    }];
+    ];
   }
 
   return []; // system/init, hooks, partials — not part of the trace contract
@@ -105,12 +152,16 @@ export function mapStreamEvent(msg) {
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs, env = {}, onTrace }) {
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
-  const childEnv = { ...process.env, ...env };
+  const configDir = path.join(workspaceDir, ".claude-config");
+  mkdirSync(configDir, { recursive: true });
+
+  const childEnv = { ...process.env, ...env, CLAUDE_CONFIG_DIR: configDir };
   delete childEnv.ANTHROPIC_API_KEY;
 
+  const argv = buildClaudeArgv({ prompt, def });
+
   return new Promise((resolve, reject) => {
-    // stream-json requires --verbose in -p mode (the CLI errors without it).
-    const child = spawn("claude", ["-p", prompt, "--output-format", "stream-json", "--verbose"], {
+    const child = spawn("claude", argv, {
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
@@ -130,7 +181,11 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env = {}, on
       const lines = createInterface({ input: child.stdout });
       lines.on("line", (line) => {
         try {
-          for (const event of mapStreamEvent(JSON.parse(line))) {
+          const parsed = JSON.parse(line);
+          for (const event of mapStreamEvent(parsed)) {
+            if (def?.mutating === false && event.kind === "tool_use" && WRITE_TOOLS.has(event.payload?.name)) {
+              child.kill("SIGTERM");
+            }
             onTrace(event.kind, event.payload);
           }
         } catch {

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -1,11 +1,17 @@
 /**
- * Unit tests for the pure stream-json → factory.trace/v1 mapper. The adapter
- * itself is never executed here — no model spawning in CI; fixtures mirror
+ * Unit tests for the pure stream-json → factory.trace/v1 mapper and CLI argument construction.
+ * The adapter itself is never executed against real LLM in CI; fixtures mirror
  * the NDJSON shapes observed from `claude -p --output-format stream-json
  * --verbose` (message types system/assistant/user/result).
  */
 import { describe, expect, test } from "bun:test";
-import { mapStreamEvent } from "./claude.mjs";
+import {
+  buildClaudeArgv,
+  deriveAllowedTools,
+  mapStreamEvent,
+  READ_ONLY_TOOLS,
+  WRITE_TOOLS,
+} from "./claude.mjs";
 
 describe("mapStreamEvent", () => {
   test("assistant text block → assistant_text", () => {
@@ -111,5 +117,53 @@ describe("mapStreamEvent", () => {
     expect(event.kind).toBe("assistant_text");
     expect(event.payload.text.length).toBeLessThan(5_000);
     expect(event.payload.text.endsWith("…[truncated]")).toBe(true);
+  });
+});
+
+describe("deriveAllowedTools (OPS-407)", () => {
+  test("defaults to read-only tools when mutating is false", () => {
+    const def = { mutating: false };
+    expect(deriveAllowedTools(def)).toEqual(READ_ONLY_TOOLS);
+  });
+
+  test("filters out write tools when mutating is false even if requested in capabilities", () => {
+    const def = {
+      mutating: false,
+      capabilities: {
+        tools: ["Read", "Write", "Edit", "Grep", "Bash"],
+      },
+    };
+    const tools = deriveAllowedTools(def);
+    expect(tools).toEqual(["Read", "Grep"]);
+    for (const tool of tools) {
+      expect(WRITE_TOOLS.has(tool)).toBe(false);
+    }
+  });
+
+  test("allows requested tools when mutating is true", () => {
+    const def = {
+      mutating: true,
+      capabilities: {
+        tools: ["Read", "Write", "Bash"],
+      },
+    };
+    expect(deriveAllowedTools(def)).toEqual(["Read", "Write", "Bash"]);
+  });
+});
+
+describe("buildClaudeArgv (OPS-407)", () => {
+  test("constructs argv with --allowedTools and --strict-mcp-config", () => {
+    const def = { mutating: false };
+    const prompt = "Do a status check.";
+    const argv = buildClaudeArgv({ prompt, def });
+
+    expect(argv).toContain("-p");
+    expect(argv).toContain(prompt);
+    expect(argv).toContain("--output-format");
+    expect(argv).toContain("stream-json");
+    expect(argv).toContain("--verbose");
+    expect(argv).toContain("--allowedTools");
+    expect(argv).toContain("Read,Grep,Glob");
+    expect(argv).toContain("--strict-mcp-config");
   });
 });

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -462,6 +462,25 @@ function admit(db, registry, res, buffer, nowMs, onEvent) {
 }
 
 /**
+ * Loopback host validation (OPS-408): only loopback addresses are accepted.
+ * Defends against DNS rebinding attacks.
+ */
+export function isLoopbackHost(hostHeader) {
+  if (!hostHeader || typeof hostHeader !== "string") return false;
+  const raw = hostHeader.trim();
+  let host;
+  if (raw.startsWith("[")) {
+    const closeBracket = raw.indexOf("]");
+    if (closeBracket === -1) return false;
+    host = raw.slice(1, closeBracket);
+  } else {
+    host = raw.split(":")[0];
+  }
+  const lower = host.toLowerCase();
+  return lower === "127.0.0.1" || lower === "localhost" || lower === "::1";
+}
+
+/**
  * Build the request handler. Returned directly (rather than only inside a
  * server) so tests can compose it however they like.
  */
@@ -486,6 +505,17 @@ export function createApi({
 
   return async function handle(req, res) {
     try {
+      // Security confinement (OPS-408): loopback Host check & Origin rejection.
+      const hostHeader = req.headers["host"];
+      if (!isLoopbackHost(hostHeader)) {
+        return send(res, 403, { error: "invalid_host" });
+      }
+
+      const isMutating = req.method === "POST" || req.method === "PUT" || req.method === "PATCH" || req.method === "DELETE";
+      if (isMutating && req.headers["origin"]) {
+        return send(res, 403, { error: "cross_origin_rejected" });
+      }
+
       const url = new URL(req.url, `http://${API_HOST}`);
       const route = `${req.method} ${url.pathname}`;
       const nowMs = now();

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -3,8 +3,9 @@ import { createHmac } from "node:crypto";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import http from "node:http";
 import * as fake from "./adapters/fake.mjs";
-import { janitorArgv, repoNamesFromInput, startApi } from "./api.mjs";
+import { isLoopbackHost, janitorArgv, repoNamesFromInput, startApi } from "./api.mjs";
 import { apiClient } from "./client.mjs";
 import { openDb } from "./db.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
@@ -872,3 +873,104 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
     expect(apply.filter((a) => a === "--apply")).toHaveLength(1);
   });
 });
+
+describe("Host and Origin header security confinement (OPS-408)", () => {
+  let s;
+  beforeAll(async () => {
+    s = await makeServer();
+  });
+  afterAll(() => s.close());
+
+  function rawRequest({ host = "127.0.0.1", path = "/", method = "GET", headers = {}, body } = {}) {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port: s.port,
+          path,
+          method,
+          headers: { host, ...headers },
+        },
+        (res) => {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => {
+            const text = Buffer.concat(chunks).toString("utf8");
+            let json = null;
+            try {
+              json = JSON.parse(text);
+            } catch {}
+            resolve({ status: res.statusCode, json, text });
+          });
+        },
+      );
+      req.on("error", reject);
+      if (body) req.write(body);
+      req.end();
+    });
+  }
+
+  test("isLoopbackHost accepts loopback variants and rejects remote/malformed hosts", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("127.0.0.1:7381")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("localhost:7381")).toBe(true);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    expect(isLoopbackHost("[::1]:7381")).toBe(true);
+
+    expect(isLoopbackHost("evil.com")).toBe(false);
+    expect(isLoopbackHost("evil.com:7381")).toBe(false);
+    expect(isLoopbackHost("192.168.1.100")).toBe(false);
+    expect(isLoopbackHost("")).toBe(false);
+    expect(isLoopbackHost(null)).toBe(false);
+    expect(isLoopbackHost(undefined)).toBe(false);
+  });
+
+  test("rejects request with non-loopback Host header", async () => {
+    const res = await rawRequest({ host: "attacker.com", path: "/health" });
+    expect(res.status).toBe(403);
+    expect(res.json?.error).toBe("invalid_host");
+  });
+
+  test("rejects mutating request carrying an Origin header", async () => {
+    const res = await rawRequest({
+      method: "POST",
+      path: "/replay",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://evil.com",
+      },
+      body: JSON.stringify(envelope()),
+    });
+    expect(res.status).toBe(403);
+    expect(res.json?.error).toBe("cross_origin_rejected");
+  });
+
+  test("rejects janitor apply carrying an Origin header", async () => {
+    const res = await rawRequest({
+      method: "POST",
+      path: "/repos/watched/janitor",
+      headers: {
+        "content-type": "application/json",
+        origin: "http://evil.com",
+      },
+      body: JSON.stringify({ apply: true }),
+    });
+    expect(res.status).toBe(403);
+    expect(res.json?.error).toBe("cross_origin_rejected");
+  });
+
+  test("allows normal loopback mutating requests without Origin header", async () => {
+    const res = await rawRequest({
+      method: "POST",
+      path: "/replay",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(envelope()),
+    });
+    expect(res.status).toBe(200);
+    expect(res.json?.admitted).toBe(true);
+  });
+});
+

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -8,7 +8,7 @@
  * so identical bytes are stored once and a result row never references a file
  * that no longer exists.
  */
-import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,7 +32,15 @@ export function storeCollected({ entries, storeRoot }) {
   mkdirSync(storeRoot, { recursive: true });
   return entries.map((entry) => {
     const dest = artifactPath(storeRoot, entry.sha256);
-    if (!existsSync(dest)) copyFileSync(fileURLToPath(entry.uri), dest);
+    const src = fileURLToPath(entry.uri);
+    if (!existsSync(src)) {
+      throw new Error(`artifact source does not exist: ${src}`);
+    }
+    const stat = lstatSync(src);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`cannot store symlinked artifact: ${src}`);
+    }
+    if (!existsSync(dest)) copyFileSync(src, dest);
     return { ...entry, uri: `file://${dest}`, sizeBytes: statSync(dest).size };
   });
 }
@@ -62,7 +70,18 @@ export function materializeArtifact({ storeRoot, sha256hex, workspaceDir, as }) 
   const root = path.resolve(workspaceDir);
   const dest = path.resolve(root, as);
   if (!dest.startsWith(root + path.sep)) throw new Error(`artifact target "${as}" escapes the workspace`);
+  const realRoot = existsSync(root) ? realpathSync(root) : root;
   mkdirSync(path.dirname(dest), { recursive: true });
+  const realDir = realpathSync(path.dirname(dest));
+  if (realDir !== realRoot && !realDir.startsWith(realRoot + path.sep)) {
+    throw new Error(`artifact target "${as}" escapes the workspace`);
+  }
+  if (existsSync(dest)) {
+    const stat = lstatSync(dest);
+    if (stat.isSymbolicLink()) throw new Error(`artifact target "${as}" is a symlink`);
+    const realDest = realpathSync(dest);
+    if (!realDest.startsWith(realRoot + path.sep)) throw new Error(`artifact target "${as}" escapes the workspace`);
+  }
   copyFileSync(found.file, dest);
   return { path: dest, sha256: sha256hex, sizeBytes: found.sizeBytes };
 }

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  artifactPath,
+  findArtifact,
+  materializeArtifact,
+  pinRunArtifact,
+  pruneArtifacts,
+  referencedHashes,
+  storeCollected,
+  storeStats,
+} from "./artifacts.mjs";
+import { sha256Hex } from "./canonical.mjs";
+import { openDb } from "./db.mjs";
+
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+function makeStore(bytes, storeRoot = tmp("evrt-store-")) {
+  mkdirSync(storeRoot, { recursive: true });
+  const hash = sha256Hex(Buffer.from(bytes));
+  writeFileSync(path.join(storeRoot, hash), bytes);
+  return { storeRoot, hash };
+}
+
+describe("artifactPath", () => {
+  test("resolves a valid 64-hex SHA", () => {
+    const hash = "a".repeat(64);
+    expect(artifactPath("/store", hash)).toBe(path.join("/store", hash));
+  });
+
+  test("rejects malformed hashes", () => {
+    expect(() => artifactPath("/store", "../etc/passwd")).toThrow(/invalid artifact hash/);
+    expect(() => artifactPath("/store", "abc")).toThrow(/invalid artifact hash/);
+    expect(() => artifactPath("/store", null)).toThrow(/invalid artifact hash/);
+  });
+});
+
+describe("findArtifact", () => {
+  test("finds artifact when present and returns null when absent or malformed", () => {
+    const { storeRoot, hash } = makeStore("test-content");
+    const found = findArtifact(storeRoot, hash);
+    expect(found).not.toBeNull();
+    expect(found.file).toBe(path.join(storeRoot, hash));
+    expect(found.sizeBytes).toBe(12);
+
+    expect(findArtifact(storeRoot, "b".repeat(64))).toBeNull();
+    expect(findArtifact(storeRoot, "invalid")).toBeNull();
+  });
+});
+
+describe("storeCollected (OPS-406)", () => {
+  test("copies collected artifacts into the store", () => {
+    const storeRoot = tmp("evrt-store-");
+    const workspaceDir = tmp("evrt-ws-");
+    const file = path.join(workspaceDir, "out.log");
+    writeFileSync(file, "hello world");
+    const hash = sha256Hex(Buffer.from("hello world"));
+
+    const entries = [{ kind: "log", uri: `file://${file}`, sha256: hash }];
+    const stored = storeCollected({ entries, storeRoot });
+    expect(stored[0].uri).toBe(`file://${path.join(storeRoot, hash)}`);
+    expect(stored[0].sizeBytes).toBe(11);
+    expect(readFileSync(path.join(storeRoot, hash), "utf8")).toBe("hello world");
+  });
+
+  test("rejects symlinked artifact source file", () => {
+    const storeRoot = tmp("evrt-store-");
+    const outsideDir = tmp("evrt-outside-");
+    const secretFile = path.join(outsideDir, "secret.key");
+    writeFileSync(secretFile, "secret-data");
+
+    const workspaceDir = tmp("evrt-ws-");
+    const symlinkFile = path.join(workspaceDir, "symlink.key");
+    symlinkSync(secretFile, symlinkFile);
+
+    const hash = sha256Hex(Buffer.from("secret-data"));
+    const entries = [{ kind: "key", uri: `file://${symlinkFile}`, sha256: hash }];
+
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(/cannot store symlinked artifact/);
+  });
+
+  test("rejects non-existent source file", () => {
+    const storeRoot = tmp("evrt-store-");
+    const workspaceDir = tmp("evrt-ws-");
+    const missingFile = path.join(workspaceDir, "missing.log");
+    const hash = "c".repeat(64);
+    const entries = [{ kind: "log", uri: `file://${missingFile}`, sha256: hash }];
+    expect(() => storeCollected({ entries, storeRoot })).toThrow(/does not exist/);
+  });
+});
+
+describe("materializeArtifact (OPS-406)", () => {
+  test("writes stored bytes into workspace under relative path", () => {
+    const { storeRoot, hash } = makeStore("test data");
+    const workspaceDir = tmp("evrt-ws-");
+    const res = materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "subdir/file.txt" });
+    expect(res.sha256).toBe(hash);
+    expect(readFileSync(path.join(workspaceDir, "subdir/file.txt"), "utf8")).toBe("test data");
+  });
+
+  test("rejects absolute paths and path escapes", () => {
+    const { storeRoot, hash } = makeStore("test data");
+    const workspaceDir = tmp("evrt-ws-");
+    expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "/abs/path" })).toThrow();
+    expect(() => materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "../outside" })).toThrow();
+  });
+
+  test("rejects symlinked destination directory pointing outside workspace", () => {
+    const { storeRoot, hash } = makeStore("test data");
+    const outsideDir = tmp("evrt-outside-");
+    const workspaceDir = tmp("evrt-ws-");
+
+    const symlinkDir = path.join(workspaceDir, "symdir");
+    symlinkSync(outsideDir, symlinkDir, "dir");
+
+    expect(() =>
+      materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "symdir/pwned.txt" })
+    ).toThrow(/escapes the workspace/);
+  });
+
+  test("rejects if destination file already exists as a symlink", () => {
+    const { storeRoot, hash } = makeStore("test data");
+    const outsideDir = tmp("evrt-outside-");
+    const targetFile = path.join(outsideDir, "target.txt");
+    writeFileSync(targetFile, "original");
+
+    const workspaceDir = tmp("evrt-ws-");
+    const symlinkFile = path.join(workspaceDir, "link.txt");
+    symlinkSync(targetFile, symlinkFile);
+
+    expect(() =>
+      materializeArtifact({ storeRoot, sha256hex: hash, workspaceDir, as: "link.txt" })
+    ).toThrow(/symlink/);
+  });
+});
+
+describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRunArtifact", () => {
+  test("storeStats and pruneArtifacts manage referenced vs unreferenced artifacts", () => {
+    const db = openDb(":memory:");
+    const { storeRoot, hash: hash1 } = makeStore("content 1");
+    const { hash: hash2 } = makeStore("content 2", storeRoot);
+
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`
+    ).run(
+      "run_1",
+      JSON.stringify({ artifacts: [{ kind: "ci-log", sha256: hash1, uri: "file:///x" }] }),
+      new Date().toISOString()
+    );
+
+    const referenced = referencedHashes(db);
+    expect(referenced.has(hash1)).toBe(true);
+    expect(referenced.has(hash2)).toBe(false);
+
+    const stats = storeStats(db, storeRoot);
+    expect(stats.files).toBe(2);
+    expect(stats.orphans).toBe(1);
+
+    const pruned = pruneArtifacts(db, storeRoot, { olderThanMs: -1000 });
+    expect(pruned.deleted).toBe(1);
+    expect(findArtifact(storeRoot, hash1)).not.toBeNull();
+    expect(findArtifact(storeRoot, hash2)).toBeNull();
+  });
+
+  test("pinRunArtifact retrieves artifact hash by kind", () => {
+    const db = openDb(":memory:");
+    const hash = "d".repeat(64);
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`
+    ).run("run_100", "idem_100", JSON.stringify({ agent: "test-agent" }), "hash_100", new Date().toISOString(), new Date().toISOString());
+
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`
+    ).run(
+      "run_100",
+      JSON.stringify({ artifacts: [{ kind: "transcript", sha256: hash, uri: "file:///x" }] }),
+      new Date().toISOString()
+    );
+
+    const pinned = pinRunArtifact(db, "run_100", { kind: "transcript" });
+    expect(pinned.transcript).toBe(hash);
+    expect(pinned.agent).toBe("test-agent");
+
+    expect(() => pinRunArtifact(db, "run_unknown")).toThrow(/unknown run/);
+    expect(() => pinRunArtifact(db, "run_100", { kind: "other" })).toThrow(/stored no "other" artifact/);
+  });
+});


### PR DESCRIPTION
Fixes OPS-406
Fixes OPS-410
Fixes OPS-408
Fixes OPS-407

## Changes

- **OPS-406 (`event-runtime/lib/artifacts.mjs`)**: Enforced `realpathSync` containment and explicit symlink rejection (`lstatSync().isSymbolicLink()`) on both artifact collection (`storeCollected`) and workspace materialization (`materializeArtifact`). Added comprehensive tests in `event-runtime/lib/artifacts.test.mjs`.
- **OPS-410 (`event-runtime/lib/adapters/actions.mjs`)**: Replaced unsafe string `.replace` with function replacers in `buildArgv` to safely preserve `$` patterns (e.g. `$1`, `$&`, `$'`). Added `validateRemotePlaceholders` to enforce that every remote template placeholder matches an input-schema property with an enum or anchored pattern (`^...$`). Added tests in `event-runtime/lib/adapters/actions.test.mjs`.
- **OPS-408 (`event-runtime/lib/api.mjs`)**: Enforced `isLoopbackHost` validation (`127.0.0.1`, `localhost`, `[::1]`) against DNS rebinding, and rejected any mutating request carrying an `Origin` header (preventing CSRF). Added tests in `event-runtime/lib/api.test.mjs`.
- **OPS-407 (`event-runtime/lib/adapters/claude.mjs`)**: Derived `--allowedTools` from definition capabilities and restricted to read-only tools when `mutating: false`. Confined `CLAUDE_CONFIG_DIR` to an isolated runtime config directory and passed `--strict-mcp-config`. Added tests in `event-runtime/lib/adapters/claude.test.mjs`.

## Verification

```bash
bun test event-runtime/lib/artifacts.test.mjs event-runtime/lib/adapters/ event-runtime/lib/api.test.mjs
bun test
bun build/emit.mjs --check
```
All 620 tests passing.