### PR TITLE
feat(web): schema-driven Form view for the Inject Event dialog (WM-76)

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -24,6 +24,328 @@ function changeInput(el: HTMLElement, value: string) {
   (el as any)[propsKey]?.onChange?.({ target: { value } });
 }
 
+// ---------------------------------------------------------------------------
+// WM-76: schema-driven Form view. Real input schemas from event-runtime/schemas
+// so the renderer is exercised against what the registry actually serves.
+
+const boilerplateAgent = {
+  version: 1,
+  outputContract: "c/v1",
+  workspace: { type: "ephemeral" as const },
+  capabilities: {},
+  limits: {},
+  mutating: false,
+  promptFile: "",
+  prompt: "",
+  inputSchemaFile: "",
+  outputSchemaFile: "",
+  outputSchema: {},
+  pins: {},
+  command: null,
+  actionRegistry: null,
+  hosts: null,
+  eventTypes: [],
+};
+
+const TRIAGE_SCAN_SCHEMA = {
+  title: "triage-scan input",
+  type: "object",
+  required: ["repo"],
+  additionalProperties: false,
+  properties: {
+    repo: { type: "string", minLength: 1 },
+    ref: { type: "string" },
+    repoPin: {
+      type: "object",
+      required: ["repo", "sha"],
+      additionalProperties: false,
+      properties: {
+        repo: { type: "string", minLength: 1 },
+        ref: { type: "string" },
+        sha: { type: "string", pattern: "^[0-9a-f]{40}$" },
+        github: { type: ["string", "null"] },
+      },
+    },
+  },
+};
+
+const DISK_DIAGNOSE_SCHEMA = {
+  title: "disk-diagnose input",
+  type: "object",
+  required: ["host", "mount", "usedPct", "alertId"],
+  additionalProperties: false,
+  properties: {
+    host: { enum: ["lab", "web"] },
+    mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
+    usedPct: { type: "number", minimum: 0, maximum: 100 },
+    alertId: { type: "string", minLength: 1 },
+  },
+};
+
+const CI_DOCTOR_SCHEMA = {
+  title: "ci-doctor input",
+  type: "object",
+  required: ["repo", "runId", "logArtifact"],
+  additionalProperties: false,
+  properties: {
+    repo: { type: "string", pattern: "^[^/\\s]+/[^/\\s]+$" },
+    runId: { type: ["string", "integer"] },
+    headSha: { type: "string" },
+    workflowName: { type: "string" },
+    logArtifact: { type: "string", pattern: "^[0-9a-f]{64}$" },
+  },
+};
+
+const STATUS_REPORT_SCHEMA = {
+  title: "factory.status-report/v1 input",
+  type: "object",
+  required: ["repos"],
+  additionalProperties: false,
+  properties: {
+    repos: { type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
+  },
+};
+
+// Synthetic: exercises Now button + boolean + array-of-objects sub-editor.
+const DEMO_SCHEMA = {
+  type: "object",
+  required: ["scheduledAt"],
+  additionalProperties: false,
+  properties: {
+    scheduledAt: { type: "string" },
+    dryRun: { type: "boolean" },
+    plan: {
+      type: "array",
+      items: { type: "object", required: ["action"], properties: { action: { type: "string" } } },
+    },
+  },
+};
+
+function schemaRegistry(): AgentsView {
+  const mk = (id: string, inputSchema: unknown) => ({
+    ...boilerplateAgent,
+    ref: `${id}@1`,
+    id,
+    inputSchema,
+  });
+  return {
+    agents: [
+      mk("triage", TRIAGE_SCAN_SCHEMA),
+      mk("disk", DISK_DIAGNOSE_SCHEMA),
+      mk("cidoctor", CI_DOCTOR_SCHEMA),
+      mk("report", STATUS_REPORT_SCHEMA),
+      mk("demo", DEMO_SCHEMA),
+    ],
+    eventTypes: [
+      { type: "triage.scan.requested", agent: "triage@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+      { type: "disk.diagnose", agent: "disk@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+      { type: "ci.run.failed", agent: "cidoctor@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+      { type: "factory.status.requested", agent: "report@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+      { type: "demo.requested", agent: "demo@1", adapter: "cmd", idempotencyScope: [], proposalTtlSeconds: null },
+    ],
+    edges: {},
+    contracts: {},
+    schemaHash: "hash123",
+    publishedAt: new Date().toISOString(),
+  } as unknown as AgentsView;
+}
+
+const REPO_ITEMS = [
+  { name: "bj29", path: "/r/bj29", github: "watt-mind/bj29", team: null, project: null, base: "develop", deployBranch: null, reportOnly: false, maxInFlight: null, worktreeRoot: null, hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false, verify: null },
+  { name: "factory", path: "/r/factory", github: null, team: null, project: null, base: "develop", reportOnly: false, deployBranch: null, maxInFlight: null, worktreeRoot: null, hasWorktreeUp: false, hasWorktreeDown: false, hasWorktreeWarm: false, verify: null },
+];
+
+function withSchemaApi(fn: (r: ReturnType<typeof renderWithClient>) => Promise<void>) {
+  const origAgents = api.agents;
+  const origRepos = api.repos;
+  api.agents = async () => schemaRegistry();
+  api.repos = async () => ({ repos: REPO_ITEMS });
+  return (async () => {
+    try {
+      const r = renderWithClient(<InjectDialog onClose={() => {}} />);
+      await fn(r);
+    } finally {
+      api.agents = origAgents;
+      api.repos = origRepos;
+    }
+  })();
+}
+
+async function selectTemplate(r: ReturnType<typeof renderWithClient>, name: RegExp) {
+  const chip = await r.findByRole("radio", { name });
+  act(() => {
+    fireEvent.click(chip);
+  });
+  return chip;
+}
+
+describe("InjectDialog schema-driven Form view (WM-76)", () => {
+  test("renders form fields from the selected template's input schema", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      // Form tab exists and is active for a schema'd template.
+      const formTab = r.getByRole("tab", { name: /form/i });
+      expect(formTab.getAttribute("aria-selected")).toBe("true");
+      // enum -> select, number -> numeric input, strings -> text inputs.
+      const host = r.getByLabelText("host") as HTMLSelectElement;
+      expect(host.tagName.toLowerCase()).toBe("select");
+      expect([...host.querySelectorAll("option")].map((o) => o.value)).toContain("web");
+      const usedPct = r.getByLabelText("usedPct") as HTMLInputElement;
+      expect(usedPct.getAttribute("type")).toBe("number");
+      expect(r.getByLabelText("mount")).toBeTruthy();
+      expect(r.getByLabelText("alertId")).toBeTruthy();
+      // Envelope preview disclosure is present in Form mode.
+      expect(r.getByText(/envelope preview/i)).toBeTruthy();
+    }));
+
+  test("hides planner-injected repoPin and collapses optional fields", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /triage\.scan\.requested/i);
+      expect(r.getByLabelText("repo")).toBeTruthy();
+      expect(r.queryByLabelText("repoPin")).toBeNull();
+      // Optional `ref` sits behind a disclosure, not in the always-visible set.
+      expect(r.getByText(/optional fields/i)).toBeTruthy();
+    }));
+
+  test("repo picker offers short names, or github slugs when the pattern wants owner/name", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /triage\.scan\.requested/i);
+      const optionsOf = (input: HTMLInputElement) => {
+        const listId = input.getAttribute("list");
+        expect(listId).toBeTruthy();
+        const list = document.getElementById(listId!);
+        expect(list).toBeTruthy();
+        return [...list!.querySelectorAll("option")].map((o) => o.getAttribute("value"));
+      };
+      const repo = r.getByLabelText("repo") as HTMLInputElement;
+      let options = optionsOf(repo);
+      expect(options).toContain("bj29");
+      expect(options).toContain("factory");
+
+      await selectTemplate(r, /ci\.run\.failed/i);
+      options = optionsOf(r.getByLabelText("repo") as HTMLInputElement);
+      expect(options).toContain("watt-mind/bj29");
+      // github:null repos are filtered from the slug convention.
+      expect(options).not.toContain("factory");
+    }));
+
+  test("*Id fields get a Generate button, *At fields get a Now button", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const gen = r.getByRole("button", { name: /generate/i });
+      act(() => {
+        fireEvent.click(gen);
+      });
+      expect((r.getByLabelText("alertId") as HTMLInputElement).value).toMatch(/^web-/);
+
+      await selectTemplate(r, /demo\.requested/i);
+      const now = r.getByRole("button", { name: /^now$/i });
+      act(() => {
+        fireEvent.click(now);
+      });
+      expect((r.getByLabelText("scheduledAt") as HTMLInputElement).value).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    }));
+
+  test("validation flags a bad payload with a field-level error", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const usedPct = r.getByLabelText("usedPct") as HTMLInputElement;
+      act(() => {
+        changeInput(usedPct, "150");
+      });
+      expect(r.getByText(/above maximum 100/i)).toBeTruthy();
+    }));
+
+  test("form ↔ JSON tab sync round trip", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const mount = r.getByLabelText("mount") as HTMLInputElement;
+      act(() => {
+        changeInput(mount, "/var");
+      });
+      // Form -> JSON regenerates the envelope text.
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /json/i }));
+      });
+      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      expect(textarea.value).toContain('"/var"');
+      // JSON -> Form re-parses on switch.
+      const parsed = JSON.parse(textarea.value);
+      parsed.payload.mount = "/data";
+      act(() => {
+        changeInput(textarea, JSON.stringify(parsed, null, 2));
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /form/i }));
+      });
+      expect((r.getByLabelText("mount") as HTMLInputElement).value).toBe("/data");
+    }));
+
+  test("unregistered type is JSON-only: form tab disabled with a stated reason", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /blank envelope/i);
+      const formTab = r.getByRole("tab", { name: /form/i });
+      expect(formTab.getAttribute("aria-disabled")).toBe("true");
+      const jsonTab = r.getByRole("tab", { name: /json/i });
+      expect(jsonTab.getAttribute("aria-selected")).toBe("true");
+      // Clicking the disabled tab states why instead of switching.
+      act(() => {
+        fireEvent.click(formTab);
+      });
+      expect(jsonTab.getAttribute("aria-selected")).toBe("true");
+      expect(r.getByText(/no schema to render/i)).toBeTruthy();
+    }));
+
+  test("schema-invalid payload warns, needs explicit ack, then still submits", () =>
+    withSchemaApi(async (r) => {
+      const origReplay = api.replay;
+      const sent: unknown[] = [];
+      api.replay = async (envelope: unknown) => {
+        sent.push(envelope);
+        return { admitted: true, duplicate: false, eventId: "e1" };
+      };
+      try {
+        await selectTemplate(r, /disk\.diagnose/i);
+        // Make the payload schema-invalid: usedPct above its maximum of 100.
+        act(() => {
+          changeInput(r.getByLabelText("usedPct"), "150");
+        });
+        const injectBtn = r.getByRole("button", { name: /inject/i });
+        act(() => {
+          fireEvent.click(injectBtn);
+        });
+        // Not submitted yet: warned and waiting on explicit acknowledgement.
+        expect(sent.length).toBe(0);
+        expect(r.getByText(/does not validate/i)).toBeTruthy();
+        const confirm = r.getByRole("button", { name: /confirm inject/i });
+        await act(async () => {
+          fireEvent.click(confirm);
+        });
+        expect(sent.length).toBe(1);
+        expect((sent[0] as any).payload.host).toBe("lab");
+        expect((sent[0] as any).payload.usedPct).toBe(150);
+      } finally {
+        api.replay = origReplay;
+      }
+    }));
+
+  test("array-of-objects field renders a JSON sub-editor with parse indicator", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /demo\.requested/i);
+      // `plan` is optional: open the optional-fields disclosure first.
+      const disclosure = r.getByText(/optional fields/i);
+      act(() => {
+        fireEvent.click(disclosure);
+      });
+      const plan = r.getByLabelText("plan") as HTMLTextAreaElement;
+      expect(plan.tagName.toLowerCase()).toBe("textarea");
+      act(() => {
+        changeInput(plan, "[{bad json");
+      });
+      expect(r.getByText(/invalid json/i)).toBeTruthy();
+    }));
+});
+
 describe("InjectDialog template selection sync (OPS-344)", () => {
   test("clicking highlighted fallback blank chip does not wipe envelope textarea", async () => {
     // Mock api.agents to return sample templates

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -329,6 +329,28 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       }
     }));
 
