### PR TITLE
docs(event-runtime): update README for prune, project tags, and port allocation (OPS-467, OPS-466, OPS-476)

### DIFF
--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -231,8 +231,10 @@ tagged fixtures are the completed `ok` run, the rejected proposal, the open
 approvable proposal, and the `hang` run; `refuse`, `crash`,
 `invalid-artifact`, and the `human_needed` proposal stay untagged because a
 tab that matches every row proves nothing about filtering. Names come from
-the reader's own registry, not a hardcoded pair; a checkout without one
-seeds the full set untagged and logs `project tags: none`.
+the running server's `GET /repos` endpoint (the same list the UI's project
+tabs offer), not the seeder checkout's local registry; a server without a
+readable registry logs `no repo registry (...) — seeding without project tags`
+and seeds the full set untagged.
 
 `event-runtime/demo/verify.mjs --port <api>` asserts the whole fixture via
 the API — the e2e smoke. `worktree-up.sh` runs it before reporting ready, so

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -125,9 +125,8 @@ keep a command's whole output (a CI log is useless truncated to the 2000-char
 tail the evidence field keeps).
 
 Retention: artifacts referenced by an accepted result are never deleted, and
-store size/orphan counts appear in `status`. **The weekly prune of unreferenced
-artifacts is currently broken** — `serve` throws a `ReferenceError` before it
-runs (OPS-412) — so nothing is reclaimed until that lands. A run's materialized inputs are capped
+store size/orphan counts appear in `status`. Unreferenced artifacts older than
+7 days are pruned hourly by `serve`. A run's materialized inputs are capped
 (64 MB) so one agent cannot fill the disk another agent then gets called to
 clean up.
 

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -213,7 +213,12 @@ Port allocation (so instances never collide):
 | :--- | :--- | :--- |
 | interactive default (`serve`) | 7381 | 7382 |
 | `--here` demo | 7391 | 7392 |
-| ticket worktree | 7400 + 2·(ticket % 200) | API + 1 |
+| ticket worktree | dynamic (7400–7798 band) | API + 1 |
+
+Ticket worktrees hash the ticket ID into a preferred even port in the 7400–7798
+band, scanning forward for the first free slot and persisting the assigned ports
+in `.factory/run/ports` (OPS-460). Operators should check the startup banner
+or `.factory/run/ports` rather than calculating fixed offsets.
 
 The seed (`event-runtime/demo/seed.mjs`) drives one of everything through the
 real intake/approval surfaces, using the fake adapter's input modes


### PR DESCRIPTION
Fixes OPS-467
Fixes OPS-466
Fixes OPS-476