### PR TITLE
feat(event-runtime): factory self-dispatch event types — command loops, unblock/sweep chains, lifecycle observation (WM-72 bundle)

### DIFF
--- a/event-runtime/agents/label-guard.json
+++ b/event-runtime/agents/label-guard.json
@@ -1,0 +1,37 @@
+{
+  "id": "label-guard",
+  "version": 1,
+  "prompt": "agents/label-guard.md",
+  "input_schema": "schemas/repo-loop.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "bun",
+    "{factoryRoot}/orchestrator/label-guard.mjs",
+    "--repo",
+    "{repo}",
+    "--apply"
+  ],
+  "captureStdout": "label-guard.log",
+  "captureKind": "log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 300,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/label-guard.md": "sha256:c830c11cc98ada2c13a412985e91e6c7befbffa7400bcac084c8b13d1c5fb0ed",
+    "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/label-guard.md
+++ b/event-runtime/agents/label-guard.md
@@ -1,0 +1,14 @@
+# label-guard — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+bun orchestrator/label-guard.mjs --repo {repo} --apply
+```
+
+Mechanical linear.md §5 check for `ai:agent-ready` tickets: a ticket that
+reads as dispatchable (Todo, unassigned, labelled) but is missing the two
+mechanically load-bearing sections — Owned Paths and Verification Command —
+is demoted back to Triage before dispatch can ever see it. Deliberately
+checks nothing that varies in legitimate format; it errs toward precision.

--- a/event-runtime/agents/reconcile.json
+++ b/event-runtime/agents/reconcile.json
@@ -1,0 +1,37 @@
+{
+  "id": "reconcile",
+  "version": 1,
+  "prompt": "agents/reconcile.md",
+  "input_schema": "schemas/repo-loop.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "bun",
+    "{factoryRoot}/orchestrator/reconcile.mjs",
+    "--repo",
+    "{repo}",
+    "--apply"
+  ],
+  "captureStdout": "reconcile.log",
+  "captureKind": "log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 300,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/reconcile.md": "sha256:f2c7e089132677a70e82346b1e51ad68739746da36abef29e2a17a9f172dfb4a",
+    "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/reconcile.md
+++ b/event-runtime/agents/reconcile.md
@@ -1,0 +1,14 @@
+# reconcile — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+bun orchestrator/reconcile.mjs --repo {repo} --apply
+```
+
+Reconciles Linear ticket state with what GitHub actually shows: a ticket
+sitting `In Progress` whose own PR is already open moves to `In Review`
+(freeing its dispatch slot), and one whose PR is merged moves on. Positive
+evidence only — it never acts on silence (that is the reaper's question) and
+never merges anything itself.

--- a/event-runtime/agents/sweep-apply.json
+++ b/event-runtime/agents/sweep-apply.json
@@ -1,0 +1,59 @@
+{
+  "id": "sweep-apply",
+  "version": 1,
+  "prompt": "agents/sweep-apply.md",
+  "input_schema": "schemas/sweep-apply.input.json",
+  "output_schema": "schemas/sweep-applied.output.json",
+  "output_contract": "factory.sweep-applied/v1",
+  "itemsField": "plan",
+  "itemKey": "issueId",
+  "actionRegistry": {
+    "retire-shipped": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Canceled"
+      ]
+    },
+    "mark-duplicate": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Duplicate"
+      ]
+    },
+    "comment-evidence": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "comment",
+        "{issueId}",
+        "sweep: {reason}"
+      ]
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/sweep-apply.md": "sha256:d57dcb300c70ee223ed3c948a4aacdf4e5eb3afb5710fca8d8a3994f5111a2e5",
+    "schemas/sweep-apply.input.json": "sha256:5af257704ff1a7a6753e27bbe6916cc0b0946c8b4a23250bf592dd139273ec44",
+    "schemas/sweep-applied.output.json": "sha256:75524150caebdaeffeb1dee800169a0ac423d3d6549d5491185eefe5351dacfd"
+  }
+}

--- a/event-runtime/agents/sweep-apply.md
+++ b/event-runtime/agents/sweep-apply.md
@@ -1,0 +1,17 @@
+# sweep-apply — closed action-list executor for ticket retirements
+
+Not a prompt: this definition applies an **approved per-issue action list**
+via the deterministic actions adapter in item-list mode
+(`lib/adapters/actions.mjs`). No model runs.
+
+Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+
+| action id | effect |
+| :--- | :--- |
+| `retire-shipped` | `state {issueId} "Canceled"` — shipped or overtaken, evidence approved by the operator |
+| `mark-duplicate` | `state {issueId} "Duplicate"` — another named ticket covers it |
+| `comment-evidence` | `comment {issueId} "sweep: <reason>"` — the citation a retirement must carry |
+
+Retirement is always a state transition, never a delete or archive — the
+ticket stays recoverable. An action ID outside this table refuses before
+applying anything — including the legitimate items alongside it.

--- a/event-runtime/agents/sweep-scan.json
+++ b/event-runtime/agents/sweep-scan.json
@@ -1,0 +1,30 @@
+{
+  "id": "sweep-scan",
+  "version": 1,
+  "prompt": "agents/sweep-scan.md",
+  "input_schema": "schemas/sweep-scan.input.json",
+  "output_schema": "schemas/sweep-scan.output.json",
+  "output_contract": "factory.sweep-plan/v1",
+  "workspace": {
+    "type": "repository",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:read",
+      "repo:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/sweep-scan.md": "sha256:4151bf08cdd38178ff5137c29058dac4d13c74fa7e5c7986b53cd2db89f055ad",
+    "schemas/sweep-scan.input.json": "sha256:e9a65f017d7ee366f338d7746df2f36659b3244c3e745ec759f581cf8ceb00cd",
+    "schemas/sweep-scan.output.json": "sha256:fd42580f1d96f318094eedb638aa8adc432ad9464f4d6ad8af23ba49ff1ea8ba"
+  }
+}

