### PR TITLE
fix(event-runtime-web): context tabs ARIA toolbar, navigation layout, and reveal feedback

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -610,7 +610,7 @@ function GoPrefixHint({ armed }: { armed: boolean }) {
     <div
       role="status"
       aria-live="polite"
-      className="pointer-events-none fixed bottom-4 left-1/2 z-30 -translate-x-1/2"
+      className="pointer-events-none fixed bottom-4 left-4 z-30 max-w-[calc(100vw-20rem)] lg:left-1/2 lg:-translate-x-1/2 lg:max-w-[calc(100vw-24rem)]"
     >
       {armed && (
         <>
@@ -619,7 +619,7 @@ function GoPrefixHint({ armed }: { armed: boolean }) {
               aloud: the sentence above says the same thing in one breath. */}
           <div
             aria-hidden="true"
-            className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-full border border-(--border-strong) bg-(--surface-2) px-3 py-1.5 text-[11px] shadow-lg"
+            className="flex max-w-full flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-full border border-(--border-strong) bg-(--surface-2) px-3 py-1.5 text-[11px] shadow-lg"
           >
             <span
               className="mono rounded px-1.5 font-semibold"

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe("ContextTabs", () => {
-  test("renders exactly one tablist and one selected tab for a given active context", () => {
+  test("renders role='toolbar' with aria-label='Context' and no tablist or tab roles", () => {
     const r = render(
       <ContextTabs
         repos={[repo("factory")]}
@@ -41,9 +41,16 @@ describe("ContextTabs", () => {
       />,
     );
 
-    expect(r.getAllByRole("tablist")).toHaveLength(1);
-    const selected = r.getAllByRole("tab").filter((el) => el.getAttribute("aria-selected") === "true");
-    expect(selected).toHaveLength(1);
-    expect(selected[0].textContent).toBe("factory");
+    expect(r.getAllByRole("toolbar")).toHaveLength(1);
+    expect(r.getByRole("toolbar", { name: "Context" })).toBeDefined();
+    expect(r.queryByRole("tablist")).toBeNull();
+    expect(r.queryByRole("tab")).toBeNull();
+
+    const pressed = r.getAllByRole("button").filter((el) => el.getAttribute("aria-pressed") === "true");
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0].textContent).toBe("factory");
+
+    const closeBtn = r.getByRole("button", { name: "Close factory" });
+    expect(closeBtn.getAttribute("tabindex")).toBe("-1");
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -1,6 +1,6 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import type { RepoItem } from "../types";
 import { ContextTabs } from "./ContextTabs";
 
@@ -52,5 +52,62 @@ describe("ContextTabs", () => {
 
     const closeBtn = r.getByRole("button", { name: "Close factory" });
     expect(closeBtn.getAttribute("tabindex")).toBe("-1");
+  });
+
+  test("focuses the remaining active context button after closing a tab when activeElement is body (Chromium recovery)", () => {
+    let open = ["factory", "client"];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={open}
+        active={{ kind: "repo", name: "client" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={(name) => {
+          open = open.filter((n) => n !== name);
+        }}
+      />,
+    );
+
+    document.body.focus();
+    expect(document.activeElement).toBe(document.body);
+
+    const closeBtn = r.getByRole("button", { name: "Close factory" });
+    act(() => {
+      fireEvent.click(closeBtn);
+      document.body.focus();
+    });
+
+    const activeBtn = r.getByRole("button", { name: "client" });
+    expect(document.activeElement).toBe(activeBtn);
+  });
+
+  test("preserves focus on another element after closing a tab (Safari/Firefox focus retention)", () => {
+    const { getByTestId, getByRole } = render(
+      <div>
+        <input data-testid="filter-input" />
+        <ContextTabs
+          repos={[repo("factory")]}
+          reposError={false}
+          openRepos={["factory"]}
+          active={{ kind: "all" }}
+          onSelect={() => {}}
+          onOpen={() => {}}
+          onClose={() => {}}
+        />
+      </div>,
+    );
+
+    const input = getByTestId("filter-input");
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const closeBtn = getByRole("button", { name: "Close factory" });
+    act(() => {
+      closeBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -57,7 +57,7 @@ export function ContextTabs({
   );
   const activeId = active.kind === "repo" ? active.name : active.kind;
   const activeTab = () =>
-    stripRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ?? null;
+    stripRef.current?.querySelector<HTMLElement>('[aria-pressed="true"]') ?? null;
 
   // The strip scrolls its own active tab: `[` / `]` scroll-into-view belongs to
   // the view's status tabs, and a repo tab can go active without being clicked
@@ -106,14 +106,13 @@ export function ContextTabs({
       <div
         ref={stripRef}
         className="flex min-w-0 flex-1 items-stretch gap-0.5"
-        role="tablist"
+        role="toolbar"
         aria-label="Context"
         {...{ [CONTEXT_TABS_ATTR]: "" }}
       >
         <button
           type="button"
-          role="tab"
-          aria-selected={active.kind === "all"}
+          aria-pressed={active.kind === "all"}
           className={tabClass("all")}
           onClick={() => onSelect({ kind: "all" })}
         >
@@ -127,8 +126,7 @@ export function ContextTabs({
             <div key={name} role="presentation" className="flex shrink-0 items-center">
               <button
                 type="button"
-                role="tab"
-                aria-selected={active.kind === "repo" && active.name === name}
+                aria-pressed={active.kind === "repo" && active.name === name}
                 className={tabClass(name)}
                 onClick={() => onSelect({ kind: "repo", name })}
               >
@@ -136,6 +134,7 @@ export function ContextTabs({
               </button>
               <button
                 type="button"
+                tabIndex={-1}
                 aria-label={`Close ${name}`}
                 title={`Close ${name}`}
                 className="rounded px-1 text-[11px] text-(--text-faint) hover:text-(--text)"
@@ -152,8 +151,7 @@ export function ContextTabs({
         </div>
         <button
           type="button"
-          role="tab"
-          aria-selected={active.kind === "inflight"}
+          aria-pressed={active.kind === "inflight"}
           className={tabClass(INFLIGHT)}
           onClick={() => onSelect({ kind: "inflight" })}
         >

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -26,9 +26,9 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
     <Dialog title="Keyboard" onClose={onClose}>
       <div className="text-[12px] text-(--text-dim)">
         {ROWS.map((r) => (
-          <div key={r.keys} className="flex items-baseline justify-between gap-4 border-b border-(--border) py-1.5 last:border-0">
+          <div key={r.keys} className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0">
             <span className="mono text-(--text)">{r.keys}</span>
-            <span className="text-right text-(--text-faint)">{r.does}</span>
+            <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
           </div>
         ))}
       </div>

--- a/event-runtime/web/src/reveal.test.ts
+++ b/event-runtime/web/src/reveal.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { formatRevealNotification } from "./reveal";
+
+describe("formatRevealNotification", () => {
+  test("returns null when neither tab nor filter was changed (silent reveal)", () => {
+    expect(
+      formatRevealNotification({
+        kind: "run",
+        id: "run_01",
+        state: "RUNNING",
+        tabChanged: false,
+        filterCleared: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      formatRevealNotification({
+        kind: "event",
+        id: "evt_01",
+        state: "queued",
+        tabChanged: false,
+        filterCleared: false,
+      }),
+    ).toBeNull();
+  });
+
+  test("formats tab changed with state reason", () => {
+    expect(
+      formatRevealNotification({
+        kind: "run",
+        id: "run_01",
+        state: "CANCELLED",
+        tabChanged: true,
+        filterCleared: false,
+      }),
+    ).toBe("Showing all states — run run_01 is CANCELLED");
+
+    expect(
+      formatRevealNotification({
+        kind: "event",
+        id: "evt_02",
+        state: "dead_lettered",
+        tabChanged: true,
+        filterCleared: false,
+      }),
+    ).toBe("Showing all states — event evt_02 is dead_lettered");
+  });
+
+  test("formats tab changed without state reason", () => {
+    expect(
+      formatRevealNotification({
+        kind: "run",
+        id: "run_01",
+        tabChanged: true,
+        filterCleared: false,
+      }),
+    ).toBe("Showing all states to show run run_01");
+  });
+
+  test("formats filter cleared", () => {
+    expect(
+      formatRevealNotification({
+        kind: "run",
+        id: "run_01",
+        tabChanged: false,
+        filterCleared: true,
+      }),
+    ).toBe("Cleared the filter to show run run_01");
+
+    expect(
+      formatRevealNotification({
+        kind: "event",
+        id: "evt_03",
+        tabChanged: false,
+        filterCleared: true,
+      }),
+    ).toBe("Cleared the filter to show event evt_03");
+  });
+
+  test("formats both tab changed and filter cleared as one message", () => {
+    expect(
+      formatRevealNotification({
+        kind: "run",
+        id: "run_01",
+        state: "CANCELLED",
+        tabChanged: true,
+        filterCleared: true,
+      }),
+    ).toBe("Showing all states and cleared filter — run run_01 is CANCELLED");
+
+    expect(
+      formatRevealNotification({
+        kind: "event",
+        id: "evt_04",
+        state: "human_needed",
+        tabChanged: true,
+        filterCleared: true,
+      }),
+    ).toBe("Showing all states and cleared filter — event evt_04 is human_needed");
+  });
+});

--- a/event-runtime/web/src/reveal.ts
+++ b/event-runtime/web/src/reveal.ts
@@ -1,0 +1,37 @@
+/**
+ * Decision helper and notification formatter for deep-link reveal operations (OPS-388).
+ *
+ * When an operator follows a deep link (#/runs/:id or #/events/:source/:id)
+ * to a row that is hidden by the active status tab and/or active filters/chips,
+ * the app adjusts view state to reveal the row and provides informative toast feedback.
+ */
+
+export interface RevealFeedbackInput {
+  kind: "run" | "event";
+  id: string;
+  state?: string | null;
+  tabChanged: boolean;
+  filterCleared: boolean;
+}
+
+/**
+ * Returns a human-readable feedback message describing what the reveal changed,
+ * or null if nothing was changed (silent reveal).
+ */
+export function formatRevealNotification(input: RevealFeedbackInput): string | null {
+  const { kind, id, state, tabChanged, filterCleared } = input;
+  if (!tabChanged && !filterCleared) return null;
+
+  const stateReason = state ? ` — ${kind} ${id} is ${state}` : ` to show ${kind} ${id}`;
+
+  if (tabChanged && filterCleared) {
+    return `Showing all states and cleared filter${stateReason}`;
+  }
+
+  if (tabChanged) {
+    return `Showing all states${stateReason}`;
+  }
+
+  // filterCleared only
+  return `Cleared the filter to show ${kind} ${id}`;
+}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -181,12 +181,17 @@ export function Events({
   // not its presence in `rows` — decides whether this tab can render it.
   useEffect(() => {
     if (!focusEvent?.source || !focusEvent?.eventId) return;
+    if (isStatusTab(focusEvent.status) && tab !== focusEvent.status) return;
+    if (list.isPending || !list.data) return;
     const key = `${focusEvent.source}:${focusEvent.eventId}`;
     const row = rows.find((e) => keyOf(e) === key);
-    const onTab = !!row && (!fetchAll || tab === "all" || row.status === tab);
-    if (!onTab && tab !== "all") setTab("all");
+    if (fetchAll) {
+      if (row && tab !== "all" && row.status !== tab) setTab("all");
+      return;
+    }
+    if (!row && tab !== "all") setTab("all");
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusEvent?.source, focusEvent?.eventId, rows, tab, fetchAll]);
+  }, [focusEvent?.source, focusEvent?.eventId, focusEvent?.status, rows, tab, fetchAll, list.isPending, list.data]);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["events"] });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -9,6 +9,7 @@ import type { AdmittedEvent, EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
 import { EVENT_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
+import { formatRevealNotification } from "../reveal";
 import {
   Ago,
   Button,
@@ -159,6 +160,7 @@ export function Events({
   // before the tab effect below has made the row renderable.
   const pendingReveal = useRef<string | null>(null);
   const lastKey = useRef<string | null>(null);
+  const tabChangedFor = useRef<string | null>(null);
   useEffect(() => {
     if (selectedKey !== lastKey.current) {
       lastKey.current = selectedKey;
@@ -170,26 +172,53 @@ export function Events({
     if (!row) return; // tab switch / poll still pending
     if (fetchAll && tab !== "all" && row.status !== tab) return; // waiting on the tab switch
     pendingReveal.current = null; // decided once
-    if (visible.some((e) => keyOf(e) === key)) return; // visible: keep the filters
-    setFilter("");
-    setSourceFilter(null);
-    if (!focusEvent?.type) setTypeFilter(null);
-  }, [selectedKey, rows, visible, focusEvent?.type, fetchAll, tab]);
+    const isHidden = !visible.some((e) => keyOf(e) === key);
+    let filterCleared = false;
+    if (isHidden) {
+      if (filter || sourceFilter || (typeFilter && !focusEvent?.type)) {
+        filterCleared = true;
+      }
+      setFilter("");
+      setSourceFilter(null);
+      if (!focusEvent?.type) setTypeFilter(null);
+    }
+    const tabChanged = tabChangedFor.current === key;
+    tabChangedFor.current = null;
+    if (tabChanged || filterCleared) {
+      const msg = formatRevealNotification({
+        kind: "event",
+        id: focusEvent?.eventId ?? row.eventId,
+        state: row.status,
+        tabChanged,
+        filterCleared,
+      });
+      if (msg) notify(msg, "info");
+    }
+  }, [selectedKey, rows, visible, focusEvent?.type, focusEvent?.eventId, fetchAll, tab, filter, sourceFilter, typeFilter]);
 
   // Hash id: switch to All if the row isn't on this tab. Don't strip the hash.
   // With a repo context the fetch ignores the tab, so the row's own status —
   // not its presence in `rows` — decides whether this tab can render it.
   useEffect(() => {
-    if (!focusEvent?.source || !focusEvent?.eventId) return;
+    if (!focusEvent?.source || !focusEvent?.eventId) {
+      tabChangedFor.current = null;
+      return;
+    }
     if (isStatusTab(focusEvent.status) && tab !== focusEvent.status) return;
     if (list.isPending || !list.data) return;
     const key = `${focusEvent.source}:${focusEvent.eventId}`;
     const row = rows.find((e) => keyOf(e) === key);
     if (fetchAll) {
-      if (row && tab !== "all" && row.status !== tab) setTab("all");
+      if (row && tab !== "all" && row.status !== tab) {
+        tabChangedFor.current = key;
+        setTab("all");
+      }
       return;
     }
-    if (!row && tab !== "all") setTab("all");
+    if (!row && tab !== "all") {
+      tabChangedFor.current = key;
+      setTab("all");
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusEvent?.source, focusEvent?.eventId, focusEvent?.status, rows, tab, fetchAll, list.isPending, list.data]);
 

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -8,6 +8,7 @@ import { RunTrace } from "../components/RunTrace";
 import type { OperatorContext } from "../context";
 import { matchesInFlight, matchesRepo } from "../context";
 import { RUN_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
+import { formatRevealNotification } from "../reveal";
 import type { Attempt, ArtifactRef, RunState } from "../types";
 import {
   Ago,
@@ -376,9 +377,11 @@ export function Runs({
   // nothing about the tab — the tab has to be part of the membership test, or
   // the switch to ALL never fires and the row stays unrendered.
   const revealedFor = useRef<string | null>(null);
+  const tabChangedFor = useRef<string | null>(null);
   useEffect(() => {
     if (!focusRunId) {
       revealedFor.current = null;
+      tabChangedFor.current = null;
       return;
     }
     const onTab = rows.some(
@@ -387,12 +390,33 @@ export function Runs({
     if (onTab) {
       if (revealedFor.current !== focusRunId) {
         revealedFor.current = focusRunId;
-        if (!visible.some((r) => r.runId === focusRunId)) setFilter("");
+        const isHidden = !visible.some((r) => r.runId === focusRunId);
+        let filterCleared = false;
+        if (isHidden && filter) {
+          setFilter("");
+          filterCleared = true;
+        }
+        const tabChanged = tabChangedFor.current === focusRunId;
+        tabChangedFor.current = null;
+        if (tabChanged || filterCleared) {
+          const row = rows.find((r) => r.runId === focusRunId);
+          const msg = formatRevealNotification({
+            kind: "run",
+            id: focusRunId,
+            state: row?.state,
+            tabChanged,
+            filterCleared,
+          });
+          if (msg) notify(msg, "info");
+        }
       }
       return;
     }
-    if (tab !== "ALL") setTab("ALL");
-  }, [focusRunId, rows, tab, visible, fetchAll]);
+    if (tab !== "ALL") {
+      tabChangedFor.current = focusRunId;
+      setTab("ALL");
+    }
+  }, [focusRunId, rows, tab, visible, fetchAll, filter]);
 
   useEffect(() => {
     if (focusState && (STATE_TABS as readonly string[]).includes(focusState)) {


### PR DESCRIPTION
Fixes OPS-446
Fixes OPS-397
Fixes OPS-395
Fixes OPS-393
Fixes OPS-388

## Changes
- **OPS-397**: Re-role ContextTabs from `role="tablist"` to `role="toolbar"`, switch buttons from `role="tab"` to `aria-pressed`, and un-tabindex close buttons (`tabIndex={-1}`).
- **OPS-446**: Add unit tests for ContextTabs close focus recovery covering Chromium `document.body` recovery and Safari/Firefox element focus retention.
- **OPS-395**: Inset `GoPrefixHint` to clear the right-hand toast lane at narrow widths (420px/600px) and stack `ShortcutsDialog` rows at narrow widths.
- **OPS-393**: Guard `Events.tsx` hash effect against pending queries and in-flight status hint transitions so `jumpToEvent` with a status hint lands on the requested status tab.
- **OPS-388**: Add pure `reveal.ts` notification helper and non-blocking `notify(..., "info")` toast feedback in `Runs.tsx` and `Events.tsx` when deep-link reveals adjust status tabs or clear filters.

## Verification
- `bun test event-runtime/web/src/components/ContextTabs.test.tsx` (3 pass, 0 fail)
- `bun test event-runtime/web/src/hash.test.ts` (26 pass, 0 fail)
- `bun test event-runtime/web/src/reveal.test.ts` (5 pass, 0 fail)
- `bun test` (588 pass across 60 files)
- `bun build/emit.mjs --check` (clean)
- `cd event-runtime/web && bun run build` (clean)