### PR TITLE
docs(event-runtime): add description strings to all agent input schemas (WM-77)

### DIFF
--- a/event-runtime/agents/ci-doctor.json
+++ b/event-runtime/agents/ci-doctor.json
@@ -28,7 +28,7 @@
   "mutating": false,
   "pins": {
     "agents/ci-doctor.md": "sha256:e963bd86229798813c627f6381c4fbafdc846c83f708f2b3f5641325d072cbaf",
-    "schemas/ci-doctor.input.json": "sha256:5a3e2c3e0150f0af150af54cd7b3fed002ec5aacc5b42534973d1aa5200d66d5",
+    "schemas/ci-doctor.input.json": "sha256:7e30326cc9f4c1fd3d76f0b279b9b9821b6343867ee5bd679b2d3ddd191fd1b5",
     "schemas/ci-doctor.output.json": "sha256:fa0d9eefc2ed4f68b97d5d7b9ec91f36a233bff945bba71b3d9e6e8343167680"
   }
 }

--- a/event-runtime/agents/ci-log-capture.json
+++ b/event-runtime/agents/ci-log-capture.json
@@ -33,7 +33,7 @@
   "mutating": false,
   "pins": {
     "agents/ci-log-capture.md": "sha256:64e2d368336668dd308376e36cdfd65566171aff3c224282b6c06e6109a3d47a",
-    "schemas/ci-log-capture.input.json": "sha256:ddb6786a6a73a289acbcdf1a76cba48e3e54e33f1bd1212dbb929fd4f6540295",
+    "schemas/ci-log-capture.input.json": "sha256:ed7be9a461a6a228c883cc86abdba47124c11cb643673830efc8c36650928aab",
     "schemas/ci-log-captured.output.json": "sha256:1f30f70e69a51187565111af202c90d54067dbd38b931459592433c51551788b"
   }
 }

--- a/event-runtime/agents/ci-notify.json
+++ b/event-runtime/agents/ci-notify.json
@@ -27,7 +27,7 @@
   "mutating": true,
   "pins": {
     "agents/ci-notify.md": "sha256:c12a7d0613ed8fc030f29447f495fd0d70c55ec099f42ac9c08e07629283510d",
-    "schemas/ci-notify.input.json": "sha256:56dce2eea1f7c4b8e18fc1b2cbdfd6f121d4f8115c6218fcc60817e810d425f2",
+    "schemas/ci-notify.input.json": "sha256:ad1596d31e703c7af6233f752a7bedcf6f97509d4a295b07a9c630f5284110bd",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/ci-rerun.json
+++ b/event-runtime/agents/ci-rerun.json
@@ -31,7 +31,7 @@
   "mutating": true,
   "pins": {
     "agents/ci-rerun.md": "sha256:1e357287cb35d28f110040f665733cb6db76d8fcc2c2bd43d412148ed3d27ad6",
-    "schemas/ci-rerun.input.json": "sha256:5a310db030e328bef28f48a403e00f00bc3f61c5ce9d3c963e3ea72afd1b42b7",
+    "schemas/ci-rerun.input.json": "sha256:d3e79e158029b58c0d4c37b36d0f1233c78763cadc9db8edda92d3d212300284",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/disk-diagnose.json
+++ b/event-runtime/agents/disk-diagnose.json
@@ -23,7 +23,7 @@
   "mutating": false,
   "pins": {
     "agents/disk-diagnose.md": "sha256:606e047275affafd71a93fd167348836e6c76a5fa16982ac8d07b0c2b2e63098",
-    "schemas/disk-diagnose.input.json": "sha256:e97b9b0bf65fdc4ae621cf23acf1b83710f9c2e74d2c8955f4ac532a67146f64",
+    "schemas/disk-diagnose.input.json": "sha256:b14b2a1cb4ffbc5f5666a1c56ef155fb048a421a47050a5623c11ab09b204e90",
     "schemas/disk-diagnose.output.json": "sha256:934dfbd1a4e72ec1de1d1d1f85cfcbdd8a5dbbb3a779e8df1c70d9d68bd77ce7"
   }
 }

--- a/event-runtime/agents/disk-remediate.json
+++ b/event-runtime/agents/disk-remediate.json
@@ -48,7 +48,7 @@
   "mutating": true,
   "pins": {
     "agents/disk-remediate.md": "sha256:f886a34a264a2c83356b9e5cc5a96df7e994dbbbebd278afa5b4564c4b99c1e8",
-    "schemas/disk-remediate.input.json": "sha256:35468a6619856bdb6b751260f941c770b9dab144a0881cf4cdd3eac0a759966f",
+    "schemas/disk-remediate.input.json": "sha256:b73ad4bb5307bf6947b94df8ced5f475ad0c4852b083b09e963afb2252799844",
     "schemas/disk-remediation.output.json": "sha256:2ead535aeab711c998a5f074ff0408acd9799ff18d95635f66bbde6116efb806"
   }
 }

