### PR TITLE
test(event-runtime-web): Dialog overlay onClose and Tab wrap tests (OPS-475)

### DIFF
--- a/event-runtime/web/src/components/Dialog.test.tsx
+++ b/event-runtime/web/src/components/Dialog.test.tsx
@@ -108,4 +108,37 @@ describe("Dialog", () => {
     fireEvent.keyDown(window, { key: "Tab" });
     expect(document.activeElement).toBe(envelope);
   });
+
+  test("Shift+Tab from the first control wraps to the last inside the panel", () => {
+    const r = render(<OpenDialog onClose={() => {}} />);
+    const envelope = r.getByTestId("envelope");
+    const chip = r.getByTestId("chip");
+    envelope.focus();
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(chip);
+  });
+
+  test("overlay backdrop click calls current onClose after parent re-render and ignores inner clicks", () => {
+    const closed: string[] = [];
+    function Parent({ tag }: { tag: string }) {
+      return (
+        <OpenDialog onClose={() => closed.push(tag)}>
+          <button type="button" data-testid="inner-btn">
+            inner
+          </button>
+        </OpenDialog>
+      );
+    }
+    const r = render(<Parent tag="first" />);
+    r.rerender(<Parent tag="current" />);
+
+    const dialogPanel = r.getByRole("dialog");
+    fireEvent.mouseDown(dialogPanel);
+    fireEvent.mouseDown(r.getByTestId("inner-btn"));
+    expect(closed).toEqual([]);
+
+    const overlay = dialogPanel.parentElement!;
+    fireEvent.mouseDown(overlay);
+    expect(closed).toEqual(["current"]);
+  });
 });

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -701,7 +701,7 @@ export function Dialog({
   return (
     <div
       className="fixed inset-0 z-40 flex items-start justify-center bg-black/50 pt-[10vh]"
-      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+      onMouseDown={(e) => e.target === e.currentTarget && onCloseRef.current()}
     >
       <div
         ref={panelRef}


### PR DESCRIPTION
Fixes OPS-475