### PR TITLE
fix(web): enrich anomaly deck rows with agent, reason, and age (WM-95)

### DIFF
--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,0 +1,160 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Overview } from "./Overview";
+import { api } from "../api";
+import type { Proposal, StatusView } from "../types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const noop = () => {};
+
+function baseStatus(overrides: Partial<StatusView["anomalies"]> = {}): StatusView {
+  return {
+    env: { name: "test", home: "/tmp/test", adapter: null },
+    events: {},
+    proposals: { open: 0, expired: 1 },
+    runs: { byState: {} },
+    workers: { live: 0, busy: 0, stale: 0 },
+    artifacts: { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 },
+    anomalies: {
+      expiredOpenProposals: [],
+      staleLeases: 0,
+      unpublishedOutbox: 0,
+      deadLettered: [],
+      stalledWorkers: [],
+      noWorkers: false,
+      ambiguousOpenProposals: [],
+      ...overrides,
+    },
+  };
+}
+
+const stubProposal: Proposal = {
+  id: "prop_abc123def456",
+  decision: "human_needed",
+  status: "open",
+  expired: true,
+  created_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+  ttl_seconds: 60,
+  decided_at: null,
+  decided_by: null,
+  reason: "ambiguous repo pin",
+  runId: null,
+  eventId: "evt-789",
+  eventSource: "github",
+  agent: "triage-scan",
+  spec: null,
+  repos: [],
+};
+
+function renderOverview() {
+  return renderWithClient(
+    <Overview
+      connected={true}
+      context={{ kind: "all" }}
+      onJumpRun={noop}
+      onJumpProposal={noop}
+      onJumpEvents={noop}
+      onJumpRuns={noop}
+      onNavigate={noop}
+      onJumpExpired={noop}
+      onJumpGraph={noop}
+      onInject={noop}
+    />,
+  );
+}
+
+describe("Overview anomaly deck (WM-95)", () => {
+  test("enriches an expired-proposal row with agent, decision/reason, origin, and age; demotes the raw id", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText, queryByTitle } = renderOverview();
+
+      await waitFor(() => getByText(/agent: triage-scan/));
+
+      expect(getByText(/agent: triage-scan/)).toBeTruthy();
+      expect(getByText(/human_needed/)).toBeTruthy();
+      expect(getByText(/ambiguous repo pin/)).toBeTruthy();
+      expect(getByText(/origin github\/evt-789/)).toBeTruthy();
+
+      // Raw id is demoted to secondary, copyable text rather than the primary label.
+      const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
+      expect(idNode).toBeTruthy();
+      expect(idNode?.textContent).toBe(stubProposal.id);
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("shows a fallback for a proposal id with no match in the proposals list", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () => baseStatus({ expiredOpenProposals: ["prop_missing"] });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText, queryByTitle } = renderOverview();
+
+      await waitFor(() => queryByTitle("prop_missing — click to copy"));
+
+      expect(getByText(/agent: —/)).toBeTruthy();
+      expect(getByText(/origin —\/—/)).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("other anomaly kinds (stale leases, unpublished outbox) render unchanged", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ staleLeases: 3, unpublishedOutbox: 2 });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText } = renderOverview();
+
+      await waitFor(() => getByText(/stale leases: 3/));
+      expect(getByText(/unpublished outbox rows: 2/)).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+});

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { hashPath } from "../hash";
 import { useNow } from "../hooks";