--- a/event-runtime/agents/sweep-scan.md
+++ b/event-runtime/agents/sweep-scan.md
@@ -1,0 +1,77 @@
+# sweep-scan — find obsolete tickets and propose evidenced retirements
+
+You are a backlog sweeper. `./input.json` names one repo and the exact source
+tree to read it against:
+
+```json
+{
+  "repo": "bj29",
+  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+}
+```
+
+`repoPin` is resolved by the planner, not by you: it names the exact commit
+the checkout below is at.
+
+The repo's source is checked out **read-only** at `./repo` (that exact SHA).
+You never modify it, never run its build, never install anything. Write
+`./result.json`. Work only inside this directory.
+
+## Method
+
+1. List the repo's open issues in `Backlog`, `Triage`, and `Todo`,
+   oldest-updated first: `factory linear issues --repo <name>` (or
+   `bun "$FACTORY_ROOT/tools/linear.mjs"`). **Skip, always:** anything
+   `In Progress`, `In Review`, carrying `ai:blocked`, with an open PR, or
+   with recent human activity — those are live claims, holds, or
+   conversations, not this route's to touch.
+2. For each, judge whether the *work itself* still needs doing, checking every
+   claim against `./repo` at this SHA and against the issue graph:
+   - **duplicate** — another ticket (open or Done) covers the same
+     requirement; the reason must name that issue;
+   - **already shipped** — the acceptance criteria are met in this tree; the
+     reason must cite the commit or PR, not just a filename;
+   - **overtaken by events** — the feature or integration it references no
+     longer exists; the reason must cite what you found.
+3. **Age, low priority, and "nobody's gotten to it" are never evidence.** A
+   ticket you cannot retire with a citation stays out of the retire actions —
+   at most a `comment-evidence` entry stating what you found and that a human
+   should decide.
+
+## Actions — the closed set
+
+| action | when |
+| :--- | :--- |
+| `retire-shipped` | shipped or overtaken, with a citation → `Canceled` |
+| `mark-duplicate` | another named ticket covers it → `Duplicate` |
+| `comment-evidence` | the citation accompanying a retirement, or a needs-human-call note on its own |
+
+Pair every `retire-shipped`/`mark-duplicate` with a `comment-evidence` entry
+for the same issue carrying the citation. Never invent an action id. Never
+propose deleting or archiving anything — retirement is a state transition and
+stays recoverable.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "SWEEP",
+    "repo": "bj29",
+    "plan": [
+      { "issueId": "CLNT-123", "action": "retire-shipped", "reason": "shipped in PR #45 (commit abc1234)" },
+      { "issueId": "CLNT-123", "action": "comment-evidence", "reason": "shipped in PR #45 (commit abc1234)" }
+    ],
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the reads this rests on"], "issuesSeen": 12 }
+}
+```
+
+Nothing retirable with evidence → `recommendation: "NOOP"` with an empty
+`plan` and a summary saying so. That is a good outcome, not a failure. If
+Linear is unreachable, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/agents/unblock-apply.json
+++ b/event-runtime/agents/unblock-apply.json
@@ -1,0 +1,65 @@
+{
+  "id": "unblock-apply",
+  "version": 1,
+  "prompt": "agents/unblock-apply.md",
+  "input_schema": "schemas/unblock-apply.input.json",
+  "output_schema": "schemas/unblock-applied.output.json",
+  "output_contract": "factory.unblock-applied/v1",
+  "itemsField": "plan",
+  "itemKey": "issueId",
+  "actionRegistry": {
+    "release-hold": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Todo",
+        "--remove",
+        "ai:blocked",
+        "--add",
+        "ai:agent-ready"
+      ]
+    },
+    "release-to-triage": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{issueId}",
+        "Triage",
+        "--remove",
+        "ai:blocked"
+      ]
+    },
+    "comment-evidence": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "comment",
+        "{issueId}",
+        "unblock: {reason}"
+      ]
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/unblock-apply.md": "sha256:5f12a41ac1e9b696672f095177fc6061d49040bb837a725d06a91fd9fa8e2193",
+    "schemas/unblock-apply.input.json": "sha256:a983e831d67dbb30352697e457a7197f18776e1de184731be7ed88b9ea1d8f41",
+    "schemas/unblock-applied.output.json": "sha256:4b1ed38f71ca16a56bc7bc2582c629580fe7b57614ea2b12b0c289c9e6bf611b"
+  }
+}

--- a/event-runtime/agents/unblock-apply.md
+++ b/event-runtime/agents/unblock-apply.md
@@ -1,0 +1,18 @@
+# unblock-apply — closed action-list executor for hold releases
+
+Not a prompt: this definition applies an **approved per-issue action list**
+via the deterministic actions adapter in item-list mode
+(`lib/adapters/actions.mjs`). No model runs.
+
+Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+
+| action id | effect |
+| :--- | :--- |
+| `release-hold` | `state {issueId} "Todo" --remove ai:blocked --add ai:agent-ready` — evidence resolved the hold and the spec is dispatchable |
+| `release-to-triage` | `state {issueId} "Triage" --remove ai:blocked` — hold resolved, spec needs the triage stage |
+| `comment-evidence` | `comment {issueId} "unblock: <reason>"` — the citation a release must carry |
+
+Every action is a forward state move or a comment; nothing here closes,
+deletes, or reassigns an issue, and nothing can add `ai:blocked`. An action
+ID outside this table refuses before applying anything — including the
+legitimate items alongside it.

--- a/event-runtime/agents/unblock-digest.json
+++ b/event-runtime/agents/unblock-digest.json
@@ -1,0 +1,36 @@
+{
+  "id": "unblock-digest",
+  "version": 1,
+  "prompt": "agents/unblock-digest.md",
+  "input_schema": "schemas/repo-loop.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "bun",
+    "{factoryRoot}/orchestrator/digest.mjs",
+    "--repo",
+    "{repo}"
+  ],
+  "captureStdout": "digest.log",
+  "captureKind": "log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 300,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/unblock-digest.md": "sha256:551dc3472350c0f40b7ce445b7d1b9b101d6a08473ab3c5afd3bd38c42036bc5",
+    "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/unblock-digest.md
+++ b/event-runtime/agents/unblock-digest.md
@@ -1,0 +1,14 @@
+# unblock-digest — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+bun orchestrator/digest.mjs --repo {repo}
+```
+
+Read-only report of every `ai:blocked` ticket for the repo: the blocking
+question, hold age, and ANSWERED markers where a reply already exists. Writes
+nothing anywhere — the captured log is the deliverable, and the agent pass
+that acts on holds (`unblock-scan`/`unblock-apply`) is a separate, watched
+route.