+  test("example-ish seeds surface as placeholders, never as values or regex source (critique r1)", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /ci\.run\.failed/i);
+      const repo = r.getByLabelText("repo") as HTMLInputElement;
+      // The owner/name example must not be a pre-filled value that ships as
+      // plausible garbage — it belongs in the placeholder, human-readable.
+      expect(repo.value).toBe("");
+      expect(repo.getAttribute("placeholder")).toBe("watt-mind/factory");
+      // Pattern-constrained fields never show the raw regex source.
+      const logArtifact = r.getByLabelText("logArtifact") as HTMLInputElement;
+      expect(logArtifact.getAttribute("placeholder") ?? "").not.toContain("^");
+    }));
+
+  test("string arrays with minItems seed zero chips; the minItems warning covers the ask (critique r1)", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /factory\.status\.requested/i);
+      // No bare unlabeled "×" chip from a seeded empty string.
+      expect(r.queryAllByRole("button", { name: /^remove/i }).length).toBe(0);
+      // The requirement is still surfaced, as a validation warning.
+      expect(r.getByText(/fewer than minItems 1/i)).toBeTruthy();
+    }));
+
   test("array-of-objects field renders a JSON sub-editor with parse indicator", () =>
     withSchemaApi(async (r) => {
       await selectTemplate(r, /demo\.requested/i);

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -15,6 +15,7 @@ import {
   errorsByField,
   isAtField,
   isIdField,
+  placeholderFor,
   repoSuggestions,
   schemaFields,
   unknownKeys,
@@ -643,7 +644,7 @@ export function InjectDialog({
               else setField(f.name, v);
             }}
             suggestions={suggestions}
-            placeholder={typeof f.schema.pattern === "string" ? f.schema.pattern : undefined}
+            placeholder={placeholderFor(f.name, f.schema) ?? undefined}
           />
         );
     }

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1,8 +1,37 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { api } from "../api";
 import { buildTemplates, triggerId, type TriggerTemplate } from "../templates";
-import { Button, Dialog, VerbError, notify } from "./ui";
+import { validate } from "../lib/schema";
+import {
+  errorsByField,
+  isAtField,
+  isIdField,
+  repoSuggestions,
+  schemaFields,
+  unknownKeys,
+  type FieldSpec,
+} from "../lib/injectForm";
+import {
+  Button,
+  ChipInput,
+  Dialog,
+  Disclosure,
+  JsonBlock,
+  Pill,
+  SuggestInput,
+  Tabs,
+  VerbError,
+  notify,
+} from "./ui";
 
 const REQUIRED = ["schemaVersion", "eventId", "type", "source", "occurredAt"];
 
@@ -23,10 +52,45 @@ function blankEnvelope(nowMs: number) {
 
 const pretty = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === "object" && !Array.isArray(v);
+
+function omitKey(obj: Record<string, unknown>, key: string): Record<string, unknown> {
+  const next = { ...obj };
+  delete next[key];
+  return next;
+}
+
+const parses = (raw: string): boolean => {
+  try {
+    JSON.parse(raw);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const warnStyle = {
+  color: "var(--hue-warn)",
+  background: "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
+};
+
+const inputCls =
+  "mono w-full rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--border-strong)";
+
+type EditorTab = "form" | "json";
+
 /**
- * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230, format OPS-361, 2-column sidebar OPS-363).
+ * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230,
+ * format OPS-361, 2-column sidebar OPS-363, schema-driven Form view WM-76).
  *
- * Left sidebar lists registered templates with instant search, right side houses the JSON editor and formatting tools.
+ * Left sidebar lists registered templates with instant search. The right side
+ * has two tabs: a Form view rendered from the selected event type's input
+ * schema (payload-only; the envelope is generated exactly as templates do) and
+ * the raw-JSON full-envelope escape hatch. Both validate the payload with the
+ * ported fail-closed validator (lib/schema.ts); invalid payloads warn and need
+ * an explicit acknowledgement, but are never hard-blocked — the runtime
+ * deliberately admits them and parks them human_needed.
  */
 export function InjectDialog({
   onClose,
@@ -39,6 +103,8 @@ export function InjectDialog({
 }) {
   const queryClient = useQueryClient();
   const registry = useQuery({ queryKey: ["agents"], queryFn: api.agents });
+  const reposQ = useQuery({ queryKey: ["repos"], queryFn: api.repos });
+  const repoItems = reposQ.data?.repos ?? [];
 
   const openedAt = useMemo(() => Date.now(), []);
   const templates = useMemo(
@@ -51,8 +117,20 @@ export function InjectDialog({
   const [text, setText] = useState(() => pretty(initialEnvelope ?? blankEnvelope(openedAt)));
   const [clientError, setClientError] = useState<string | null>(null);
   const [unregisteredAck, setUnregisteredAck] = useState(false);
+  const [schemaAck, setSchemaAck] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+
+  // WM-76 Form view state. The base is the envelope minus payload (generated
+  // exactly as templates do); the form edits payload only. Nested object /
+  // array-of-object fields keep their raw text in subJson (a per-field JSON
+  // sub-editor); formPayload holds their last successfully parsed value.
+  const [tab, setTab] = useState<EditorTab>("json");
+  const [formBase, setFormBase] = useState<Record<string, unknown>>({});
+  const [formPayload, setFormPayload] = useState<Record<string, unknown>>({});
+  const [subJson, setSubJson] = useState<Record<string, string>>({});
+  const [tabNotice, setTabNotice] = useState<string | null>(null);
+  const fieldIdBase = useId();
 
   const filteredTemplates = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -79,12 +157,42 @@ export function InjectDialog({
     },
   });
 
+  /** The registered input schema for an event type, or null. */
+  function schemaFor(type: string): Record<string, unknown> | null {
+    const route = registry.data?.eventTypes.find((r) => r.type === type);
+    if (!route) return null;
+    const agent = registry.data?.agents.find((a) => a.ref === route.agent);
+    const s = agent?.inputSchema;
+    return isPlainObject(s) ? s : null;
+  }
+
+  function initFormFromEnvelope(env: Record<string, unknown>, fields: FieldSpec[] | null) {
+    const { payload, ...base } = env;
+    const pay = isPlainObject(payload) ? { ...payload } : {};
+    setFormBase(base);
+    setFormPayload(pay);
+    const sub: Record<string, string> = {};
+    for (const f of fields ?? []) {
+      if (f.kind === "json") sub[f.name] = f.name in pay ? JSON.stringify(pay[f.name], null, 2) : "";
+    }
+    setSubJson(sub);
+  }
+
+  function resetAcks() {
+    setClientError(null);
+    setUnregisteredAck(false);
+    setSchemaAck(false);
+    setConfirming(false);
+  }
+
   function choose(template: TriggerTemplate) {
     setSelected(template.eventType);
     setText(pretty(template.envelope));
-    setClientError(null);
-    setUnregisteredAck(false);
-    setConfirming(false);
+    const fields = schemaFields(schemaFor(template.eventType));
+    initFormFromEnvelope(template.envelope, fields);
+    setTab(fields ? "form" : "json");
+    setTabNotice(null);
+    resetAcks();
     inject.reset();
   }
 
@@ -93,16 +201,18 @@ export function InjectDialog({
     if (next === null) {
       setSelected(null);
       setText(pretty(blankEnvelope(openedAt)));
-      setUnregisteredAck(false);
-      setConfirming(false);
+      setTab("json");
+      setTabNotice(null);
+      resetAcks();
       inject.reset();
       return;
     }
     if (next === "__given__" && initialEnvelope) {
       setSelected("__given__");
       setText(pretty(initialEnvelope));
-      setUnregisteredAck(false);
-      setConfirming(false);
+      setTab("json");
+      setTabNotice(null);
+      resetAcks();
       inject.reset();
       return;
     }
@@ -142,6 +252,136 @@ export function InjectDialog({
     listRef.current?.querySelectorAll<HTMLElement>('[role="radio"]')[nextIdx]?.focus();
   }
 
+  // ---------------------------------------------------------------------------
+  // Form model (WM-76)
+
+  const formSchema = useMemo(
+    () => (typeof formBase.type === "string" ? schemaFor(formBase.type) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- schemaFor reads registry.data
+    [formBase, registry.data],
+  );
+  const formFields = useMemo(() => schemaFields(formSchema) ?? [], [formSchema]);
+  const requiredFields = formFields.filter((f) => f.required);
+  const optionalFields = formFields.filter((f) => !f.required);
+
+  const formEnvelope = useMemo(
+    () => ({ ...formBase, payload: formPayload }),
+    [formBase, formPayload],
+  );
+
+  const formValidation = useMemo(
+    () => (formSchema ? validate(formSchema, formPayload) : { valid: true, errors: [] as string[] }),
+    [formSchema, formPayload],
+  );
+  const fieldErrors = useMemo(() => errorsByField(formValidation.errors), [formValidation]);
+  const knownNames = useMemo(() => new Set(formFields.map((f) => f.name)), [formFields]);
+  const formLevelErrors = useMemo(() => {
+    const out: string[] = [];
+    for (const [k, msgs] of fieldErrors) {
+      if (k === "") out.push(...msgs);
+      else if (!knownNames.has(k)) out.push(...msgs.map((m) => `${k}: ${m}`));
+    }
+    return out;
+  }, [fieldErrors, knownNames]);
+  const unknown = useMemo(
+    () => (formSchema ? unknownKeys(formSchema, formPayload) : []),
+    [formSchema, formPayload],
+  );
+  const invalidSubs = formFields
+    .filter((f) => f.kind === "json")
+    .map((f) => f.name)
+    .filter((name) => (subJson[name] ?? "").trim() !== "" && !parses(subJson[name]));
+
+  function setField(name: string, v: unknown) {
+    setFormPayload((p) => ({ ...p, [name]: v }));
+    resetAcks();
+  }
+  function clearField(name: string) {
+    setFormPayload((p) => omitKey(p, name));
+    resetAcks();
+  }
+  function setSub(name: string, raw: string) {
+    setSubJson((s) => ({ ...s, [name]: raw }));
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      setFormPayload((p) => omitKey(p, name));
+    } else if (parses(trimmed)) {
+      setFormPayload((p) => ({ ...p, [name]: JSON.parse(trimmed) }));
+    }
+    resetAcks();
+  }
+
+  /**
+   * Whether the current JSON text can open in the Form view (WM-76 decision 7).
+   * `disabled` marks identity-level impossibility (no schema to render);
+   * a `reason` with disabled=false is a fixable state (bad JSON, odd payload).
+   */
+  const formAvailability = useMemo((): { disabled: boolean; reason: string | null } => {
+    if (checkedId === "__given__") {
+      return {
+        disabled: true,
+        reason: "Trigger again re-sends the captured envelope as-is — no schema to render.",
+      };
+    }
+    let env: unknown;
+    try {
+      env = JSON.parse(text);
+    } catch (err) {
+      return {
+        disabled: false,
+        reason: `the envelope is not valid JSON (${(err as Error).message}) — fix it or reselect a template to revert`,
+      };
+    }
+    if (!isPlainObject(env)) {
+      return {
+        disabled: false,
+        reason: "the envelope must be a JSON object — fix it or reselect a template to revert",
+      };
+    }
+    const type = typeof env.type === "string" ? env.type : "";
+    const schema = schemaFor(type);
+    if (!schema || !schemaFields(schema)) {
+      return {
+        disabled: true,
+        reason: `"${type || "(empty type)"}" is not a registered event type with an input schema — no schema to render`,
+      };
+    }
+    if (env.payload !== undefined && !isPlainObject(env.payload)) {
+      return {
+        disabled: false,
+        reason: "payload is not a JSON object, which the form cannot represent — fix it or reselect a template to revert",
+      };
+    }
+    return { disabled: false, reason: null };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- schemaFor reads registry.data
+  }, [checkedId, text, registry.data]);
+
+  function selectTab(next: string) {
+    if (next === tab) return;
+    if (next === "json") {
+      if (invalidSubs.length > 0) {
+        setTabNotice(
+          `Cannot switch to JSON: field ${invalidSubs.join(", ")} holds invalid JSON — fix it first so nothing is lost.`,
+        );
+        return;
+      }
+      setText(pretty(formEnvelope));
+      setTab("json");
+      setTabNotice(null);
+      return;
+    }
+    if (formAvailability.reason) {
+      setTabNotice(`Cannot switch to Form: ${formAvailability.reason}.`);
+      return;
+    }
+    const env = JSON.parse(text) as Record<string, unknown>;
+    initFormFromEnvelope(env, schemaFields(schemaFor(typeof env.type === "string" ? env.type : "")));
+    setTab("form");
+    setTabNotice(null);
+  }
+
+  // ---------------------------------------------------------------------------
+
   function formatJson() {
     try {
       const parsed = JSON.parse(text);
@@ -156,7 +396,35 @@ export function InjectDialog({
   const formatJsonRef = useRef(formatJson);
   formatJsonRef.current = formatJson;
 
-  function submit() {
+  /** Warn-and-ack for a schema-invalid payload; returns true when submission should pause. */
+  function needsSchemaAck(type: string, errs: string[]): boolean {
+    if (errs.length === 0 || schemaAck) return false;
+    const summary = errs.slice(0, 3).join("; ") + (errs.length > 3 ? ` (+${errs.length - 3} more)` : "");
+    setClientError(
+      `payload does not validate against the "${type}" input schema: ${summary}. Intake will admit it, but planning will park it human_needed. Confirm inject to proceed.`,
+    );
+    setSchemaAck(true);
+    setConfirming(true);
+    return true;
+  }
+
+  function submitForm() {
+    setClientError(null);
+    if (invalidSubs.length > 0) {
+      setClientError(`field ${invalidSubs.join(", ")}: not valid JSON`);
+      setConfirming(false);
+      return;
+    }
+    const type = typeof formBase.type === "string" ? formBase.type : "";
+    if (needsSchemaAck(type, formValidation.errors)) return;
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+    inject.mutate(formEnvelope);
+  }
+
+  function submitJson() {
     setClientError(null);
     let envelope: Record<string, unknown>;
     try {
@@ -181,6 +449,13 @@ export function InjectDialog({
       setConfirming(true);
       return;
     }
+    if (registered && typeof envelope.type === "string") {
+      const schema = schemaFor(envelope.type);
+      if (schema) {
+        const errs = validate(schema, envelope.payload ?? {}).errors;
+        if (needsSchemaAck(envelope.type, errs)) return;
+      }
+    }
     if (!confirming) {
       setConfirming(true);
       return;
@@ -188,8 +463,15 @@ export function InjectDialog({
     inject.mutate(envelope);
   }
 
+  function submit() {
+    if (tab === "form") submitForm();
+    else submitJson();
+  }
+
   const submitRef = useRef(submit);
   submitRef.current = submit;
+  const tabRef = useRef(tab);
+  tabRef.current = tab;
 
   useLayoutEffect(() => {
     listRef.current
@@ -200,6 +482,7 @@ export function InjectDialog({
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "f" || e.key === "F")) {
+        if (tabRef.current !== "json") return;
         e.preventDefault();
         formatJsonRef.current();
         return;
@@ -213,14 +496,200 @@ export function InjectDialog({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  const isValidJson = useMemo(() => {
+  const isValidJson = useMemo(() => parses(text), [text]);
+
+  /** Live JSON-tab error summary: payload vs the registered schema of the typed event type. */
+  const jsonSchemaErrors = useMemo(() => {
+    if (tab !== "json") return [];
+    let env: unknown;
     try {
-      JSON.parse(text);
-      return true;
+      env = JSON.parse(text);
     } catch {
-      return false;
+      return [];
     }
-  }, [text]);
+    if (!isPlainObject(env) || typeof env.type !== "string") return [];
+    const schema = schemaFor(env.type);
+    if (!schema) return [];
+    return validate(schema, env.payload ?? {}).errors;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- schemaFor reads registry.data
+  }, [tab, text, registry.data]);
+
+  // ---------------------------------------------------------------------------
+  // Form field rendering
+
+  function renderField(f: FieldSpec) {
+    const fid = `${fieldIdBase}-${f.name}`;
+    const value = formPayload[f.name];
+    const errs = fieldErrors.get(f.name) ?? [];
+    const suggestions = repoSuggestions(f.name, f.schema, f.kind, repoItems);
+
+    let control: React.ReactNode;
+    switch (f.kind) {
+      case "const":
+        control = <Pill title="Fixed by the schema">{JSON.stringify(f.schema.const)}</Pill>;
+        break;
+      case "enum": {
+        const options = (f.schema.enum as unknown[]) ?? [];
+        control = (
+          <select
+            id={fid}
+            value={value === undefined ? "" : String(value)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              if (raw === "" && !f.required) clearField(f.name);
+              else setField(f.name, options.find((o) => String(o) === raw) ?? raw);
+            }}
+            className={inputCls}
+          >
+            {!f.required && <option value="">—</option>}
+            {options.map((o) => (
+              <option key={String(o)} value={String(o)}>
+                {typeof o === "string" ? o : JSON.stringify(o)}
+              </option>
+            ))}
+          </select>
+        );
+        break;
+      }
+      case "boolean":
+        control = (
+          <input
+            id={fid}
+            type="checkbox"
+            checked={value === true}
+            onChange={(e) => setField(f.name, e.target.checked)}
+            className="size-3.5 accent-(--accent)"
+          />
+        );
+        break;
+      case "number":
+        control = (
+          <input
+            id={fid}
+            type="number"
+            step="any"
+            value={typeof value === "number" || typeof value === "string" ? String(value) : ""}
+            onChange={(e) => {
+              const raw = e.target.value;
+              if (raw === "") clearField(f.name);
+              else {
+                const n = Number(raw);
+                setField(f.name, Number.isNaN(n) ? raw : n);
+              }
+            }}
+            className={inputCls}
+          />
+        );
+        break;
+      case "string-array":
+        control = (
+          <ChipInput
+            id={fid}
+            values={Array.isArray(value) ? value.map(String) : []}
+            onChange={(vals) => {
+              if (vals.length === 0 && !f.required) clearField(f.name);
+              else setField(f.name, vals);
+            }}
+            suggestions={suggestions}
+          />
+        );
+        break;
+      case "json": {
+        const raw = subJson[f.name] ?? "";
+        const state = raw.trim() === "" ? "empty" : parses(raw) ? "valid" : "invalid";
+        control = (
+          <>
+            <textarea
+              id={fid}
+              value={raw}
+              onChange={(e) => setSub(f.name, e.target.value)}
+              rows={4}
+              spellCheck={false}
+              placeholder="JSON…"
+              className={`${inputCls} resize-y leading-relaxed`}
+            />
+            <div className="mt-0.5 flex items-center gap-1.5 text-[10px]">
+              <span
+                className="size-1.5 rounded-full"
+                style={{
+                  background:
+                    state === "invalid" ? "var(--hue-err)" : state === "valid" ? "var(--hue-ok)" : "var(--hue-idle)",
+                }}
+              />
+              <span
+                className="text-(--text-faint)"
+                style={state === "invalid" ? { color: "var(--hue-err)" } : undefined}
+              >
+                {state === "invalid"
+                  ? "Invalid JSON — fix before injecting"
+                  : state === "valid"
+                    ? "Valid JSON"
+                    : f.required
+                      ? "required — enter JSON"
+                      : "not set"}
+              </span>
+            </div>
+          </>
+        );
+        break;
+      }
+      default:
+        control = (
+          <SuggestInput
+            id={fid}
+            value={typeof value === "string" ? value : value === undefined ? "" : String(value)}
+            onChange={(v) => {
+              if (v === "" && !f.required) clearField(f.name);
+              else setField(f.name, v);
+            }}
+            suggestions={suggestions}
+            placeholder={typeof f.schema.pattern === "string" ? f.schema.pattern : undefined}
+          />
+        );
+    }
+
+    return (
+      <div key={f.name} className="mb-2.5 last:mb-0">
+        <div className="mb-0.5 flex items-center gap-2">
+          <label
+            htmlFor={f.kind === "const" ? undefined : fid}
+            className="mono text-[11px] font-medium text-(--text-dim)"
+          >
+            {f.name}
+          </label>
+          {f.required && <span className="text-[10px] text-(--text-faint)">required</span>}
+          <span className="flex-1" />
+          {f.kind === "string" && isAtField(f.name) && (
+            <button
+              type="button"
+              onClick={() => setField(f.name, new Date().toISOString())}
+              className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
+              title="Write the current time as an ISO timestamp"
+            >
+              Now
+            </button>
+          )}
+          {f.kind === "string" && isIdField(f.name) && (
+            <button
+              type="button"
+              onClick={() => setField(f.name, triggerId(Date.now()))}
+              className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
+              title="Generate a fresh web-trigger id"
+            >
+              Generate
+            </button>
+          )}
+        </div>
+        {f.description && <div className="mb-1 text-[10px] text-(--text-faint)">{f.description}</div>}
+        {control}
+        {errs.map((e, i) => (
+          <div key={i} className="mt-0.5 text-[11px]" style={{ color: "var(--hue-err)" }}>
+            {e}
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   const outcome = inject.data;
   const seeded = Boolean(initialEnvelope);
@@ -233,7 +702,7 @@ export function InjectDialog({
       <div className="mb-3 text-[12px] text-(--text-dim)">
         {seeded
           ? "Trigger again copies this envelope with a new event id so intake admits it as a new event."
-          : "Templates come from the agent registry. Select an event type on the left to load its required schema skeleton, or paste a custom envelope."}
+          : "Templates come from the agent registry. Select an event type on the left to load its schema-driven form, or paste a custom envelope in the JSON tab."}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
@@ -323,39 +792,119 @@ export function InjectDialog({
           </div>
         </div>
 
-        {/* Right Column: JSON Editor & Controls */}
+        {/* Right Column: Form / JSON editor */}
         <div className="md:col-span-7 flex flex-col min-h-0">
-          <div className="mb-1.5 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-[11px]">
-              <span
-                className="size-1.5 rounded-full"
-                style={{ background: isValidJson ? "var(--hue-ok)" : "var(--hue-err)" }}
-              />
-              <span className="text-(--text-faint)">{isValidJson ? "Valid JSON" : "Invalid JSON syntax"}</span>
-            </div>
-            <button
-              type="button"
-              onClick={formatJson}
-              className="text-[11px] text-(--text-dim) hover:text-(--accent)"
-              title="Format JSON (⌘⇧F)"
-            >
-              Format JSON <span className="mono opacity-70">⌘⇧F</span>
-            </button>
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <Tabs
+              label="Envelope editor mode"
+              active={tab}
+              onSelect={selectTab}
+              tabs={[
+                {
+                  id: "form",
+                  label: "Form",
+                  disabled: tab === "json" && formAvailability.disabled,
+                  title: formAvailability.reason ?? undefined,
+                },
+                { id: "json", label: "JSON" },
+              ]}
+            />
+            {tab === "json" && (
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 text-[11px]">
+                  <span
+                    className="size-1.5 rounded-full"
+                    style={{ background: isValidJson ? "var(--hue-ok)" : "var(--hue-err)" }}
+                  />
+                  <span className="text-(--text-faint)">{isValidJson ? "Valid JSON" : "Invalid JSON syntax"}</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={formatJson}
+                  className="text-[11px] text-(--text-dim) hover:text-(--accent)"
+                  title="Format JSON (⌘⇧F)"
+                >
+                  Format JSON <span className="mono opacity-70">⌘⇧F</span>
+                </button>
+              </div>
+            )}
           </div>
 
-          <textarea
-            value={text}
-            onChange={(e) => {
-              setText(e.target.value);
-              setClientError(null);
-              setUnregisteredAck(false);
-              setConfirming(false);
-            }}
-            spellCheck={false}
-            rows={15}
-            aria-label="Event envelope JSON"
-            className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] leading-relaxed text-(--text) outline-none focus:border-(--border-strong)"
-          />
+          {tabNotice && (
+            <div className="mb-2 rounded-md px-2.5 py-1.5 text-[12px]" style={warnStyle}>
+              {tabNotice}
+            </div>
+          )}
+
+          {/* Form view: payload-only, schema-driven (WM-76). */}
+          <div hidden={tab !== "form"}>
+            {formFields.length === 0 ? (
+              <div className="rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] text-(--text-faint)">
+                {String(formBase.type ?? "this event type")} takes no payload fields — inject as-is, or switch to
+                the JSON tab.
+              </div>
+            ) : (
+              <div className="max-h-[340px] overflow-y-auto rounded-md border border-(--border) bg-(--surface-0) p-3">
+                {requiredFields.map(renderField)}
+                {optionalFields.length > 0 && (
+                  <div className="mt-2 border-t border-(--border) pt-2">
+                    <Disclosure label={`Optional fields (${optionalFields.length})`}>
+                      {optionalFields.map(renderField)}
+                    </Disclosure>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {unknown.length > 0 && (
+              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
+                Unknown payload key{unknown.length > 1 ? "s" : ""} kept: {unknown.join(", ")} — the schema does
+                not declare {unknown.length > 1 ? "them" : "it"}; edit or remove in the JSON tab.
+              </div>
+            )}
+            {formLevelErrors.length > 0 && (
+              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
+                {formLevelErrors.map((e, i) => (
+                  <div key={i}>{e}</div>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-2">
+              <Disclosure label="Envelope preview — the exact envelope that will be sent">
+                <JsonBlock value={formEnvelope} />
+              </Disclosure>
+            </div>
+          </div>
+
+          {/* JSON view: full-envelope escape hatch. */}
+          <div hidden={tab !== "json"}>
+            <textarea
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+                resetAcks();
+              }}
+              spellCheck={false}
+              rows={15}
+              aria-label="Event envelope JSON"
+              className="mono w-full resize-y rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px] leading-relaxed text-(--text) outline-none focus:border-(--border-strong)"
+            />
+            {jsonSchemaErrors.length > 0 && (
+              <div className="mt-2 rounded-md px-2.5 py-1.5 text-[11px]" style={warnStyle}>
+                <div className="mb-0.5 font-medium">
+                  payload does not validate against the registered input schema (
+                  {jsonSchemaErrors.length} issue{jsonSchemaErrors.length > 1 ? "s" : ""}):
+                </div>
+                {jsonSchemaErrors.slice(0, 6).map((e, i) => (
+                  <div key={i} className="mono">
+                    {e}
+                  </div>
+                ))}
+                {jsonSchemaErrors.length > 6 && <div>… and {jsonSchemaErrors.length - 6} more</div>}
+              </div>
+            )}
+          </div>
 
           {clientError && <VerbError error={new Error(clientError)} />}
           <VerbError error={inject.error} />

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -723,6 +723,179 @@ export function Dialog({
   );
 }
 
+/** Segmented tab strip (WM-76). Disabled tabs stay clickable so the owner can state why. */
+export function Tabs({
+  tabs,
+  active,
+  onSelect,
+  label,
+}: {
+  tabs: { id: string; label: ReactNode; disabled?: boolean; title?: string }[];
+  active: string;
+  onSelect: (id: string) => void;
+  label: string;
+}) {
+  return (
+    <div role="tablist" aria-label={label} className="inline-flex gap-0.5 rounded-md border border-(--border) bg-(--surface-0) p-0.5">
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="tab"
+          aria-selected={active === t.id}
+          aria-disabled={t.disabled || undefined}
+          title={t.title}
+          onClick={() => onSelect(t.id)}
+          className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+            active === t.id
+              ? "bg-(--surface-3) text-(--text)"
+              : t.disabled
+                ? "text-(--text-faint) opacity-60"
+                : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Read-only value badge (schema `const` fields). */
+export function Pill({ children, title }: { children: ReactNode; title?: string }) {
+  return (
+    <span
+      title={title}
+      className="mono inline-flex items-center rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[11px] text-(--text-dim)"
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Text input with datalist suggestions and free write-in (WM-76 repo picker). */
+export function SuggestInput({
+  id,
+  value,
+  onChange,
+  suggestions,
+  placeholder,
+  ariaLabel,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  suggestions?: string[] | null;
+  placeholder?: string;
+  ariaLabel?: string;
+}) {
+  const listId = useId();
+  return (
+    <>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        list={suggestions && suggestions.length > 0 ? listId : undefined}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        spellCheck={false}
+        className="mono w-full rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--border-strong)"
+      />
+      {suggestions && suggestions.length > 0 && (
+        <datalist id={listId}>
+          {suggestions.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+      )}
+    </>
+  );
+}
+
+/** Chip list editor for arrays of strings: add via input (Enter or +), remove per chip. */
+export function ChipInput({
+  id,
+  values,
+  onChange,
+  suggestions,
+  placeholder,
+}: {
+  id?: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+  suggestions?: string[] | null;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState("");
+  const listId = useId();
+  const add = (raw: string) => {
+    const v = raw.trim();
+    if (!v) return;
+    if (!values.includes(v)) onChange([...values, v]);
+    setDraft("");
+  };
+  return (
+    <div className="rounded-md border border-(--border) bg-(--surface-0) p-1.5">
+      {values.length > 0 && (
+        <div className="mb-1.5 flex flex-wrap gap-1">
+          {values.map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => onChange(values.filter((x) => x !== v))}
+              title={`Remove ${v}`}
+              aria-label={`Remove ${v}`}
+              className="group inline-flex cursor-pointer items-center gap-1 rounded-md border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[11px] hover:border-(--border-strong) hover:bg-(--surface-3)"
+            >
+              <span className="mono">{v}</span>
+              <span aria-hidden className="text-(--text-faint) group-hover:text-(--text)">
+                ×
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-1">
+        <input
+          id={id}
+          type="text"
+          value={draft}
+          list={suggestions && suggestions.length > 0 ? listId : undefined}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key !== "Enter") return;
+            e.preventDefault();
+            e.stopPropagation();
+            add(draft);
+          }}
+          placeholder={placeholder ?? "add…"}
+          spellCheck={false}
+          className="mono w-full rounded border-0 bg-transparent px-1 py-0.5 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint)"
+        />
+        {suggestions && suggestions.length > 0 && (
+          <datalist id={listId}>
+            {suggestions
+              .filter((s) => !values.includes(s))
+              .map((s) => (
+                <option key={s} value={s} />
+              ))}
+          </datalist>
+        )}
+        <button
+          type="button"
+          onClick={() => add(draft)}
+          disabled={!draft.trim()}
+          className="rounded border border-(--border) px-1.5 py-0.5 text-[11px] text-(--text-dim) hover:bg-(--surface-2) disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          add
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /** Inline verb-failure line: 404/409 are normal raced outcomes (spec §6). */
 export function VerbError({ error }: { error: unknown }) {
   if (!error) return null;

--- a/event-runtime/web/src/lib/injectForm.ts
+++ b/event-runtime/web/src/lib/injectForm.ts
@@ -115,6 +115,20 @@ export function repoSuggestions(
 }
 
 /**
+ * Human-readable example for a string field's placeholder (WM-76 critique r1).
+ * Mirrors the pattern heuristics templates.ts seedFor used to seed as values:
+ * examples belong in the placeholder, never pre-filled — and never show the
+ * raw regex source.
+ */
+export function placeholderFor(name: string, schema: Record<string, unknown>): string | null {
+  if (typeof schema.pattern !== "string") return null;
+  // Order matters: a path pattern ("^/…") also contains a slash.
+  if (schema.pattern.startsWith("^/")) return "/absolute/path";
+  if (schema.pattern.includes("/")) return name === "repo" ? "watt-mind/factory" : "owner/name";
+  return null;
+}
+
+/**
  * Route validator errors ("$.host: …", `$: missing required property "x"`)
  * to field names; unrouteable errors land under "" (form-level).
  */

--- a/event-runtime/web/src/lib/injectForm.ts
+++ b/event-runtime/web/src/lib/injectForm.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure helpers for the Inject dialog's schema-driven Form view (WM-76):
+ * field classification over the closed keyword subset of lib/schema.ts,
+ * name-convention detection (repo picker, Now/Generate buttons), and
+ * validation-error → field routing. No DOM, fully unit-testable.
+ */
+import type { RepoItem } from "../types";
+
+/** Planner-injected fields (lib/planner.mjs) — never shown in the form. */
+export const PLANNER_FIELDS = new Set(["repoPin", "runPin"]);
+
+export type FieldKind =
+  | "const" // read-only pill
+  | "enum" // select
+  | "boolean" // checkbox
+  | "number" // numeric input
+  | "string" // text input (also string|integer unions)
+  | "string-array" // chip list
+  | "json"; // nested object / array of objects → JSON sub-editor
+
+export interface FieldSpec {
+  name: string;
+  schema: Record<string, unknown>;
+  required: boolean;
+  kind: FieldKind;
+  description: string | null;
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === "object" && !Array.isArray(v);
+
+function typesOf(schema: Record<string, unknown>): string[] {
+  if (Array.isArray(schema.type)) return schema.type as string[];
+  if (typeof schema.type === "string") return [schema.type];
+  return [];
+}
+
+export function kindOf(schema: unknown): FieldKind {
+  if (!isPlainObject(schema)) return "json";
+  if ("const" in schema) return "const";
+  if (Array.isArray(schema.enum)) return "enum";
+  const types = typesOf(schema);
+  if (types.length === 1) {
+    const t = types[0];
+    if (t === "boolean") return "boolean";
+    if (t === "number" || t === "integer") return "number";
+    if (t === "string") return "string";
+    if (t === "array") {
+      const items = schema.items;
+      if (isPlainObject(items) && typesOf(items).length === 1 && typesOf(items)[0] === "string" && !Array.isArray(items.enum)) {
+        return "string-array";
+      }
+      return "json";
+    }
+    return "json"; // object, null, …
+  }
+  // Union types: string|integer (e.g. ci-doctor runId) edits fine as text.
+  if (types.length > 1 && types.every((t) => t === "string" || t === "integer" || t === "number")) {
+    return "string";
+  }
+  return "json";
+}
+
+/**
+ * A renderable object schema's fields, required first. Returns null when the
+ * schema cannot drive a form (not an object schema).
+ */
+export function schemaFields(schema: unknown): FieldSpec[] | null {
+  if (!isPlainObject(schema)) return null;
+  const types = typesOf(schema);
+  if (types.length > 0 && !types.includes("object")) return null;
+  const props = isPlainObject(schema.properties) ? schema.properties : {};
+  const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
+  const specs: FieldSpec[] = Object.entries(props)
+    .filter(([name]) => !PLANNER_FIELDS.has(name))
+    .map(([name, propSchema]) => ({
+      name,
+      schema: isPlainObject(propSchema) ? propSchema : {},
+      required: required.includes(name),
+      kind: kindOf(propSchema),
+      description:
+        isPlainObject(propSchema) && typeof propSchema.description === "string"
+          ? propSchema.description
+          : null,
+    }));
+  return [...specs.filter((s) => s.required), ...specs.filter((s) => !s.required)];
+}
+
+/** Name conventions from templates.ts seedFor — never keyed off `format`. */
+export const isAtField = (name: string): boolean =>
+  name === "at" || /(?:[a-z0-9](?:At|_at|-at))$/.test(name);
+
+export const isIdField = (name: string): boolean =>
+  name === "id" || name === "ID" || /(?:[a-z0-9](?:Id|_id|-id)|ID)$/.test(name);
+
+/**
+ * Repo picker suggestions (WM-76 decision 4). String field named `repo`:
+ * a pattern containing "/" wants owner/name → github slugs (nulls filtered);
+ * otherwise short configured names. Array field `repos`: short names.
+ */
+export function repoSuggestions(
+  name: string,
+  schema: Record<string, unknown>,
+  kind: FieldKind,
+  repos: RepoItem[],
+): string[] | null {
+  if (name === "repo" && kind === "string") {
+    if (typeof schema.pattern === "string" && schema.pattern.includes("/")) {
+      return repos.map((r) => r.github).filter((g): g is string => typeof g === "string" && g.length > 0);
+    }
+    return repos.map((r) => r.name);
+  }
+  if (name === "repos" && kind === "string-array") return repos.map((r) => r.name);
+  return null;
+}
+
+/**
+ * Route validator errors ("$.host: …", `$: missing required property "x"`)
+ * to field names; unrouteable errors land under "" (form-level).
+ */
+export function errorsByField(errors: string[]): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  const push = (key: string, msg: string) => {
+    const list = out.get(key) ?? [];
+    list.push(msg);
+    out.set(key, list);
+  };
+  for (const err of errors) {
+    const missing = err.match(/^\$: missing required property "([^"]+)"$/);
+    if (missing) {
+      push(missing[1], "missing required value");
+      continue;
+    }
+    const fielded = err.match(/^\$\.([A-Za-z0-9_$-]+)((?:[.[])[^:]*)?: (.*)$/);
+    if (fielded) {
+      push(fielded[1], `${fielded[2] ?? ""}${fielded[2] ? ": " : ""}${fielded[3]}`.trim());
+      continue;
+    }
+    push("", err.replace(/^\$: /, ""));
+  }
+  return out;
+}
+
+/** Payload keys the schema does not declare — kept, surfaced, never dropped. */
+export function unknownKeys(schema: unknown, payload: Record<string, unknown>): string[] {
+  if (!isPlainObject(schema)) return [];
+  const props = isPlainObject(schema.properties) ? schema.properties : {};
+  return Object.keys(payload).filter((k) => !(k in props));
+}

--- a/event-runtime/web/src/lib/schema.test.ts
+++ b/event-runtime/web/src/lib/schema.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { validate } from "./schema";
+
+// Representative cases ported from event-runtime/lib/schema.test.mjs (WM-76)
+// so the browser port provably matches the runtime validator's behavior.
+describe("validate (web port of lib/schema.mjs)", () => {
+  test("accepts a conforming object", () => {
+    const schema = {
+      type: "object",
+      required: ["name", "count"],
+      additionalProperties: false,
+      properties: {
+        name: { type: "string", minLength: 1 },
+        count: { type: "integer", minimum: 0 },
+        tags: { type: "array", items: { type: "string" } },
+      },
+    };
+    expect(validate(schema, { name: "bj29", count: 2, tags: ["a"] }).valid).toBe(true);
+  });
+
+  test("rejects unknown properties when additionalProperties is false", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" } },
+    };
+    const { valid, errors } = validate(schema, { a: "x", extra: 1 });
+    expect(valid).toBe(false);
+    expect(errors[0]).toContain('"extra"');
+  });
+
+  test("integer is a number, but number is not an integer", () => {
+    expect(validate({ type: "number" }, 1).valid).toBe(true);
+    expect(validate({ type: "integer" }, 1.5).valid).toBe(false);
+  });
+
+  test("supports type arrays (nullable fields)", () => {
+    expect(validate({ type: ["string", "null"] }, null).valid).toBe(true);
+    expect(validate({ type: ["string", "null"] }, 5).valid).toBe(false);
+  });
+
+  test("const, enum, pattern, bounds", () => {
+    expect(validate({ const: "factory.event/v1" }, "factory.event/v1").valid).toBe(true);
+    expect(validate({ enum: ["a", "b"] }, "c").valid).toBe(false);
+    expect(validate({ type: "string", pattern: "^run_" }, "prop_1").valid).toBe(false);
+    expect(validate({ type: "array", minItems: 1 }, []).valid).toBe(false);
+    expect(validate({ type: "number", minimum: 0, maximum: 100 }, 150).valid).toBe(false);
+  });
+
+  test("empty schema accepts anything", () => {
+    expect(validate({}, { any: ["thing", 1, null] }).valid).toBe(true);
+  });
+
+  test("unsupported keywords fail closed", () => {
+    const { valid, errors } = validate({ anyOf: [{ type: "string" }] }, "x");
+    expect(valid).toBe(false);
+    expect(errors[0]).toContain("unsupported schema keyword");
+  });
+
+  test("nested errors carry a path", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        repos: {
+          type: "array",
+          items: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        },
+      },
+    };
+    const { errors } = validate(schema, { repos: [{}] });
+    expect(errors[0]).toContain("$.repos[0]");
+  });
+
+  test("rejects prototype-inherited keys when additionalProperties is false", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" } },
+    };
+    expect(validate(schema, { a: "x", toString: "evil" }).valid).toBe(false);
+  });
+});

--- a/event-runtime/web/src/lib/schema.ts
+++ b/event-runtime/web/src/lib/schema.ts
@@ -1,0 +1,136 @@
+/**
+ * Minimal JSON Schema validator — browser port of event-runtime/lib/schema.mjs
+ * (WM-76). Keep the two in sync: this file mirrors the runtime validator
+ * line-for-line so what the form flags matches what the contract gate flags.
+ * Contracts fail closed (docs/event-runtime.md §5): an unsupported schema
+ * keyword is an error in the schema, not a silently-passing check.
+ */
+
+const SUPPORTED = new Set([
+  "type", "enum", "const", "required", "properties", "additionalProperties",
+  "items", "minItems", "maxItems", "minLength", "maxLength", "pattern",
+  "minimum", "maximum", "description", "title", "$schema",
+]);
+
+const hasOwn = (obj: unknown, key: string): boolean =>
+  obj !== null && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validate(schema: unknown, value: unknown, path = "$"): ValidationResult {
+  const errors: string[] = [];
+  check(schema, value, path, errors);
+  return { valid: errors.length === 0, errors };
+}
+
+function typeOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  return typeof value;
+}
+
+function matchesType(declared: string, actual: string): boolean {
+  return declared === actual || (declared === "number" && actual === "integer");
+}
+
+function check(schema: unknown, value: unknown, path: string, errors: string[]): void {
+  if (schema === undefined || schema === null) {
+    errors.push(`${path}: schema is missing`);
+    return;
+  }
+  if (typeof schema !== "object" || Array.isArray(schema)) {
+    errors.push(`${path}: schema must be an object`);
+    return;
+  }
+  const s = schema as Record<string, unknown>;
+  for (const key of Object.keys(s)) {
+    if (!SUPPORTED.has(key)) {
+      errors.push(`${path}: unsupported schema keyword "${key}" — contracts fail closed`);
+      return;
+    }
+  }
+
+  const actual = typeOf(value);
+
+  if (hasOwn(s, "type") && s.type !== undefined) {
+    const declared = Array.isArray(s.type) ? (s.type as string[]) : [s.type as string];
+    if (!declared.some((t) => matchesType(t, actual))) {
+      errors.push(`${path}: expected type ${declared.join("|")}, got ${actual}`);
+      return;
+    }
+  }
+
+  if (hasOwn(s, "const") && JSON.stringify(value) !== JSON.stringify(s.const)) {
+    errors.push(`${path}: expected const ${JSON.stringify(s.const)}`);
+  }
+  if (hasOwn(s, "enum") && Array.isArray(s.enum) && !s.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))) {
+    errors.push(`${path}: value not in enum ${JSON.stringify(s.enum)}`);
+  }
+
+  if (actual === "string") {
+    const str = value as string;
+    if (hasOwn(s, "minLength") && typeof s.minLength === "number" && str.length < s.minLength) {
+      errors.push(`${path}: shorter than minLength ${s.minLength}`);
+    }
+    if (hasOwn(s, "maxLength") && typeof s.maxLength === "number" && str.length > s.maxLength) {
+      errors.push(`${path}: longer than maxLength ${s.maxLength}`);
+    }
+    if (hasOwn(s, "pattern") && typeof s.pattern === "string" && !new RegExp(s.pattern).test(str)) {
+      errors.push(`${path}: does not match pattern ${s.pattern}`);
+    }
+  }
+
+  if (actual === "integer" || actual === "number") {
+    const num = value as number;
+    if (hasOwn(s, "minimum") && typeof s.minimum === "number" && num < s.minimum) {
+      errors.push(`${path}: below minimum ${s.minimum}`);
+    }
+    if (hasOwn(s, "maximum") && typeof s.maximum === "number" && num > s.maximum) {
+      errors.push(`${path}: above maximum ${s.maximum}`);
+    }
+  }
+
+  if (actual === "array") {
+    const arr = value as unknown[];
+    if (hasOwn(s, "minItems") && typeof s.minItems === "number" && arr.length < s.minItems) {
+      errors.push(`${path}: fewer than minItems ${s.minItems}`);
+    }
+    if (hasOwn(s, "maxItems") && typeof s.maxItems === "number" && arr.length > s.maxItems) {
+      errors.push(`${path}: more than maxItems ${s.maxItems}`);
+    }
+    if (hasOwn(s, "items")) {
+      arr.forEach((item, i) => check(s.items, item, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (actual === "object") {
+    const obj = value as Record<string, unknown>;
+    if (hasOwn(s, "required") && Array.isArray(s.required)) {
+      for (const key of s.required as string[]) {
+        if (!hasOwn(obj, key)) errors.push(`${path}: missing required property "${key}"`);
+      }
+    }
+    const properties: Record<string, unknown> =
+      hasOwn(s, "properties") && s.properties && typeof s.properties === "object"
+        ? (s.properties as Record<string, unknown>)
+        : {};
+    for (const [key, propSchema] of Object.entries(properties)) {
+      if (hasOwn(obj, key)) check(propSchema, obj[key], `${path}.${key}`, errors);
+    }
+    if (hasOwn(s, "additionalProperties")) {
+      if (s.additionalProperties === false) {
+        for (const key of Object.keys(obj)) {
+          if (!hasOwn(properties, key)) errors.push(`${path}: unknown property "${key}"`);
+        }
+      } else if (typeof s.additionalProperties === "object" && s.additionalProperties !== null) {
+        for (const key of Object.keys(obj)) {
+          if (!hasOwn(properties, key)) check(s.additionalProperties, obj[key], `${path}.${key}`, errors);
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/web/src/templates.test.ts
+++ b/event-runtime/web/src/templates.test.ts
@@ -51,19 +51,24 @@ describe("buildSkeleton", () => {
     ).toEqual({ host: "lab", usedPct: 0, flag: false });
   });
 
-  test("arrays with minItems seed one element — an empty array would be a guaranteed 422", () => {
+  test("string arrays seed empty even under minItems — the warning covers the ask; object arrays keep one skeleton element", () => {
     expect(
       buildSkeleton({
-        required: ["repos", "tags"],
+        required: ["repos", "tags", "plan"],
         properties: {
           repos: { type: "array", minItems: 1, items: { type: "string" } },
           tags: { type: "array", items: { type: "string" } },
+          plan: {
+            type: "array",
+            minItems: 1,
+            items: { type: "object", required: ["action"], properties: { action: { type: "string" } } },
+          },
         },
       }),
-    ).toEqual({ repos: [""], tags: [] });
+    ).toEqual({ repos: [], tags: [], plan: [{ action: "" }] });
   });
 
-  test("pattern hints produce a recognisable placeholder, not invented content", () => {
+  test("example-ish pattern hints seed empty values — the form surfaces the example as a placeholder instead", () => {
     expect(
       buildSkeleton({
         required: ["repo", "mount"],
@@ -72,7 +77,7 @@ describe("buildSkeleton", () => {
           mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
         },
       }),
-    ).toEqual({ repo: "owner/name", mount: "/" });
+    ).toEqual({ repo: "", mount: "" });
   });
 
   test("nested objects recurse", () => {
@@ -188,7 +193,7 @@ describe("buildTemplates", () => {
       type: "keephq.disk-alert.raised",
       source: "web-trigger",
       occurredAt: "2026-08-13T09:15:00.000Z",
-      payload: { host: "lab", mount: "/", usedPct: 0, alertId: triggerId(NOW) },
+      payload: { host: "lab", mount: "", usedPct: 0, alertId: triggerId(NOW) },
     });
   });
 

--- a/event-runtime/web/src/templates.ts
+++ b/event-runtime/web/src/templates.ts
@@ -28,21 +28,26 @@ function seedFor(name: string, schema: any, nowMs: number = Date.now()): unknown
     case "boolean":
       return false;
     case "array": {
-      // minItems > 0 means "empty is invalid" — seed one element so the
-      // template is submittable, not a guaranteed 422.
-      const item = seedFor(name, schema.items, nowMs);
-      return (schema.minItems ?? 0) > 0 ? [item] : [];
+      // Arrays of objects under minItems > 0 seed one skeleton element so the
+      // required shape is visible. Arrays of strings seed empty even under
+      // minItems (WM-76 critique r1): a seeded empty-string chip reads as a
+      // rendering glitch, and the minItems validation warning covers the ask.
+      const itemType = Array.isArray(schema.items?.type) ? schema.items.type[0] : schema.items?.type;
+      if ((schema.minItems ?? 0) > 0 && itemType !== "string") {
+        return [seedFor(name, schema.items, nowMs)];
+      }
+      return [];
     }
     case "object":
       return buildSkeleton(schema, nowMs);
     default:
-      // Pattern-constrained strings get a hint the operator can recognise and
-      // replace; anything else stays empty rather than inventing content.
+      // Example-ish pattern hints are placeholders, not values (WM-76
+      // critique r1): a pre-filled "owner/name" renders as real typed text,
+      // satisfies the pattern, and ships as plausible garbage. Seed "" —
+      // validation warns, never blocks — and let the form surface the
+      // example via placeholderFor() (lib/injectForm.ts).
       if (typeof schema.pattern === "string") {
-        // Order matters: a path pattern ("^/…") also contains a slash, so the
-        // absolute-path case must be tested before the owner/name case.
-        if (schema.pattern.startsWith("^/")) return "/";
-        if (schema.pattern.includes("/")) return "owner/name";
+        if (schema.pattern.startsWith("^/") || schema.pattern.includes("/")) return "";
       }
       if (
         schema.format === "date-time" ||


### PR DESCRIPTION
Fixes WM-76

The Inject Event dialog's right pane is now [ Form ] / [ JSON ] tabs. Form mode is payload-only and schema-driven from the agent's input schema: repo fields get a suggestion picker from `GET /repos` (short names vs `owner/name` slugs detected by pattern), `*At` fields get a Now button, `*Id` fields get Generate, enums→selects, string arrays→chips, complex fields→JSON sub-editors; planner-injected `repoPin`/`runPin` are hidden; required fields always visible, optionals behind a disclosure; a collapsed preview shows the exact outgoing envelope. The JSON tab keeps full-envelope editing as the escape hatch.

New: `web/src/lib/schema.ts` — dependency-free TS port of `lib/schema.mjs` (fail-closed on unsupported keywords) so the payload validates client-side in both tabs; schema-invalid payloads warn and require an explicit second confirm instead of hard-blocking (the server deliberately admits them and parks `human_needed`). Unregistered types and "Trigger again" seeds open JSON-only with the Form tab disabled and a stated reason.

UX critique round (factory-ux-critic, live app): FIX-FIRST → both in-scope findings fixed in `12fe80f` (example-ish seeds like `owner/name` are now placeholders, never values; string-array fields seed zero chips). Follow-ups filed: WM-78–WM-82.

No new dependencies; no server changes.

## Verification

```
bun test event-runtime/web && (cd event-runtime/web && bun run build)
→ 195 pass, 0 fail (530 expect calls, 19 files); vite build green
```

18 new dialog/validator tests plus 5 critique-fix assertions, all observed failing against the pre-change code first.