-import type { JournalEntry, EventFocus, RunState } from "../types";
+import type { JournalEntry, EventFocus, Proposal, RunState } from "../types";
 import type { OperatorContext } from "../context";
 import { ScopeCaption } from "../components/ContextTabs";
 import {
@@ -99,6 +99,14 @@ export function Overview({
     queryFn: () => api.outbox(15),
     refetchInterval: 2000,
   });
+  // Client-side join for the anomaly deck (WM-95): the doctor only reports
+  // expired proposal ids, so pull the same proposals list the Proposals view
+  // uses to enrich each id with agent/decision/reason/origin/age.
+  const proposalsForDeck = useQuery({
+    queryKey: ["proposals"],
+    queryFn: api.proposals,
+    refetchInterval: 2000,
+  });
   const feed = useJournalFeed();
 
   const requeue = useMutation({
@@ -137,16 +145,23 @@ export function Overview({
 
   const s = status.data;
   const anomalies = s?.anomalies;
+  const proposalsById = new Map<string, Proposal>(
+    (proposalsForDeck.data?.proposals ?? []).map((p) => [p.id, p]),
+  );
   const anomalyRows: {
     text: string;
     links: { label: string; go: () => void }[];
     requeue?: { source: string; eventId: string };
     dismissProposalId?: string;
+    proposalId?: string;
+    proposal?: Proposal;
   }[] = [];
   if (anomalies) {
     for (const id of anomalies.expiredOpenProposals) {
       anomalyRows.push({
         text: `expired open proposal ${id}`,
+        proposalId: id,
+        proposal: proposalsById.get(id),
         links: [{ label: "View proposal", go: () => onJumpProposal(id) }],
         dismissProposalId: id,
       });
@@ -245,13 +260,45 @@ export function Overview({
                 key={i}
                 className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0"
               >
-                <span
-                  className="min-w-0 break-words sm:truncate text-[12px]"
-                  title={a.text}
-                  style={{ color: "var(--hue-warn)" }}
-                >
-                  {a.text}
-                </span>
+                {a.proposalId ? (
+                  <span className="min-w-0 flex flex-col gap-0.5 text-[12px]" style={{ color: "var(--hue-warn)" }}>
+                    <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words">
+                      <span>expired open proposal</span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span>agent: {a.proposal?.agent ?? "—"}</span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span>
+                        {a.proposal?.decision ?? "—"}
+                        {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
+                      </span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span className="text-(--text-faint)">
+                        origin {a.proposal?.eventSource ?? "—"}/{a.proposal?.eventId ?? "—"}
+                      </span>
+                      <span className="text-(--text-faint)">·</span>
+                      {a.proposal?.created_at ? (
+                        <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
+                      ) : (
+                        <span className="text-(--text-faint)">age —</span>
+                      )}
+                    </span>
+                    <span
+                      className="mono truncate text-[11px] text-(--text-faint) cursor-pointer"
+                      title={`${a.proposalId} — click to copy`}
+                      onClick={() => copyText(a.proposalId!, "proposal id")}
+                    >
+                      {a.proposalId}
+                    </span>
+                  </span>
+                ) : (
+                  <span
+                    className="min-w-0 break-words sm:truncate text-[12px]"
+                    title={a.text}
+                    style={{ color: "var(--hue-warn)" }}
+                  >
+                    {a.text}
+                  </span>
+                )}
                 <span className="flex flex-wrap items-center gap-1.5 sm:gap-2 sm:shrink-0">
                   <Button onClick={() => copyText(a.text, "anomaly")}>Copy</Button>
                   {a.requeue && (


### PR DESCRIPTION
## Summary
- The Doctor Anomaly Deck's expired-proposal rows showed only a raw `prop_<uuid>` — every triage decision needed a click-through to see anything actionable.
- `Overview.tsx` now joins each expired proposal id against the proposals list already fetched by the app (`api.proposals()`, same `["proposals"]` query the Proposals view uses — client-side join, no server changes) and renders: agent ref (or `—`), planner decision + reason, origin `eventSource/eventId`, and relative age via the existing `Ago` component.
- The raw `prop_` id is demoted to secondary, copyable text below the enriched line (click to copy via the existing `copyText` helper); a proposal with no match in the fetched list falls back to `—` for each enriched field rather than breaking the row.
- Other anomaly kinds (stale leases, unpublished outbox, dead-lettered, stalled workers, ambiguous proposals, no-workers) are untouched — only the `expiredOpenProposals` row path changed.

Fixes WM-95

## Test plan
- [x] `cd event-runtime/web && bunx tsc --noEmit && bun test src` — clean, all green (output below)
- [x] New `event-runtime/web/src/views/Overview.test.tsx` covers: enriched row rendering with a stubbed proposal, fallback rendering when no proposal matches the id, and that stale-lease/unpublished-outbox rows render unchanged

```
$ bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 198 pass
 0 fail
 539 expect() calls
Ran 198 tests across 20 files. [1441.00ms]
```