### PR TITLE
fix(web): give sidebar nav buttons accessible names (WM-92)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -1,0 +1,124 @@
+import "./test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor, within } from "@testing-library/react";
+import { App } from "./App";
+import { NAV } from "./nav";
+import type { StatusView } from "./types";
+
+const ENV = { name: "dev", home: "/tmp/factory", adapter: null };
+
+// Deterministic counts so the badge cases (Events, Proposals) are exercised:
+// the fixture keeps proposals/events/runs badges visible in the "all" context.
+// Typed so a StatusView shape change breaks here, not as an Overview crash.
+const STATUS: StatusView = {
+  env: ENV,
+  proposals: { open: 9, expired: 0 },
+  runs: { byState: { RUNNING: 2, QUEUED: 1 } },
+  events: { human_needed: 4, dead_lettered: 2 },
+  workers: { busy: 1, stale: 0, live: 1 },
+  artifacts: { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 },
+  anomalies: {
+    expiredOpenProposals: [],
+    ambiguousOpenProposals: [],
+    staleLeases: 0,
+    stalledWorkers: [],
+    deadLettered: [],
+    unpublishedOutbox: 0,
+    noWorkers: false,
+  },
+};
+
+const HEALTH = { ok: true, policyVersion: "test", env: ENV };
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const realFetch = globalThis.fetch;
+
+function renderApp() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>,
+  );
+  // Scope queries to the sidebar landmark: views render their own controls
+  // (Overview has a "Graph" button too) and must not satisfy nav assertions.
+  const sidebar = within(utils.getByRole("navigation", { name: "Primary" }));
+  return { ...utils, sidebar };
+}
+
+beforeEach(() => {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/health")) return jsonResponse(HEALTH);
+    if (url.includes("/api/status")) return jsonResponse(STATUS);
+    // Views poll their own endpoints; an empty list keeps them quiet.
+    return jsonResponse([]);
+  }) as typeof fetch;
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+describe("sidebar navigation accessibility", () => {
+  test("every NAV entry is a button whose accessible name is exactly its label", async () => {
+    const { sidebar } = renderApp();
+    // Wait for the status fixture to land so badge-carrying entries (Events 6,
+    // Proposals 9, Runs 3) are tested with their badges actually rendered.
+    await waitFor(() => {
+      expect(sidebar.getByRole("button", { name: "Proposals" }).textContent).toContain("9");
+    });
+    for (const n of NAV) {
+      // Exact match: a badge that leaks into the name ("Events 6") fails here.
+      const button = sidebar.getByRole("button", { name: n.label });
+      expect(button.tagName).toBe("BUTTON");
+    }
+  });
+
+  test("count badges are exposed as the button's accessible description", async () => {
+    const { sidebar } = renderApp();
+    await waitFor(() => {
+      expect(sidebar.getByRole("button", { name: "Events" }).textContent).toContain("6");
+    });
+    for (const [label, expected] of [
+      ["Events", "6"],
+      ["Proposals", "9"],
+      ["Runs", "3"],
+    ] as const) {
+      const button = sidebar.getByRole("button", { name: label });
+      const describedBy = button.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const badge = document.getElementById(describedBy!)!;
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toContain(expected);
+      // The badge must not leak into the name (exact-name match above already
+      // guarantees this; the explicit visible count keeps the fixture honest).
+      expect(within(button).getByText(expected)).toBeTruthy();
+    }
+    // Badge-less entries carry no dangling describedby reference.
+    expect(sidebar.getByRole("button", { name: "Overview" }).hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  test("the active entry — and only it — exposes aria-current=page", async () => {
+    window.location.hash = "#/events";
+    const { sidebar } = renderApp();
+    await waitFor(() => {
+      expect(sidebar.getByRole("button", { name: "Events" }).getAttribute("aria-current")).toBe("page");
+    });
+    for (const n of NAV) {
+      const button = sidebar.getByRole("button", { name: n.label });
+      expect(button.getAttribute("aria-current")).toBe(n.key === "events" ? "page" : null);
+    }
+  });
+});

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -288,7 +288,10 @@ export function App() {
         onClose={closeRepo}
       />
       <div className="flex min-h-0 flex-1">
-      <nav className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)">
+      <nav
+        aria-label="Primary"
+        className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)"
+      >
         <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
           <div className="flex items-center gap-2">
             <img src="/watt-mind-logo.svg" alt="Watt Mind" className="size-5.5 shrink-0" />
@@ -352,6 +355,7 @@ export function App() {
                 key={n.key}
                 type="button"
                 aria-current={view === n.key || (n.key === "runs" && view === "run") ? "page" : undefined}
+                aria-describedby={badge.count > 0 ? `nav-badge-${n.key}` : undefined}
                 onClick={() => navigate(n.key)}
                 className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] ${
                   view === n.key || (n.key === "runs" && view === "run")
@@ -361,7 +365,14 @@ export function App() {
               >
                 <span>{n.label}</span>
                 {badge.count > 0 && (
+                  /* aria-hidden keeps the count out of the accessible name —
+                     "Events" must not announce as "Events 6" — while the
+                     aria-describedby reference above still reads it back as
+                     the button's description (accname spec includes hidden
+                     nodes referenced by labelledby/describedby). */
                   <span
+                    id={`nav-badge-${n.key}`}
+                    aria-hidden="true"
                     className="rounded px-1.5 text-[11px] tabular-nums"
                     title={badge.title}
                     style={{


### PR DESCRIPTION
Fixes WM-92

## Problem
The sidebar nav buttons' count badges (Events 6, Proposals 9, Runs 3) were plain text content inside the button, so the computed accessible name was "Events 6" rather than the visible label "Events" — `getByRole("button", { name: "Events" })` and voice-control targeting by label failed. (Badge-less entries like Overview already resolved; `aria-current="page"` was already present from OPS-226.)

## Fix
- Badge span: `aria-hidden="true"` + `id="nav-badge-<key>"` — excluded from the name.
- Button: `aria-describedby` references the badge when it renders, so the count is still announced as the button's description (accname spec includes hidden nodes referenced by describedby).
- Sidebar `<nav>` gains `aria-label="Primary"` as a named landmark (also lets tests scope queries past view-level buttons like Overview's "Graph").

## Tests
New `event-runtime/web/src/App.test.tsx` renders the real `App` (happy-dom, mocked `fetch` with a typed `StatusView` fixture, QueryClientProvider) and asserts:
- one button per NAV entry whose accessible name is exactly its label (exact match — badge leakage fails it),
- badge-carrying entries expose the count via `aria-describedby`, badge-less entries carry no dangling reference,
- `aria-current="page"` on the active entry and only it.

## Verification
`cd event-runtime/web && bunx tsc --noEmit && bun test src`

```
bun test v1.3.14 (0d9b296a)

 206 pass
 0 fail
 585 expect() calls
Ran 206 tests across 21 files. [875.00ms]
```
tsc: clean (no output).