### PR TITLE
feat(webui): artifact store health tiles on Overview (WM-103)

### DIFF
--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -306,6 +306,8 @@ export interface StatusView {
   runs: { byState: Partial<Record<RunState, number>> };
   /** Fleet counts; `live` and `busy` exclude stale workers, as the API does. */
   workers: { live: number; busy: number; stale: number };
+  /** Artifact store rollup; `orphans` counts files no result references. Cached ~10s server-side (`at` = when computed). */
+  artifacts: { files: number; bytes: number; orphans: number; orphanBytes: number; at?: string };
   anomalies: {
     expiredOpenProposals: string[];
     staleLeases: number;

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   Disclosure,
   EVENT_STATUS_HUES,
+  humanSize,
   JsonBlock,
   JumpLink,
   Section,
@@ -371,6 +372,22 @@ export function Overview({
                 value={s.workers.stale}
                 hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
                 onClick={() => onNavigate("workers")}
+              />
+            </div>
+          </div>
+
+          {/* Stage 3: Artifact store health */}
+          <div>
+            <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+              4. Artifact Store
+            </div>
+            <div className="grid grid-cols-3 gap-2 lg:max-w-md">
+              <StatTile label="artifacts · files" value={s.artifacts.files} />
+              <StatTile label="artifacts · size" value={humanSize(s.artifacts.bytes)} />
+              <StatTile
+                label="artifacts · orphans"
+                value={s.artifacts.orphans}
+                hue={s.artifacts.orphanBytes > 0 ? "var(--hue-warn)" : undefined}
               />
             </div>
           </div>


### PR DESCRIPTION
Fixes WM-103

Renders the artifact-store rollup the control API already reports in its status payload (files / total size / orphans, warn hue when orphanBytes > 0) as a fourth tile group on the Overview dashboard. No new API calls — data comes from the existing 2s status poll. Adds the `artifacts` field to `StatusView`.

Verification: `bun run build` (typecheck+build) green, `bun test event-runtime/web` 195 pass / 0 fail; visually confirmed on the seeded demo env.