--- a/event-runtime/agents/factory-status-report.json
+++ b/event-runtime/agents/factory-status-report.json
@@ -22,7 +22,7 @@
   "mutating": false,
   "pins": {
     "agents/factory-status-report.md": "sha256:dd0fde64a31eb88178a94e07efffa6035c8be7a90e13efe8c577d3da4dd4fda3",
-    "schemas/factory-status-report.input.json": "sha256:f36a1b1752b860e5c9bced6a8f542b469927be31de065fa76bff6b3366adc3e5",
+    "schemas/factory-status-report.input.json": "sha256:44036797807c8b3ead4226e84dc8c0c1c70476fc7a8cbe9250760ccfe41a4435",
     "schemas/factory-status-report.output.json": "sha256:d837152174abfa145dae38497d651d90da1fc440ce95d71b2f2a6d01bcc4e481"
   }
 }

--- a/event-runtime/agents/reaper.json
+++ b/event-runtime/agents/reaper.json
@@ -29,7 +29,7 @@
   "mutating": true,
   "pins": {
     "agents/reaper.md": "sha256:87836b6d71a90d39c0a27639f3bb959c9a8f1919186bfa0bc2fe11697fc557cb",
-    "schemas/reaper.input.json": "sha256:22a4cc569a8c46cf8f199566f7d432b931ab311547fae41ec3934b454f9074dd",
+    "schemas/reaper.input.json": "sha256:f97328e93b2cbc9b782322d8aebc9373cc29352906b686e817b327b92cf88f2b",
     "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
   }
 }

--- a/event-runtime/agents/run-postmortem.json
+++ b/event-runtime/agents/run-postmortem.json
@@ -26,7 +26,7 @@
   "mutating": false,
   "pins": {
     "agents/run-postmortem.md": "sha256:7564db016c3de24dec763f873d4e70cb7ca201da6a19d0efd6a6734c5cc850e5",
-    "schemas/run-postmortem.input.json": "sha256:c0127cbec0af57ee98f6eaa4a65cc5de7ceef9e5c004aef62bc85d18d53d6bfa",
+    "schemas/run-postmortem.input.json": "sha256:a21960e032daf352269d81d2a71e1fa7490cc5c18b6c11c8eef99b70378ded6e",
     "schemas/run-postmortem.output.json": "sha256:41de372ab6513cbbc2065fb7ca7367005d9a5cc0268dc02bb4d53e94cc07e644"
   }
 }

