### PR TITLE
feat(event-runtime): deploy, update, and manage remote workers via SSH with version-skew tracking

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -69,6 +69,7 @@ case "$cmd" in
   state)        run_bun orchestrator/state.mjs "$@" ;;
   status)       run_bun orchestrator/status.mjs "$@" ;;
   ps)           run_bun orchestrator/ps.mjs "$@" ;;
+  workers)      run_bun orchestrator/workers.mjs "$@" ;;
   friction)     run_bun orchestrator/friction.mjs "$@" ;;
   economics)    run_bun orchestrator/economics.mjs "$@" ;;
   ci)           run_bun orchestrator/ci.mjs "$@" ;;
@@ -165,6 +166,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   state         orchestrator/state.mjs
   status        orchestrator/status.mjs (repo, deployment, and factory snapshot)
   ps            orchestrator/ps.mjs (factory processes, ports, workers, and agents)
+  workers       orchestrator/workers.mjs (remote worker fleet and version skew)
   friction      orchestrator/friction.mjs
   economics     orchestrator/economics.mjs
   ci            orchestrator/ci.mjs

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -83,3 +83,14 @@ test("factory ps executes orchestrator/ps.mjs via CLI", () => {
   expect(Array.isArray(data.controlPlane)).toBe(true);
 });
 
