### PR TITLE
fix(event-runtime): harden and speed demo seed tests

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -450,10 +450,14 @@ async function serve(args) {
  * on one machine SQLite (WAL + BEGIN IMMEDIATE claims) makes concurrent
  * claiming correct; Postgres is what remote nodes need, not this.
  *
- *   bun event-runtime/cli.mjs work [--label k=v ...] [--adapter-override fake]
+ *   bun event-runtime/cli.mjs work [--label k=v ...] [--adapter-override fake] [--poll-ms 500]
  */
 async function work(args) {
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
+  const pollMs = Number(flagValue(args, "--poll-ms") ?? 500);
+  if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
+    fail("work: --poll-ms must be an integer between 25 and 5000");
+  }
   const adapters = { actions, claude, command, fake };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`work: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
@@ -504,7 +508,7 @@ async function work(args) {
           ...(adapterOverride ? { adapterOverride } : {}),
         });
         if (!claim) {
-          await new Promise((resolve) => setTimeout(resolve, 500));
+          await new Promise((resolve) => setTimeout(resolve, pollMs));
           continue;
         }
         inFlight = claim.runId;

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -40,6 +40,12 @@ describe("cli", () => {
     expect(r.all).toContain("usage:");
   });
 
+  test("work rejects an unsafe idle poll interval", () => {
+    const r = runCli(["work", "--poll-ms", "0"]);
+    expect(r.status).not.toBe(0);
+    expect(r.all).toContain("work: --poll-ms must be an integer between 25 and 5000");
+  });
+
   test("status against a dead port says serve is not running, non-zero exit", () => {
     const r = runCli(["status"], { FACTORY_EVENT_PORT: DEAD_PORT });
     expect(r.status).not.toBe(0);

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -39,7 +39,7 @@
  *
  *   RUNNING     repos:["hang"] (approved LAST — single worker holds until 600s timeout)
  *
- *   bun event-runtime/demo/seed.mjs [--port 7381] [--prefix demo]
+ *   bun event-runtime/demo/seed.mjs [--port 7381] [--prefix demo] [--poll-ms 300]
  */
 import { apiClient } from "../lib/client.mjs";
 import { openDb } from "../lib/db.mjs";
@@ -52,7 +52,22 @@ const flag = (name) => {
 };
 const port = Number(flag("--port") ?? process.env.FACTORY_EVENT_PORT ?? 7381);
 const prefix = flag("--prefix") ?? "demo";
-const client = apiClient({ port });
+const pollMs = Number(flag("--poll-ms") ?? 300);
+if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
+  console.error("seed: --poll-ms must be an integer between 25 and 5000");
+  process.exit(2);
+}
+const rawClient = apiClient({ port });
+const client = new Proxy(rawClient, {
+  get(target, prop) {
+    const value = target[prop];
+    if (typeof value !== "function") return value;
+    if (["approve", "cancel", "reject", "replay", "retry"].includes(prop)) {
+      return (...args) => retryDatabaseLock(`${prop} ${args[0] ?? ""}`, () => value(...args));
+    }
+    return value;
+  },
+});
 
 const log = (line) => console.log(`seed: ${line}`);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -93,6 +108,20 @@ function envelope(id, repos, type = "factory.status-report.requested") {
  * Replay an envelope, exiting immediately (<1s) if intake detects a duplicate
  * event id/prefix instead of timing out downstream in until() (OPS-464).
  */
+async function retryDatabaseLock(label, operation) {
+  let last;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await operation();
+    } catch (err) {
+      last = err;
+      if (!/database is locked/i.test(String(err?.message))) throw err;
+      await sleep(25 * (attempt + 1));
+    }
+  }
+  throw new Error(`${label}: database remained locked after 20 retries (${last?.message ?? "unknown error"})`);
+}
+
 async function replay(env) {
   const res = await client.replay(env);
   if (res.duplicate) {
@@ -108,7 +137,7 @@ async function replay(env) {
 }
 
 /** Poll until `fn` returns truthy, or die loudly — a seed must not half-run. */
-async function until(what, fn, { timeoutMs = 30_000, everyMs = 300 } = {}) {
+async function until(what, fn, { timeoutMs = 30_000, everyMs = pollMs } = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const value = await fn();

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -9,6 +9,19 @@ const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
 const SEED = fileURLToPath(new URL("./seed.mjs", import.meta.url));
 const VERIFY = fileURLToPath(new URL("./verify.mjs", import.meta.url));
 
+const redact = (text) => String(text ?? "")
+  .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
+  .replace(/(authorization\s*[:=]\s*)\S+/gi, "$1[REDACTED]");
+
+function expectSuccess(label, result) {
+  const diagnostic = [
+    `${label} exited ${result.status ?? "null"}${result.signal ? ` (signal ${result.signal})` : ""}`,
+    `stdout:\n${redact(result.stdout)}`,
+    `stderr:\n${redact(result.stderr)}`,
+  ].join("\n");
+  expect(result.status, diagnostic).toBe(0);
+}
+
 describe("seed & re-seed deduplication (OPS-464)", () => {
   let home;
   let port;
@@ -45,10 +58,27 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     }
     expect(up).toBe(true);
 
-    workerChild = spawn("bun", [CLI, "work", "--adapter-override", "fake", "--port", port], {
+    workerChild = spawn("bun", [CLI, "work", "--adapter-override", "fake", "--port", port, "--poll-ms", "40"], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
+
+    // Health only proves the control API is listening. Seed drives approvals
+    // immediately, so wait for the separate worker process to register first.
+    let workerReady = false;
+    const workerDeadline = Date.now() + 8_000;
+    while (Date.now() < workerDeadline) {
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/workers`);
+        const body = await res.json();
+        if (res.ok && Array.isArray(body.workers) && body.workers.length > 0) {
+          workerReady = true;
+          break;
+        }
+      } catch {}
+      await Bun.sleep(50);
+    }
+    expect(workerReady).toBe(true);
   });
 
   afterAll(async () => {
@@ -65,17 +95,19 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   });
 
   test("initial seed succeeds and verify passes", () => {
-    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t1"], {
+    const t0 = Date.now();
+    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t1", "--poll-ms", "40"], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
-    expect(seedRes.status).toBe(0);
+    expectSuccess("initial seed", seedRes);
+    expect(Date.now() - t0).toBeLessThan(8_000);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
-    expect(verifyRes.status).toBe(0);
+    expectSuccess("initial verify", verifyRes);
   }, 30_000);
 
   test("re-running seed with the SAME prefix fails immediately (<1s) on duplicate intake", () => {
@@ -92,16 +124,18 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   }, 10_000);
 
   test("re-seeding with a NEW prefix cleans up hang runs and allows verify to pass", () => {
-    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t2"], {
+    const t0 = Date.now();
+    const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t2", "--poll-ms", "40"], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
-    expect(seedRes.status).toBe(0);
+    expectSuccess("re-seed", seedRes);
+    expect(Date.now() - t0).toBeLessThan(8_000);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
-    expect(verifyRes.status).toBe(0);
+    expectSuccess("re-seed verify", verifyRes);
   }, 30_000);
 });


### PR DESCRIPTION
## Summary
- Wait for fake-worker registration and preserve redacted seed subprocess diagnostics.
- Retry transient SQLite write locks while seeding.
- Add a bounded test-only worker idle-poll interval; demo seed phases now complete in 7.0s and 6.0s locally.

Fixes OPS-494
Fixes OPS-495