--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -73,7 +73,7 @@
   "mutating": true,
   "pins": {
     "agents/triage-apply.md": "sha256:4ff7a95e86abb5bbc82bdff3202090673a87347e256e40c03bd1d963b2499992",
-    "schemas/triage-apply.input.json": "sha256:9f62f3ba601e031e96a26d4c9ee42f3008b6f12fe3d7c832d63ffa42474688ad",
+    "schemas/triage-apply.input.json": "sha256:db490430a3794775aa33263b12c8a91af1a8b5e5fcb532aa4e66a91788ff68a4",
     "schemas/triage-applied.output.json": "sha256:5e4d4a2e59423a2aab88357521ff1e37889d50d658bee7278d599400f5dc3365"
   }
 }

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -24,7 +24,7 @@
   "mutating": false,
   "pins": {
     "agents/triage-scan.md": "sha256:f78451d1e543ee57bc18c514770a9082af58052a27b0bcf5ee78409a3a67fa89",
-    "schemas/triage-scan.input.json": "sha256:9ba24feb44d0b20da3529d978a286d9173ecc5dbd9559da29fc8f98461ec6724",
+    "schemas/triage-scan.input.json": "sha256:893c6ada3445fdcf2c5507319fe4933618ca6104298493b6339677ab2e295614",
     "schemas/triage-scan.output.json": "sha256:27f7e5bbe5e109561f2a3f055dd7801ef263f6750b84936105e6d54070efba97"
   }
 }

--- a/event-runtime/schemas/ci-doctor.input.json
+++ b/event-runtime/schemas/ci-doctor.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "ci-doctor input \u2014 one failed GitHub Actions run",
+  "title": "ci-doctor input — one failed GitHub Actions run",
   "type": "object",
   "required": [
     "repo",
@@ -10,23 +10,28 @@
   "properties": {
     "repo": {
       "type": "string",
-      "pattern": "^[^/\\s]+/[^/\\s]+$"
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub repository slug (owner/name) the failed run belongs to — not the config/repos.yaml short name"
     },
     "runId": {
       "type": [
         "string",
         "integer"
-      ]
+      ],
+      "description": "GitHub Actions run id to diagnose (number, or numeric string as gh prints it)"
     },
     "headSha": {
-      "type": "string"
+      "type": "string",
+      "description": "Optional commit SHA the failed run built, for correlating with the branch history"
     },
     "workflowName": {
-      "type": "string"
+      "type": "string",
+      "description": "Optional workflow name of the failed run, used in the report only"
     },
     "logArtifact": {
       "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of the captured failed-run log in the artifact store (produced by ci-log-capture); mounted into the workspace as failed.log"
     }
   }
 }

--- a/event-runtime/schemas/ci-log-capture.input.json
+++ b/event-runtime/schemas/ci-log-capture.input.json
@@ -4,7 +4,14 @@
   "required": ["repo", "runId"],
   "additionalProperties": false,
   "properties": {
-    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
-    "runId": { "type": ["string", "integer"] }
+    "repo": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub repository slug (owner/name) the failed run belongs to — not the config/repos.yaml short name"
+    },
+    "runId": {
+      "type": ["string", "integer"],
+      "description": "GitHub Actions run id whose failed-job logs to capture (number, or numeric string as gh prints it)"
+    }
   }
 }

--- a/event-runtime/schemas/ci-notify.input.json
+++ b/event-runtime/schemas/ci-notify.input.json
@@ -4,8 +4,19 @@
   "required": ["repo", "runId", "summary"],
   "additionalProperties": false,
   "properties": {
-    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
-    "runId": { "type": ["string", "integer"] },
-    "summary": { "type": "string", "minLength": 1 }
+    "repo": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub repository slug (owner/name) the failed run belongs to — not the config/repos.yaml short name"
+    },
+    "runId": {
+      "type": ["string", "integer"],
+      "description": "GitHub Actions run id the diagnosis is about (number, or numeric string as gh prints it)"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-paragraph diagnosis to push to the operator"
+    }
   }
 }

--- a/event-runtime/schemas/ci-rerun.input.json
+++ b/event-runtime/schemas/ci-rerun.input.json
@@ -4,7 +4,14 @@
   "required": ["repo", "runId"],
   "additionalProperties": false,
   "properties": {
-    "repo": { "type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$" },
-    "runId": { "type": ["string", "integer"] }
+    "repo": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub repository slug (owner/name) the failed run belongs to — not the config/repos.yaml short name"
+    },
+    "runId": {
+      "type": ["string", "integer"],
+      "description": "GitHub Actions run id to re-run (number, or numeric string as gh prints it)"
+    }
   }
 }

