### PR TITLE
fix(web): surface terminal run failure reason as a banner (WM-93)

### DIFF
--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -19,7 +19,7 @@ import {
   copyText,
   notify,
 } from "../components/ui";
-import { ActorRef, ArtifactRow, TERMINAL } from "./Runs";
+import { ActorRef, ArtifactRow, RunFailureBanner, TERMINAL } from "./Runs";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -172,6 +172,9 @@ export function RunFull({
             {detail.isError ? "Could not load run detail." : "Loading run…"}
           </div>
         ) : (
+          <>
+          {/* The failure first, full width under the header (WM-93) — renders nothing for other states. */}
+          <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} className="mx-6 mt-6 mb-0" />
           <div className="flex flex-col gap-8 p-6 xl:flex-row">
             {/* Main column: the trace, at a readable measure — the point of the page. */}
             <main className="min-w-0 flex-1 xl:max-w-[900px]">
@@ -330,6 +333,7 @@ export function RunFull({
               )}
             </aside>
           </div>
+          </>
         )}
       </div>
 

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1,0 +1,173 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Runs } from "./Runs";
+import { api } from "../api";
+import type { LifecycleEvent, RunDetail, RunListItem, RunState, StatusView } from "../types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const noop = () => {};
+
+const FAILURE_REASON = 'contract_violation: $: unknown property "captured"';
+
+function stubStatus(): StatusView {
+  return {
+    env: { name: "test", home: "/tmp/test", adapter: null },
+    events: {},
+    proposals: { open: 0, expired: 0 },
+    runs: { byState: {} },
+    workers: { live: 0, busy: 0, stale: 0 },
+    artifacts: { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 },
+    anomalies: {
+      expiredOpenProposals: [],
+      staleLeases: 0,
+      unpublishedOutbox: 0,
+      deadLettered: [],
+      stalledWorkers: [],
+      noWorkers: false,
+      ambiguousOpenProposals: [],
+    },
+  };
+}
+
+const NOW = new Date().toISOString();
+
+function stubListItem(runId: string, state: RunState): RunListItem {
+  return {
+    runId,
+    state,
+    attempts: 1,
+    maxAttempts: 3,
+    agent: "triage-scan",
+    adapter: "claude-code",
+    reasonCode: state === "FAILED" ? "contract_violation" : null,
+    eventId: null,
+    eventSource: null,
+    created_at: NOW,
+    updated_at: NOW,
+    repos: [],
+  };
+}
+
+function stubDetail(runId: string, state: RunState, lifecycle: LifecycleEvent[]): RunDetail {
+  return {
+    run: {
+      runId,
+      state,
+      attempts: 1,
+      idempotencyKey: "idem-1",
+      specHash: "hash-1",
+      created_at: NOW,
+      updated_at: NOW,
+      spec: {
+        schemaVersion: "1",
+        runId,
+        agent: "triage-scan",
+        input: {},
+        inputHash: "in-1",
+        workspace: { type: "ephemeral" },
+        adapter: "claude-code",
+        promptVersion: "1",
+        policyVersion: "1",
+        outputContract: "triage/v1",
+        capabilities: [],
+        timeoutSeconds: 600,
+        maxAttempts: 3,
+        idempotencyKey: "idem-1",
+      },
+    },
+    lifecycle,
+    attempts: [],
+    result: null,
+    receipt: null,
+    workspace: null,
+  };
+}
+
+function transition(seq: number, runId: string, from: string | null, to: string, reason: string | null): LifecycleEvent {
+  return { seq, run_id: runId, from_state: from, to_state: to, actor: "worker_1", reason, attempt: 1, at: NOW };
+}
+
+function renderRuns(focusRunId: string) {
+  return renderWithClient(
+    <Runs
+      connected={true}
+      context={{ kind: "all" }}
+      focusRunId={focusRunId}
+      onSelectRun={noop}
+      onOpenFull={noop}
+      focusState={null}
+      onFocusStateConsumed={noop}
+      onJumpAgent={noop}
+      onJumpEvent={noop}
+    />,
+  );
+}
+
+function withApi(runs: RunListItem[], detail: RunDetail, fn: () => Promise<void>) {
+  const orig = { runs: api.runs, run: api.run, status: api.status, trace: api.trace };
+  api.runs = async () => ({ runs });
+  api.run = async () => detail;
+  api.status = async () => stubStatus();
+  api.trace = async () => ({ head: 0, entries: [] });
+  return fn().finally(() => {
+    api.runs = orig.runs;
+    api.run = orig.run;
+    api.status = orig.status;
+    api.trace = orig.trace;
+  });
+}
+
+describe("Runs detail failure banner (WM-93)", () => {
+  test("FAILED run renders the terminal transition's reason as a banner with a copy affordance", async () => {
+    const runId = "run_failed_1";
+    const detail = stubDetail(runId, "FAILED", [
+      transition(1, runId, null, "QUEUED", null),
+      transition(2, runId, "QUEUED", "LEASED", null),
+      transition(3, runId, "LEASED", "RUNNING", null),
+      transition(4, runId, "RUNNING", "FAILED", FAILURE_REASON),
+    ]);
+    await withApi([stubListItem(runId, "FAILED")], detail, async () => {
+      const { getByRole, getByText } = renderRuns(runId);
+
+      await waitFor(() => getByRole("alert"));
+
+      const banner = getByRole("alert");
+      // The full, untruncated reason string, plus the copy affordance.
+      expect(banner.textContent).toContain(FAILURE_REASON);
+      expect(getByText("Copy reason")).toBeTruthy();
+
+      // Before the metadata rows: the banner precedes the "Run" section in the document.
+      const runSection = getByText("idempotencyKey");
+      expect(banner.compareDocumentPosition(runSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
+
+  test("COMPLETED run renders no banner", async () => {
+    const runId = "run_ok_1";
+    const detail = stubDetail(runId, "COMPLETED", [
+      transition(1, runId, null, "QUEUED", null),
+      transition(2, runId, "QUEUED", "LEASED", null),
+      transition(3, runId, "LEASED", "RUNNING", null),
+      transition(4, runId, "RUNNING", "COMPLETED", "ok"),
+    ]);
+    await withApi([stubListItem(runId, "COMPLETED")], detail, async () => {
+      const { getByText, queryByRole } = renderRuns(runId);
+
+      // Wait for the detail panel to load, then assert no banner appeared.
+      await waitFor(() => getByText("idempotencyKey"));
+      expect(queryByRole("alert")).toBeNull();
+    });
+  });
+});

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -11,7 +11,7 @@ import type { OperatorContext } from "../context";
 import { matchesInFlight, matchesRepo } from "../context";
 import { RUN_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
-import type { Attempt, ArtifactRef, RunListItem, RunState } from "../types";
+import type { Attempt, ArtifactRef, LifecycleEvent, RunListItem, RunState } from "../types";
 import {
   Ago,
   Button,
@@ -158,6 +158,57 @@ function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
       {hasT && <BudgetClock c={t} timeoutSeconds={timeoutSeconds} />}
       {hasT && hasL && <span>·</span>}
       {hasL && <LeaseClock c={l} urgent={t?.kind === "spent"} />}
+    </div>
+  );
+}
+
+/** Terminal states whose reason is a failure the operator reads first (WM-93). */
+const ERROR_STATES: RunState[] = ["FAILED", "TIMED_OUT", "REFUSED"];
+
+/**
+ * Why the run ended badly, surfaced first (WM-93): a FAILED/TIMED_OUT/REFUSED
+ * run's reason used to live only in the last LIFECYCLE row, below the spec
+ * JSON. Derived from the same lifecycle data the LIFECYCLE section renders —
+ * the last transition into the current terminal state — no new API surface.
+ * Renders nothing for any other state.
+ */
+export function RunFailureBanner({
+  state,
+  lifecycle,
+  className = "mb-4",
+}: {
+  state: RunState;
+  lifecycle: LifecycleEvent[];
+  className?: string;
+}) {
+  if (!ERROR_STATES.includes(state)) return null;
+  const terminal = [...lifecycle].reverse().find((e) => e.to_state === state);
+  const reason = terminal?.reason ?? null;
+  const hue = state === "REFUSED" ? "var(--hue-warn)" : "var(--hue-err)";
+  return (
+    <div
+      role="alert"
+      className={`rounded-md border px-3 py-2 ${className}`}
+      style={{ borderColor: hue, background: `color-mix(in oklch, ${hue} 8%, transparent)` }}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-[11px] font-medium tracking-wider uppercase" style={{ color: hue }}>
+          {state}
+        </span>
+        {reason && (
+          <button
+            type="button"
+            onClick={() => copyText(reason, "failure reason")}
+            className="shrink-0 text-[12px] text-(--text-dim) hover:text-(--accent)"
+          >
+            Copy reason
+          </button>
+        )}
+      </div>
+      {/* Full string, wrapping allowed — never truncate the one line that explains the failure. */}
+      <div className="mono mt-1 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text)">
+        {reason ?? "No reason recorded on the terminal transition."}
+      </div>
     </div>
   );
 }
@@ -706,6 +757,8 @@ export function Runs({
 
           {d && (
             <>
+          <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} />
+
           <Section title="Run">
             <KV k="run" v={d.run.runId} />
             <KV


### PR DESCRIPTION
Fixes WM-93

## Summary

A FAILED run's detail panel led with metadata and the RunSpec JSON; the failure string (e.g. `contract_violation: $: unknown property "captured"`) was buried as the last LIFECYCLE row. Same in the full-page view.

- New `RunFailureBanner` in `event-runtime/web/src/views/Runs.tsx`: for runs in FAILED / TIMED_OUT / REFUSED it renders an error banner (err hue; warn for REFUSED) with the terminal transition's full reason string — wrapping, never truncated — plus a "Copy reason" affordance. Derived from the last lifecycle transition into the terminal state, the same data the LIFECYCLE section renders; no new API surface.
- Detail panel: banner renders directly under the panel header, before the metadata rows. `RunFull.tsx` reuses the same component full-width under the page header.
- Non-terminal, COMPLETED, and CANCELLED runs render exactly as before (component returns null).
- New colocated test `views/Runs.test.tsx`: FAILED run shows the banner with the full reason and copy button, positioned before the metadata rows; COMPLETED run shows no banner.

## Verification

`cd event-runtime/web && bunx tsc --noEmit && bun test src`

```
bun test v1.3.14 (0d9b296a)

 205 pass
 0 fail
 553 expect() calls
Ran 205 tests across 21 files. [1140.00ms]
```

tsc: clean, no output.