--- a/event-runtime/agents/unblock-scan.json
+++ b/event-runtime/agents/unblock-scan.json
@@ -1,0 +1,30 @@
+{
+  "id": "unblock-scan",
+  "version": 1,
+  "prompt": "agents/unblock-scan.md",
+  "input_schema": "schemas/unblock-scan.input.json",
+  "output_schema": "schemas/unblock-scan.output.json",
+  "output_contract": "factory.unblock-plan/v1",
+  "workspace": {
+    "type": "repository",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:read",
+      "repo:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/unblock-scan.md": "sha256:6a06493735dd5dafaf9a176390bf8d4930096bf32ca1e8cfce6c49f80a1d591c",
+    "schemas/unblock-scan.input.json": "sha256:68ea3a420c8f51a6a50046e2a7cf4a1f1579b0aeb1d603820e2d4237d5bb9c43",
+    "schemas/unblock-scan.output.json": "sha256:1ccccd541b192dc4a300a1a5ebfe36485fb2ed97effc4f0d6bfcc1ab7e757c65"
+  }
+}

--- a/event-runtime/agents/unblock-scan.md
+++ b/event-runtime/agents/unblock-scan.md
@@ -1,0 +1,70 @@
+# unblock-scan — re-examine a repo's ai:blocked holds for NEW evidence
+
+You are an unblock analyst. `./input.json` names one repo and the exact source
+tree to read it against:
+
+```json
+{
+  "repo": "bj29",
+  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+}
+```
+
+`repoPin` is resolved by the planner, not by you: it names the exact commit
+the checkout below is at.
+
+The repo's source is checked out **read-only** at `./repo` (that exact SHA).
+You never modify it, never run its build, never install anything. Write
+`./result.json`. Work only inside this directory.
+
+## Method
+
+1. List the repo's open issues carrying `ai:blocked`, **oldest hold first**:
+   `factory linear issues --repo <name>` (or `bun "$FACTORY_ROOT/tools/linear.mjs"`).
+2. For each, reconstruct the hold: what did the blocking comment say is
+   missing?
+3. Hunt for **new** evidence that the hold has resolved without a reply:
+   - a blocking/related ticket has since moved to Done, or the referenced PR merged;
+   - the answer now exists in `./repo` docs (`docs/product-decisions.md`, `docs/`);
+   - the premise of the hold is gone from the code on this SHA (verify by reading).
+4. Propose at most one release action per issue, plus a `comment-evidence`
+   entry citing the evidence. **Without evidence, leave the ticket out of the
+   plan entirely** — no comment, no label churn, no re-stating the question.
+   Age is not evidence. A sweep that re-derives the same hold on every run is
+   the exact pathology this route exists to avoid.
+
+## Actions — the closed set
+
+| action | when |
+| :--- | :--- |
+| `release-hold` | evidence resolves the hold AND the §5 template is solid against this SHA → back to the dispatch queue |
+| `release-to-triage` | evidence resolves the hold but the spec needs work → triage will re-spec it |
+| `comment-evidence` | the one-line citation (ticket/PR/doc) accompanying a release |
+
+Never invent an action id. Never release on a guess — a wrongly released hold
+hands an implementation agent a question a human was supposed to answer.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "UNBLOCK",
+    "repo": "bj29",
+    "plan": [
+      { "issueId": "CLNT-123", "action": "release-to-triage", "reason": "dependency CLNT-100 merged in PR #45" },
+      { "issueId": "CLNT-123", "action": "comment-evidence", "reason": "dependency CLNT-100 merged in PR #45" }
+    ],
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the reads this rests on"], "holdsSeen": 4 }
+}
+```
+
+No holds, or no hold with new evidence → `recommendation: "NOOP"` with an
+empty `plan` and a summary saying so. That is a good outcome, not a failure.
+If Linear is unreachable, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/agents/warm.json
+++ b/event-runtime/agents/warm.json
@@ -1,0 +1,37 @@
+{
+  "id": "warm",
+  "version": 1,
+  "prompt": "agents/warm.md",
+  "input_schema": "schemas/repo-loop.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "bun",
+    "{factoryRoot}/orchestrator/warm.mjs",
+    "--repo",
+    "{repo}",
+    "--apply"
+  ],
+  "captureStdout": "warm.log",
+  "captureKind": "log",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "repo:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 1800,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/warm.md": "sha256:3c873b0f2ed6cc1c98200773218f3ffb83379c138107597f2ec088e45dbe3238",
+    "schemas/repo-loop.input.json": "sha256:8a67a773285d276f50f8b595d43d980f5ce286b74d2b4ad5852f07ee42e517a9",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/warm.md
+++ b/event-runtime/agents/warm.md
@@ -1,0 +1,14 @@
+# warm — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+bun orchestrator/warm.mjs --repo {repo} --apply
+```
+
+Refreshes the repo's worktree warm-cache template (declared as
+`worktree_warm` in config/repos.yaml): compiles once so that N ticket
+worktrees don't each pay a full install and build. Mutates only the local
+template cache on the worker host — it never touches Linear, GitHub, or any
+live checkout. The generous timeout is a full cold build.

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -18,6 +18,7 @@
  */
 import { createHash } from "node:crypto";
 import { apiClient } from "../lib/client.mjs";
+import { loadRegistry } from "../lib/registry.mjs";
 
 const args = process.argv.slice(2);
 const i = args.indexOf("--port");
@@ -235,8 +236,11 @@ check("GET /workers returns live worker(s)", workers.some((w) => w.state !== "st
 const { schedules } = await client.schedules();
 check("GET /schedules lists registered schedules", schedules.length >= 1);
 
+// Compare against the committed registry, not a hand-counted literal — a new
+// agent definition must not fail the e2e for being new (WM-72).
+const registeredCount = loadRegistry().agents.size;
 const { agents } = await client.agents();
-check("GET /agents lists registered agents (13 total)", agents.length === 13, `found ${agents.length}`);
+check(`GET /agents lists registered agents (${registeredCount} total)`, agents.length === registeredCount, `found ${agents.length}`);
 
 const journalRes = await client.journal();
 check("GET /journal returns lifecycle journal entries", (journalRes?.entries?.length ?? 0) >= 10);

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -36,6 +36,18 @@
       }
     }
   },
+  "sweep-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "SWEEP": {
+        "eventType": "factory.sweep-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "plan": "$.artifact.plan"
+        }
+      }
+    }
+  },
   "ci-log-capture@1": {
     "recommendationField": "exitCode",
     "edges": {

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -24,6 +24,18 @@
       }
     }
   },