--- a/event-runtime/schemas/disk-diagnose.input.json
+++ b/event-runtime/schemas/disk-diagnose.input.json
@@ -4,9 +4,25 @@
   "required": ["host", "mount", "usedPct", "alertId"],
   "additionalProperties": false,
   "properties": {
-    "host": { "enum": ["lab", "web"] },
-    "mount": { "type": "string", "pattern": "^/[A-Za-z0-9/._-]*$" },
-    "usedPct": { "type": "number", "minimum": 0, "maximum": 100 },
-    "alertId": { "type": "string", "minLength": 1 }
+    "host": {
+      "enum": ["lab", "web"],
+      "description": "Target host short name; the enum is the allowlist of hosts this agent may touch"
+    },
+    "mount": {
+      "type": "string",
+      "pattern": "^/[A-Za-z0-9/._-]*$",
+      "description": "Absolute mount point the alert fired for (e.g. /)"
+    },
+    "usedPct": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Disk usage percentage reported by the alert (0–100)"
+    },
+    "alertId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Keep HQ alert id this diagnosis answers, carried through for dedup and audit"
+    }
   }
 }

--- a/event-runtime/schemas/disk-remediate.input.json
+++ b/event-runtime/schemas/disk-remediate.input.json
@@ -4,18 +4,33 @@
   "required": ["host", "mount", "actions"],
   "additionalProperties": false,
   "properties": {
-    "host": { "enum": ["lab", "web"] },
-    "mount": { "type": "string", "pattern": "^/[A-Za-z0-9/._-]*$" },
+    "host": {
+      "enum": ["lab", "web"],
+      "description": "Target host short name; the enum is the allowlist of hosts this agent may touch"
+    },
+    "mount": {
+      "type": "string",
+      "pattern": "^/[A-Za-z0-9/._-]*$",
+      "description": "Absolute mount point being remediated (e.g. /)"
+    },
     "actions": {
       "type": "array",
       "minItems": 1,
+      "description": "Approved remediation steps, executed in order",
       "items": {
         "type": "object",
         "required": ["action"],
         "additionalProperties": false,
         "properties": {
-          "action": { "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"] },
-          "expectedReclaimBytes": { "type": "integer", "minimum": 0 }
+          "action": {
+            "enum": ["docker-builder-prune", "docker-system-prune", "journal-vacuum-3d"],
+            "description": "Remediation command from the fixed safe-action allowlist"
+          },
+          "expectedReclaimBytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Bytes the diagnosis expected this action to reclaim, for before/after comparison"
+          }
         }
       }
     }

--- a/event-runtime/schemas/factory-status-report.input.json
+++ b/event-runtime/schemas/factory-status-report.input.json
@@ -7,7 +7,12 @@
     "repos": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "description": "Repos to include in the report, by short name as configured in config/repos.yaml",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Short repo name from config/repos.yaml — not the GitHub owner/name slug"
+      }
     }
   }
 }

--- a/event-runtime/schemas/reaper.input.json
+++ b/event-runtime/schemas/reaper.input.json
@@ -4,9 +4,25 @@
   "required": ["loop", "slot"],
   "additionalProperties": false,
   "properties": {
-    "loop": { "type": "string", "minLength": 1 },
-    "slot": { "type": "string", "minLength": 1 },
-    "cadenceSeconds": { "type": "integer", "minimum": 1 },
-    "skippedSlots": { "type": "integer", "minimum": 0 }
+    "loop": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name of the standing schedule loop this tick belongs to"
+    },
+    "slot": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Interval slot identity (floor of the moment over the cadence since epoch); the tick's event id is clock:<loop>:<slot>"
+    },
+    "cadenceSeconds": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The loop's cadence in seconds"
+    },
+    "skippedSlots": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "How many missed slots this catch-up tick stands for (0 for an on-time tick)"
+    }
   }
 }