+test("factory workers executes orchestrator/workers.mjs via CLI", () => {
+  const result = Bun.spawnSync({
+    cmd: ["bash", FACTORY, "workers", "--help"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout.toString()).toContain("factory workers");
+});
+
+

--- a/config/nodes.yaml
+++ b/config/nodes.yaml
@@ -1,0 +1,20 @@
+# Remote worker nodes configuration (OPS-445)
+# Defines remote nodes available for distributed worker offloading via SSH.
+
+nodes:
+  mac-mini:
+    host: "mac-mini.local"
+    user: "hdkiller"
+    port: 22
+    factory_root: "~/Develop/factory"
+    branch: "develop"
+    env:
+      FACTORY_EVENT_PORT: 7381
+    labels:
+      node: "mac-mini"
+      arch: "arm64"
+      can: "infra-exec"
+    adapters:
+      - "claude"
+      - "actions"
+      - "command"

--- a/event-runtime/lib/workers-remote.mjs
+++ b/event-runtime/lib/workers-remote.mjs
@@ -1,0 +1,423 @@
+/**
+ * Remote worker management and SSH orchestration (OPS-445; docs/event-runtime-workers.md §3).
+ *
+ * Provides safe SSH command execution, remote node health probing, version-skew tracking,
+ * and remote worker lifecycle operations (deploy, update, start, stop, restart).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { FACTORY_ROOT } from "./config.mjs";
+
+export class NodeConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "NodeConfigError";
+  }
+}
+
+export function nodesConfigPath(root = FACTORY_ROOT) {
+  return process.env.FACTORY_NODES_CONFIG || path.join(root, "config", "nodes.yaml");
+}
+
+/** Expand leading ~ in paths */
+export function expandHome(p, home = process.env.HOME) {
+  if (typeof p !== "string") return p;
+  if (p === "~") return home ?? p;
+  if (p.startsWith("~/")) return path.join(home ?? "", p.slice(2));
+  return p;
+}
+
+/**
+ * Load and validate remote nodes configuration.
+ *
+ * @returns {Map<string, {
+ *   name: string,
+ *   host: string,
+ *   user: string | null,
+ *   port: number,
+ *   factoryRoot: string,
+ *   branch: string,
+ *   env: Record<string, string | number>,
+ *   labels: Record<string, string>,
+ *   adapters: string[]
+ * }>}
+ */
+export function loadNodesConfig({ configPath = null, root = FACTORY_ROOT } = {}) {
+  const filePath = configPath || nodesConfigPath(root);
+  if (!existsSync(filePath)) {
+    return new Map();
+  }
+
+  let parsed;
+  try {
+    parsed = Bun.YAML.parse(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    throw new NodeConfigError(`malformed nodes config at ${filePath}: ${err.message}`);
+  }
+
+  const nodes = new Map();
+  if (!parsed || typeof parsed !== "object" || !parsed.nodes) {
+    return nodes;
+  }
+
+  for (const [name, entry] of Object.entries(parsed.nodes)) {
+    if (!entry || typeof entry !== "object") {
+      throw new NodeConfigError(`invalid node entry for "${name}" in ${filePath}`);
+    }
+    if (!entry.host || typeof entry.host !== "string") {
+      throw new NodeConfigError(`node "${name}" is missing required "host" property`);
+    }
+
+    const port = Number(entry.port ?? 22);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      throw new NodeConfigError(`node "${name}" has invalid port: ${entry.port}`);
+    }
+
+    const factoryRoot = entry.factory_root || "~/Develop/factory";
+    const branch = entry.branch || "develop";
+    const user = entry.user || null;
+    const env = entry.env && typeof entry.env === "object" ? { ...entry.env } : {};
+    const labels = entry.labels && typeof entry.labels === "object" ? { ...entry.labels } : {};
+    const adapters = Array.isArray(entry.adapters) ? entry.adapters.map(String) : [];
+
+    nodes.set(name, {
+      name,
+      host: entry.host,
+      user,
+      port,
+      factoryRoot,
+      branch,
+      env,
+      labels,
+      adapters,
+    });
+  }
+
+  return nodes;
+}
+
+/**
+ * Build safe ssh argv array for child process execution.
+ */
+export function buildSshArgv(node, remoteCommand, { batchMode = true, connectTimeout = 5 } = {}) {
+  const args = [];
+  if (node.port && node.port !== 22) {
+    args.push("-p", String(node.port));
+  }
+  if (batchMode) {
+    args.push("-o", "BatchMode=yes");
+  }
+  if (connectTimeout) {
+    args.push("-o", `ConnectTimeout=${connectTimeout}`);
+  }
+
+  const target = node.user ? `${node.user}@${node.host}` : node.host;
+  args.push(target);
+
+  if (typeof remoteCommand === "string") {
+    args.push(remoteCommand);
+  } else if (Array.isArray(remoteCommand)) {
+    args.push(remoteCommand.join(" "));
+  }
+
+  return args;
+}
+
+/**
+ * Execute an SSH command against a remote node.
+ */
+export function executeSsh(node, remoteCommand, {
+  batchMode = true,
+  connectTimeout = 5,
+  spawnFn = null,
+} = {}) {
+  const args = buildSshArgv(node, remoteCommand, { batchMode, connectTimeout });
+  const runner = spawnFn || ((cmd) => {
+    const proc = Bun.spawnSync({
+      cmd: ["ssh", ...cmd],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      exitCode: proc.exitCode,
+      stdout: proc.stdout.toString(),
+      stderr: proc.stderr.toString(),
+    };
+  });
+
+  const res = runner(args);
+  return {
+    exitCode: res.exitCode,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    ok: res.exitCode === 0,
+  };
+}
+
+/**
+ * Probe remote node connectivity, git commit, runtime version, and running worker processes.
+ */
+export function probeRemoteNode(node, {
+  localTrunkSha = null,
+  connectTimeout = 2,
+  spawnFn = null,
+} = {}) {
+  const remotePath = node.factoryRoot;
+  // Probe script: checks git sha, branch, arch, os, bun version, and running worker pid
+  const probeScript = [
+    `REMOTE_DIR="${remotePath}";`,
+    `if [ -d "$REMOTE_DIR" ]; then`,
+    `  cd "$REMOTE_DIR" 2>/dev/null;`,
+    `  HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown");`,
+    `  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown");`,
+    `  DIRTY=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ');`,
+    `else`,
+    `  HEAD_SHA="missing_dir";`,
+    `  BRANCH="missing_dir";`,
+    `  DIRTY="0";`,
+    `fi;`,
+    `ARCH=$(uname -m 2>/dev/null || echo "unknown");`,
+    `OS=$(uname -s 2>/dev/null || echo "unknown");`,
+    `BUN_VER=$(bun --version 2>/dev/null || echo "not_found");`,
+    `WORKER_PIDS=$(ps -axo pid,command 2>/dev/null | grep -E "bun.*event-runtime/cli\\.mjs work" | grep -v grep | awk '{print $1}' | tr '\\n' ',' | sed 's/,$//');`,
+    `echo "PROBE_RESULT:$$HEAD_SHA|$$BRANCH|$$DIRTY|$$ARCH|$$OS|$$BUN_VER|$$WORKER_PIDS"`,
+  ].join(" ");
+
+  const res = executeSsh(node, probeScript, { spawnFn, connectTimeout });
+
+  if (!res.ok) {
+    return {
+      name: node.name,
+      host: node.host,
+      connected: false,
+      error: (res.stderr || res.stdout || "ssh connection failed").trim(),
+      outdated: null,
+      skewStatus: "unreachable",
+      details: null,
+    };
+  }
+
+  const match = res.stdout.match(/PROBE_RESULT:(.*)/);
+  if (!match) {
+    return {
+      name: node.name,
+      host: node.host,
+      connected: true,
+      error: "invalid probe output format",
+      outdated: null,
+      skewStatus: "unknown",
+      details: null,
+    };
+  }
+
+  const [headSha, branch, dirtyCount, arch, osName, bunVer, pidsRaw] = match[1].trim().split("|");
+  const pids = pidsRaw ? pidsRaw.split(",").map(Number).filter(Boolean) : [];
+  const isMissingDir = headSha === "missing_dir";
+  const isDirty = Number(dirtyCount) > 0;
+
+  let outdated = false;
+  let skewStatus = "synced";
+
+  if (isMissingDir) {
+    skewStatus = "not_deployed";
+    outdated = true;
+  } else if (localTrunkSha && headSha && headSha !== "unknown") {
+    if (localTrunkSha !== headSha) {
+      outdated = true;
+      skewStatus = "outdated";
+    }
+  }
+
+  return {
+    name: node.name,
+    host: node.host,
+    port: node.port,
+    connected: true,
+    outdated,
+    skewStatus,
+    workerPids: pids,
+    workerActive: pids.length > 0,
+    details: {
+      factoryRoot: node.factoryRoot,
+      headSha: isMissingDir ? null : headSha,
+      branch: isMissingDir ? null : branch,
+      dirty: isDirty,
+      arch,
+      os: osName,
+      bunVersion: bunVer,
+      labels: node.labels,
+      adapters: node.adapters,
+    },
+  };
+}
+
+/**
+ * Deploy or update repository code and dependencies on a remote worker node.
+ */
+export function deployRemoteWorker(node, {
+  ref = null,
+  spawnFn = null,
+} = {}) {
+  const targetBranch = ref || node.branch || "develop";
+  const remotePath = node.factoryRoot;
+
+  const deployScript = [
+    `set -e;`,
+    `mkdir -p "${remotePath}";`,
+    `cd "${remotePath}";`,
+    `if [ ! -d ".git" ]; then`,
+    `  echo "Cloning repository...";`,
+    `  git clone https://github.com/watt-mind/factory.git . 2>&1;`,
+    `fi;`,
+    `echo "Updating branch ${targetBranch}...";`,
+    `git fetch origin 2>&1;`,
+    `git checkout "${targetBranch}" 2>&1;`,
+    `git pull --ff-only origin "${targetBranch}" 2>&1;`,
+    `echo "Installing dependencies...";`,
+    `bun install 2>&1;`,
+    `echo "DEPLOY_SUCCESS";`,
+  ].join(" ");
+
+  const res = executeSsh(node, deployScript, { spawnFn, connectTimeout: 10 });
+  const ok = res.ok && res.stdout.includes("DEPLOY_SUCCESS");
+
+  return {
+    name: node.name,
+    ok,
+    stdout: res.stdout,
+    stderr: res.stderr,
+    error: ok ? null : (res.stderr || res.stdout || "deploy failed").trim(),
+  };
+}
+
+/**
+ * Start a worker daemon process on the remote node.
+ */
+export function startRemoteWorker(node, {
+  spawnFn = null,
+} = {}) {
+  const remotePath = node.factoryRoot;
+  const envVars = Object.entries(node.env || {})
+    .map(([k, v]) => `export ${k}="${v}";`)
+    .join(" ");
+
+  const labelsArg = Object.entries(node.labels || {})
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+
+  const adaptersArg = (node.adapters || []).join(",");
+
+  const startScript = [
+    `cd "${remotePath}" 2>/dev/null || exit 1;`,
+    `mkdir -p .factory/run;`,
+    `${envVars}`,
+    `CMD="bun event-runtime/cli.mjs work";`,
+    labelsArg ? `CMD="$CMD --labels ${labelsArg}";` : ``,
+    adaptersArg ? `CMD="$CMD --adapters ${adaptersArg}";` : ``,
+    `nohup $CMD >> .factory/run/worker.log 2>&1 &`,
+    `PID=$!;`,
+    `echo $PID > .factory/run/worker.pid;`,
+    `echo "START_SUCCESS:$PID"`,
+  ].join(" ");
+
+  const res = executeSsh(node, startScript, { spawnFn });
+  const match = res.stdout.match(/START_SUCCESS:(\d+)/);
+  const ok = res.ok && Boolean(match);
+  const pid = match ? Number(match[1]) : null;
+
+  return {
+    name: node.name,
+    ok,
+    pid,
+    error: ok ? null : (res.stderr || res.stdout || "failed to start remote worker").trim(),
+  };
+}
+
+/**
+ * Stop running worker daemon processes on the remote node with graceful drain timeout.
+ */
+export function stopRemoteWorker(node, {
+  drainTimeout = 15,
+  spawnFn = null,
+} = {}) {
+  const remotePath = node.factoryRoot;
+
+  const stopScript = [
+    `cd "${remotePath}" 2>/dev/null;`,
+    `PIDS=$(ps -axo pid,command 2>/dev/null | grep -E "bun.*event-runtime/cli\\.mjs work" | grep -v grep | awk '{print $1}');`,
+    `if [ -z "$PIDS" ]; then`,
+    `  echo "STOP_SUCCESS:0";`,
+    `  exit 0;`,
+    `fi;`,
+    `for PID in $PIDS; do`,
+    `  kill -TERM "$PID" 2>/dev/null || true;`,
+    `done;`,
+    `for i in $(seq ${drainTimeout}); do`,
+    `  ALIVE=0;`,
+    `  for PID in $PIDS; do`,
+    `    if kill -0 "$PID" 2>/dev/null; then ALIVE=1; break; fi;`,
+    `  done;`,
+    `  if [ "$ALIVE" -eq 0 ]; then break; fi;`,
+    `  sleep 1;`,
+    `done;`,
+    `for PID in $PIDS; do`,
+    `  kill -9 "$PID" 2>/dev/null || true;`,
+    `done;`,
+    `rm -f .factory/run/worker.pid 2>/dev/null || true;`,
+    `echo "STOP_SUCCESS:1"`,
+  ].join(" ");
+
+  const res = executeSsh(node, stopScript, { spawnFn });
+  const ok = res.ok && res.stdout.includes("STOP_SUCCESS");
+
+  return {
+    name: node.name,
+    ok,
+    error: ok ? null : (res.stderr || res.stdout || "failed to stop remote worker").trim(),
+  };
+}
+
+/**
+ * Perform rolling update of remote worker: stop -> deploy/pull -> start.
+ */
+export function updateRemoteWorker(node, {
+  ref = null,
+  drainTimeout = 15,
+  spawnFn = null,
+} = {}) {
+  const stopRes = stopRemoteWorker(node, { drainTimeout, spawnFn });
+  if (!stopRes.ok) {
+    return {
+      name: node.name,
+      ok: false,
+      step: "stop",
+      error: stopRes.error,
+    };
+  }
+
+  const deployRes = deployRemoteWorker(node, { ref, spawnFn });
+  if (!deployRes.ok) {
+    return {
+      name: node.name,
+      ok: false,
+      step: "deploy",
+      error: deployRes.error,
+    };
+  }
+
+  const startRes = startRemoteWorker(node, { spawnFn });
+  if (!startRes.ok) {
+    return {
+      name: node.name,
+      ok: false,
+      step: "start",
+      error: startRes.error,
+    };
+  }
+
+  return {
+    name: node.name,
+    ok: true,
+    pid: startRes.pid,
+  };
+}

--- a/event-runtime/lib/workers-remote.test.mjs
+++ b/event-runtime/lib/workers-remote.test.mjs
@@ -1,0 +1,253 @@
+import { test, expect, describe } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  loadNodesConfig,
+  buildSshArgv,
+  executeSsh,
+  probeRemoteNode,
+  deployRemoteWorker,
+  startRemoteWorker,
+  stopRemoteWorker,
+  updateRemoteWorker,
+  NodeConfigError,
+} from "./workers-remote.mjs";
+
+describe("nodes config loader", () => {
+  test("loadNodesConfig parses valid nodes.yaml correctly", () => {
+    const dir = path.join(tmpdir(), `test-nodes-${Date.now()}`);
+    mkdirSync(path.join(dir, "config"), { recursive: true });
+    writeFileSync(
+      path.join(dir, "config", "nodes.yaml"),
+      `
+nodes:
+  mac-mini:
+    host: "mac-mini.local"
+    user: "dev"
+    port: 2222
+    factory_root: "~/Develop/factory"
+    branch: "main"
+    env:
+      FACTORY_EVENT_PORT: 7381
+    labels:
+      node: "mac-mini"
+      arch: "arm64"
+    adapters:
+      - "claude"
+      - "command"
+`,
+    );
+
+    try {
+      const nodes = loadNodesConfig({ root: dir });
+      expect(nodes.size).toBe(1);
+      const node = nodes.get("mac-mini");
+      expect(node).toEqual({
+        name: "mac-mini",
+        host: "mac-mini.local",
+        user: "dev",
+        port: 2222,
+        factoryRoot: "~/Develop/factory",
+        branch: "main",
+        env: { FACTORY_EVENT_PORT: 7381 },
+        labels: { node: "mac-mini", arch: "arm64" },
+        adapters: ["claude", "command"],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("loadNodesConfig handles missing file gracefully", () => {
+    const nodes = loadNodesConfig({ configPath: "/nonexistent/nodes.yaml" });
+    expect(nodes.size).toBe(0);
+  });
+
+  test("loadNodesConfig rejects invalid node definitions", () => {
+    const dir = path.join(tmpdir(), `test-nodes-err-${Date.now()}`);
+    mkdirSync(path.join(dir, "config"), { recursive: true });
+    writeFileSync(
+      path.join(dir, "config", "nodes.yaml"),
+      `
+nodes:
+  bad-node:
+    port: "invalid"
+`,
+    );
+
+    try {
+      expect(() => loadNodesConfig({ root: dir })).toThrow(NodeConfigError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ssh argv builder", () => {
+  test("buildSshArgv constructs correct arguments", () => {
+    const node = {
+      name: "node1",
+      host: "192.168.1.50",
+      user: "worker",
+      port: 2200,
+    };
+    const argv = buildSshArgv(node, "echo hello", { batchMode: true, connectTimeout: 3 });
+    expect(argv).toEqual([
+      "-p", "2200",
+      "-o", "BatchMode=yes",
+      "-o", "ConnectTimeout=3",
+      "worker@192.168.1.50",
+      "echo hello",
+    ]);
+  });
+
+  test("buildSshArgv handles default port and omitted user", () => {
+    const node = {
+      name: "node2",
+      host: "box.internal",
+      user: null,
+      port: 22,
+    };
+    const argv = buildSshArgv(node, ["git", "status"]);
+    expect(argv).toEqual([
+      "-o", "BatchMode=yes",
+      "-o", "ConnectTimeout=5",
+      "box.internal",
+      "git status",
+    ]);
+  });
+});
+
+describe("remote probe and version skew", () => {
+  const testNode = {
+    name: "mini",
+    host: "mini.local",
+    user: "dev",
+    port: 22,
+    factoryRoot: "~/Develop/factory",
+    labels: { arch: "arm64" },
+    adapters: ["claude"],
+  };
+
+  test("probeRemoteNode detects synced remote worker", () => {
+    const mockSpawn = () => ({
+      exitCode: 0,
+      stdout: "PROBE_RESULT:abc12345|develop|0|arm64|Darwin|1.3.14|45001",
+      stderr: "",
+    });
+
+    const result = probeRemoteNode(testNode, {
+      localTrunkSha: "abc12345",
+      spawnFn: mockSpawn,
+    });
+
+    expect(result.connected).toBe(true);
+    expect(result.outdated).toBe(false);
+    expect(result.skewStatus).toBe("synced");
+    expect(result.workerActive).toBe(true);
+    expect(result.workerPids).toEqual([45001]);
+    expect(result.details.headSha).toBe("abc12345");
+  });
+
+  test("probeRemoteNode detects outdated version skew", () => {
+    const mockSpawn = () => ({
+      exitCode: 0,
+      stdout: "PROBE_RESULT:oldsha99|develop|0|arm64|Darwin|1.3.14|",
+      stderr: "",
+    });
+
+    const result = probeRemoteNode(testNode, {
+      localTrunkSha: "newsha00",
+      spawnFn: mockSpawn,
+    });
+
+    expect(result.connected).toBe(true);
+    expect(result.outdated).toBe(true);
+    expect(result.skewStatus).toBe("outdated");
+    expect(result.workerActive).toBe(false);
+    expect(result.workerPids).toEqual([]);
+  });
+
+  test("probeRemoteNode handles unreachable node", () => {
+    const mockSpawn = () => ({
+      exitCode: 255,
+      stdout: "",
+      stderr: "ssh: connect to host mini.local port 22: Operation timed out",
+    });
+
+    const result = probeRemoteNode(testNode, {
+      localTrunkSha: "abc",
+      spawnFn: mockSpawn,
+    });
+
+    expect(result.connected).toBe(false);
+    expect(result.skewStatus).toBe("unreachable");
+    expect(result.error).toContain("timed out");
+  });
+});
+
+describe("remote lifecycle operations", () => {
+  const node = {
+    name: "mini",
+    host: "mini.local",
+    user: "dev",
+    port: 22,
+    factoryRoot: "~/Develop/factory",
+    branch: "develop",
+    env: { FACTORY_EVENT_PORT: 7381 },
+    labels: { node: "mini" },
+    adapters: ["claude"],
+  };
+
+  test("deployRemoteWorker executes deploy script successfully", () => {
+    const mockSpawn = () => ({
+      exitCode: 0,
+      stdout: "Updating branch develop...\nInstalling dependencies...\nDEPLOY_SUCCESS\n",
+      stderr: "",
+    });
+
+    const res = deployRemoteWorker(node, { spawnFn: mockSpawn });
+    expect(res.ok).toBe(true);
+    expect(res.error).toBe(null);
+  });
+
+  test("startRemoteWorker parses launched PID", () => {
+    const mockSpawn = () => ({
+      exitCode: 0,
+      stdout: "START_SUCCESS:88123\n",
+      stderr: "",
+    });
+
+    const res = startRemoteWorker(node, { spawnFn: mockSpawn });
+    expect(res.ok).toBe(true);
+    expect(res.pid).toBe(88123);
+  });
+
+  test("stopRemoteWorker handles stop signal and drain", () => {
+    const mockSpawn = () => ({
+      exitCode: 0,
+      stdout: "STOP_SUCCESS:1\n",
+      stderr: "",
+    });
+
+    const res = stopRemoteWorker(node, { spawnFn: mockSpawn });
+    expect(res.ok).toBe(true);
+  });
+
+  test("updateRemoteWorker chains stop, deploy, and start", () => {
+    let callCount = 0;
+    const mockSpawn = () => {
+      callCount += 1;
+      if (callCount === 1) return { exitCode: 0, stdout: "STOP_SUCCESS:1", stderr: "" };
+      if (callCount === 2) return { exitCode: 0, stdout: "DEPLOY_SUCCESS", stderr: "" };
+      if (callCount === 3) return { exitCode: 0, stdout: "START_SUCCESS:99201", stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+
+    const res = updateRemoteWorker(node, { spawnFn: mockSpawn });
+    expect(res.ok).toBe(true);
+    expect(res.pid).toBe(99201);
+    expect(callCount).toBe(3);
+  });
+});

--- a/orchestrator/workers.mjs
+++ b/orchestrator/workers.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env bun
+/**
+ * Remote worker nodes CLI (OPS-445; docs/event-runtime-workers.md §3).
+ *
+ * Usage:
+ *   factory workers [list]            inspect remote worker nodes and version skew
+ *   factory workers deploy            deploy/bootstrap factory code on remote nodes
+ *   factory workers update            pull latest code, install deps, restart remote workers
+ *   factory workers start             start worker daemons on remote nodes
+ *   factory workers stop              stop worker daemons on remote nodes
+ *   factory workers restart           restart worker daemons on remote nodes
+ *
+ * Flags:
+ *   --node <name>                     target a specific node (default: all nodes)
+ *   --ref <branch/tag/sha>            target git ref (default: develop)
+ *   --json                            machine-readable JSON output
+ *   -h, --help                        show this help
+ */
+import {
+  loadNodesConfig,
+  probeRemoteNode,
+  deployRemoteWorker,
+  updateRemoteWorker,
+  startRemoteWorker,
+  stopRemoteWorker,
+} from "../event-runtime/lib/workers-remote.mjs";
+import { FACTORY_ROOT } from "../event-runtime/lib/config.mjs";
+
+const argv = process.argv.slice(2);
+
+function val(flag) {
+  const i = argv.indexOf(flag);
+  if (i === -1 || i === argv.length - 1) return null;
+  return argv[i + 1];
+}
+
+const c = {
+  reset: (s) => `\x1b[0m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+};
+
+function pad(str, len) {
+  const s = String(str ?? "");
+  return s.length >= len ? s : s + " ".repeat(len - s.length);
+}
+
+function printHelp() {
+  console.log(`
+${c.bold("factory workers")} — remote worker node orchestration and version skew tracking
+
+${c.bold("USAGE")}
+  factory workers [list]             inspect configured nodes and version skew
+  factory workers deploy             deploy/clone factory and install dependencies
+  factory workers update             pull latest code and restart remote workers
+  factory workers start              start worker daemon on remote nodes
+  factory workers stop               stop worker daemon on remote nodes
+  factory workers restart            restart worker daemon on remote nodes
+
+${c.bold("FLAGS")}
+  --node <name>                      target a specific node (default: all nodes)
+  --ref <ref>                        target git ref for deploy/update (default: node config branch)
+  --json                             output structured JSON
+  -h, --help                         display this help message
+`);
+  process.exit(0);
+}
+
+if (argv.includes("-h") || argv.includes("--help")) {
+  printHelp();
+}
+
+const JSON_OUT = argv.includes("--json");
+const targetNode = val("--node");
+const targetRef = val("--ref");
+const command = argv[0] && !argv[0].startsWith("-") ? argv[0] : "list";
+
+function getLocalTrunkSha() {
+  try {
+    const res = Bun.spawnSync({
+      cmd: ["git", "rev-parse", "HEAD"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return res.exitCode === 0 ? res.stdout.toString().trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+try {
+  const nodesMap = loadNodesConfig({ root: FACTORY_ROOT });
+
+  if (nodesMap.size === 0) {
+    if (JSON_OUT) {
+      console.log(JSON.stringify({ nodes: [], count: 0, message: "no nodes configured in config/nodes.yaml" }, null, 2));
+    } else {
+      console.log(c.yellow("No remote worker nodes configured in config/nodes.yaml"));
+    }
+    process.exit(0);
+  }
+
+  const selectedNodes = targetNode
+    ? (nodesMap.has(targetNode) ? [nodesMap.get(targetNode)] : null)
+    : Array.from(nodesMap.values());
+
+  if (!selectedNodes) {
+    console.error(c.red(`Error: unknown node "${targetNode}". Configured nodes: ${Array.from(nodesMap.keys()).join(", ")}`));
+    process.exit(1);
+  }
+
+  const localSha = getLocalTrunkSha();
+
+  if (command === "list") {
+    const probes = selectedNodes.map((node) => probeRemoteNode(node, { localTrunkSha: localSha }));
+
+    if (JSON_OUT) {
+      console.log(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        localTrunkSha: localSha,
+        nodes: probes,
+      }, null, 2));
+      process.exit(0);
+    }
+
+    console.log(c.bold(`factory workers — remote worker fleet (${probes.length} configured)`));
+    if (localSha) {
+      console.log(c.dim(`Local trunk SHA: ${localSha.slice(0, 8)}`));
+    }
+    console.log();
+
+    console.log(
+      c.dim("  ") +
+      c.bold(pad("NODE", 16)) + "  " +
+      c.bold(pad("HOST", 22)) + "  " +
+      c.bold(pad("STATUS", 14)) + "  " +
+      c.bold(pad("SKEW", 12)) + "  " +
+      c.bold(pad("BRANCH / SHA", 24)) + "  " +
+      c.bold(pad("WORKER", 10)) + "  " +
+      c.bold("LABELS"),
+    );
+
+    for (const p of probes) {
+      let statusStr = c.red("unreachable");
+      let skewStr = c.dim("-");
+      let branchSha = c.dim("-");
+      let workerStr = c.dim("stopped");
+      let labelsStr = "";
+
+      if (p.connected) {
+        statusStr = c.green("connected");
+        if (p.skewStatus === "synced") {
+          skewStr = c.green("synced");
+        } else if (p.skewStatus === "outdated") {
+          skewStr = c.yellow("outdated");
+        } else if (p.skewStatus === "not_deployed") {
+          skewStr = c.red("not deployed");
+        }
+
+        if (p.details?.branch || p.details?.headSha) {
+          const b = p.details.branch ?? "";
+          const s = p.details.headSha ? p.details.headSha.slice(0, 7) : "";
+          branchSha = `${b}@${s}`;
+        }
+
+        if (p.workerActive) {
+          workerStr = c.green(`PID ${p.workerPids.join(",")}`);
+        }
+
+        labelsStr = Object.entries(p.details?.labels || {})
+          .map(([k, v]) => `${k}:${v}`)
+          .join(" ");
+      } else {
+        skewStr = c.red("error");
+        branchSha = c.dim(p.error?.slice(0, 24) ?? "");
+      }
+
+      console.log(
+        "  " +
+        pad(p.name, 16) + "  " +
+        pad(p.host, 22) + "  " +
+        pad(statusStr, 23) + "  " +
+        pad(skewStr, 21) + "  " +
+        pad(branchSha, 24) + "  " +
+        pad(workerStr, 19) + "  " +
+        c.dim(labelsStr),
+      );
+    }
+    console.log();
+    process.exit(0);
+  }
+
+  if (command === "deploy") {
+    const results = [];
+    for (const node of selectedNodes) {
+      if (!JSON_OUT) console.log(c.cyan(`Deploying to node ${node.name} (${node.host})...`));
+      const res = deployRemoteWorker(node, { ref: targetRef });
+      results.push(res);
+      if (!JSON_OUT) {
+        if (res.ok) {
+          console.log(c.green(`✓ Node ${node.name} deployed successfully`));
+        } else {
+          console.log(c.red(`✗ Node ${node.name} deploy failed: ${res.error}`));
+        }
+      }
+    }
+    if (JSON_OUT) console.log(JSON.stringify(results, null, 2));
+    process.exit(results.every((r) => r.ok) ? 0 : 1);
+  }
+
+  if (command === "start") {
+    const results = [];
+    for (const node of selectedNodes) {
+      if (!JSON_OUT) console.log(c.cyan(`Starting worker on node ${node.name}...`));
+      const res = startRemoteWorker(node);
+      results.push(res);
+      if (!JSON_OUT) {
+        if (res.ok) {
+          console.log(c.green(`✓ Worker started on ${node.name} (PID ${res.pid})`));
+        } else {
+          console.log(c.red(`✗ Failed to start worker on ${node.name}: ${res.error}`));
+        }
+      }
+    }
+    if (JSON_OUT) console.log(JSON.stringify(results, null, 2));
+    process.exit(results.every((r) => r.ok) ? 0 : 1);
+  }
+
+  if (command === "stop") {
+    const results = [];
+    for (const node of selectedNodes) {
+      if (!JSON_OUT) console.log(c.cyan(`Stopping worker on node ${node.name}...`));
+      const res = stopRemoteWorker(node);
+      results.push(res);
+      if (!JSON_OUT) {
+        if (res.ok) {
+          console.log(c.green(`✓ Worker stopped on ${node.name}`));
+        } else {
+          console.log(c.red(`✗ Failed to stop worker on ${node.name}: ${res.error}`));
+        }
+      }
+    }
+    if (JSON_OUT) console.log(JSON.stringify(results, null, 2));
+    process.exit(results.every((r) => r.ok) ? 0 : 1);
+  }
+
+  if (command === "update" || command === "restart") {
+    const results = [];
+    for (const node of selectedNodes) {
+      if (!JSON_OUT) console.log(c.cyan(`Updating/restarting worker on node ${node.name}...`));
+      const res = updateRemoteWorker(node, { ref: targetRef });
+      results.push(res);
+      if (!JSON_OUT) {
+        if (res.ok) {
+          console.log(c.green(`✓ Node ${node.name} updated and worker restarted (PID ${res.pid})`));
+        } else {
+          console.log(c.red(`✗ Failed on step "${res.step}" for node ${node.name}: ${res.error}`));
+        }
+      }
+    }
+    if (JSON_OUT) console.log(JSON.stringify(results, null, 2));
+    process.exit(results.every((r) => r.ok) ? 0 : 1);
+  }
+
+  console.error(c.red(`Unknown command "${command}". Run "factory workers --help" for usage.`));
+  process.exit(1);
+} catch (err) {
+  console.error(c.red(`factory workers error: ${err.message}`));
+  process.exit(1);
+}

--- a/orchestrator/workers.test.mjs
+++ b/orchestrator/workers.test.mjs
@@ -1,0 +1,66 @@
+import { test, expect, describe } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT = path.resolve(import.meta.dir, "workers.mjs");
+
+describe("orchestrator/workers CLI", () => {
+  test("factory workers --help exits 0 with usage banner", () => {
+    const res = Bun.spawnSync({
+      cmd: ["bun", SCRIPT, "--help"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(res.exitCode).toBe(0);
+    const text = res.stdout.toString();
+    expect(text).toContain("factory workers");
+    expect(text).toContain("USAGE");
+    expect(text).toContain("deploy");
+    expect(text).toContain("update");
+  });
+
+  test("factory workers --json returns empty array when no nodes are configured", () => {
+    const emptyConfig = path.join(tmpdir(), `empty-nodes-${Date.now()}.yaml`);
+    writeFileSync(emptyConfig, "nodes: {}\n");
+
+    try {
+      const res = Bun.spawnSync({
+        cmd: ["bun", SCRIPT, "--json"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          FACTORY_NODES_CONFIG: emptyConfig,
+        },
+      });
+      expect(res.exitCode).toBe(0);
+      const data = JSON.parse(res.stdout.toString());
+      expect(data.count).toBe(0);
+      expect(Array.isArray(data.nodes)).toBe(true);
+    } finally {
+      rmSync(emptyConfig, { force: true });
+    }
+  });
+
+  test("factory workers returns warning when no nodes configured in plain text mode", () => {
+    const emptyConfig = path.join(tmpdir(), `empty-nodes-txt-${Date.now()}.yaml`);
+    writeFileSync(emptyConfig, "nodes: {}\n");
+
+    try {
+      const res = Bun.spawnSync({
+        cmd: ["bun", SCRIPT],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          FACTORY_NODES_CONFIG: emptyConfig,
+        },
+      });
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.toString()).toContain("No remote worker nodes configured");
+    } finally {
+      rmSync(emptyConfig, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes OPS-445

### Summary of Changes
- Added remote worker node registry configuration schema in `config/nodes.yaml` with node hosts, users, ports, labels, environment variables, and enabled adapters.
- Implemented `event-runtime/lib/workers-remote.mjs` providing:
  - Configuration loader (`loadNodesConfig`) with validation and `FACTORY_NODES_CONFIG` override support.
  - Safe SSH argument construction (`buildSshArgv`, `executeSsh`) with configurable timeouts and batch mode.
  - Remote node probing and version skew tracking (`probeRemoteNode`) comparing remote git commit SHA with local develop trunk.
  - Remote lifecycle operations: `deployRemoteWorker`, `startRemoteWorker`, `stopRemoteWorker`, `updateRemoteWorker`.
- Implemented CLI entry point `orchestrator/workers.mjs` with subcommands:
  - `factory workers [list]`: tabular inspection of nodes, connectivity, branch/SHA, skew, worker PIDs, and labels.
  - `factory workers deploy [--node <name>] [--ref <branch>]`: bootstrap / pull repo and install deps on remote nodes.
  - `factory workers update [--node <name>] [--ref <branch>]`: rolling update (drain/stop -> pull -> restart).
  - `factory workers start / stop / restart [--node <name>]`: remote worker daemon lifecycle control.
  - `--json`: machine-readable snapshot output.
- Routed `workers` command in `bin/factory` and added CLI integration tests.
- Comprehensive unit and integration test suites in `event-runtime/lib/workers-remote.test.mjs`, `orchestrator/workers.test.mjs`, and `bin/factory.test.mjs`.

### Verification
`bun test event-runtime/lib/workers-remote.test.mjs && bun test orchestrator/workers.test.mjs && bun test bin/factory.test.mjs && bun build/emit.mjs --check` — pass (all 19 tests pass, full suite 739 tests pass).

### UX Critique
UX critique: skipped — CLI developer tooling only, no browser UI changed.