### PR TITLE
fix(ci): seed e2e asks the OS for a free port instead of pid-modulo (WM-89)

### DIFF
--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -17,7 +17,13 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
 
   beforeAll(async () => {
     home = mkdtempSync(path.join(os.tmpdir(), "evrt-seed-test-"));
-    port = String(59100 + (process.pid % 500));
+    // Ask the OS for a genuinely free port instead of pid-modulo arithmetic:
+    // on a shared self-hosted runner a leftover server from an earlier
+    // (aborted) job can squat any precomputed port, and the seed then fails
+    // in milliseconds against a stranger's already-seeded state (WM-89).
+    const probe = Bun.serve({ port: 0, fetch: () => new Response("") });
+    port = String(probe.port);
+    probe.stop(true);
 
     serveChild = spawn("bun", [CLI, "serve", "--adapter-override", "fake", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },


### PR DESCRIPTION
Fixes WM-89

`seed.test.mjs` derived its port as `59100 + (pid % 500)` — on the shared self-hosted runner a leftover `bun serve` from an earlier aborted job can squat that port, and the seed fails in ~33 ms against a stranger's already-seeded state. This is what kept develop red after WM-83 (runs 31815961721 ×2, CI-doctor classified FLAKE→ENV). Now the test binds port 0 and uses whatever the OS hands back.

Verification: `bun test event-runtime/demo/seed.test.mjs` → 3 pass / 0 fail.