### PR TITLE
fix(web): label proposal TTL countdowns and expose absolute expiry (WM-94)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, render } from "@testing-library/react";
-import { notify, ToastContainer } from "./ui";
+import { Countdown, notify, ToastContainer } from "./ui";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
   const parent = r.getByRole("status").parentElement;
@@ -78,5 +78,48 @@ describe("ToastContainer", () => {
       button.click();
     });
     expect(r.queryByRole("button", { name: /Operation succeeded/i })).toBeNull();
+  });
+});
+
+describe("Countdown", () => {
+  // useNow() re-renders off a 1s setInterval; jest.advanceTimersByTime does not
+  // reliably fake Date.now() inside that interval callback under bun:test, so
+  // these assert the two render states directly (live vs. expired) rather than
+  // driving the tick via fake-timer advancement.
+
+  test("renders a live countdown with a 'left' qualifier and the absolute expiry as title", () => {
+    const now = new Date("2024-01-01T00:00:00Z");
+    jest.setSystemTime(now);
+    const createdAt = now.toISOString();
+    const ttlSeconds = 15 * 60 + 14;
+    const r = render(<Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />);
+
+    const el = r.container.querySelector("span");
+    if (!el) throw new Error("Countdown span is missing");
+    expect(el.textContent).toBe("15:14 left");
+    expect(el.getAttribute("title")).toBe(new Date(now.getTime() + ttlSeconds * 1000).toISOString());
+  });
+
+  test("counts down as time passes, without losing the 'left' qualifier", () => {
+    const created = new Date("2024-01-01T00:00:00Z");
+    jest.setSystemTime(new Date(created.getTime() + 60_000));
+    const r = render(<Countdown createdAt={created.toISOString()} ttlSeconds={15 * 60 + 14} />);
+
+    const el = r.container.querySelector("span");
+    if (!el) throw new Error("Countdown span is missing");
+    expect(el.textContent).toBe("14:14 left");
+  });
+
+  test("shows relative age instead of a bare 'expired' once the TTL has elapsed", () => {
+    const now = new Date("2024-01-01T00:00:00Z");
+    jest.setSystemTime(now);
+    const ttlSeconds = 60;
+    const createdAt = new Date(now.getTime() - (ttlSeconds * 1000 + 2 * 3600 * 1000)).toISOString();
+    const r = render(<Countdown createdAt={createdAt} ttlSeconds={ttlSeconds} />);
+
+    const el = r.container.querySelector("span");
+    if (!el) throw new Error("Countdown span is missing");
+    expect(el.textContent).toBe("expired 2h ago");
+    expect(el.getAttribute("title")).toBe(new Date(new Date(createdAt).getTime() + ttlSeconds * 1000).toISOString());
   });
 });

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -371,16 +371,32 @@ export function JumpLink({
   );
 }
 
+/**
+ * Live countdown to `createdAt + ttlSeconds`. Always carries a unit/qualifier
+ * so it can't be misread as a wall-clock time, and exposes the absolute
+ * expiry as a `title` tooltip. Once past expiry it switches to relative age
+ * ("expired 2h ago") instead of a bare "expired" — callers that already show
+ * an expired badge elsewhere (e.g. the Proposals Decision column) should not
+ * also repeat the word "expired" next to this.
+ */
 export function Countdown({ createdAt, ttlSeconds }: { createdAt: string; ttlSeconds: number }) {
   const now = useNow();
-  const left = Math.floor((new Date(createdAt).getTime() + ttlSeconds * 1000 - now) / 1000);
-  if (left <= 0) return <span style={{ color: "var(--hue-err)" }}>expired</span>;
+  const expiryMs = new Date(createdAt).getTime() + ttlSeconds * 1000;
+  const expiryIso = new Date(expiryMs).toISOString();
+  const left = Math.floor((expiryMs - now) / 1000);
+  if (left <= 0) {
+    return (
+      <span className="tabular-nums" style={{ color: "var(--hue-err)" }} title={expiryIso}>
+        expired {ago(expiryIso, now)}
+      </span>
+    );
+  }
   const m = Math.floor(left / 60);
   const s = left % 60;
   const low = left < 300;
   return (
-    <span className="tabular-nums" style={low ? { color: "var(--hue-warn)" } : undefined}>
-      {m}:{String(s).padStart(2, "0")}
+    <span className="tabular-nums" style={low ? { color: "var(--hue-warn)" } : undefined} title={expiryIso}>
+      {m}:{String(s).padStart(2, "0")} left
     </span>
   );
 }

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -445,11 +445,6 @@ export function Proposals({
                   <>
                     <td className={tdCls}>
                       <StateBadge state={p.decision} hues={DECISION_HUES} />
-                      {p.expired && (
-                        <span className="ml-2" style={{ color: "var(--hue-warn)" }}>
-                          expired
-                        </span>
-                      )}
                       {staleState(p) && (
                         <span className="ml-2" style={{ color: "var(--hue-err)" }}>
                           run {staleState(p)}


### PR DESCRIPTION
Fixes WM-94

## Summary

- `Countdown` (`event-runtime/web/src/components/ui.tsx`) now renders with a unit/qualifier instead of a bare `mm:ss`: `15:14 left` while live, `expired 2h ago` once past TTL — no longer readable as a wall-clock time.
- `Countdown` now exposes the absolute expiry timestamp (ISO) as a `title` tooltip on the rendered span, for both live and expired states. This flows through to every call site: Proposals table, Proposals detail panel, Proposals "Approve and queue" confirm dialog, and Schedules (table + detail, unmodified — Schedules.tsx is outside this ticket's owned paths but benefits from the shared component change; wording ("… left" / "expired … ago") reads correctly there too, since it renders "time until next due" / "overdue by").
- Removed the redundant plain `expired` text span from the Proposals table's Decision cell (`event-runtime/web/src/views/Proposals.tsx`), since the TTL cell's `Countdown` now shows `expired 2h ago` — so "expired" appears once per row instead of twice. The Decision cell still keeps its `StateBadge` and the `stale` run-state text where relevant; the whole row still gets the `row-wash-warn` treatment when expired.
- Added unit tests for `Countdown` in `event-runtime/web/src/components/ui.test.tsx`: live countdown text + title, live countdown after time has passed, and expired relative-age text + title.

## Notes

- Checked all `Countdown` call sites via grep (Proposals.tsx x3, Schedules.tsx x2) — the new "left" / "expired … ago" wording reads correctly at every one.
- `useNow()`'s 1s `setInterval` doesn't reliably fake `Date.now()` inside the interval callback under `bun:test`'s fake timers (confirmed via a throwaway repro — `jest.advanceTimersByTime` advances the interval but the callback sees real wall-clock time, not the faked one). Worked around by asserting the two render states directly (via `jest.setSystemTime` before render) rather than driving the tick through fake-timer advancement.

## Verification (clean)

```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
TSC OK
bun test v1.3.14 (0d9b296a)

 198 pass
 0 fail
 535 expect() calls
Ran 198 tests across 19 files. [820.00ms]
```