--- a/event-runtime/schemas/run-postmortem.input.json
+++ b/event-runtime/schemas/run-postmortem.input.json
@@ -4,16 +4,35 @@
   "required": ["runId"],
   "additionalProperties": false,
   "properties": {
-    "runId": { "type": "string", "minLength": 1 },
+    "runId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Run id of the terminal run to analyse"
+    },
     "runPin": {
       "type": "object",
       "required": ["runId", "transcript"],
       "additionalProperties": false,
+      "description": "Filled by the planner from the run record at plan time — not operator-supplied",
       "properties": {
-        "runId": { "type": "string", "minLength": 1 },
-        "transcript": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-        "state": { "type": "string" },
-        "agent": { "type": "string" }
+        "runId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Echo of the pinned run id"
+        },
+        "transcript": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "sha256 of the run transcript in the artifact store; mounted into the workspace"
+        },
+        "state": {
+          "type": "string",
+          "description": "Terminal state the run ended in"
+        },
+        "agent": {
+          "type": "string",
+          "description": "agent@version that executed the pinned run"
+        }
       }
     }
   }

--- a/event-runtime/schemas/triage-apply.input.json
+++ b/event-runtime/schemas/triage-apply.input.json
@@ -4,20 +4,33 @@
   "required": ["repo", "plan"],
   "additionalProperties": false,
   "properties": {
-    "repo": { "type": "string", "minLength": 1 },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    },
     "plan": {
       "type": "array",
       "minItems": 1,
+      "description": "Approved per-issue actions from the triage-scan proposal, applied in order",
       "items": {
         "type": "object",
         "required": ["issueId", "action"],
         "additionalProperties": false,
         "properties": {
-          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
-          "action": {
-            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"]
+          "issueId": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear issue identifier (e.g. WM-76)"
           },
-          "reason": { "type": "string" }
+          "action": {
+            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"],
+            "description": "Triage action to apply to the issue"
+          },
+          "reason": {
+            "type": "string",
+            "description": "One-line justification for the action, kept for the audit trail"
+          }
         }
       }
     }

--- a/event-runtime/schemas/triage-scan.input.json
+++ b/event-runtime/schemas/triage-scan.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "triage-scan input \u2014 one repo; repoPin is resolved by the planner (OPS-228)",
+  "title": "triage-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
   "type": "object",
   "required": [
     "repo"
@@ -8,10 +8,12 @@
   "properties": {
     "repo": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
     },
     "ref": {
-      "type": "string"
+      "type": "string",
+      "description": "Optional git ref to scan instead of the repo's configured base branch"
     },
     "repoPin": {
       "type": "object",
@@ -20,23 +22,28 @@
         "sha"
       ],
       "additionalProperties": false,
+      "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
       "properties": {
         "repo": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Echo of the pinned short repo name"
         },
         "ref": {
-          "type": "string"
+          "type": "string",
+          "description": "Ref the pin was resolved from, when one was requested"
         },
         "sha": {
           "type": "string",
-          "pattern": "^[0-9a-f]{40}$"
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Commit SHA the scan runs against"
         },
         "github": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }
     }


### PR DESCRIPTION
Fixes WM-77

Additive `description` metadata on every property of the 12 agent input schemas (janitor already had them). Repo-field conventions are now stated in-schema (short `config/repos.yaml` name vs GitHub `owner/name` slug vs array of short names), and planner-injected fields (`repoPin`, `runPin`) are marked as not operator-supplied. Agent def pins re-hashed via the sanctioned `bun event-runtime/cli.mjs update-pins` verb — no version bumps, since validation behavior is unchanged (`description` is in the `lib/schema.mjs` supported-keyword whitelist).

Feeds WM-76 (schema-driven Inject form renders these as field help text).

## Verification

```
bun test event-runtime/lib/schema.test.mjs event-runtime/lib/registry.test.mjs
→ 18 pass, 0 fail (37 expect calls)
```

Plus a live `loadRegistry()` smoke: 13 agents load with re-verified pins; descriptions flow through `inputSchema`.