### PR TITLE
fix(web): group activity feed rows per run (WM-100)

### DIFF
--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -2,9 +2,9 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Overview } from "./Overview";
+import { Overview, groupJournalEntries } from "./Overview";
 import { api } from "../api";
-import type { Proposal, StatusView } from "../types";
+import type { JournalEntry, Proposal, StatusView } from "../types";
 
 afterEach(() => {
   cleanup();
@@ -74,6 +74,113 @@ function renderOverview() {
     />,
   );
 }
+
+/** Build a journal entry; the feed keeps entries newest-first, so tests pass them that way. */
+function entry(overrides: Partial<JournalEntry> & Pick<JournalEntry, "seq" | "runId" | "to">): JournalEntry {
+  return {
+    from: null,
+    actor: "worker",
+    reason: null,
+    attempt: 1,
+    at: new Date(Date.now() - overrides.seq * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("groupJournalEntries (WM-100)", () => {
+  test("collapses consecutive transitions of one run into a single row spanning first → last state", () => {
+    // Newest-first: run_a went PROPOSED → QUEUED → LEASED → RUNNING → FAILED.
+    const entries: JournalEntry[] = [
+      entry({ seq: 5, runId: "run_a", from: "RUNNING", to: "FAILED" }),
+      entry({ seq: 4, runId: "run_a", from: "LEASED", to: "RUNNING" }),
+      entry({ seq: 3, runId: "run_a", from: "QUEUED", to: "LEASED" }),
+      entry({ seq: 2, runId: "run_a", from: "PROPOSED", to: "QUEUED" }),
+    ];
+    const groups = groupJournalEntries(entries);
+    expect(groups.length).toBe(1);
+    expect(groups[0]!.runId).toBe("run_a");
+    expect(groups[0]!.from).toBe("PROPOSED");
+    expect(groups[0]!.to).toBe("FAILED");
+    expect(groups[0]!.count).toBe(4);
+    // Key, timestamp, and actor come from the most recent transition.
+    expect(groups[0]!.seq).toBe(5);
+    expect(groups[0]!.at).toBe(entries[0]!.at);
+  });
+
+  test("interleaved runs group only consecutive spans, preserving newest-first order", () => {
+    const entries: JournalEntry[] = [
+      entry({ seq: 6, runId: "run_a", from: "RUNNING", to: "COMPLETED" }),
+      entry({ seq: 5, runId: "run_a", from: "LEASED", to: "RUNNING" }),
+      entry({ seq: 4, runId: "run_b", from: "QUEUED", to: "LEASED" }),
+      entry({ seq: 3, runId: "run_a", from: "QUEUED", to: "LEASED" }),
+      entry({ seq: 2, runId: "run_b", from: null, to: "QUEUED" }),
+    ];
+    const groups = groupJournalEntries(entries);
+    expect(groups.map((g) => [g.runId, g.from, g.to, g.count])).toEqual([
+      ["run_a", "LEASED", "COMPLETED", 2],
+      ["run_b", "QUEUED", "LEASED", 1],
+      ["run_a", "QUEUED", "LEASED", 1],
+      ["run_b", null, "QUEUED", 1],
+    ]);
+  });
+
+  test("single-transition runs pass through one row each", () => {
+    const entries: JournalEntry[] = [
+      entry({ seq: 3, runId: "run_c", from: "RUNNING", to: "COMPLETED" }),
+      entry({ seq: 2, runId: "run_b", from: null, to: "QUEUED" }),
+      entry({ seq: 1, runId: "run_a", from: "QUEUED", to: "CANCELLED", reason: "operator" }),
+    ];
+    const groups = groupJournalEntries(entries);
+    expect(groups.length).toBe(3);
+    expect(groups.map((g) => g.count)).toEqual([1, 1, 1]);
+    expect(groups.map((g) => g.seq)).toEqual([3, 2, 1]);
+    expect(groups[2]!.reason).toBe("operator");
+  });
+
+  test("empty input produces no rows", () => {
+    expect(groupJournalEntries([])).toEqual([]);
+  });
+});
+
+describe("Overview activity feed rendering (WM-100)", () => {
+  test("renders one grouped row per run span with the collapsed transition count", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () => baseStatus();
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({
+      head: 4,
+      entries: [
+        entry({ seq: 4, runId: "run_cda2b3c0", from: "RUNNING", to: "FAILED" }),
+        entry({ seq: 3, runId: "run_cda2b3c0", from: "LEASED", to: "RUNNING" }),
+        entry({ seq: 2, runId: "run_cda2b3c0", from: "PROPOSED", to: "LEASED" }),
+        entry({ seq: 1, runId: "run_other", from: null, to: "QUEUED" }),
+      ],
+    });
+
+    try {
+      const { getByText, getByTitle } = renderOverview();
+
+      await waitFor(() => getByTitle("run_cda2b3c0"));
+
+      // One row spanning the whole run: first state, ellipsis, transition count.
+      expect(getByText(/PROPOSED → … →/)).toBeTruthy();
+      expect(getByText(/· 3 transitions/)).toBeTruthy();
+      // Last state keeps its badge; the single-transition run renders plainly.
+      expect(getByText("FAILED")).toBeTruthy();
+      expect(getByTitle("run_other")).toBeTruthy();
+      expect(getByText("QUEUED")).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+});
 
 describe("Overview anomaly deck (WM-95)", () => {
   test("enriches an expired-proposal row with agent, decision/reason, origin, and age; demotes the raw id", async () => {

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -26,6 +26,59 @@ import {
 const FEED_CAP = 50;
 
 /**
+ * One collapsed activity-feed row (WM-100): a consecutive span of state
+ * transitions belonging to the same run, keyed by its most recent entry.
+ */
+export interface ActivityGroup {
+  /** seq of the most recent entry in the span — stable render key. */
+  seq: number;
+  runId: string;
+  /** Starting state of the span (the `from` of its oldest transition). */
+  from: string | null;
+  /** Last (most recent) state — carries the state color badge. */
+  to: string;
+  /** Number of transitions collapsed into this row. */
+  count: number;
+  /** Actor / reason / attempt of the most recent transition. */
+  actor: string;
+  reason: string | null;
+  attempt: number | null;
+  /** Timestamp of the most recent transition. */
+  at: string;
+}
+
+/**
+ * Collapse consecutive transitions of the same run into one row (WM-100).
+ * `entries` is newest-first (as kept by useJournalFeed); the output preserves
+ * that order. A run interleaved with other runs' activity produces a separate
+ * group per consecutive span — only adjacent same-run entries merge.
+ */
+export function groupJournalEntries(entries: JournalEntry[]): ActivityGroup[] {
+  const groups: ActivityGroup[] = [];
+  for (const e of entries) {
+    const open = groups[groups.length - 1];
+    if (open && open.runId === e.runId) {
+      // `e` is older than the entries already merged: extend the span's start.
+      open.from = e.from;
+      open.count += 1;
+    } else {
+      groups.push({
+        seq: e.seq,
+        runId: e.runId,
+        from: e.from,
+        to: e.to,
+        count: 1,
+        actor: e.actor,
+        reason: e.reason,
+        attempt: e.attempt,
+        at: e.at,
+      });
+    }
+  }
+  return groups;
+}
+
+/**
  * Live activity feed off GET /journal: first fetch seeds the latest entries,
  * then each 2 s poll asks only for `since=<last head>` and prepends what is
  * new — an append-only log consumed incrementally, capped at FEED_CAP shown.
@@ -464,23 +517,28 @@ export function Overview({
                   : "No lifecycle activity yet."}
             </div>
           ) : (
-            <div className="rounded-md border border-(--border) px-3 py-1" aria-live="off">
-              {feed.entries.map((e) => (
-                <div key={e.seq} className="flex items-baseline gap-2 border-b border-(--border) py-1.5 last:border-0">
-                  <Ago iso={e.at} now={now} className="mono w-[52px] shrink-0 text-(--text-faint)" />
+            <div
+              className="max-h-[420px] overflow-y-auto rounded-md border border-(--border) px-3 py-1"
+              aria-live="off"
+            >
+              {groupJournalEntries(feed.entries).map((g) => (
+                <div key={g.seq} className="flex items-baseline gap-2 border-b border-(--border) py-1.5 last:border-0">
+                  <Ago iso={g.at} now={now} className="mono w-[52px] shrink-0 text-(--text-faint)" />
                   <JumpLink
-                    onClick={() => onJumpRun(e.runId)}
-                    title={e.runId}
+                    onClick={() => onJumpRun(g.runId)}
+                    title={g.runId}
                     className="max-w-36 shrink-0 truncate"
                   >
-                    {e.runId}
+                    {g.runId}
                   </JumpLink>
                   <span className="shrink-0">
-                    {e.from ?? "·"} → <StateBadge state={e.to} />
+                    {g.from ?? "·"} → {g.count > 1 ? "… → " : ""}
+                    <StateBadge state={g.to} />
                   </span>
                   <span className="truncate text-(--text-faint)">
-                    by {e.actor}
-                    {e.reason ? ` (${e.reason})` : ""}
+                    by {g.actor}
+                    {g.reason ? ` (${g.reason})` : ""}
+                    {g.count > 1 ? ` · ${g.count} transitions` : ""}
                   </span>
                 </div>
               ))}


### PR DESCRIPTION
Fixes WM-100

## Summary
The Overview "Activity — latest 50" feed rendered one row per run state transition, so a single run contributed 6–7 near-identical rows and three runs could fill the whole window.

- New pure exported helper `groupJournalEntries(entries)` in `Overview.tsx` collapses consecutive same-run transitions (newest-first) into one `ActivityGroup` row: `run_id · FIRST → … → LAST · <n> transitions`, keyed by the most recent entry's seq. Interleaved runs merge only adjacent spans.
- Grouped row keeps the `StateBadge` of the last (most recent) state, the newest timestamp/actor/reason, and the existing click-to-run-detail navigation.
- Feed container is now a bounded scroll region (`max-h-[420px] overflow-y-auto`) so Overview keeps its two-column layout next to Outbox.
- `Overview.test.tsx` extended with 4 unit tests for the helper (collapse, interleaving/ordering, single-transition pass-through, empty) and 1 render test of the grouped feed.

## Verification
```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 208 pass
 0 fail
 567 expect() calls
Ran 208 tests across 20 files. [871.00ms]
```