### PR TITLE
fix(webui): artifact preview on RunFull + save-as filenames (WM-104)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -703,9 +703,17 @@ export function createApi({
       if (req.method === "GET" && artifactGet) {
         const found = findArtifact(artifactsRoot(env.home), artifactGet[1]);
         if (!found) return send(res, 404, { error: `no artifact ${artifactGet[1]}` });
+        // Optional ?name= gives the browser a save-as filename instead of the
+        // bare hash. Sanitized to a header-safe charset; the sha12 suffix keeps
+        // two same-named artifacts distinguishable on disk.
+        const rawName = url.searchParams.get("name");
+        const safeName = rawName ? rawName.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64) : "";
         res.writeHead(200, {
           "content-type": looksLikeText(found.file) ? "text/plain; charset=utf-8" : "application/octet-stream",
           "content-length": found.sizeBytes,
+          ...(safeName
+            ? { "content-disposition": `inline; filename="${safeName}-${artifactGet[1].slice(0, 12)}"` }
+            : {}),
         });
         createReadStream(found.file).pipe(res);
         return;

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -623,6 +623,21 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(res.headers.get("content-type")).toContain("text/plain");
       expect(await res.text()).toBe("fake report for with-artifact\n");
 
+      expect(res.headers.get("content-disposition")).toBeNull();
+
+      const named = await fetch(`http://127.0.0.1:${port}/artifacts/${report.sha256}?name=report`);
+      expect(named.status).toBe(200);
+      expect(named.headers.get("content-disposition")).toBe(
+        `inline; filename="report-${report.sha256.slice(0, 12)}"`,
+      );
+
+      const hostile = await fetch(
+        `http://127.0.0.1:${port}/artifacts/${report.sha256}?name=${encodeURIComponent('a/b\\"c\r\nx')}`,
+      );
+      expect(hostile.headers.get("content-disposition")).toBe(
+        `inline; filename="a_b__c__x-${report.sha256.slice(0, 12)}"`,
+      );
+
       expect((await fetch(`http://127.0.0.1:${port}/artifacts/${"0".repeat(64)}`)).status).toBe(404);
       expect((await fetch(`http://127.0.0.1:${port}/artifacts/not-a-hash`)).status).toBe(404);
     } finally {

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -103,5 +103,6 @@ export const api = {
   workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
 };
 
-/** Browser URL for a stored artifact's bytes (streamed by the control API). */
-export const artifactUrl = (sha256: string) => `/api/artifacts/${encodeURIComponent(sha256)}`;
+/** Browser URL for a stored artifact's bytes (streamed by the control API); `name` becomes the save-as filename. */
+export const artifactUrl = (sha256: string, name?: string) =>
+  `/api/artifacts/${encodeURIComponent(sha256)}${name ? `?name=${encodeURIComponent(name)}` : ""}`;

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import { api, ApiError, artifactUrl } from "../api";
+import { api, ApiError } from "../api";
 import { keyGuard, useNow } from "../hooks";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
@@ -9,7 +9,6 @@ import {
   Button,
   Dialog,
   Disclosure,
-  humanSize,
   JsonBlock,
   JumpLink,
   KV,
@@ -20,7 +19,7 @@ import {
   copyText,
   notify,
 } from "../components/ui";
-import { ActorRef, TERMINAL } from "./Runs";
+import { ActorRef, ArtifactRow, TERMINAL } from "./Runs";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -315,28 +314,7 @@ export function RunFull({
                   ) : (
                     <div className="rounded-md border border-(--border) px-3 py-1">
                       {(d.result.artifacts ?? []).map((a) => (
-                        <div
-                          key={a.sha256}
-                          className="flex items-baseline justify-between gap-3 border-b border-(--border) py-1.5 last:border-0"
-                        >
-                          <span className="truncate">
-                            {a.kind}
-                            <span className="mono ml-2 text-[11px] text-(--text-faint)" title={a.sha256}>
-                              {a.sha256.slice(0, 12)}
-                            </span>
-                          </span>
-                          <span className="flex shrink-0 items-baseline gap-3">
-                            <span className="tabular-nums text-(--text-faint)">{humanSize(a.sizeBytes)}</span>
-                            <a
-                              href={artifactUrl(a.sha256)}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="text-(--accent) hover:underline"
-                            >
-                              Open
-                            </a>
-                          </span>
-                        </div>
+                        <ArtifactRow key={a.sha256} a={a} />
                       ))}
                     </div>
                   )}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -183,7 +183,7 @@ export function ActorRef({ actor, className }: { actor: string; className?: stri
 const isTextArtifact = (k: string) =>
   /^(transcript|diff|report|evidence)$/i.test(k) || /\.(txt|json|jsonl|md|log)$/i.test(k);
 
-function ArtifactRow({ a }: { a: ArtifactRef }) {
+export function ArtifactRow({ a }: { a: ArtifactRef }) {
   const [open, setOpen] = useState(false);
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -233,7 +233,7 @@ function ArtifactRow({ a }: { a: ArtifactRef }) {
             </button>
           )}
           <a
-            href={artifactUrl(a.sha256)}
+            href={artifactUrl(a.sha256, a.kind)}
             target="_blank"
             rel="noreferrer"
             className="text-(--accent) hover:underline"


### PR DESCRIPTION
Fixes WM-104

- Exports `ArtifactRow` from Runs.tsx and reuses it in RunFull's Artifacts section, so the inline text preview works on the full-page run view too (was download-only).
- `GET /artifacts/:sha256` accepts an optional sanitized `?name=` and sets `content-disposition: inline; filename="<name>-<sha12>"`; absent param keeps prior behavior byte-for-byte. `artifactUrl` passes the artifact kind from the UI.
- Test coverage for the header (present/absent/sanitized hostile input).

Verification: `bun test event-runtime/lib/api.test.mjs` 59 pass / 0 fail; web `bun run build` (typecheck+build) green; visually confirmed Preview renders on RunFull in the seeded demo env.