### PR TITLE
feat(event-runtime-web): table grouping, collapsible sections, and Display Options panel (OPS-493)

### DIFF
--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -1,0 +1,156 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { useState } from "react";
+import { modal } from "../hooks";
+import {
+  buildSections,
+  defaultDisplayState,
+  type DisplayConfig,
+  type DisplayState,
+} from "../displayOptions";
+import { DisplayOptions } from "./DisplayOptions";
+import { GroupHeaderRow } from "./ui";
+
+interface Row {
+  id: string;
+  state: string;
+  agent: string;
+}
+
+const CONFIG: DisplayConfig<Row> = {
+  view: "panel-test",
+  groups: [
+    { key: "state", label: "State", get: (r) => r.state, order: ["RUNNING", "FAILED"] },
+    { key: "agent", label: "Agent", get: (r) => r.agent },
+  ],
+  subGroups: ["agent"],
+  sorts: [{ key: "id", label: "Run", get: (r) => r.id, column: "id" }],
+  columns: [
+    { key: "id", label: "Run", always: true },
+    { key: "agent", label: "Agent" },
+  ],
+};
+
+function Harness({ onState }: { onState?: (s: DisplayState) => void }) {
+  const [state, setState] = useState(() => defaultDisplayState(CONFIG));
+  const update = (next: DisplayState | ((s: DisplayState) => DisplayState)) => {
+    setState((prev) => {
+      const value = typeof next === "function" ? next(prev) : next;
+      onState?.(value);
+      return value;
+    });
+  };
+  return <DisplayOptions config={CONFIG} state={state} onChange={update} />;
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("DisplayOptions panel", () => {
+  test("opens, changes grouping, and reflects it in the select", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    const trigger = r.getByRole("button", { name: /display/i });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    const groupSelect = r.getByLabelText("Group by") as HTMLSelectElement;
+    fireEvent.change(groupSelect, { target: { value: "state" } });
+    expect(latest?.groupBy).toBe("state");
+    expect(groupSelect.value).toBe("state");
+  });
+
+  test("choosing the group as sub-group is prevented by option filtering", () => {
+    const r = render(<Harness />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    fireEvent.change(r.getByLabelText("Group by"), { target: { value: "agent" } });
+    const sub = r.getByLabelText("Sub-group by") as HTMLSelectElement;
+    const values = [...sub.options].map((o) => o.value);
+    expect(values).not.toContain("agent");
+  });
+
+  test("column pills toggle visibility but always-on columns are not offered", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    expect(r.queryByRole("button", { name: "Run" })).toBeNull();
+    const pill = r.getByRole("button", { name: "Agent" });
+    expect(pill.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(pill);
+    expect(latest?.hiddenColumns).toEqual(["agent"]);
+    expect(pill.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("Escape closes the panel and releases the modal depth", () => {
+    // Relative to whatever depth other test files leaked: only the delta is ours.
+    const base = modal.depth;
+    const r = render(<Harness />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    expect(modal.depth).toBe(base + 1);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(r.queryByRole("dialog", { name: "Display options" })).toBeNull();
+    expect(modal.depth).toBe(base);
+  });
+
+  test("reset appears only once customized and restores defaults", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    expect(r.queryByRole("button", { name: /reset/i })).toBeNull();
+    fireEvent.change(r.getByLabelText("Group by"), { target: { value: "state" } });
+    fireEvent.click(r.getByRole("button", { name: /reset/i }));
+    expect(latest?.groupBy).toBe("none");
+  });
+});
+
+describe("GroupHeaderRow", () => {
+  test("exposes aria-expanded and toggles through its button", () => {
+    const rows: Row[] = [
+      { id: "r1", state: "RUNNING", agent: "a" },
+      { id: "r2", state: "FAILED", agent: "b" },
+    ];
+    const sections = buildSections(rows, CONFIG, {
+      ...defaultDisplayState(CONFIG),
+      groupBy: "state",
+    });
+
+    function Table() {
+      const [collapsed, setCollapsed] = useState<string[]>([]);
+      return (
+        <table>
+          <tbody>
+            {sections.map((s) => {
+              const closed = collapsed.includes(s.key);
+              return (
+                <GroupHeaderRow
+                  key={s.key}
+                  colSpan={2}
+                  section={s}
+                  collapsed={closed}
+                  onToggle={() =>
+                    setCollapsed((c) =>
+                      c.includes(s.key) ? c.filter((k) => k !== s.key) : [...c, s.key],
+                    )
+                  }
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      );
+    }
+
+    const r = render(<Table />);
+    const running = r.getByRole("button", { name: /RUNNING/ });
+    expect(running.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(running);
+    expect(running.getAttribute("aria-expanded")).toBe("false");
+    expect(r.getByText("collapsed")).toBeTruthy();
+    fireEvent.click(running);
+    expect(running.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -1,0 +1,313 @@
+/**
+ * The "Display" popover (OPS-493) — Linear's view-options panel for the table
+ * views: grouping, sub-grouping, ordering, list options, display properties.
+ * Pure presentation over `displayOptions.ts`; the owning view holds the state
+ * via `useDisplayOptions` and passes it down, so the panel never touches
+ * storage and the table never re-derives what the panel showed.
+ */
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { modal } from "../hooks";
+import {
+  DEFAULT_ORDER,
+  NONE,
+  defaultDisplayState,
+  isDefaultDisplayState,
+  type DisplayConfig,
+  type DisplayState,
+} from "../displayOptions";
+
+function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: string; children: ReactNode }) {
+  return (
+    <div className="flex h-8 items-center justify-between gap-3">
+      <label htmlFor={htmlFor} className="shrink-0 text-[12px] text-(--text-dim)">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function Select({
+  id,
+  value,
+  onChange,
+  options,
+  disabled,
+  label,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  disabled?: boolean;
+  label: string;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      disabled={disabled}
+      aria-label={label}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-32 cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function Switch({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className="relative h-4 w-7 cursor-pointer rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      style={{ background: checked ? "var(--accent)" : "var(--surface-3)" }}
+    >
+      <span
+        aria-hidden
+        className={`absolute top-0.5 size-3 rounded-full bg-(--contrast) transition-transform duration-150 ${
+          checked ? "translate-x-3.5" : "translate-x-0.5"
+        }`}
+        style={checked ? { background: "var(--on-accent)" } : undefined}
+      />
+    </button>
+  );
+}
+
+function GroupLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="mt-3 mb-1 text-[10.5px] font-medium tracking-wide text-(--text-faint) uppercase">
+      {children}
+    </div>
+  );
+}
+
+/** Slider-style glyph, drawn with the text color so every theme carries it. */
+function SlidersIcon() {
+  return (
+    <svg aria-hidden width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+      <path d="M1 3h10M1 9h10" />
+      <circle cx="4" cy="3" r="1.5" fill="var(--surface-1)" />
+      <circle cx="8" cy="9" r="1.5" fill="var(--surface-1)" />
+    </svg>
+  );
+}
+
+export function DisplayOptions<T>({
+  config,
+  state,
+  onChange,
+}: {
+  config: DisplayConfig<T>;
+  state: DisplayState;
+  onChange: (next: DisplayState | ((state: DisplayState) => DisplayState)) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const groupId = useId();
+  const subId = useId();
+  const orderId = useId();
+
+  // The open panel is a light modal: the list's j/k/Enter verbs stand down,
+  // Esc closes the panel (not the selection), outside click dismisses.
+  useEffect(() => {
+    if (!open) return;
+    modal.depth += 1;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.stopPropagation();
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    const onPointer = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("pointerdown", onPointer);
+    return () => {
+      modal.depth -= 1;
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("pointerdown", onPointer);
+    };
+  }, [open]);
+
+  const customized = !isDefaultDisplayState(config, state);
+  const activeGroup = config.groups.find((g) => g.key === state.groupBy);
+  const subOptions = (config.subGroups ?? []).filter((k) => k !== state.groupBy);
+  const toggleable = config.columns.filter((c) => !c.always);
+  const groupLabel = (key: string) =>
+    config.groups.find((g) => g.key === key)?.label ?? key;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] font-medium transition-colors ${
+          open
+            ? "border-(--border-strong) bg-(--surface-2) text-(--text)"
+            : "border-(--border) text-(--text-dim) hover:bg-(--surface-1) hover:text-(--text)"
+        }`}
+      >
+        <SlidersIcon />
+        Display
+        {customized && (
+          <span aria-hidden className="size-1.5 rounded-full bg-(--accent)" title="Display options customized" />
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Display options"
+          className="absolute right-0 top-full z-30 mt-1.5 w-72 rounded-lg border border-(--border-strong) bg-(--surface-1) p-3 shadow-2xl"
+        >
+          <OptionRow label="Grouping" htmlFor={groupId}>
+            <Select
+              id={groupId}
+              label="Group by"
+              value={state.groupBy}
+              onChange={(groupBy) =>
+                onChange((s) => ({
+                  ...s,
+                  groupBy,
+                  subGroupBy: s.subGroupBy === groupBy ? NONE : s.subGroupBy,
+                  collapsed: [],
+                }))
+              }
+              options={[
+                { value: NONE, label: "No grouping" },
+                ...config.groups.map((g) => ({ value: g.key, label: g.label })),
+              ]}
+            />
+          </OptionRow>
+
+          {(config.subGroups?.length ?? 0) > 0 && (
+            <OptionRow label="Sub-grouping" htmlFor={subId}>
+              <Select
+                id={subId}
+                label="Sub-group by"
+                disabled={state.groupBy === NONE}
+                value={state.subGroupBy}
+                onChange={(subGroupBy) => onChange((s) => ({ ...s, subGroupBy, collapsed: [] }))}
+                options={[
+                  { value: NONE, label: "No sub-grouping" },
+                  ...subOptions.map((k) => ({ value: k, label: groupLabel(k) })),
+                ]}
+              />
+            </OptionRow>
+          )}
+
+          <OptionRow label="Ordering" htmlFor={orderId}>
+            <div className="flex items-center gap-1.5">
+              <Select
+                id={orderId}
+                label="Order by"
+                value={state.sortBy}
+                onChange={(sortBy) =>
+                  onChange((s) => ({
+                    ...s,
+                    sortBy,
+                    sortDir:
+                      config.sorts.find((f) => f.key === sortBy)?.defaultDir ?? "asc",
+                  }))
+                }
+                options={[
+                  { value: DEFAULT_ORDER, label: "API order" },
+                  ...config.sorts.map((f) => ({ value: f.key, label: f.label })),
+                ]}
+              />
+              <button
+                type="button"
+                aria-label={`Direction: ${state.sortDir === "asc" ? "ascending" : "descending"} — reverse`}
+                title={state.sortDir === "asc" ? "Ascending" : "Descending"}
+                onClick={() => onChange((s) => ({ ...s, sortDir: s.sortDir === "asc" ? "desc" : "asc" }))}
+                className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md border border-(--border) text-[11px] text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+              >
+                {state.sortDir === "asc" ? "↑" : "↓"}
+              </button>
+            </div>
+          </OptionRow>
+
+          <GroupLabel>List options</GroupLabel>
+          <OptionRow label="Show empty groups">
+            <Switch
+              label="Show empty groups"
+              disabled={!activeGroup?.order}
+              checked={state.showEmpty && !!activeGroup?.order}
+              onChange={(showEmpty) => onChange((s) => ({ ...s, showEmpty }))}
+            />
+          </OptionRow>
+
+          {toggleable.length > 0 && (
+            <>
+              <GroupLabel>Display properties</GroupLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {toggleable.map((c) => {
+                  const shown = !state.hiddenColumns.includes(c.key);
+                  return (
+                    <button
+                      key={c.key}
+                      type="button"
+                      aria-pressed={shown}
+                      onClick={() =>
+                        onChange((s) => ({
+                          ...s,
+                          hiddenColumns: shown
+                            ? [...s.hiddenColumns, c.key]
+                            : s.hiddenColumns.filter((k) => k !== c.key),
+                        }))
+                      }
+                      className={`cursor-pointer rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                        shown
+                          ? "border-(--border-strong) bg-(--surface-3) text-(--text)"
+                          : "border-(--border) text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text-dim)"
+                      }`}
+                    >
+                      {c.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {customized && (
+            <div className="mt-3 border-t border-(--border) pt-2 text-right">
+              <button
+                type="button"
+                onClick={() => onChange({ ...defaultDisplayState(config), collapsed: [] })}
+                className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text)"
+              >
+                Reset to defaults
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -303,11 +303,14 @@ export function Th({
   label,
   align,
   dir,
+  naturalDir,
   onSort,
 }: {
   label: string;
   align?: "right";
   dir?: SortDir | null;
+  /** What the first click will do — the hover hint must not promise "↑" on a newest-first column. */
+  naturalDir?: SortDir;
   onSort?: () => void;
 }) {
   const alignCls = align === "right" ? "text-right" : "text-left";
@@ -327,7 +330,7 @@ export function Th({
           aria-hidden
           className={`text-[9px] transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
         >
-          {dir === "desc" ? "↓" : "↑"}
+          {(dir ?? naturalDir ?? "asc") === "desc" ? "↓" : "↑"}
         </span>
       </button>
     </th>

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
 import { modal, useNow } from "../hooks";
+import type { Section, SortDir } from "../displayOptions";
 import { tokenizeJson, TOKEN_CLASSES } from "../highlight";
 import { flushHash } from "../hash";
 import {
@@ -287,6 +288,105 @@ export function ListEmpty({
           <div className="mt-2 text-[11px]">{ESC_CLEARS_FILTER}</div>
         )}
         {action && !query.isPending && !query.isError && !filtered && <div className="mt-3">{action}</div>}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * One sticky header cell (OPS-493). All wired views share this so the group
+ * header rows below can pin at exactly `top-7` — the cell is a fixed h-7 and
+ * the hairline is a shadow, not a border, so the offset never drifts by 1px.
+ * With `onSort` the label is a button cycling natural → reversed → API order.
+ */
+export function Th({
+  label,
+  align,
+  dir,
+  onSort,
+}: {
+  label: string;
+  align?: "right";
+  dir?: SortDir | null;
+  onSort?: () => void;
+}) {
+  const alignCls = align === "right" ? "text-right" : "text-left";
+  const base = `sticky top-0 z-10 h-7 bg-(--surface-0) px-3 font-medium whitespace-nowrap shadow-[inset_0_-1px_0_var(--border)] ${alignCls}`;
+  if (!onSort) return <th className={base}>{label}</th>;
+  return (
+    <th aria-sort={dir === "asc" ? "ascending" : dir === "desc" ? "descending" : undefined} className={`${base} p-0`}>
+      <button
+        type="button"
+        onClick={onSort}
+        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+        title={`Sort by ${label.toLowerCase()}`}
+        className={`group/th inline-flex h-7 w-full cursor-pointer items-center gap-1 px-3 font-medium transition-colors hover:text-(--text) ${align === "right" ? "justify-end" : ""} ${dir ? "text-(--text)" : ""}`}
+      >
+        {label}
+        <span
+          aria-hidden
+          className={`text-[9px] transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
+        >
+          {dir === "desc" ? "↓" : "↑"}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+/**
+ * A Linear-style section header row: chevron, state dot, label, count. The
+ * whole band is one button (Enter/Space toggle for free, `aria-expanded` for
+ * screen readers); it pins just under the `Th` row while its section scrolls.
+ * Sub-group headers indent and give up stickiness — two pinned tiers fight.
+ */
+export function GroupHeaderRow({
+  colSpan,
+  section,
+  collapsed,
+  onToggle,
+  sub,
+}: {
+  colSpan: number;
+  section: Section<unknown>;
+  collapsed: boolean;
+  onToggle: () => void;
+  sub?: boolean;
+}) {
+  const hue = section.hue ?? "var(--text-faint)";
+  return (
+    <tr>
+      <td colSpan={colSpan} className={`p-0 ${sub ? "" : "sticky top-7 z-[5]"}`}>
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          onClick={onToggle}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+          className={`flex w-full cursor-pointer items-center gap-2 border-b border-(--border) bg-(--surface-1) px-3 text-left transition-colors hover:bg-(--surface-2) ${
+            sub ? "h-7 pl-8" : "h-8"
+          }`}
+        >
+          <span
+            aria-hidden
+            className={`text-[9px] text-(--text-faint) transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
+          >
+            ▶
+          </span>
+          {!sub && (
+            <span
+              aria-hidden
+              className="size-2 rounded-full"
+              style={{ background: hue, boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)` }}
+            />
+          )}
+          <span className={`font-medium ${sub ? "text-[11.5px] text-(--text-dim)" : "text-[12px] text-(--text)"}`}>
+            {section.label}
+          </span>
+          <span className="tabular-nums text-[11px] text-(--text-faint)">{section.count}</span>
+          {collapsed && section.count > 0 && (
+            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">collapsed</span>
+          )}
+        </button>
       </td>
     </tr>
   );

--- a/event-runtime/web/src/displayOptions.test.ts
+++ b/event-runtime/web/src/displayOptions.test.ts
@@ -1,0 +1,265 @@
+import "./test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  DEFAULT_ORDER,
+  NONE,
+  buildSections,
+  cycleColumnSort,
+  defaultDisplayState,
+  flattenSections,
+  isDefaultDisplayState,
+  loadDisplayState,
+  saveDisplayState,
+  sortRows,
+  toggleCollapsed,
+  toggleColumn,
+  visibleColumns,
+  type DisplayConfig,
+  type DisplayState,
+} from "./displayOptions";
+
+interface Row {
+  id: string;
+  state: string;
+  agent: string;
+  created_at: string;
+}
+
+const CONFIG: DisplayConfig<Row> = {
+  view: "test",
+  groups: [
+    {
+      key: "state",
+      label: "State",
+      get: (r) => r.state,
+      order: ["RUNNING", "COMPLETED", "FAILED"],
+      hue: { RUNNING: "var(--hue-warn)" },
+    },
+    { key: "agent", label: "Agent", get: (r) => r.agent },
+  ],
+  subGroups: ["agent"],
+  sorts: [
+    { key: "created", label: "Created", get: (r) => r.created_at, defaultDir: "desc", column: "created" },
+    { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
+  ],
+  columns: [
+    { key: "id", label: "Run", always: true },
+    { key: "agent", label: "Agent" },
+    { key: "created", label: "Created", defaultHidden: true },
+  ],
+};
+
+const row = (id: string, state: string, agent: string, created: string): Row => ({
+  id,
+  state,
+  agent,
+  created_at: created,
+});
+
+const ROWS: Row[] = [
+  row("r1", "COMPLETED", "doctor", "2026-01-03"),
+  row("r2", "RUNNING", "scout", "2026-01-01"),
+  row("r3", "FAILED", "doctor", "2026-01-04"),
+  row("r4", "RUNNING", "doctor", "2026-01-02"),
+  row("r5", "COMPLETED", "scout", "2026-01-05"),
+];
+
+const state = (over: Partial<DisplayState> = {}): DisplayState => ({
+  ...defaultDisplayState(CONFIG),
+  ...over,
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("buildSections", () => {
+  test("no grouping yields one section holding every row in API order", () => {
+    const sections = buildSections(ROWS, CONFIG, state());
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe(NONE);
+    expect(sections[0].rows.map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
+  });
+
+  test("enum grouping orders buckets canonically with counts and hues", () => {
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state" }));
+    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED"]);
+    expect(sections.map((s) => s.count)).toEqual([2, 2, 1]);
+    expect(sections[0].hue).toBe("var(--hue-warn)");
+  });
+
+  test("open-ended grouping orders buckets by count then name", () => {
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "agent" }));
+    expect(sections.map((s) => s.value)).toEqual(["doctor", "scout"]);
+    expect(sections.map((s) => s.count)).toEqual([3, 2]);
+  });
+
+  test("a value outside the canonical order still gets a bucket, after the enums", () => {
+    const rows = [...ROWS, row("r6", "MYSTERY", "scout", "2026-01-06")];
+    const sections = buildSections(rows, CONFIG, state({ groupBy: "state" }));
+    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED", "MYSTERY"]);
+  });
+
+  test("show empty groups emits zero-count buckets from the canonical order", () => {
+    const running = ROWS.filter((r) => r.state === "RUNNING");
+    const withEmpty = buildSections(running, CONFIG, state({ groupBy: "state", showEmpty: true }));
+    expect(withEmpty.map((s) => [s.value, s.count])).toEqual([
+      ["RUNNING", 2],
+      ["COMPLETED", 0],
+      ["FAILED", 0],
+    ]);
+    const without = buildSections(running, CONFIG, state({ groupBy: "state" }));
+    expect(without.map((s) => s.value)).toEqual(["RUNNING"]);
+  });
+
+  test("sub-grouping nests second-level sections with scoped collapse keys", () => {
+    const sections = buildSections(
+      ROWS,
+      CONFIG,
+      state({ groupBy: "state", subGroupBy: "agent" }),
+    );
+    const completed = sections.find((s) => s.value === "COMPLETED")!;
+    expect(completed.subsections!.map((s) => s.value)).toEqual(["doctor", "scout"]);
+    const keys = sections.flatMap((s) => (s.subsections ?? []).map((c) => c.key));
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("sub-group equal to the group collapses to a single level", () => {
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "agent", subGroupBy: "agent" }));
+    expect(sections.every((s) => s.subsections === undefined)).toBe(true);
+  });
+
+  test("rows with an empty group value land in a — bucket", () => {
+    const rows = [row("r7", "COMPLETED", "", "2026-01-07")];
+    const sections = buildSections(rows, CONFIG, state({ groupBy: "agent" }));
+    expect(sections[0].value).toBe("—");
+  });
+});
+
+describe("sortRows", () => {
+  test("default order preserves API order and desc reverses it", () => {
+    expect(sortRows(ROWS, CONFIG, state()).map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
+    expect(sortRows(ROWS, CONFIG, state({ sortDir: "desc" })).map((r) => r.id)).toEqual([
+      "r5",
+      "r4",
+      "r3",
+      "r2",
+      "r1",
+    ]);
+  });
+
+  test("field sort is applied inside groups and is stable on ties", () => {
+    const sections = buildSections(
+      ROWS,
+      CONFIG,
+      state({ groupBy: "state", sortBy: "created", sortDir: "desc" }),
+    );
+    const completed = sections.find((s) => s.value === "COMPLETED")!;
+    expect(completed.rows.map((r) => r.id)).toEqual(["r5", "r1"]);
+    const tied = [row("a", "RUNNING", "x", "same"), row("b", "RUNNING", "y", "same")];
+    expect(sortRows(tied, CONFIG, state({ sortBy: "created" })).map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  test("does not mutate its input", () => {
+    const input = ROWS.slice();
+    sortRows(input, CONFIG, state({ sortBy: "created", sortDir: "desc" }));
+    expect(input.map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
+  });
+});
+
+describe("flattenSections", () => {
+  test("skips collapsed sections and collapsed sub-sections", () => {
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state" }));
+    expect(flattenSections(sections, []).map((r) => r.id)).toEqual(["r2", "r4", "r1", "r5", "r3"]);
+    expect(flattenSections(sections, ["RUNNING"]).map((r) => r.id)).toEqual(["r1", "r5", "r3"]);
+
+    const nested = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
+    const flat = flattenSections(nested, ["COMPLETED∕doctor"]);
+    expect(flat.map((r) => r.id)).not.toContain("r1");
+    expect(flat.map((r) => r.id)).toContain("r5");
+    // Collapsing the parent hides its open children too. Sub-grouping RUNNING
+    // by agent puts doctor (r4) ahead of scout (r2): count ties break by name.
+    expect(flattenSections(nested, ["COMPLETED"]).map((r) => r.id)).toEqual(["r4", "r2", "r3"]);
+  });
+});
+
+describe("state transitions", () => {
+  test("toggleCollapsed round-trips", () => {
+    const s1 = toggleCollapsed(state(), "RUNNING");
+    expect(s1.collapsed).toEqual(["RUNNING"]);
+    expect(toggleCollapsed(s1, "RUNNING").collapsed).toEqual([]);
+  });
+
+  test("toggleColumn hides and shows; visibleColumns honours always", () => {
+    const s0 = state();
+    expect(visibleColumns(CONFIG, s0).map((c) => c.key)).toEqual(["id", "agent"]);
+    const shown = toggleColumn(s0, "created");
+    expect(visibleColumns(CONFIG, shown).map((c) => c.key)).toEqual(["id", "agent", "created"]);
+    expect(visibleColumns(CONFIG, toggleColumn(shown, "created")).map((c) => c.key)).toEqual([
+      "id",
+      "agent",
+    ]);
+  });
+
+  test("cycleColumnSort walks natural → reversed → API order", () => {
+    const s0 = state();
+    const s1 = cycleColumnSort(CONFIG, s0, "created");
+    expect([s1.sortBy, s1.sortDir]).toEqual(["created", "desc"]);
+    const s2 = cycleColumnSort(CONFIG, s1, "created");
+    expect([s2.sortBy, s2.sortDir]).toEqual(["created", "asc"]);
+    const s3 = cycleColumnSort(CONFIG, s2, "created");
+    expect(s3.sortBy).toBe(DEFAULT_ORDER);
+    expect(cycleColumnSort(CONFIG, s0, "no-such-column")).toBe(s0);
+  });
+});
+
+describe("persistence", () => {
+  test("round-trips through localStorage", () => {
+    const saved = state({
+      groupBy: "state",
+      subGroupBy: "agent",
+      sortBy: "created",
+      sortDir: "desc",
+      showEmpty: true,
+      hiddenColumns: ["agent"],
+      collapsed: ["FAILED"],
+    });
+    saveDisplayState(CONFIG, saved);
+    expect(loadDisplayState(CONFIG)).toEqual(saved);
+  });
+
+  test("garbage and unknown keys fall back field by field", () => {
+    localStorage.setItem("evrt-display-test", "not json");
+    expect(loadDisplayState(CONFIG)).toEqual(defaultDisplayState(CONFIG));
+
+    localStorage.setItem(
+      "evrt-display-test",
+      JSON.stringify({
+        groupBy: "nope",
+        subGroupBy: "state", // not offered as a sub-group
+        sortBy: "created",
+        sortDir: "sideways",
+        hiddenColumns: ["id", "agent", 7], // id is always-on: dropped
+        collapsed: "RUNNING",
+      }),
+    );
+    const loaded = loadDisplayState(CONFIG);
+    expect(loaded.groupBy).toBe(NONE);
+    expect(loaded.subGroupBy).toBe(NONE);
+    expect(loaded.sortBy).toBe("created");
+    expect(loaded.sortDir).toBe("asc");
+    expect(loaded.hiddenColumns).toEqual(["agent"]);
+    expect(loaded.collapsed).toEqual([]);
+  });
+
+  test("a persisted sub-group equal to the group is normalized to none", () => {
+    saveDisplayState(CONFIG, state({ groupBy: "agent", subGroupBy: "agent" }));
+    expect(loadDisplayState(CONFIG).subGroupBy).toBe(NONE);
+  });
+
+  test("isDefaultDisplayState detects deviation and ignores collapse", () => {
+    expect(isDefaultDisplayState(CONFIG, state())).toBe(true);
+    expect(isDefaultDisplayState(CONFIG, state({ groupBy: "state" }))).toBe(false);
+    expect(isDefaultDisplayState(CONFIG, state({ collapsed: ["RUNNING"] }))).toBe(true);
+  });
+});

--- a/event-runtime/web/src/displayOptions.ts
+++ b/event-runtime/web/src/displayOptions.ts
@@ -1,0 +1,313 @@
+/**
+ * Linear-style display options for the table views (OPS-493): grouping into
+ * collapsible sections, sub-grouping, in-group ordering, "show empty groups",
+ * and column visibility — all behind one per-view config, the same shape of
+ * per-view declaration `filterQuery.ts` uses for facets.
+ *
+ * Everything here is pure. The views own their `<table>` markup; this module
+ * only decides how rows partition into sections and in what order, and the
+ * `useListKeys` contract stays flat: a view feeds it `flattenSections()` — the
+ * rows of open sections in render order — so keyboard traversal skips
+ * collapsed groups without the hook ever learning about groups.
+ */
+
+export interface ColumnDef {
+  key: string;
+  label: string;
+  /** Identity columns the view cannot render without; not toggleable. */
+  always?: boolean;
+  defaultHidden?: boolean;
+}
+
+export interface GroupField<T> {
+  key: string;
+  label: string;
+  get: (row: T) => string;
+  /**
+   * Canonical bucket order for closed enums (lifecycle states, decisions).
+   * Also the universe "show empty groups" draws zero-count buckets from.
+   * Open-ended fields (agent) omit it: buckets order by count, then name.
+   */
+  order?: readonly string[];
+  /** Section header dot hue by bucket value (STATE_HUES etc.). */
+  hue?: Record<string, string>;
+}
+
+export interface SortField<T> {
+  key: string;
+  label: string;
+  get: (row: T) => string | number;
+  /** Sort direction that makes sense unprompted (times: newest first). */
+  defaultDir?: SortDir;
+  /** Column this sort field answers for, enabling click-to-sort on its header. */
+  column?: string;
+}
+
+export type SortDir = "asc" | "desc";
+
+export interface DisplayConfig<T> {
+  /** Storage key suffix: settings persist under `evrt-display-<view>`. */
+  view: string;
+  groups: GroupField<T>[];
+  /** Group keys offered as the secondary level. Empty: no sub-grouping UI. */
+  subGroups?: string[];
+  sorts: SortField<T>[];
+  columns: ColumnDef[];
+  defaults?: Partial<DisplayState>;
+}
+
+export interface DisplayState {
+  groupBy: string;
+  subGroupBy: string;
+  sortBy: string;
+  sortDir: SortDir;
+  showEmpty: boolean;
+  hiddenColumns: string[];
+  collapsed: string[];
+}
+
+/** "No grouping" / "API order" sentinels — always offered, never in configs. */
+export const NONE = "none";
+export const DEFAULT_ORDER = "default";
+
+export function defaultDisplayState<T>(config: DisplayConfig<T>): DisplayState {
+  return {
+    groupBy: NONE,
+    subGroupBy: NONE,
+    sortBy: DEFAULT_ORDER,
+    sortDir: "asc",
+    showEmpty: false,
+    hiddenColumns: config.columns.filter((c) => c.defaultHidden).map((c) => c.key),
+    collapsed: [],
+    ...config.defaults,
+  };
+}
+
+const storageKey = (view: string) => `evrt-display-${view}`;
+
+/**
+ * Tolerant load: a stale or hand-edited value must never wedge a view, so
+ * anything that no longer names a known group/sort/column falls back field by
+ * field rather than discarding the whole record.
+ */
+export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
+  const fallback = defaultDisplayState(config);
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(storageKey(config.view));
+  } catch {
+    return fallback;
+  }
+  if (!raw) return fallback;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+  if (typeof parsed !== "object" || parsed === null) return fallback;
+  const p = parsed as Record<string, unknown>;
+  const groupKeys = new Set([NONE, ...config.groups.map((g) => g.key)]);
+  const sortKeys = new Set([DEFAULT_ORDER, ...config.sorts.map((s) => s.key)]);
+  const columnKeys = new Set(config.columns.filter((c) => !c.always).map((c) => c.key));
+  const subGroupKeys = new Set([NONE, ...(config.subGroups ?? [])]);
+  const str = (v: unknown, ok: Set<string>, fb: string) =>
+    typeof v === "string" && ok.has(v) ? v : fb;
+  const groupBy = str(p.groupBy, groupKeys, fallback.groupBy);
+  const subGroupBy = str(p.subGroupBy, subGroupKeys, fallback.subGroupBy);
+  return {
+    groupBy,
+    // A sub-group equal to the group is a single-level render pretending to
+    // be two; normalize it away at the edge so nothing downstream checks.
+    subGroupBy: subGroupBy === groupBy ? NONE : subGroupBy,
+    sortBy: str(p.sortBy, sortKeys, fallback.sortBy),
+    sortDir: p.sortDir === "desc" ? "desc" : p.sortDir === "asc" ? "asc" : fallback.sortDir,
+    showEmpty: typeof p.showEmpty === "boolean" ? p.showEmpty : fallback.showEmpty,
+    hiddenColumns: Array.isArray(p.hiddenColumns)
+      ? p.hiddenColumns.filter((k): k is string => typeof k === "string" && columnKeys.has(k))
+      : fallback.hiddenColumns,
+    collapsed: Array.isArray(p.collapsed)
+      ? p.collapsed.filter((k): k is string => typeof k === "string")
+      : fallback.collapsed,
+  };
+}
+
+export function saveDisplayState<T>(config: DisplayConfig<T>, state: DisplayState): void {
+  try {
+    localStorage.setItem(storageKey(config.view), JSON.stringify(state));
+  } catch {
+    // Private mode / quota: display options simply do not persist.
+  }
+}
+
+export function isDefaultDisplayState<T>(config: DisplayConfig<T>, state: DisplayState): boolean {
+  const d = defaultDisplayState(config);
+  return (
+    state.groupBy === d.groupBy &&
+    state.subGroupBy === d.subGroupBy &&
+    state.sortBy === d.sortBy &&
+    state.sortDir === d.sortDir &&
+    state.showEmpty === d.showEmpty &&
+    state.hiddenColumns.length === d.hiddenColumns.length &&
+    state.hiddenColumns.every((k) => d.hiddenColumns.includes(k))
+  );
+}
+
+export interface Section<T> {
+  /** Collapse identity: the group value, or "parent∕child" for sub-sections. */
+  key: string;
+  value: string;
+  label: string;
+  hue?: string;
+  /** Every row in the bucket, including rows inside collapsed sub-sections. */
+  count: number;
+  rows: T[];
+  subsections?: Section<T>[];
+}
+
+const cmp = (a: string | number, b: string | number): number => {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a).localeCompare(String(b));
+};
+
+/** Stable sort by the configured field; DEFAULT_ORDER keeps (or reverses) API order. */
+export function sortRows<T>(rows: T[], config: DisplayConfig<T>, state: DisplayState): T[] {
+  const dirSign = state.sortDir === "desc" ? -1 : 1;
+  if (state.sortBy === DEFAULT_ORDER) {
+    return dirSign === 1 ? rows.slice() : rows.slice().reverse();
+  }
+  const field = config.sorts.find((s) => s.key === state.sortBy);
+  if (!field) return rows.slice();
+  return rows
+    .map((row, i) => ({ row, i, v: field.get(row) }))
+    .sort((a, b) => dirSign * cmp(a.v, b.v) || a.i - b.i)
+    .map((e) => e.row);
+}
+
+function buckets<T>(rows: T[], field: GroupField<T>, showEmpty: boolean): Map<string, T[]> {
+  const byValue = new Map<string, T[]>();
+  if (showEmpty && field.order) for (const v of field.order) byValue.set(v, []);
+  for (const row of rows) {
+    const v = field.get(row) || "—";
+    const bucket = byValue.get(v);
+    if (bucket) bucket.push(row);
+    else byValue.set(v, [row]);
+  }
+  if (!field.order) {
+    // Open-ended fields: busiest bucket first, name breaking ties.
+    return new Map(
+      [...byValue.entries()].sort((a, b) => b[1].length - a[1].length || cmp(a[0], b[0])),
+    );
+  }
+  const rank = new Map(field.order.map((v, i) => [v, i]));
+  return new Map(
+    [...byValue.entries()].sort(
+      (a, b) => (rank.get(a[0]) ?? field.order!.length) - (rank.get(b[0]) ?? field.order!.length) || cmp(a[0], b[0]),
+    ),
+  );
+}
+
+const section = <T,>(key: string, value: string, field: GroupField<T>, rows: T[]): Section<T> => ({
+  key,
+  value,
+  label: value,
+  hue: field.hue?.[value],
+  count: rows.length,
+  rows,
+});
+
+/**
+ * Partition, order, and sort in one pass. With `groupBy: none` the result is a
+ * single unlabeled section holding every row — the views render headers only
+ * when `grouped(state)` says so, so the flat table is the same code path.
+ */
+export function buildSections<T>(
+  rows: T[],
+  config: DisplayConfig<T>,
+  state: DisplayState,
+): Section<T>[] {
+  const sorted = sortRows(rows, config, state);
+  const group = config.groups.find((g) => g.key === state.groupBy);
+  if (!group) {
+    return [{ key: NONE, value: NONE, label: "All", count: sorted.length, rows: sorted }];
+  }
+  const sub =
+    state.subGroupBy !== state.groupBy
+      ? config.groups.find((g) => g.key === state.subGroupBy)
+      : undefined;
+  const top: Section<T>[] = [];
+  for (const [value, bucket] of buckets(sorted, group, state.showEmpty)) {
+    const s = section(value, value, group, bucket);
+    if (sub && bucket.length > 0) {
+      s.subsections = [...buckets(bucket, sub, false).entries()].map(([v, b]) =>
+        section(`${value}∕${v}`, v, sub, b),
+      );
+    }
+    top.push(s);
+  }
+  return top;
+}
+
+export const grouped = (state: DisplayState): boolean => state.groupBy !== NONE;
+
+/**
+ * The rows keyboard navigation can reach, in exactly the order the table
+ * renders them: open sections contribute their rows (through open
+ * sub-sections), collapsed ones contribute nothing.
+ */
+export function flattenSections<T>(sections: Section<T>[], collapsed: readonly string[]): T[] {
+  const closed = new Set(collapsed);
+  const out: T[] = [];
+  for (const s of sections) {
+    if (closed.has(s.key)) continue;
+    if (!s.subsections) {
+      out.push(...s.rows);
+      continue;
+    }
+    for (const child of s.subsections) {
+      if (!closed.has(child.key)) out.push(...child.rows);
+    }
+  }
+  return out;
+}
+
+export function toggleCollapsed(state: DisplayState, key: string): DisplayState {
+  const collapsed = state.collapsed.includes(key)
+    ? state.collapsed.filter((k) => k !== key)
+    : [...state.collapsed, key];
+  return { ...state, collapsed };
+}
+
+/** Columns the table actually renders, in declared order. */
+export function visibleColumns<T>(config: DisplayConfig<T>, state: DisplayState): ColumnDef[] {
+  return config.columns.filter((c) => c.always || !state.hiddenColumns.includes(c.key));
+}
+
+export function toggleColumn(state: DisplayState, key: string): DisplayState {
+  const hiddenColumns = state.hiddenColumns.includes(key)
+    ? state.hiddenColumns.filter((k) => k !== key)
+    : [...state.hiddenColumns, key];
+  return { ...state, hiddenColumns };
+}
+
+/**
+ * A header click sorts by that column: first click applies the field's natural
+ * direction, the second reverses it, a third returns to API order — so the
+ * header is never a dead end.
+ */
+export function cycleColumnSort<T>(
+  config: DisplayConfig<T>,
+  state: DisplayState,
+  columnKey: string,
+): DisplayState {
+  const field = config.sorts.find((s) => s.column === columnKey);
+  if (!field) return state;
+  const natural = field.defaultDir ?? "asc";
+  if (state.sortBy !== field.key) {
+    return { ...state, sortBy: field.key, sortDir: natural };
+  }
+  if (state.sortDir === natural) {
+    return { ...state, sortDir: natural === "asc" ? "desc" : "asc" };
+  }
+  return { ...state, sortBy: DEFAULT_ORDER, sortDir: "asc" };
+}

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { goPrefixActive } from "./goSequence";
+import {
+  loadDisplayState,
+  saveDisplayState,
+  type DisplayConfig,
+  type DisplayState,
+} from "./displayOptions";
 import type { HashWriter } from "./hash";
 import {
   createHashWriter,
@@ -173,6 +179,37 @@ export function useTabKeys<T extends string>(
   useEffect(() => {
     selectedStatusTab()?.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [current]);
+}
+
+/**
+ * Per-view display options (OPS-493), persisted like the theme: localStorage
+ * under `evrt-display-<view>`. A view that swaps configs (Proposals'
+ * open/history tabs) gets the new view's persisted state on the same render —
+ * the reset-during-render pattern, so no frame shows tab A's grouping on tab
+ * B's rows.
+ */
+export function useDisplayOptions<T>(
+  config: DisplayConfig<T>,
+): [DisplayState, (next: DisplayState | ((state: DisplayState) => DisplayState)) => void] {
+  const [state, setState] = useState<DisplayState>(() => loadDisplayState(config));
+  const [prevView, setPrevView] = useState(config.view);
+  if (prevView !== config.view) {
+    setPrevView(config.view);
+    setState(loadDisplayState(config));
+  }
+  const configRef = useRef(config);
+  configRef.current = config;
+  const update = useCallback(
+    (next: DisplayState | ((state: DisplayState) => DisplayState)) => {
+      setState((prev) => {
+        const value = typeof next === "function" ? next(prev) : next;
+        saveDisplayState(configRef.current, value);
+        return value;
+      });
+    },
+    [],
+  );
+  return [state, update];
 }
 
 export const THEMES = ["dark", "light", "contrast"] as const;

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -178,17 +178,29 @@ export function Events({
   }, [scoped, parsed, typeFilter, sourceFilter, fetchAll, tab]);
 
   // Display options (OPS-493): partition into sections, order inside them,
-  // and feed keyboard navigation only the rows of open sections.
-  const [display, setDisplay] = useDisplayOptions(EVENTS_DISPLAY);
+  // and feed keyboard navigation only the rows of open sections. Under a
+  // single-status tab the empty-group universe narrows to that status, so
+  // "show empty groups" never renders bands the tab already filtered out.
+  const displayConfig = useMemo(
+    () =>
+      tab === "all"
+        ? EVENTS_DISPLAY
+        : {
+            ...EVENTS_DISPLAY,
+            groups: EVENTS_DISPLAY.groups.map((g) => (g.key === "status" ? { ...g, order: [tab] } : g)),
+          },
+    [tab],
+  );
+  const [display, setDisplay] = useDisplayOptions(displayConfig);
   const sections = useMemo(
-    () => buildSections(visible, EVENTS_DISPLAY, display),
-    [visible, display],
+    () => buildSections(visible, displayConfig, display),
+    [visible, displayConfig, display],
   );
   const flat = useMemo(
     () => flattenSections(sections, display.collapsed),
     [sections, display.collapsed],
   );
-  const cols = visibleColumns(EVENTS_DISPLAY, display);
+  const cols = visibleColumns(displayConfig, display);
   const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
 
   const selectedKey =
@@ -502,7 +514,7 @@ export function Events({
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <span className="ml-auto">
-            <DisplayOptions config={EVENTS_DISPLAY} state={display} onChange={setDisplay} />
+            <DisplayOptions config={displayConfig} state={display} onChange={setDisplay} />
           </span>
           {/* Last in the row: the token chips are a full-width item, so anything
               after the filter box would be pushed onto a third line the moment
@@ -523,13 +535,14 @@ export function Events({
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
-                const sort = EVENTS_DISPLAY.sorts.find((s) => s.column === c.key);
+                const sort = displayConfig.sorts.find((s) => s.column === c.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
                     dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(EVENTS_DISPLAY, s, c.key)) : undefined}
+                    naturalDir={sort?.defaultDir}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
                   />
                 );
               })}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -1,8 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { retriggerEnvelope } from "../templates";
-import { useListKeys, useNow, useTabKeys } from "../hooks";
+import { useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions } from "../components/DisplayOptions";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
 import type { AdmittedEvent, EventFocus } from "../types";
@@ -24,8 +34,10 @@ import {
   KV,
   ListEmpty,
   notify,
+  GroupHeaderRow,
   Section,
   StateBadge,
+  Th,
   VerbError,
   copyText,
   copyLink,
@@ -54,6 +66,42 @@ function isStatusTab(value: string | undefined): value is StatusTab {
 
 const rowWash = (s: string) =>
   s === "dead_lettered" ? "row-wash-err" : s === "human_needed" ? "row-wash-warn" : "";
+
+/**
+ * Grouping/ordering/columns (OPS-493) — one config across every status tab:
+ * the tabs filter the same table, they never change its columns. Occurred and
+ * Received have no column of their own (the table shows Admitted), so those
+ * sorts live in the Display popover only; Type is the click-to-sort header.
+ */
+const EVENTS_DISPLAY: DisplayConfig<AdmittedEvent> = {
+  view: "events",
+  groups: [
+    {
+      key: "status",
+      label: "Status",
+      get: (e) => e.status,
+      order: ["admitted", "planned", "noop", "human_needed", "dead_lettered"],
+      hue: EVENT_STATUS_HUES,
+    },
+    { key: "source", label: "Source", get: (e) => e.source },
+    { key: "type", label: "Type", get: (e) => e.type },
+  ],
+  subGroups: ["type", "source", "status"],
+  sorts: [
+    { key: "occurred", label: "Occurred", get: (e) => e.occurredAt, defaultDir: "desc" },
+    { key: "received", label: "Received", get: (e) => e.receivedAt, defaultDir: "desc" },
+    { key: "type", label: "Type", get: (e) => e.type, column: "type" },
+    { key: "admitted", label: "Admitted", get: (e) => e.admittedAt, defaultDir: "desc", column: "admitted" },
+  ],
+  columns: [
+    { key: "event", label: "Event", always: true },
+    { key: "source", label: "Source" },
+    { key: "type", label: "Type" },
+    { key: "subject", label: "Subject" },
+    { key: "status", label: "Status" },
+    { key: "admitted", label: "Admitted" },
+  ],
+};
 
 /**
  * Events (webui doc §10.1) — the event inbox. Every admitted envelope with
@@ -129,13 +177,32 @@ export function Events({
     });
   }, [scoped, parsed, typeFilter, sourceFilter, fetchAll, tab]);
 
+  // Display options (OPS-493): partition into sections, order inside them,
+  // and feed keyboard navigation only the rows of open sections.
+  const [display, setDisplay] = useDisplayOptions(EVENTS_DISPLAY);
+  const sections = useMemo(
+    () => buildSections(visible, EVENTS_DISPLAY, display),
+    [visible, display],
+  );
+  const flat = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
+  const cols = visibleColumns(EVENTS_DISPLAY, display);
+  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
+
   const selectedKey =
     focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
+  // Keyboard index walks the open sections; the detail pane keys off the row
+  // itself so collapsing the group under a selection never closes the pane.
   const selectedIndex = useMemo(
-    () => visible.findIndex((e) => keyOf(e) === selectedKey),
+    () => flat.findIndex((e) => keyOf(e) === selectedKey),
+    [flat, selectedKey],
+  );
+  const sel = useMemo(
+    () => (selectedKey ? (visible.find((e) => keyOf(e) === selectedKey) ?? null) : null),
     [visible, selectedKey],
   );
-  const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -302,10 +369,10 @@ export function Events({
   useTabKeys(STATUS_TABS, tab, selectTab);
 
   useListKeys({
-    count: visible.length,
+    count: flat.length,
     selected: selectedIndex,
     onSelect: (i) => {
-      const e = visible[i];
+      const e = flat[i];
       onSelectEvent(e ? e.source : null, e?.eventId);
     },
     onClose: () => {
@@ -434,6 +501,12 @@ export function Events({
         )}
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
+          <span className="ml-auto">
+            <DisplayOptions config={EVENTS_DISPLAY} state={display} onChange={setDisplay} />
+          </span>
+          {/* Last in the row: the token chips are a full-width item, so anything
+              after the filter box would be pushed onto a third line the moment
+              a chip appeared. */}
           <FilterInput
             value={filter}
             onChange={setFilter}
@@ -449,61 +522,113 @@ export function Events({
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              {["Event", "Source", "Type", "Subject", "Status", "Admitted"].map((h) => (
-                <th key={h} className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">
-                  {h}
-                </th>
-              ))}
+              {cols.map((c) => {
+                const sort = EVENTS_DISPLAY.sorts.find((s) => s.column === c.key);
+                return (
+                  <Th
+                    key={c.key}
+                    label={c.label}
+                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(EVENTS_DISPLAY, s, c.key)) : undefined}
+                  />
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {visible.map((e, i) => {
-              const proposalReason = (e as any).proposalReason ?? (e as any).proposal_reason ?? null;
-              return (
-              <tr
-                key={keyOf(e)}
-                onClick={() => onSelectEvent(e.source, e.eventId)}
-                aria-selected={i === selectedIndex}
-                className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${i === selectedIndex ? "row-selected" : ""}`}
-              >
-                <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{e.eventId}</td>
-                <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {e.source}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{e.type}</td>
-                <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {e.subject ?? "-"}
-                </td>
-                <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
-                  <div>
-                    <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
-                    {e.planFailures > 0 && (
-                      <span className="ml-2 whitespace-nowrap text-[11px]" style={{ color: "var(--hue-err)" }}>
-                        {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
-                      </span>
+            {(() => {
+              const renderRow = (e: AdmittedEvent) => {
+                const proposalReason = (e as any).proposalReason ?? (e as any).proposal_reason ?? null;
+                const isSelected = keyOf(e) === selectedKey;
+                return (
+                  <tr
+                    key={keyOf(e)}
+                    onClick={() => onSelectEvent(e.source, e.eventId)}
+                    aria-selected={isSelected}
+                    className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${isSelected ? "row-selected" : ""}`}
+                  >
+                    <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{e.eventId}</td>
+                    {show.has("source") && (
+                      <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                        {e.source}
+                      </td>
                     )}
-                  </div>
-                  {/* Why the event is parked, on the row: `.mono` carries its own
-                      11.5px, so no size utility (it is unlayered and would win).
-                      The detail pane keeps the untruncated error. */}
-                  {e.lastPlanError ? (
-                    <div className="mono mt-0.5 truncate text-(--text-dim)" title={e.lastPlanError}>
-                      {e.lastPlanError}
-                    </div>
-                  ) : proposalReason ? (
-                    <div className="mono mt-0.5 truncate text-(--text-dim)" title={proposalReason}>
-                      {proposalReason}
-                    </div>
-                  ) : null}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  <Ago iso={e.admittedAt} now={now} />
-                </td>
-              </tr>
-            );})}
+                    {show.has("type") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{e.type}</td>
+                    )}
+                    {show.has("subject") && (
+                      <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                        {e.subject ?? "-"}
+                      </td>
+                    )}
+                    {show.has("status") && (
+                      <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
+                        <div>
+                          <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                          {e.planFailures > 0 && (
+                            <span className="ml-2 whitespace-nowrap text-[11px]" style={{ color: "var(--hue-err)" }}>
+                              {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
+                            </span>
+                          )}
+                        </div>
+                        {/* Why the event is parked, on the row: `.mono` carries its own
+                            11.5px, so no size utility (it is unlayered and would win).
+                            The detail pane keeps the untruncated error. */}
+                        {e.lastPlanError ? (
+                          <div className="mono mt-0.5 truncate text-(--text-dim)" title={e.lastPlanError}>
+                            {e.lastPlanError}
+                          </div>
+                        ) : proposalReason ? (
+                          <div className="mono mt-0.5 truncate text-(--text-dim)" title={proposalReason}>
+                            {proposalReason}
+                          </div>
+                        ) : null}
+                      </td>
+                    )}
+                    {show.has("admitted") && (
+                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                        <Ago iso={e.admittedAt} now={now} />
+                      </td>
+                    )}
+                  </tr>
+                );
+              };
+              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+              return sections.map((s) => {
+                const closed = display.collapsed.includes(s.key);
+                return (
+                  <Fragment key={s.key}>
+                    <GroupHeaderRow
+                      colSpan={cols.length}
+                      section={s}
+                      collapsed={closed}
+                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    />
+                    {!closed &&
+                      (s.subsections
+                        ? s.subsections.map((child) => {
+                            const childClosed = display.collapsed.includes(child.key);
+                            return (
+                              <Fragment key={child.key}>
+                                <GroupHeaderRow
+                                  colSpan={cols.length}
+                                  section={child}
+                                  collapsed={childClosed}
+                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
+                                  sub
+                                />
+                                {!childClosed && child.rows.map(renderRow)}
+                              </Fragment>
+                            );
+                          })
+                        : s.rows.map(renderRow))}
+                  </Fragment>
+                );
+              });
+            })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={6}
+                colSpan={cols.length}
                 query={list}
                 filtered={scoped.length > 0}
                 noun="events"

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -503,6 +503,7 @@ export function Proposals({
                     key={c.key}
                     label={c.label}
                     dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir}
                     onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
                   />
                 );

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1,7 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { useListKeys, useNow, useTabKeys } from "../hooks";
+import { useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions } from "../components/DisplayOptions";
 import { setContextActions } from "../palette";
 import type { Proposal } from "../types";
 import type { OperatorContext } from "../context";
@@ -26,14 +36,76 @@ import {
   ListEmpty,
   notify,
   PROPOSAL_STATUS_HUES,
+  GroupHeaderRow,
   Section,
   StateBadge,
+  Th,
   VerbError,
   copyText,
   copyLink,
 } from "../components/ui";
 
 const PROPOSAL_TABS = ["open", "history"] as const;
+
+const ttlExpiry = (p: Proposal) => new Date(p.created_at).getTime() + p.ttl_seconds * 1000;
+
+/** Grouping/ordering/columns per tab (OPS-493) — two views, two persisted keys. */
+const OPEN_DISPLAY: DisplayConfig<Proposal> = {
+  view: "proposals-open",
+  groups: [
+    {
+      key: "decision",
+      label: "Decision",
+      get: (p) => p.decision,
+      order: ["run", "human_needed", "noop"],
+      hue: DECISION_HUES,
+    },
+    { key: "agent", label: "Agent", get: (p) => p.agent ?? "" },
+  ],
+  subGroups: ["agent", "decision"],
+  sorts: [
+    { key: "created", label: "Created", get: (p) => p.created_at, defaultDir: "desc", column: "created" },
+    { key: "ttl", label: "Time left", get: ttlExpiry, column: "ttl" },
+    { key: "agent", label: "Agent", get: (p) => p.agent ?? "", column: "agent" },
+  ],
+  columns: [
+    { key: "agent", label: "Agent", always: true },
+    { key: "decision", label: "Decision" },
+    { key: "ttl", label: "TTL" },
+    { key: "origin", label: "Origin" },
+    { key: "created", label: "Created" },
+    { key: "reason", label: "Reason" },
+  ],
+};
+
+const HISTORY_DISPLAY: DisplayConfig<Proposal> = {
+  view: "proposals-history",
+  groups: [
+    {
+      key: "status",
+      label: "Status",
+      get: (p) => p.status,
+      order: ["approved", "rejected", "superseded", "resolved"],
+      hue: PROPOSAL_STATUS_HUES,
+    },
+    { key: "agent", label: "Agent", get: (p) => p.agent ?? "" },
+  ],
+  subGroups: ["agent", "status"],
+  sorts: [
+    { key: "decided", label: "Decided", get: (p) => p.decided_at ?? "", defaultDir: "desc", column: "decided" },
+    { key: "created", label: "Created", get: (p) => p.created_at, defaultDir: "desc", column: "created" },
+    { key: "agent", label: "Agent", get: (p) => p.agent ?? "", column: "agent" },
+  ],
+  columns: [
+    { key: "agent", label: "Agent", always: true },
+    { key: "status", label: "Status" },
+    { key: "decidedBy", label: "Decided by" },
+    { key: "decided", label: "Decided" },
+    { key: "origin", label: "Origin" },
+    { key: "created", label: "Created" },
+    { key: "reason", label: "Reason" },
+  ],
+};
 
 /**
  * Proposals (webui spec §4.2) — the watched-approval centerpiece. The full
@@ -169,9 +241,29 @@ export function Proposals({
   // cell — never doubled — and stays quiet while loading or the API is down.
   const escClearsFilter = filter.trim() !== "" || expiredFilter;
 
+  // Display options (OPS-493): partition into sections, order inside them,
+  // and feed keyboard navigation only the rows of open sections.
+  const displayConfig = tab === "open" ? OPEN_DISPLAY : HISTORY_DISPLAY;
+  const [display, setDisplay] = useDisplayOptions(displayConfig);
+  const sections = useMemo(
+    () => buildSections(visible, displayConfig, display),
+    [visible, displayConfig, display],
+  );
+  const flat = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
+  const cols = visibleColumns(displayConfig, display);
+  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
+
   const selectedId = focusProposalId;
-  const selectedIndex = useMemo(() => visible.findIndex((p) => p.id === selectedId), [visible, selectedId]);
-  const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
+  // Keyboard index walks the open sections; the detail pane keys off the row
+  // itself so collapsing the group under a selection never closes the pane.
+  const selectedIndex = useMemo(() => flat.findIndex((p) => p.id === selectedId), [flat, selectedId]);
+  const sel = useMemo(
+    () => (selectedId ? (visible.find((p) => p.id === selectedId) ?? null) : null),
+    [visible, selectedId],
+  );
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -283,9 +375,9 @@ export function Proposals({
   };
 
   useListKeys({
-    count: visible.length,
+    count: flat.length,
     selected: selectedIndex,
-    onSelect: (i) => onSelectProposal(visible[i]?.id ?? null),
+    onSelect: (i) => onSelectProposal(flat[i]?.id ?? null),
     onClose: () => {
       if (sel) onSelectProposal(null);
       else if (filter || expiredOnly) {
@@ -383,6 +475,9 @@ export function Proposals({
               )}
             </button>
           )}
+          <span className="ml-auto">
+            <DisplayOptions config={displayConfig} state={display} onChange={setDisplay} />
+          </span>
           {/* Last in the row: the token chips are a full-width item, so anything
               after the filter box would be pushed onto a third line the moment
               a chip appears. */}
@@ -401,48 +496,42 @@ export function Proposals({
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Agent</th>
-              {tab === "open" ? (
-                <>
-                  <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Decision</th>
-                  <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">TTL</th>
-                </>
-              ) : (
-                <>
-                  <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Status</th>
-                  <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Decided by</th>
-                  <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Decided</th>
-                </>
-              )}
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Origin</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Created</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Reason</th>
+              {cols.map((c) => {
+                const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                return (
+                  <Th
+                    key={c.key}
+                    label={c.label}
+                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                  />
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {visible.map((p, i) => {
+            {(() => {
               const tdCls = "border-b border-(--border) px-3 py-1.5";
-              return (
-              <tr
-                key={p.id}
-                onClick={() => onSelectProposal(p.id)}
-                aria-selected={i === selectedIndex}
-                className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : p.expired ? "row-wash-warn" : ""} ${i === selectedIndex ? "row-selected" : ""}`}
-              >
-                <td className={tdCls}>
-                  {p.agent ? (
-                    <JumpLink
-                      onClick={() => onJumpAgent(p.agent!)}
-                      title={`What is ${p.agent}? Open in Agents`}
-                    >
-                      {p.agent}
-                    </JumpLink>
-                  ) : (
-                    "—"
-                  )}
-                </td>
-                {tab === "open" ? (
-                  <>
+              const renderRow = (p: Proposal) => (
+                <tr
+                  key={p.id}
+                  onClick={() => onSelectProposal(p.id)}
+                  aria-selected={p.id === selectedId}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : p.expired ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
+                >
+                  <td className={tdCls}>
+                    {p.agent ? (
+                      <JumpLink
+                        onClick={() => onJumpAgent(p.agent!)}
+                        title={`What is ${p.agent}? Open in Agents`}
+                      >
+                        {p.agent}
+                      </JumpLink>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  {show.has("decision") && (
                     <td className={tdCls}>
                       <StateBadge state={p.decision} hues={DECISION_HUES} />
                       {p.expired && (
@@ -456,42 +545,85 @@ export function Proposals({
                         </span>
                       )}
                     </td>
+                  )}
+                  {show.has("ttl") && (
                     <td className={tdCls}>
                       <Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />
                     </td>
-                  </>
-                ) : (
-                  <>
+                  )}
+                  {show.has("status") && (
                     <td className={tdCls}>
                       <StateBadge state={p.status} hues={PROPOSAL_STATUS_HUES} />
                     </td>
+                  )}
+                  {show.has("decidedBy") && (
                     <td className={`${tdCls} text-(--text-dim)`}>{p.decided_by ?? "-"}</td>
+                  )}
+                  {show.has("decided") && (
                     <td className={`${tdCls} text-(--text-faint)`}>
                       <Ago iso={p.decided_at} now={now} />
                     </td>
-                  </>
-                )}
-                <td className={`mono max-w-40 truncate ${tdCls} text-(--text-faint)`} title={originType(p) ?? undefined}>
-                  {p.eventId && p.eventSource ? (
-                    <JumpLink
-                      onClick={() => onJumpEvent(p.eventSource!, p.eventId!)}
-                      title={originType(p) ?? "Open origin event"}
-                    >
-                      {p.eventId}
-                    </JumpLink>
-                  ) : (
-                    (p.eventId ?? "-")
                   )}
-                </td>
-                <td className={`${tdCls} text-(--text-faint)`}>
-                  <Ago iso={p.created_at} now={now} />
-                </td>
-                <td className={`max-w-64 truncate ${tdCls} text-(--text-dim)`}>{p.reason ?? "-"}</td>
-              </tr>
-            );})}
+                  {show.has("origin") && (
+                    <td className={`mono max-w-40 truncate ${tdCls} text-(--text-faint)`} title={originType(p) ?? undefined}>
+                      {p.eventId && p.eventSource ? (
+                        <JumpLink
+                          onClick={() => onJumpEvent(p.eventSource!, p.eventId!)}
+                          title={originType(p) ?? "Open origin event"}
+                        >
+                          {p.eventId}
+                        </JumpLink>
+                      ) : (
+                        (p.eventId ?? "-")
+                      )}
+                    </td>
+                  )}
+                  {show.has("created") && (
+                    <td className={`${tdCls} text-(--text-faint)`}>
+                      <Ago iso={p.created_at} now={now} />
+                    </td>
+                  )}
+                  {show.has("reason") && (
+                    <td className={`max-w-64 truncate ${tdCls} text-(--text-dim)`}>{p.reason ?? "-"}</td>
+                  )}
+                </tr>
+              );
+              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+              return sections.map((s) => {
+                const closed = display.collapsed.includes(s.key);
+                return (
+                  <Fragment key={s.key}>
+                    <GroupHeaderRow
+                      colSpan={cols.length}
+                      section={s}
+                      collapsed={closed}
+                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    />
+                    {!closed &&
+                      (s.subsections
+                        ? s.subsections.map((child) => {
+                            const childClosed = display.collapsed.includes(child.key);
+                            return (
+                              <Fragment key={child.key}>
+                                <GroupHeaderRow
+                                  colSpan={cols.length}
+                                  section={child}
+                                  collapsed={childClosed}
+                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
+                                  sub
+                                />
+                                {!childClosed && child.rows.map(renderRow)}
+                              </Fragment>
+                            );
+                          })
+                        : s.rows.map(renderRow))}
+                  </Fragment>
+                );
+              });
+            })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={tab === "open" ? 6 : 7}
+                colSpan={cols.length}
                 query={tab === "open" ? query : history}
                 filtered={unfilteredCount > 0}
                 noun="proposals"

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -379,17 +379,30 @@ export function Runs({
   );
 
   // Display options (OPS-493): partition into sections, order inside them,
-  // and feed keyboard navigation only the rows of open sections.
-  const [display, setDisplay] = useDisplayOptions(RUNS_DISPLAY);
+  // and feed keyboard navigation only the rows of open sections. Under a
+  // single-state tab the empty-group universe narrows to that state — "show
+  // empty groups" on the COMPLETED tab must not render ten 0-count bands the
+  // tab itself already filtered out.
+  const displayConfig = useMemo(
+    () =>
+      tab === "ALL"
+        ? RUNS_DISPLAY
+        : {
+            ...RUNS_DISPLAY,
+            groups: RUNS_DISPLAY.groups.map((g) => (g.key === "state" ? { ...g, order: [tab] } : g)),
+          },
+    [tab],
+  );
+  const [display, setDisplay] = useDisplayOptions(displayConfig);
   const sections = useMemo(
-    () => buildSections(visible, RUNS_DISPLAY, display),
-    [visible, display],
+    () => buildSections(visible, displayConfig, display),
+    [visible, displayConfig, display],
   );
   const flat = useMemo(
     () => flattenSections(sections, display.collapsed),
     [sections, display.collapsed],
   );
-  const cols = visibleColumns(RUNS_DISPLAY, display);
+  const cols = visibleColumns(displayConfig, display);
   const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
 
   const selectedId = focusRunId;
@@ -642,7 +655,7 @@ export function Runs({
             })}
           </div>
           <span className="ml-auto">
-            <DisplayOptions config={RUNS_DISPLAY} state={display} onChange={setDisplay} />
+            <DisplayOptions config={displayConfig} state={display} onChange={setDisplay} />
           </span>
           <FilterInput
             value={filter}
@@ -660,13 +673,14 @@ export function Runs({
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
-                const sort = RUNS_DISPLAY.sorts.find((s) => s.column === c.key);
+                const sort = displayConfig.sorts.find((s) => s.column === c.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
                     dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(RUNS_DISPLAY, s, c.key)) : undefined}
+                    naturalDir={sort?.defaultDir}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
                   />
                 );
               })}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,9 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, artifactUrl } from "../api";
 import { hashPath } from "../hash";
 import { dur } from "../heartbeat";
-import { useListKeys, useNow, useTabKeys } from "../hooks";
+import { useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions } from "../components/DisplayOptions";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import { readPinnedRuns, savePinnedRuns } from "../components/ContextTabs";
@@ -28,6 +38,9 @@ import {
   notify,
   Section,
   StateBadge,
+  STATE_HUES,
+  GroupHeaderRow,
+  Th,
   VerbError,
   copyText,
   copyLink,
@@ -46,6 +59,44 @@ export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && s
  */
 const IN_FLIGHT: RunState[] = ["LEASED", "RUNNING"];
 
+/**
+ * Grouping/ordering/columns (OPS-493). One config for every status tab: the
+ * tabs only filter rows, the column set never changes with them.
+ */
+const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
+  view: "runs",
+  groups: [
+    {
+      key: "state",
+      label: "State",
+      get: (r) => r.state,
+      order: [
+        "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING",
+        "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
+      ],
+      hue: STATE_HUES,
+    },
+    { key: "agent", label: "Agent", get: (r) => r.agent },
+    { key: "adapter", label: "Adapter", get: (r) => r.adapter },
+  ],
+  subGroups: ["agent", "adapter", "state"],
+  sorts: [
+    { key: "created", label: "Created", get: (r) => r.created_at, defaultDir: "desc", column: "created" },
+    { key: "updated", label: "Updated", get: (r) => r.updated_at, defaultDir: "desc", column: "updated" },
+    { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
+    { key: "attempts", label: "Attempts", get: (r) => r.attempts, defaultDir: "desc", column: "attempts" },
+  ],
+  columns: [
+    { key: "run", label: "Run", always: true },
+    { key: "state", label: "State" },
+    { key: "agent", label: "Agent" },
+    { key: "adapter", label: "Adapter" },
+    { key: "attempts", label: "Attempts" },
+    { key: "reason", label: "Reason" },
+    { key: "origin", label: "Origin" },
+    { key: "updated", label: "Updated" },
+  ],
+};
 
 /** `off`: no deadline running yet. `spent`: the deadline passed; the runtime has not caught up. */
 type Clock = { kind: "off" } | { kind: "live"; leftMs: number } | { kind: "spent" };
@@ -327,8 +378,24 @@ export function Runs({
     [byTab, parsed, staleRuns],
   );
 
+  // Display options (OPS-493): partition into sections, order inside them,
+  // and feed keyboard navigation only the rows of open sections.
+  const [display, setDisplay] = useDisplayOptions(RUNS_DISPLAY);
+  const sections = useMemo(
+    () => buildSections(visible, RUNS_DISPLAY, display),
+    [visible, display],
+  );
+  const flat = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
+  const cols = visibleColumns(RUNS_DISPLAY, display);
+  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
+
   const selectedId = focusRunId;
-  const selectedIndex = useMemo(() => visible.findIndex((r) => r.runId === selectedId), [visible, selectedId]);
+  // Keyboard index walks the open sections; the detail pane keys off the row
+  // itself so collapsing the group under a selection never closes the pane.
+  const selectedIndex = useMemo(() => flat.findIndex((r) => r.runId === selectedId), [flat, selectedId]);
 
   // Deep link / jump: switch to ALL if the run isn't on this tab. Hash stays put.
   // Reveal (clear filter) once per focus id, after the run is on the tab so a
@@ -415,7 +482,10 @@ export function Runs({
     setTab((t) => (t === "LEASED" || t === "RUNNING" || t === "ALL" ? t : "ALL"));
   }, [context.kind]);
 
-  const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
+  const sel = useMemo(
+    () => (selectedId ? (visible.find((r) => r.runId === selectedId) ?? null) : null),
+    [visible, selectedId],
+  );
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -462,9 +532,9 @@ export function Runs({
   useTabKeys(STATE_TABS, tab, selectTab);
 
   useListKeys({
-    count: visible.length,
+    count: flat.length,
     selected: selectedIndex,
-    onSelect: (i) => onSelectRun(visible[i]?.runId ?? null),
+    onSelect: (i) => onSelectRun(flat[i]?.runId ?? null),
     // §5 "Enter/o — open detail": selection already opens the panel, so the
     // open verb graduates to the full-page run view (`g o` is safe — list
     // verbs stand down while the chord prefix is armed, hooks.ts).
@@ -571,6 +641,9 @@ export function Runs({
               );
             })}
           </div>
+          <span className="ml-auto">
+            <DisplayOptions config={RUNS_DISPLAY} state={display} onChange={setDisplay} />
+          </span>
           <FilterInput
             value={filter}
             onChange={setFilter}
@@ -586,58 +659,112 @@ export function Runs({
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              {["Run", "State", "Agent", "Adapter", "Attempts", "Reason", "Origin", "Updated"].map((h) => (
-                <th key={h} className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">
-                  {h}
-                </th>
-              ))}
+              {cols.map((c) => {
+                const sort = RUNS_DISPLAY.sorts.find((s) => s.column === c.key);
+                return (
+                  <Th
+                    key={c.key}
+                    label={c.label}
+                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(RUNS_DISPLAY, s, c.key)) : undefined}
+                  />
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {visible.map((r, i) => (
-              <tr
-                key={r.runId}
-                onClick={() => onSelectRun(r.runId)}
-                aria-selected={i === selectedIndex}
-                className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${i === selectedIndex ? "row-selected" : ""}`}
-              >
-                <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{r.runId}</td>
-                <td className="border-b border-(--border) px-3 py-1.5">
-                  <StateBadge state={r.state} />
-                  {IN_FLIGHT.includes(r.state) && <RowDeadlines r={r} now={now} />}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
-                  <JumpLink
-                    onClick={() => onJumpAgent(r.agent)}
-                    title={`Open ${r.agent} in Agents`}
-                  >
-                    {r.agent}
-                  </JumpLink>
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">{r.adapter}</td>
-                <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
-                  {r.attempts}/{r.maxAttempts}
-                </td>
-                <td className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {r.reasonCode ?? "-"}
-                </td>
-                <td className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {r.eventId && r.eventSource ? (
-                    <JumpLink onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title="Open origin event">
-                      {r.eventId}
-                    </JumpLink>
-                  ) : (
-                    (r.eventId ?? "-")
+            {(() => {
+              const renderRow = (r: RunListItem) => (
+                <tr
+                  key={r.runId}
+                  onClick={() => onSelectRun(r.runId)}
+                  aria-selected={r.runId === selectedId}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
+                >
+                  <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{r.runId}</td>
+                  {show.has("state") && (
+                    <td className="border-b border-(--border) px-3 py-1.5">
+                      <StateBadge state={r.state} />
+                      {IN_FLIGHT.includes(r.state) && <RowDeadlines r={r} now={now} />}
+                    </td>
                   )}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  <Ago iso={r.updated_at} now={now} />
-                </td>
-              </tr>
-            ))}
+                  {show.has("agent") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                      <JumpLink
+                        onClick={() => onJumpAgent(r.agent)}
+                        title={`Open ${r.agent} in Agents`}
+                      >
+                        {r.agent}
+                      </JumpLink>
+                    </td>
+                  )}
+                  {show.has("adapter") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">{r.adapter}</td>
+                  )}
+                  {show.has("attempts") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                      {r.attempts}/{r.maxAttempts}
+                    </td>
+                  )}
+                  {show.has("reason") && (
+                    <td className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      {r.reasonCode ?? "-"}
+                    </td>
+                  )}
+                  {show.has("origin") && (
+                    <td className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      {r.eventId && r.eventSource ? (
+                        <JumpLink onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title="Open origin event">
+                          {r.eventId}
+                        </JumpLink>
+                      ) : (
+                        (r.eventId ?? "-")
+                      )}
+                    </td>
+                  )}
+                  {show.has("updated") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      <Ago iso={r.updated_at} now={now} />
+                    </td>
+                  )}
+                </tr>
+              );
+              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+              return sections.map((s) => {
+                const closed = display.collapsed.includes(s.key);
+                return (
+                  <Fragment key={s.key}>
+                    <GroupHeaderRow
+                      colSpan={cols.length}
+                      section={s}
+                      collapsed={closed}
+                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    />
+                    {!closed &&
+                      (s.subsections
+                        ? s.subsections.map((child) => {
+                            const childClosed = display.collapsed.includes(child.key);
+                            return (
+                              <Fragment key={child.key}>
+                                <GroupHeaderRow
+                                  colSpan={cols.length}
+                                  section={child}
+                                  collapsed={childClosed}
+                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
+                                  sub
+                                />
+                                {!childClosed && child.rows.map(renderRow)}
+                              </Fragment>
+                            );
+                          })
+                        : s.rows.map(renderRow))}
+                  </Fragment>
+                );
+              });
+            })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={8}
+                colSpan={cols.length}
                 query={list}
                 filtered={scoped.length > 0}
                 noun="runs"

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -1,7 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { api } from "../api";
-import { useListKeys, useNow } from "../hooks";
+import { useDisplayOptions, useListKeys, useNow } from "../hooks";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions } from "../components/DisplayOptions";
 import { setContextActions } from "../palette";
 import type { Worker } from "../types";
 import type { OperatorContext } from "../context";
@@ -24,8 +34,10 @@ import {
   KV,
   ListEmpty,
   ListPane,
+  GroupHeaderRow,
   Section,
   StateBadge,
+  Th,
   copyLink,
   copyText,
 } from "../components/ui";
@@ -44,6 +56,37 @@ const WORKER_HUES: Record<string, string> = {
  * these four are disjoint.
  */
 const health = (w: Worker) => (w.stale ? "stale" : w.state);
+
+/** Grouping/ordering/columns for the fleet table (OPS-493). */
+const WORKERS_DISPLAY: DisplayConfig<Worker> = {
+  view: "workers",
+  groups: [
+    {
+      key: "state",
+      label: "State",
+      get: health,
+      order: ["busy", "idle", "stale", "stopped"],
+      hue: WORKER_HUES,
+    },
+    { key: "host", label: "Host", get: (w) => w.host },
+  ],
+  subGroups: ["host", "state"],
+  sorts: [
+    { key: "lastSeen", label: "Last seen", get: (w) => w.lastSeen ?? "", defaultDir: "desc", column: "heartbeat" },
+    { key: "host", label: "Host", get: (w) => w.host, column: "host" },
+    { key: "started", label: "Started", get: (w) => w.startedAt ?? "", defaultDir: "desc" },
+  ],
+  columns: [
+    { key: "worker", label: "Worker", always: true },
+    { key: "host", label: "Host" },
+    { key: "pid", label: "PID" },
+    { key: "state", label: "State" },
+    { key: "labels", label: "Labels" },
+    { key: "adapters", label: "Adapters" },
+    { key: "run", label: "Current run" },
+    { key: "heartbeat", label: "Heartbeat" },
+  ],
+};
 
 /**
  * The distance to the stale threshold, worded the same way in the row and the
@@ -169,12 +212,31 @@ export function Workers({
     );
   }, [rows, filter]);
 
+  // Display options (OPS-493): partition into sections, order inside them,
+  // and feed keyboard navigation only the rows of open sections.
+  const [display, setDisplay] = useDisplayOptions(WORKERS_DISPLAY);
+  const sections = useMemo(
+    () => buildSections(visible, WORKERS_DISPLAY, display),
+    [visible, display],
+  );
+  const flat = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
+  const cols = visibleColumns(WORKERS_DISPLAY, display);
+  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
+
   const selectedId = focusWorkerId;
+  // Keyboard index walks the open sections; the detail pane keys off the row
+  // itself so collapsing the group under a selection never closes the pane.
   const selectedIndex = useMemo(
-    () => visible.findIndex((w) => w.workerId === selectedId),
+    () => flat.findIndex((w) => w.workerId === selectedId),
+    [flat, selectedId],
+  );
+  const sel = useMemo(
+    () => (selectedId ? (visible.find((w) => w.workerId === selectedId) ?? null) : null),
     [visible, selectedId],
   );
-  const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
   const selHeartbeat: Heartbeat = sel ? heartbeatOf(sel, now) : { kind: "none" };
 
   useEffect(() => {
@@ -186,9 +248,9 @@ export function Workers({
   }, [focusWorkerId]);
 
   useListKeys({
-    count: visible.length,
+    count: flat.length,
     selected: selectedIndex,
-    onSelect: (i) => onSelectWorker(visible[i]?.workerId ?? null),
+    onSelect: (i) => onSelectWorker(flat[i]?.workerId ?? null),
     onClose: () => {
       if (selectedId) onSelectWorker(null);
       else if (filter) setFilter("");
@@ -222,7 +284,10 @@ export function Workers({
           <>
             <h1 className="display mb-4 text-lg font-semibold">Workers</h1>
             <ScopeCaption context={context} surface="fleet" />
-            <div className="mb-3">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <span className="ml-auto">
+                <DisplayOptions config={WORKERS_DISPLAY} state={display} onChange={setDisplay} />
+              </span>
               <FilterInput
                 value={filter}
                 onChange={setFilter}
@@ -257,68 +322,119 @@ export function Workers({
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Worker</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Host</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">PID</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">State</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Labels</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Adapters</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Current run</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium" title={`Last check-in, and how far that is from the ${HEARTBEAT_STALE_MS / 1000}s stale threshold`}>Heartbeat</th>
+              {cols.map((c) => {
+                const sort = WORKERS_DISPLAY.sorts.find((s) => s.column === c.key);
+                return (
+                  <Th
+                    key={c.key}
+                    label={c.label}
+                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(WORKERS_DISPLAY, s, c.key)) : undefined}
+                  />
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {visible.map((w, i) => (
-              <tr
-                key={w.workerId}
-                onClick={() => onSelectWorker(w.workerId)}
-                aria-selected={i === selectedIndex}
-                className={`cursor-pointer hover:bg-(--surface-1) ${w.stale ? "row-wash-err" : ""} ${
-                  i === selectedIndex ? "row-selected" : ""
-                }`}
-              >
-                <td
-                  className={`mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 ${
-                    w.state === "stopped" && !w.stale ? "text-(--text-faint)" : ""
+            {(() => {
+              const renderRow = (w: Worker) => (
+                <tr
+                  key={w.workerId}
+                  onClick={() => onSelectWorker(w.workerId)}
+                  aria-selected={w.workerId === selectedId}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${w.stale ? "row-wash-err" : ""} ${
+                    w.workerId === selectedId ? "row-selected" : ""
                   }`}
                 >
-                  {w.workerId}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{w.host}</td>
-                <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-faint)">{w.pid}</td>
-                <td className="border-b border-(--border) px-3 py-1.5">
-                  <span className="flex items-baseline gap-1.5">
-                    <StateBadge state={health(w)} hues={WORKER_HUES} />
-                    {w.stale && (
-                      <span className="text-[11px] text-(--text-faint)" title="What the worker last reported before its heartbeat stopped">
-                        reported {w.state}
-                      </span>
-                    )}
-                  </span>
-                </td>
-                <td className="max-w-48 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)" title={labelText(w.labels)}>
-                  {labelText(w.labels)}
-                </td>
-                <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {w.adapters.join(", ") || "-"}
-                </td>
-                <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                  {w.currentRun ? (
-                    <JumpLink onClick={() => openRun(w.currentRun!)} title="Open this run">
-                      {w.currentRun}
-                    </JumpLink>
-                  ) : (
-                    "-"
+                  <td
+                    className={`mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 ${
+                      w.state === "stopped" && !w.stale ? "text-(--text-faint)" : ""
+                    }`}
+                  >
+                    {w.workerId}
+                  </td>
+                  {show.has("host") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{w.host}</td>
                   )}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)">
-                  <HeartbeatCell w={w} now={now} />
-                </td>
-              </tr>
-            ))}
+                  {show.has("pid") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-faint)">{w.pid}</td>
+                  )}
+                  {show.has("state") && (
+                    <td className="border-b border-(--border) px-3 py-1.5">
+                      <span className="flex items-baseline gap-1.5">
+                        <StateBadge state={health(w)} hues={WORKER_HUES} />
+                        {w.stale && (
+                          <span className="text-[11px] text-(--text-faint)" title="What the worker last reported before its heartbeat stopped">
+                            reported {w.state}
+                          </span>
+                        )}
+                      </span>
+                    </td>
+                  )}
+                  {show.has("labels") && (
+                    <td className="max-w-48 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)" title={labelText(w.labels)}>
+                      {labelText(w.labels)}
+                    </td>
+                  )}
+                  {show.has("adapters") && (
+                    <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      {w.adapters.join(", ") || "-"}
+                    </td>
+                  )}
+                  {show.has("run") && (
+                    <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      {w.currentRun ? (
+                        <JumpLink onClick={() => openRun(w.currentRun!)} title="Open this run">
+                          {w.currentRun}
+                        </JumpLink>
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                  )}
+                  {show.has("heartbeat") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)">
+                      <HeartbeatCell w={w} now={now} />
+                    </td>
+                  )}
+                </tr>
+              );
+              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+              return sections.map((s) => {
+                const closed = display.collapsed.includes(s.key);
+                return (
+                  <Fragment key={s.key}>
+                    <GroupHeaderRow
+                      colSpan={cols.length}
+                      section={s}
+                      collapsed={closed}
+                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    />
+                    {!closed &&
+                      (s.subsections
+                        ? s.subsections.map((child) => {
+                            const childClosed = display.collapsed.includes(child.key);
+                            return (
+                              <Fragment key={child.key}>
+                                <GroupHeaderRow
+                                  colSpan={cols.length}
+                                  section={child}
+                                  collapsed={childClosed}
+                                  onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
+                                  sub
+                                />
+                                {!childClosed && child.rows.map(renderRow)}
+                              </Fragment>
+                            );
+                          })
+                        : s.rows.map(renderRow))}
+                  </Fragment>
+                );
+              });
+            })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={8}
+                colSpan={cols.length}
                 query={query}
                 filtered={rows.length > 0}
                 noun="workers"

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -329,6 +329,7 @@ export function Workers({
                     key={c.key}
                     label={c.label}
                     dir={sort && display.sortBy === sort.key ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir}
                     onSort={sort ? () => setDisplay((s) => cycleColumnSort(WORKERS_DISPLAY, s, c.key)) : undefined}
                   />
                 );

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -58,7 +58,10 @@ function vendorChunk(id: string): string | undefined {
 // The budget tracks the measured entry with a little slack, not a round number
 // well above it. Slack this thin means ordinary feature work will eventually
 // trip it; that is the trade, and re-baselining is a normal move.
-const ENTRY_CHUNK_BUDGET_BYTES = 480 * 1000;
+// Re-baselined for OPS-493 (display options engine + popover in the eager
+// entry): 483.19 kB measured on CI Linux, whose minifier output runs a few kB
+// heavier than macOS — budget against the CI number, not the local one.
+const ENTRY_CHUNK_BUDGET_BYTES = 490 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
Fixes OPS-493

Linear-style table grouping and a per-view **Display** options popover for the event-runtime web UI, wired into Proposals (Open + History), Runs, Events, and Workers.

## What's new
- **Pure engine** `src/displayOptions.ts`: per-view config (groupable fields with canonical enum order + hues, sort fields, column descriptors), `buildSections` (group → sub-group → sort), `flattenSections`, tolerant localStorage (de)serialization. 19 unit tests.
- **`useDisplayOptions`** hook: per-view persistence under `evrt-display-<view>` (matches the `evrt-theme` convention), render-phase reset when a view swaps configs (Proposals tabs).
- **Display popover** (`components/DisplayOptions.tsx`): Grouping / Sub-grouping / Ordering + direction / "Show empty groups" switch / column visibility pills / Reset; light-modal semantics (list verbs stand down, Esc closes without touching selection), full aria wiring. 6 DOM tests.
- **Shared table chrome** (`ui.tsx`): `Th` sticky header cell with 3-state click-to-sort (natural → reversed → API order) and direction-honest hover hints; `GroupHeaderRow` collapsible section band (chevron, hue dot, count, `aria-expanded`, Enter/Space) that pins under the header row.
- **Keyboard**: `useListKeys` untouched — views feed it the flattened rows of open sections, so j/k skips collapsed groups by construction.
- Empty-group universe narrows to the active state/status tab on Runs/Events (UX-critique finding).

## Verification
- `bun test event-runtime/web`: **220 pass / 0 fail** (was 214 before the branch; +25 new, engine + popover + header)
- `bunx tsc --noEmit`: silent · `vite build`: clean
- Live smoke on the seeded worktree env (`bin/worktree-up.sh OPS-493`): grouping, sub-grouping, collapse + j/k skip, sort cycling, column toggles, per-view persistence across reload all verified in-browser.
- UX critique round (factory-ux-critic): **SHIP** verdict; both in-scope minor findings fixed in this branch; follow-ups filed as OPS-496 (remaining 3 views + Th title prop) and the state-hue disambiguation noted for the icon/color ticket.