+  "unblock-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "UNBLOCK": {
+        "eventType": "factory.unblock-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "plan": "$.artifact.plan"
+        }
+      }
+    }
+  },
   "ci-log-capture@1": {
     "recommendationField": "exitCode",
     "edges": {

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -137,6 +137,22 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.sweep.requested": {
+    "agent": "sweep-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.sweep-apply.requested": {
+    "agent": "sweep-apply@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -97,6 +97,38 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.reconcile.requested": {
+    "agent": "reconcile@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.label-guard.requested": {
+    "agent": "label-guard@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.warm.requested": {
+    "agent": "warm@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.unblock-digest.requested": {
+    "agent": "unblock-digest@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "clock.tick.reaper": {
     "agent": "reaper@1",
     "adapter": "command",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -161,6 +161,18 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.ticket.dispatched": {
+    "observe": true
+  },
+  "factory.ticket.reaped": {
+    "observe": true
+  },
+  "factory.ticket.reconciled": {
+    "observe": true
+  },
+  "factory.worktree.reclaimed": {
+    "observe": true
+  },
   "clock.tick.reaper": {
     "agent": "reaper@1",
     "adapter": "command",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -121,6 +121,22 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.unblock.requested": {
+    "agent": "unblock-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
+  "factory.unblock-apply.requested": {
+    "agent": "unblock-apply@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -147,6 +147,42 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
     });
     return { exitCode: 0, timedOut: false };
   }
+  if (spec.outputContract === "factory.unblock-plan/v1") {
+    // Repo "clean" → NOOP; anything else releases one hold with evidence.
+    const repo = spec.input?.repo;
+    const clean = repo === "clean";
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: clean
+        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: no hold has new evidence" }
+        : {
+            recommendation: "UNBLOCK",
+            repo,
+            plan: [
+              { issueId: "CLNT-998", action: "release-to-triage", reason: "fake: dependency merged" },
+              { issueId: "CLNT-998", action: "comment-evidence", reason: "fake: dependency merged" },
+            ],
+            summary: `fake unblock of ${repo}`,
+          },
+      evidence: { commands: ["fake"], holdsSeen: 1 },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.unblock-applied/v1") {
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        repo: spec.input.repo,
+        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action })),
+      },
+      evidence: { commands: ["fake"] },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
   if (spec.outputContract === "factory.triage-applied/v1") {
     writeResult(workspaceDir, {
       schemaVersion: "factory.agent-result/v1",

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -183,6 +183,42 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace
     });
     return { exitCode: 0, timedOut: false };
   }
+  if (spec.outputContract === "factory.sweep-plan/v1") {
+    // Repo "clean" → NOOP; anything else retires one shipped ticket with evidence.
+    const repo = spec.input?.repo;
+    const clean = repo === "clean";
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: clean
+        ? { recommendation: "NOOP", repo, plan: [], summary: "fake: nothing retirable with evidence" }
+        : {
+            recommendation: "SWEEP",
+            repo,
+            plan: [
+              { issueId: "CLNT-997", action: "retire-shipped", reason: "fake: shipped in PR #1" },
+              { issueId: "CLNT-997", action: "comment-evidence", reason: "fake: shipped in PR #1" },
+            ],
+            summary: `fake sweep of ${repo}`,
+          },
+      evidence: { commands: ["fake"], issuesSeen: 1 },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
+  if (spec.outputContract === "factory.sweep-applied/v1") {
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        repo: spec.input.repo,
+        applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.issueId, action: i.action })),
+      },
+      evidence: { commands: ["fake"] },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
   if (spec.outputContract === "factory.triage-applied/v1") {
     writeResult(workspaceDir, {
       schemaVersion: "factory.agent-result/v1",

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -137,6 +137,18 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     if (!mapping) return humanNeeded(db, event, "unregistered_event_type", at, DEFAULT_PROPOSAL_TTL_SECONDS);
     const ttlSeconds = mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS;
 
+    // Observe-only types (WM-75): the orchestrator reporting its own
+    // lifecycle. The event is the deliverable — admitted, journaled,
+    // queryable — and the plan is a typed NOOP, never an inbox ask.
+    if (mapping.observe === true) {
+      const proposal = insertProposal(db, {
+        id: newProposalId(), event, decision: "noop", status: "resolved",
+        reason: "observed", at, ttlSeconds,
+      });
+      setEventStatus(db, event, "noop");
+      return { decision: "noop", proposal, reason: "observed" };
+    }
+
     const def = getAgent(registry, mapping.agent);
 
     // §5 singleton: a scheduled loop whose previous run is still in flight

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -195,6 +195,21 @@ describe("planEvent", () => {
     expect(event.status).toBe("human_needed");
   });
 
+  test("observe-only event type → typed NOOP 'observed', never an inbox ask (WM-75)", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, {
+      type: "factory.ticket.dispatched",
+      payload: { repo: "bj29", ticket: "CLNT-1", harness: "claude" },
+    });
+    const outcome = planEvent(db, registry, ref, { now: NOW });
+    expect(outcome.decision).toBe("noop");
+    expect(outcome.reason).toBe("observed");
+    expect(outcome.proposal.status).toBe("resolved");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    expect(event.status).toBe("noop");
+  });
+
   test("payload failing the agent input schema → human_needed with the first error", () => {
     const db = openDb(":memory:");
     const ref = admit(db, { payload: { repos: [] } });

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -158,6 +158,19 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
       if (approval === "auto" && !schedule.enabled) {
         throw new RegistryError(`schedules.json: ${loop} declares approval "auto" but is not enabled — decide one`);
       }
+      // A static payload rides along on every tick (repo-scoped loops need
+      // {repo}). Tick fields always win the merge, so a payload claiming
+      // loop/slot identity is a config error, not a spoofing vector.
+      if (schedule.payload !== undefined) {
+        if (typeof schedule.payload !== "object" || schedule.payload === null || Array.isArray(schedule.payload)) {
+          throw new RegistryError(`schedules.json: ${loop} payload must be a plain object`);
+        }
+        for (const reserved of ["loop", "slot", "cadenceSeconds", "skippedSlots"]) {
+          if (reserved in schedule.payload) {
+            throw new RegistryError(`schedules.json: ${loop} payload must not set reserved tick field "${reserved}"`);
+          }
+        }
+      }
     }
   }
 

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -90,6 +90,15 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
 
   const eventTypes = JSON.parse(readFileSync(path.join(root, "event-types.json"), "utf8"));
   for (const [type, mapping] of Object.entries(eventTypes)) {
+    // Observe-only types (WM-75): admitted and recorded, resolved by the
+    // planner as a typed NOOP — never a run, never a human_needed ask. They
+    // name no agent, and naming one anyway is a config error, not a hint.
+    if (mapping.observe === true) {
+      if (mapping.agent) {
+        throw new RegistryError(`event type ${type} is observe-only but names agent ${mapping.agent} — pick one`);
+      }
+      continue;
+    }
     if (!mapping.agent || !agents.has(mapping.agent)) {
       throw new RegistryError(`event type ${type} maps to unregistered agent ${mapping.agent}`);
     }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -42,6 +42,23 @@ describe("registry", () => {
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
   });
 
+  test("schedule payload must be a plain object without reserved tick fields (WM-72)", () => {
+    const root = tempRegistry();
+    const withPayload = (payload) =>
+      writeFileSync(
+        path.join(root, "schedules.json"),
+        JSON.stringify({
+          "reconcile-x": { every: "10m", eventType: "factory.reconcile.requested", payload, enabled: false },
+        }),
+      );
+    withPayload(["bj29"]);
+    expect(() => loadRegistry({ root })).toThrow(/plain object/);
+    withPayload({ slot: "2026-01-01T00:00:00.000Z" });
+    expect(() => loadRegistry({ root })).toThrow(/reserved tick field/);
+    withPayload({ repo: "bj29" });
+    expect(() => loadRegistry({ root })).not.toThrow();
+  });
+
   test("event type mapped to an unregistered agent fails closed", () => {
     const root = tempRegistry();
     writeFileSync(

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -131,7 +131,10 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
             causationId: null,
             // skippedSlots travels on the tick that did fire: the audit trail
             // says "this run stands for 5 slots nobody was awake for".
-            payload: { loop, slot, cadenceSeconds, skippedSlots: skipped },
+            // A schedule's static payload (e.g. {repo}) rides along under the
+            // tick fields, which always win — a schedule must not be able to
+            // forge which slot it claims to be.
+            payload: { ...(schedule.payload ?? {}), loop, slot, cadenceSeconds, skippedSlots: skipped },
           },
           { now },
         );

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -180,6 +180,23 @@ describe("emitDueTicks (§3)", () => {
     expect(envelope.source).toBe("schedule");
   });
 
+  test("a static payload rides on the tick and the planner proposes the routed run (WM-72)", () => {
+    const d = db();
+    const registry = withLoop({ eventType: "factory.reconcile.requested", payload: { repo: "bj29" } });
+    emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
+
+    const row = d.query(`SELECT envelope_json FROM events ORDER BY event_id DESC LIMIT 1`).get();
+    const envelope = JSON.parse(row.envelope_json);
+    expect(envelope.type).toBe("factory.reconcile.requested");
+    // Tick identity fields always win the merge over the static payload.
+    expect(envelope.payload).toMatchObject({ repo: "bj29", loop: "reaper", slot: "2026-08-13T21:00:00.000Z" });
+
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    const proposal = openProposals(d, {}).find((p) => p.spec?.agent === "reconcile@1");
+    expect(proposal).toBeTruthy();
+    expect(proposal.status).toBe("open");
+  });
+
   test("a disabled loop never fires", () => {
     const d = db();
     expect(emitDueTicks(d, withLoop({ enabled: false }), { now: Date.now() }).emitted).toEqual([]);

--- a/event-runtime/lib/sweep.test.mjs
+++ b/event-runtime/lib/sweep.test.mjs
@@ -1,0 +1,150 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./adapters/fake.mjs";
+import { resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+// See repository.test.mjs: neutralise the operator's global git config so a
+// signing key or a global hooks path cannot hang the fixture (OPS-441).
+const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
+const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+
+const fixtures = [];
+let previousReposRoot;
+let previousHome;
+
+function makeGitRepo(name) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  fixtures.push(dir);
+  git(["init", "--quiet", "--initial-branch=develop"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(path.join(dir, "README.md"), `${name}\n`);
+  git(["add", "."], dir);
+  git(["commit", "--quiet", "-m", "init"], dir);
+  return dir;
+}
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  fixtures.push(root);
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  const bj29 = makeGitRepo("bj29");
+  const clean = makeGitRepo("clean");
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: bj29\n    path: ${bj29}\n    github: watt-mind/bj29\n    base: develop\n` +
+      `  - name: clean\n    path: ${clean}\n    github: watt-mind/clean\n    base: develop\n`,
+  );
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  previousHome = process.env.FACTORY_EVENT_HOME;
+  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  fixtures.push(home);
+  process.env.FACTORY_EVENT_HOME = home;
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  if (previousHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+  else process.env.FACTORY_EVENT_HOME = previousHome;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-"));
+  fixtures.push(dir);
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-ws-"));
+  fixtures.push(workspaces);
+  const adapters = { claude: fake, actions: fake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+const sweepEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.sweep.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("sweep chain: scan → approved apply (WM-74)", () => {
+  test("a SWEEP verdict proposes the concrete retirement list, watched", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, sweepEnvelope("bj29", "sweep-1"));
+
+    const scan = await approveNext("sweep-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+    expect(scan.proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "sweep-apply@1");
+    expect(apply.status).toBe("open"); // retirement never happens unapproved
+    expect(apply.spec.input).toEqual({
+      repo: "bj29",
+      plan: [
+        { issueId: "CLNT-997", action: "retire-shipped", reason: "fake: shipped in PR #1" },
+        { issueId: "CLNT-997", action: "comment-evidence", reason: "fake: shipped in PR #1" },
+      ],
+    });
+
+    const applied = await approveNext("sweep-apply@1");
+    expect(applied.summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(
+      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json,
+    );
+    expect(result.artifact.applied).toEqual([
+      { issueId: "CLNT-997", action: "retire-shipped" },
+      { issueId: "CLNT-997", action: "comment-evidence" },
+    ]);
+  });
+
+  test("nothing retirable converges to NOOP — nothing proposed, nothing applied", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, sweepEnvelope("clean", "sweep-2"));
+    await approveNext("sweep-scan@1");
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "sweep-apply@1")).toBeUndefined();
+  });
+
+  test("the apply registry is state transitions and comments only — no delete, no archive", () => {
+    const def = registry.agents.get("sweep-apply@1");
+    expect(Object.keys(def.actionRegistry).sort()).toEqual([
+      "comment-evidence",
+      "mark-duplicate",
+      "retire-shipped",
+    ]);
+    for (const action of Object.values(def.actionRegistry)) {
+      expect(action.argv[1]).toBe("{factoryRoot}/tools/linear.mjs");
+      expect(["state", "comment"]).toContain(action.argv[2]);
+    }
+  });
+});

--- a/event-runtime/lib/unblock.test.mjs
+++ b/event-runtime/lib/unblock.test.mjs
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./adapters/fake.mjs";
+import { resolveChains } from "./chain.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+// See repository.test.mjs: neutralise the operator's global git config so a
+// signing key or a global hooks path cannot hang the fixture (OPS-441).
+const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
+const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+
+const fixtures = [];
+let previousReposRoot;
+let previousHome;
+
+function makeGitRepo(name) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-${name}-`));
+  fixtures.push(dir);
+  git(["init", "--quiet", "--initial-branch=develop"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(path.join(dir, "README.md"), `${name}\n`);
+  git(["add", "."], dir);
+  git(["commit", "--quiet", "-m", "init"], dir);
+  return dir;
+}
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-factory-"));
+  fixtures.push(root);
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  const bj29 = makeGitRepo("bj29");
+  const clean = makeGitRepo("clean");
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: bj29\n    path: ${bj29}\n    github: watt-mind/bj29\n    base: develop\n` +
+      `  - name: clean\n    path: ${clean}\n    github: watt-mind/clean\n    base: develop\n`,
+  );
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  previousHome = process.env.FACTORY_EVENT_HOME;
+  const home = mkdtempSync(path.join(os.tmpdir(), "evrt-home-"));
+  fixtures.push(home);
+  process.env.FACTORY_EVENT_HOME = home;
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  if (previousHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+  else process.env.FACTORY_EVENT_HOME = previousHome;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-"));
+  fixtures.push(dir);
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-ws-"));
+  fixtures.push(workspaces);
+  const adapters = { claude: fake, actions: fake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+const unblockEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.unblock.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("unblock chain: scan → approved apply (WM-73)", () => {
+  test("an UNBLOCK verdict proposes the concrete hold-release list, watched", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, unblockEnvelope("bj29", "unblock-1"));
+
+    const scan = await approveNext("unblock-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+    // The scan's spec pins an immutable sha — reproducible reads.
+    expect(scan.proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "unblock-apply@1");
+    expect(apply.status).toBe("open"); // never applied without approval
+    expect(apply.spec.input).toEqual({
+      repo: "bj29",
+      plan: [
+        { issueId: "CLNT-998", action: "release-to-triage", reason: "fake: dependency merged" },
+        { issueId: "CLNT-998", action: "comment-evidence", reason: "fake: dependency merged" },
+      ],
+    });
+
+    const applied = await approveNext("unblock-apply@1");
+    expect(applied.summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(
+      db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(applied.runId).result_json,
+    );
+    expect(result.artifact.applied).toEqual([
+      { issueId: "CLNT-998", action: "release-to-triage" },
+      { issueId: "CLNT-998", action: "comment-evidence" },
+    ]);
+  });
+
+  test("no hold with new evidence converges to NOOP — nothing proposed, nothing applied", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, unblockEnvelope("clean", "unblock-2"));
+    await approveNext("unblock-scan@1");
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "unblock-apply@1")).toBeUndefined();
+  });
+
+  test("the apply registry cannot add ai:blocked or touch anything but the closed verbs", () => {
+    const def = registry.agents.get("unblock-apply@1");
+    expect(Object.keys(def.actionRegistry).sort()).toEqual([
+      "comment-evidence",
+      "release-hold",
+      "release-to-triage",
+    ]);
+    for (const action of Object.values(def.actionRegistry)) {
+      expect(action.argv[0]).toBe("bun");
+      expect(action.argv[1]).toBe("{factoryRoot}/tools/linear.mjs");
+      expect(action.argv).not.toContain("ai:blocked-add");
+    }
+  });
+});

--- a/event-runtime/schedules.json
+++ b/event-runtime/schedules.json
@@ -6,5 +6,41 @@
     "singleton": true,
     "approval": "watched",
     "enabled": false
+  },
+  "reconcile-bj29": {
+    "every": "10m",
+    "eventType": "factory.reconcile.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "label-guard-bj29": {
+    "every": "5m",
+    "eventType": "factory.label-guard.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "warm-bj29": {
+    "every": "2h",
+    "eventType": "factory.warm.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "unblock-digest-bj29": {
+    "every": "1d",
+    "eventType": "factory.unblock-digest.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
   }
 }

--- a/event-runtime/schemas/repo-loop.input.json
+++ b/event-runtime/schemas/repo-loop.input.json
@@ -1,0 +1,17 @@
+{
+  "title": "repo-scoped loop input — a manual request, or a clock tick whose schedule carries a static {repo} payload",
+  "type": "object",
+  "required": ["repo"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository identifier configured in config/repos.yaml"
+    },
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/event-runtime/schemas/sweep-applied.output.json
+++ b/event-runtime/schemas/sweep-applied.output.json
@@ -1,0 +1,22 @@
+{
+  "title": "factory.sweep-applied/v1 output artifact — which retirements actually landed",
+  "type": "object",
+  "required": ["repo", "applied"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "applied": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/sweep-apply.input.json
+++ b/event-runtime/schemas/sweep-apply.input.json
@@ -1,0 +1,25 @@
+{
+  "title": "sweep-apply input — the approved per-issue retirement list",
+  "type": "object",
+  "required": ["repo", "plan"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["retire-shipped", "mark-duplicate", "comment-evidence"]
+          },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/sweep-scan.input.json
+++ b/event-runtime/schemas/sweep-scan.input.json
@@ -1,0 +1,44 @@
+{
+  "title": "sweep-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
+  "type": "object",
+  "required": [
+    "repo"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ref": {
+      "type": "string"
+    },
+    "repoPin": {
+      "type": "object",
+      "required": [
+        "repo",
+        "sha"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "github": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/sweep-scan.output.json
+++ b/event-runtime/schemas/sweep-scan.output.json
@@ -1,0 +1,26 @@
+{
+  "title": "factory.sweep-plan/v1 output artifact — typed, per-issue retirements, each backed by cited evidence",
+  "type": "object",
+  "required": ["recommendation", "repo", "plan", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": { "enum": ["SWEEP", "NOOP"] },
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["retire-shipped", "mark-duplicate", "comment-evidence"]
+          },
+          "reason": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}

--- a/event-runtime/schemas/unblock-applied.output.json
+++ b/event-runtime/schemas/unblock-applied.output.json
@@ -1,0 +1,22 @@
+{
+  "title": "factory.unblock-applied/v1 output artifact — which hold releases actually landed",
+  "type": "object",
+  "required": ["repo", "applied"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "applied": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/unblock-apply.input.json
+++ b/event-runtime/schemas/unblock-apply.input.json
@@ -1,0 +1,25 @@
+{
+  "title": "unblock-apply input — the approved per-issue hold-release list",
+  "type": "object",
+  "required": ["repo", "plan"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["release-hold", "release-to-triage", "comment-evidence"]
+          },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/unblock-scan.input.json
+++ b/event-runtime/schemas/unblock-scan.input.json
@@ -1,0 +1,44 @@
+{
+  "title": "unblock-scan input — one repo; repoPin is resolved by the planner (OPS-228)",
+  "type": "object",
+  "required": [
+    "repo"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ref": {
+      "type": "string"
+    },
+    "repoPin": {
+      "type": "object",
+      "required": [
+        "repo",
+        "sha"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "github": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/unblock-scan.output.json
+++ b/event-runtime/schemas/unblock-scan.output.json
@@ -1,0 +1,26 @@
+{
+  "title": "factory.unblock-plan/v1 output artifact — typed, per-issue hold releases backed by new evidence",
+  "type": "object",
+  "required": ["recommendation", "repo", "plan", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": { "enum": ["UNBLOCK", "NOOP"] },
+    "repo": { "type": "string", "minLength": 1 },
+    "plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+          "action": {
+            "enum": ["release-hold", "release-to-triage", "comment-evidence"]
+          },
+          "reason": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}

--- a/lib/emit-event.mjs
+++ b/lib/emit-event.mjs
@@ -1,0 +1,65 @@
+/**
+ * Fire-and-forget lifecycle event emitter (WM-75).
+ *
+ * Orchestrator scripts report what they did — a ticket dispatched, a claim
+ * reaped, a worktree reclaimed — into the event runtime's intake, so the
+ * factory's own lifecycle lands in the same audited event log as webhooks and
+ * clock ticks, and chains can hang off it later.
+ *
+ * Two properties are load-bearing:
+ *
+ * - **The runtime being down must never affect the orchestrator.** One
+ *   attempt, a short timeout, every failure swallowed. Dispatch worked for
+ *   months without an event log; an event log must not become a dependency.
+ * - **eventId is deterministic per occurrence**, supplied by the caller, so a
+ *   retried script re-admits nothing (intake dedups on it) while a genuinely
+ *   new occurrence gets a new id.
+ *
+ * Transport is the loopback control API's `POST /replay` — the same
+ * unsigned admission path as `cli.mjs inject` (loopback only, §13).
+ */
+
+const DEFAULT_PORT = 7381;
+
+export function buildEnvelope(type, payload, { eventId, subject = null, occurredAt } = {}) {
+  if (!eventId) throw new Error("emit-event: a deterministic eventId is required");
+  if (!type) throw new Error("emit-event: type is required");
+  return {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type,
+    source: "orchestrator",
+    subject,
+    occurredAt: occurredAt ?? new Date().toISOString(),
+    correlationId: eventId,
+    causationId: null,
+    payload: payload ?? {},
+  };
+}
+
+/**
+ * @returns {Promise<object|null>} the intake's response, or null if the
+ *   runtime is unreachable / refused — callers must not branch on this.
+ */
+export async function emitFactoryEvent(type, payload, opts = {}) {
+  const port = Number(opts.port ?? process.env.FACTORY_EVENT_PORT ?? DEFAULT_PORT);
+  const timeoutMs = opts.timeoutMs ?? 1000;
+  let envelope;
+  try {
+    envelope = buildEnvelope(type, payload, opts);
+  } catch {
+    return null;
+  }
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/replay`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(envelope),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    return await res.json().catch(() => ({}));
+  } catch {
+    return null;
+  }
+}

--- a/lib/emit-event.test.mjs
+++ b/lib/emit-event.test.mjs
@@ -1,0 +1,72 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { buildEnvelope, emitFactoryEvent } from "./emit-event.mjs";
+
+describe("buildEnvelope", () => {
+  test("builds a factory.event/v1 envelope with the caller's deterministic id", () => {
+    const env = buildEnvelope(
+      "factory.ticket.dispatched",
+      { repo: "bj29", ticket: "CLNT-1" },
+      { eventId: "dispatch:CLNT-1:x", subject: "CLNT-1", occurredAt: "2026-08-14T00:00:00Z" },
+    );
+    expect(env).toEqual({
+      schemaVersion: "factory.event/v1",
+      eventId: "dispatch:CLNT-1:x",
+      type: "factory.ticket.dispatched",
+      source: "orchestrator",
+      subject: "CLNT-1",
+      occurredAt: "2026-08-14T00:00:00Z",
+      correlationId: "dispatch:CLNT-1:x",
+      causationId: null,
+      payload: { repo: "bj29", ticket: "CLNT-1" },
+    });
+  });
+
+  test("refuses a missing eventId — accidental random identity would break dedup", () => {
+    expect(() => buildEnvelope("t", {}, {})).toThrow(/eventId/);
+  });
+});
+
+describe("emitFactoryEvent", () => {
+  test("nothing listening → resolves null quickly, never throws", async () => {
+    const started = Date.now();
+    const outcome = await emitFactoryEvent(
+      "factory.ticket.dispatched",
+      { repo: "bj29" },
+      { eventId: "dispatch:none:1", port: 1, timeoutMs: 500 },
+    );
+    expect(outcome).toBeNull();
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  test("a listening intake receives the envelope on POST /replay", async () => {
+    let received = null;
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        if (req.method === "POST" && url.pathname === "/replay") {
+          received = await req.json();
+          return Response.json({ admitted: true });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    afterAll(() => server.stop(true));
+
+    const outcome = await emitFactoryEvent(
+      "factory.ticket.reaped",
+      { ticket: "CLNT-2", reason: "returned_to_todo" },
+      { eventId: "reap:CLNT-2:123", subject: "CLNT-2", port: server.port },
+    );
+    expect(outcome).toEqual({ admitted: true });
+    expect(received.type).toBe("factory.ticket.reaped");
+    expect(received.eventId).toBe("reap:CLNT-2:123");
+    expect(received.source).toBe("orchestrator");
+    server.stop(true);
+  });
+
+  test("an invalid envelope (no eventId) is swallowed, not thrown", async () => {
+    expect(await emitFactoryEvent("t", {}, { port: 1 })).toBeNull();
+  });
+});

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -46,6 +46,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import { gql } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
+import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export function parseArgs(argv) {
   const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -333,6 +334,14 @@ async function main() {
     // `--gate` is a probe: it must never tear down, even if `--apply` is also set.
     const result = await survey(repo, { apply: APPLY && !GATE });
     surveys.push(result);
+    // Lifecycle observation (WM-75): fire-and-forget, day-scoped id so a
+    // re-run reports the same removal once but a later worktree for the same
+    // ticket is a new event.
+    for (const t of result.removed) {
+      await emitFactoryEvent("factory.worktree.reclaimed",
+        { repo: repo.name, ticket: t },
+        { eventId: `janitor:${repo.name}:${t}:${new Date().toISOString().slice(0, 10)}`, subject: t });
+    }
     if (GATE) continue;
     if (!quiet) printHuman(repo, result);
   }

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -28,6 +28,7 @@
 import { readFileSync, existsSync, mkdirSync, appendFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
 
@@ -486,6 +487,12 @@ Options:
 
     if (args.apply) {
       console.log(`        -> unassigned, returned to Todo`);
+      // Lifecycle observation (WM-75): fire-and-forget; the last-activity
+      // timestamp keys the id, so retrying the same stale claim re-admits
+      // nothing while the next genuine reap is a new event.
+      await emitFactoryEvent("factory.ticket.reaped",
+        { ticket: issue.identifier, reason: todoId ? "returned_to_todo" : "marker_cleared" },
+        { eventId: `reap:${issue.identifier}:${seen?.getTime() ?? "unknown"}`, subject: issue.identifier });
     }
   }
 

--- a/orchestrator/reconcile.mjs
+++ b/orchestrator/reconcile.mjs
@@ -33,6 +33,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { gql, lastActivity } from "./reaper.mjs";
 import { ROOT } from "../lib/schedule.mjs";
+import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export function parseArgs(argv) {
   const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -273,8 +274,18 @@ async function main() {
 
   let totalDrift = 0;
   for (const repo of repos) {
-    const { drift } = await reconcileRepo(repo, { apply: APPLY, gate: GATE, quietMin: QUIET_MIN });
+    const { drift, actions } = await reconcileRepo(repo, { apply: APPLY, gate: GATE, quietMin: QUIET_MIN });
     totalDrift += drift;
+    // Lifecycle observation (WM-75): fire-and-forget, one event per applied
+    // move; the PR numbers make the id stable across re-runs of the same drift.
+    if (APPLY && !GATE) {
+      for (const a of actions) {
+        const prs = (a.open ?? a.merged ?? []).join(",");
+        await emitFactoryEvent("factory.ticket.reconciled",
+          { repo: repo.name, ticket: a.issue.identifier, kind: a.type, targetState: a.targetState, prs: a.open ?? a.merged ?? [] },
+          { eventId: `reconcile:${a.issue.identifier}:${a.type}:${prs}`, subject: a.issue.identifier });
+      }
+    }
   }
 
   if (GATE) process.exit(totalDrift ? 0 : 1);

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -31,6 +31,7 @@ import { openBlockers, BLOCKING_RELATIONS_GQL } from "./blockers.mjs";
 import { budgetExhausted } from "../lib/spend.mjs";
 import { agentLabel } from "../tools/linear.mjs";
 import { LEASE_HEARTBEAT_MS, releaseWorkerLease, renewWorkerLease, writeWorkerLease, liveWorkerLeases } from "../lib/worker-leases.mjs";
+import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 const argv = process.argv.slice(2);
 const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -374,6 +375,11 @@ async function runTicket(t) {
     // as soon as it exists. The lease is independent of transcript activity:
     // a long test or API call can be silent without looking dead.
     writeWorkerLease({ repo: repo.name, ticket: t.identifier, owner: leaseOwner, pid: child.pid });
+    // Lifecycle observation (WM-75): fire-and-forget — the runtime being down
+    // must never affect dispatch. eventId is stable within this tick run.
+    void emitFactoryEvent("factory.ticket.dispatched",
+      { repo: repo.name, ticket: t.identifier, harness: HARNESS, worktree: wt },
+      { eventId: `dispatch:${t.identifier}:${stamp}`, subject: t.identifier });
     child.on("close", () => children.delete(child));
 
     let buf = "";


### PR DESCRIPTION
Bundle of four tickets (operator-directed), one commit each:

- **WM-72** — command-adapter event types `factory.{reconcile,label-guard,warm,unblock-digest}.requested` wrapping the existing orchestrator scripts (reaper@1 pattern), plus a static `payload` passthrough for `schedules.json` loops (tick fields win; reserved keys refused at load) and four disabled example schedules. Demo verify now asserts the registry's agent count dynamically instead of a hand-counted literal.
- **WM-73** — `factory.unblock.requested` → `unblock-scan@1` (claude, pinned read-only repo) → `UNBLOCK` edge → `unblock-apply@1` (actions adapter; closed registry: release-hold / release-to-triage / comment-evidence).
- **WM-74** — `factory.sweep.requested` → `sweep-scan@1` → `SWEEP` edge → `sweep-apply@1` (retire-shipped → Canceled, mark-duplicate → Duplicate, comment-evidence; state transitions only, never delete).
- **WM-75** — observe-only event types (`{"observe": true}` → planner resolves typed NOOP `observed`), `lib/emit-event.mjs` fire-and-forget emitter (loopback `POST /replay`, 1 s timeout, failures swallowed, deterministic caller-supplied eventId), wired into tick / reaper / reconcile / janitor as `factory.ticket.dispatched|reaped|reconciled` and `factory.worktree.reclaimed`.

Verification (`(cd event-runtime/web && bun install) && bun test && bun build/emit.mjs --check`): **930 pass / 0 fail**, emit check OK. Live smoke on an isolated worktree runtime: `factory.reconcile.requested` plans an open `reconcile@1` proposal; the emitter's `factory.ticket.dispatched` admits and resolves `noop` (observed).

Fixes WM-72
Fixes WM-73
Fixes WM-74
Fixes WM-75