### PR TITLE
fix(web): make In flight context a true toggle with visible active state (WM-91)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -1,6 +1,7 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { OperatorContext } from "../context";
 import type { RepoItem } from "../types";
 import { ContextTabs } from "./ContextTabs";
 
@@ -109,5 +110,26 @@ describe("ContextTabs", () => {
     });
 
     expect(document.activeElement).toBe(input);
+  });
+
+  test("clicking In flight while active toggles back to All (WM-91)", () => {
+    const selected: OperatorContext[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "inflight" }}
+        onSelect={(ctx) => selected.push(ctx)}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const inflightBtn = r.getByRole("button", { name: "In flight" });
+    expect(inflightBtn.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(inflightBtn);
+    expect(selected).toEqual([{ kind: "all" }]);
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { OperatorContext } from "../context";
-import { INFLIGHT } from "../context";
+import { INFLIGHT, toggleInflight } from "../context";
 import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
 
@@ -200,9 +200,13 @@ export function ContextTabs({
     }
   };
 
+  // Active state uses the accent tokens (not --surface-3) so it stays visible
+  // against --surface-1 in light theme, where the two grays sit too close (WM-91).
   const tabClass = (id: string) =>
     `flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-      activeId === id ? "bg-(--surface-3) text-(--text)" : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+      activeId === id
+        ? "bg-(--accent-dim) text-(--text) ring-1 ring-inset ring-(--accent)"
+        : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
     }`;
 
   return (
@@ -312,8 +316,11 @@ export function ContextTabs({
           aria-pressed={!activeRunId && active.kind === "inflight"}
           className={tabClass(INFLIGHT)}
           onClick={() => {
-            if (activeRunId && typeof window !== "undefined") window.location.hash = "#/runs?project=inflight";
-            onSelect({ kind: "inflight" });
+            const next = toggleInflight(active);
+            if (activeRunId && typeof window !== "undefined") {
+              window.location.hash = next.kind === "inflight" ? "#/runs?project=inflight" : "#/runs";
+            }
+            onSelect(next);
           }}
           onFocus={() => setTabStopId(INFLIGHT)}
         >

--- a/event-runtime/web/src/context.test.ts
+++ b/event-runtime/web/src/context.test.ts
@@ -8,6 +8,7 @@ import {
   projectFromContext,
   readContextTabs,
   rememberOpenRepo,
+  toggleInflight,
 } from "./context";
 
 describe("contextFromProject / projectFromContext", () => {
@@ -53,6 +54,14 @@ describe("readContextTabs", () => {
       active: "all",
     });
     expect(CONTEXT_STORAGE_KEY).toBe("factory.contextTabs");
+  });
+});
+
+describe("toggleInflight", () => {
+  test("In flight from any other context; All when already in flight", () => {
+    expect(toggleInflight({ kind: "all" })).toEqual({ kind: "inflight" });
+    expect(toggleInflight({ kind: "repo", name: "bj29" })).toEqual({ kind: "inflight" });
+    expect(toggleInflight({ kind: "inflight" })).toEqual({ kind: "all" });
   });
 });
 

--- a/event-runtime/web/src/context.ts
+++ b/event-runtime/web/src/context.ts
@@ -39,6 +39,11 @@ export function matchesInFlight(state: string, ctx: OperatorContext): boolean {
   return state === "LEASED" || state === "RUNNING";
 }
 
+/** In flight is a toggle: clicking it while active exits to All (WM-91). */
+export function toggleInflight(active: OperatorContext): OperatorContext {
+  return active.kind === "inflight" ? { kind: "all" } : { kind: "inflight" };
+}
+
 export function readContextTabs(raw: string | null): ContextTabsPersisted {
   if (!raw) return { openRepos: [], active: "all" };
   try {

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -650,6 +650,19 @@ export function Runs({
                         ? "No runs."
                         : `No ${tab} runs.`
                 }
+                action={
+                  // Only In flight can strand an operator with no way back but the
+                  // context strip's All tab — offer the same exit inline (WM-91).
+                  context.kind === "inflight" ? (
+                    <Button
+                      onClick={() => {
+                        if (typeof window !== "undefined") window.location.hash = "#/runs";
+                      }}
+                    >
+                      Show all runs
+                    </Button>
+                  ) : undefined
+                }
               />
             )}
           </tbody>


### PR DESCRIPTION
Fixes WM-91

## Summary
- `In flight` chip's onClick was unconditional `onSelect({ kind: "inflight" })`, so clicking it while already active was a no-op — the only way out was the `All` tab. Added `toggleInflight()` in `context.ts` (all -> inflight, repo -> inflight, inflight -> all) and wired the chip's onClick through it, including the pinned-run hash-exit path.
- Active chip styling switched from `bg-(--surface-3) text-(--text)` to `bg-(--accent-dim) text-(--text) ring-1 ring-inset ring-(--accent)`, using the existing accent tokens so the active state stays visible against `--surface-1` in all three themes (dark/light/contrast) instead of blending in (worst in light theme).
- `Runs.tsx`'s "No runs in flight." empty state now gets an inline `Show all runs` action (using the existing `ListEmpty` `action` prop, same pattern as the Events view's `Inject event…` action) that jumps back to `#/runs` (All).

## Test plan
- `ContextTabs.test.tsx`: added a test asserting a click on the active In flight chip calls `onSelect({ kind: "all" })`.
- `context.test.ts`: added coverage for `toggleInflight` (all/repo -> inflight, inflight -> all).
- Existing ContextTabs/context tests still pass.

Theme screenshots will be attached by the orchestrator's visual pass.

## Verification output
\`\`\`
$ bunx tsc --noEmit
(clean, no output)

$ bun test src
bun test v1.3.14 (0d9b296a)

 197 pass
 0 fail
 535 expect() calls
Ran 197 tests across 19 files. [1.67s]
\`\`\`