### PR TITLE
fix(event-runtime-web): generate valid default seeds for uuid and date fields (OPS-328)

### DIFF
--- a/event-runtime/web/src/templates.test.ts
+++ b/event-runtime/web/src/templates.test.ts
@@ -85,6 +85,68 @@ describe("buildSkeleton", () => {
       }),
     ).toEqual({ outer: { inner: 3 } });
   });
+
+  test("seeds uuid-like property names or format: 'uuid' to a non-empty id", () => {
+    expect(
+      buildSkeleton(
+        {
+          required: ["id", "ID", "eventId", "correlationId", "alertId", "user_id", "task-id", "customRef", "grid"],
+          properties: {
+            id: { type: "string" },
+            ID: { type: "string" },
+            eventId: { type: "string" },
+            correlationId: { type: "string" },
+            alertId: { type: "string" },
+            user_id: { type: "string" },
+            "task-id": { type: "string" },
+            customRef: { type: "string", format: "uuid" },
+            grid: { type: "string" },
+          },
+        },
+        NOW,
+      ),
+    ).toEqual({
+      id: triggerId(NOW),
+      ID: triggerId(NOW),
+      eventId: triggerId(NOW),
+      correlationId: triggerId(NOW),
+      alertId: triggerId(NOW),
+      user_id: triggerId(NOW),
+      "task-id": triggerId(NOW),
+      customRef: triggerId(NOW),
+      grid: "",
+    });
+  });
+
+  test("seeds date/timestamp property names or format: 'date-time' / 'date' to an ISO timestamp", () => {
+    expect(
+      buildSkeleton(
+        {
+          required: ["occurredAt", "createdAt", "updated_at", "started-at", "at", "timeField", "dateOnly", "plain"],
+          properties: {
+            occurredAt: { type: "string" },
+            createdAt: { type: "string" },
+            updated_at: { type: "string" },
+            "started-at": { type: "string" },
+            at: { type: "string" },
+            timeField: { type: "string", format: "date-time" },
+            dateOnly: { type: "string", format: "date" },
+            plain: { type: "string" },
+          },
+        },
+        NOW,
+      ),
+    ).toEqual({
+      occurredAt: "2026-08-13T09:15:00.000Z",
+      createdAt: "2026-08-13T09:15:00.000Z",
+      updated_at: "2026-08-13T09:15:00.000Z",
+      "started-at": "2026-08-13T09:15:00.000Z",
+      at: "2026-08-13T09:15:00.000Z",
+      timeField: "2026-08-13T09:15:00.000Z",
+      dateOnly: "2026-08-13T09:15:00.000Z",
+      plain: "",
+    });
+  });
 });
 
 describe("buildTemplates", () => {
@@ -126,7 +188,7 @@ describe("buildTemplates", () => {
       type: "keephq.disk-alert.raised",
       source: "web-trigger",
       occurredAt: "2026-08-13T09:15:00.000Z",
-      payload: { host: "lab", mount: "/", usedPct: 0, alertId: "" },
+      payload: { host: "lab", mount: "/", usedPct: 0, alertId: triggerId(NOW) },
     });
   });
 

--- a/event-runtime/web/src/templates.ts
+++ b/event-runtime/web/src/templates.ts
@@ -15,7 +15,7 @@ export interface TriggerTemplate {
 }
 
 /** A plausible starting value for one schema property — never a lie, just a seed. */
-function seedFor(name: string, schema: any): unknown {
+function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown {
   if (!schema || typeof schema !== "object") return "";
   if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0];
   if (schema.const !== undefined) return schema.const;
@@ -30,11 +30,11 @@ function seedFor(name: string, schema: any): unknown {
     case "array": {
       // minItems > 0 means "empty is invalid" — seed one element so the
       // template is submittable, not a guaranteed 422.
-      const item = seedFor(name, schema.items);
+      const item = seedFor(name, schema.items, nowMs);
       return (schema.minItems ?? 0) > 0 ? [item] : [];
     }
     case "object":
-      return buildSkeleton(schema);
+      return buildSkeleton(schema, nowMs);
     default:
       // Pattern-constrained strings get a hint the operator can recognise and
       // replace; anything else stays empty rather than inventing content.
@@ -44,17 +44,33 @@ function seedFor(name: string, schema: any): unknown {
         if (schema.pattern.startsWith("^/")) return "/";
         if (schema.pattern.includes("/")) return "owner/name";
       }
+      if (
+        schema.format === "date-time" ||
+        schema.format === "date" ||
+        name === "at" ||
+        /(?:[a-z0-9](?:At|_at|-at))$/.test(name)
+      ) {
+        return new Date(nowMs).toISOString();
+      }
+      if (
+        schema.format === "uuid" ||
+        name === "id" ||
+        name === "ID" ||
+        /(?:[a-z0-9](?:Id|_id|-id)|ID)$/.test(name)
+      ) {
+        return triggerId(nowMs);
+      }
       return "";
   }
 }
 
 /** Required properties only: the smallest envelope that can pass validation. */
-export function buildSkeleton(schema: any): Record<string, unknown> {
+export function buildSkeleton(schema: any, nowMs: number = Date.now()): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   const required: string[] = schema?.required ?? [];
   const props = schema?.properties ?? {};
   for (const name of required) {
-    out[name] = seedFor(name, props[name]);
+    out[name] = seedFor(name, props[name], nowMs);
   }
   return out;
 }
@@ -93,7 +109,7 @@ export function buildTemplates(view: AgentsView, nowMs: number): TriggerTemplate
         subject: "factory",
         occurredAt: new Date(nowMs).toISOString(),
         correlationId: id,
-        payload: buildSkeleton(def?.inputSchema),
+        payload: buildSkeleton(def?.inputSchema, nowMs),
       },
     };
   });


### PR DESCRIPTION
Fixes OPS-328