### PR TITLE
fix(web): graph legibility — bounded initial zoom, legend, node search (WM-99)

### DIFF
--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -1,21 +1,27 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { GraphNode } from "./model";
+import { NODE_STYLES } from "./style";
 
 // Custom nodes: plain components on the app's OKLCH tokens, so the canvas
-// reads as part of the tool rather than an embedded diagram widget.
+// reads as part of the tool rather than an embedded diagram widget. Accents
+// and dash styles come from ./style so the legend stays truthful (WM-99).
 
 const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
+
+const searchHitOf = (data: NodeProps["data"]) => Boolean((data as { searchHit?: boolean }).searchHit);
 
 function Shell({
   children,
   accent,
   selected,
   dashed,
+  searchHit,
 }: {
   children: React.ReactNode;
   accent: string;
   selected?: boolean;
   dashed?: boolean;
+  searchHit?: boolean;
 }) {
   return (
     <div
@@ -28,6 +34,8 @@ function Shell({
         border: `1px ${dashed ? "dashed" : "solid"} ${selected ? accent : "var(--border)"}`,
         boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
         borderLeft: `3px solid ${accent}`,
+        outline: searchHit ? "2px solid var(--accent)" : undefined,
+        outlineOffset: searchHit ? 2 : undefined,
       }}
     >
       {children}
@@ -49,9 +57,9 @@ function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
 export function EventTypeNode({ data, selected }: NodeProps) {
   const node = data.node as Extract<GraphNode, { kind: "eventType" }>;
   return (
-    <Shell accent="var(--hue-info)" selected={selected}>
+    <Shell accent={NODE_STYLES.eventType.accent} selected={selected} searchHit={searchHitOf(data)}>
       <Handle type="target" position={Position.Left} style={handleStyle} />
-      <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--hue-info)" }}>
+      <div className="text-[10px] tracking-wide uppercase" style={{ color: NODE_STYLES.eventType.accent }}>
         event type
       </div>
       <div className="mono truncate text-[12px]" title={node.label}>
@@ -66,9 +74,9 @@ export function EventTypeNode({ data, selected }: NodeProps) {
 
 export function AgentNode({ data, selected }: NodeProps) {
   const node = data.node as Extract<GraphNode, { kind: "agent" }>;
-  const accent = node.mutating ? "var(--hue-warn)" : "var(--hue-ok)";
+  const accent = node.mutating ? NODE_STYLES.agentMutating.accent : NODE_STYLES.agentReadOnly.accent;
   return (
-    <Shell accent={accent} selected={selected}>
+    <Shell accent={accent} selected={selected} searchHit={searchHitOf(data)}>
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-2">
         <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
@@ -77,7 +85,10 @@ export function AgentNode({ data, selected }: NodeProps) {
         {node.mutating && (
           <span
             className="rounded px-1 text-[9.5px] font-semibold tracking-wide uppercase"
-            style={{ color: "var(--hue-warn)", background: "color-mix(in oklch, var(--hue-warn) 15%, transparent)" }}
+            style={{
+              color: NODE_STYLES.agentMutating.accent,
+              background: `color-mix(in oklch, ${NODE_STYLES.agentMutating.accent} 15%, transparent)`,
+            }}
           >
             mutating
           </span>
@@ -100,7 +111,12 @@ export function AgentNode({ data, selected }: NodeProps) {
 export function TerminalNode({ data, selected }: NodeProps) {
   const node = data.node as Extract<GraphNode, { kind: "terminal" }>;
   return (
-    <Shell accent="var(--hue-idle)" selected={selected} dashed>
+    <Shell
+      accent={NODE_STYLES.terminal.accent}
+      selected={selected}
+      dashed={NODE_STYLES.terminal.dashed}
+      searchHit={searchHitOf(data)}
+    >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--text-faint)" }}>
         terminal

--- a/event-runtime/web/src/graph/search.test.ts
+++ b/event-runtime/web/src/graph/search.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { largestComponentIds, matchNodes } from "./search";
+import type { CapabilityGraph, GraphNode } from "./model";
+
+const event = (type: string): GraphNode => ({
+  id: `event:${type}`,
+  kind: "eventType",
+  label: type,
+  adapter: "claude",
+  scope: [],
+  ttl: null,
+});
+
+const agent = (ref: string): GraphNode => ({
+  id: `agent:${ref}`,
+  kind: "agent",
+  label: ref,
+  adapter: "claude",
+  mutating: false,
+  execution: "model",
+  contract: "c/v1",
+  capabilities: [],
+  actions: [],
+  hosts: [],
+});
+
+describe("matchNodes", () => {
+  const nodes = [event("gh.run.failed"), agent("ci-doctor@1"), agent("rerun@2")];
+
+  test("case-insensitive substring on label", () => {
+    expect(matchNodes(nodes, "DOCTOR")).toEqual(["agent:ci-doctor@1"]);
+  });
+
+  test("matches on id prefix too", () => {
+    expect(matchNodes(nodes, "event:")).toEqual(["event:gh.run.failed"]);
+  });
+
+  test("preserves node order across multiple matches", () => {
+    expect(matchNodes(nodes, "r")).toEqual([
+      "event:gh.run.failed",
+      "agent:ci-doctor@1",
+      "agent:rerun@2",
+    ]);
+  });
+
+  test("blank and whitespace-only queries match nothing", () => {
+    expect(matchNodes(nodes, "")).toEqual([]);
+    expect(matchNodes(nodes, "   ")).toEqual([]);
+  });
+
+  test("no match returns empty", () => {
+    expect(matchNodes(nodes, "zzz")).toEqual([]);
+  });
+});
+
+describe("largestComponentIds", () => {
+  const edge = (id: string, source: string, target: string) =>
+    ({ id, source, target, kind: "routes" }) as CapabilityGraph["edges"][number];
+
+  test("picks the component with the most nodes", () => {
+    const graph: CapabilityGraph = {
+      nodes: [event("a"), agent("a@1"), event("b"), agent("b@1"), event("c")],
+      edges: [
+        edge("1", "event:a", "agent:a@1"),
+        edge("2", "event:b", "agent:b@1"),
+        edge("3", "agent:a@1", "event:b"),
+      ],
+    };
+    expect(largestComponentIds(graph).sort()).toEqual(
+      ["agent:a@1", "agent:b@1", "event:a", "event:b"].sort(),
+    );
+  });
+
+  test("breaks node-count ties by edge count", () => {
+    const graph: CapabilityGraph = {
+      nodes: [event("a"), agent("a@1"), event("b"), agent("b@1")],
+      edges: [
+        edge("1", "event:b", "agent:b@1"),
+        edge("2", "agent:b@1", "event:b"),
+      ],
+    };
+    // Both components have 2 nodes; b's has 2 edges vs a's 0... a's are isolated.
+    expect(largestComponentIds(graph).sort()).toEqual(["agent:b@1", "event:b"].sort());
+  });
+
+  test("empty graph yields empty", () => {
+    expect(largestComponentIds({ nodes: [], edges: [] })).toEqual([]);
+  });
+
+  test("isolated single nodes form one-node components", () => {
+    const graph: CapabilityGraph = { nodes: [event("solo")], edges: [] };
+    expect(largestComponentIds(graph)).toEqual(["event:solo"]);
+  });
+});

--- a/event-runtime/web/src/graph/search.ts
+++ b/event-runtime/web/src/graph/search.ts
@@ -1,0 +1,56 @@
+import type { CapabilityGraph, GraphNode } from "./model";
+
+// Pure view helpers for the Graph page (WM-99): node search and the
+// initial-fit target. No React Flow types here so both stay unit-testable.
+
+/**
+ * Case-insensitive substring match on node label and id, in the order the
+ * nodes appear in the graph. A blank query matches nothing — an empty search
+ * box must not highlight the whole canvas.
+ */
+export function matchNodes(nodes: GraphNode[], query: string): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  return nodes
+    .filter((n) => n.label.toLowerCase().includes(needle) || n.id.toLowerCase().includes(needle))
+    .map((n) => n.id);
+}
+
+/**
+ * Node ids of the largest connected component (undirected), edges winning
+ * ties — the initial view centers here instead of fitting every stray island
+ * on screen at once.
+ */
+export function largestComponentIds(graph: CapabilityGraph): string[] {
+  const adjacency = new Map<string, string[]>(graph.nodes.map((n) => [n.id, []]));
+  for (const edge of graph.edges) {
+    adjacency.get(edge.source)?.push(edge.target);
+    adjacency.get(edge.target)?.push(edge.source);
+  }
+
+  const seen = new Set<string>();
+  let best: { ids: string[]; edges: number } = { ids: [], edges: 0 };
+  for (const start of adjacency.keys()) {
+    if (seen.has(start)) continue;
+    const ids: string[] = [];
+    let edgeEndpoints = 0;
+    const stack = [start];
+    seen.add(start);
+    while (stack.length) {
+      const id = stack.pop() as string;
+      ids.push(id);
+      const neighbors = adjacency.get(id) ?? [];
+      edgeEndpoints += neighbors.length;
+      for (const next of neighbors) {
+        if (seen.has(next)) continue;
+        seen.add(next);
+        stack.push(next);
+      }
+    }
+    const edges = edgeEndpoints / 2;
+    if (ids.length > best.ids.length || (ids.length === best.ids.length && edges > best.edges)) {
+      best = { ids, edges };
+    }
+  }
+  return best.ids;
+}

--- a/event-runtime/web/src/graph/style.test.ts
+++ b/event-runtime/web/src/graph/style.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { EDGE_STYLES, NODE_STYLES, legendEntries, nodeStyleKey } from "./style";
+import type { CapabilityGraph, GraphNode } from "./model";
+
+const agent = (ref: string, mutating: boolean): GraphNode => ({
+  id: `agent:${ref}`,
+  kind: "agent",
+  label: ref,
+  adapter: "claude",
+  mutating,
+  execution: "model",
+  contract: "c/v1",
+  capabilities: [],
+  actions: [],
+  hosts: [],
+});
+
+describe("nodeStyleKey", () => {
+  test("splits agents by mutating flag, passes other kinds through", () => {
+    expect(nodeStyleKey(agent("a@1", false))).toBe("agentReadOnly");
+    expect(nodeStyleKey(agent("a@1", true))).toBe("agentMutating");
+    expect(
+      nodeStyleKey({ id: "terminal:a@1", kind: "terminal", label: "chain ends", reason: "done" }),
+    ).toBe("terminal");
+  });
+});
+
+describe("legendEntries", () => {
+  test("lists only styles the graph actually uses", () => {
+    const graph: CapabilityGraph = {
+      nodes: [
+        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null },
+        agent("a@1", false),
+      ],
+      edges: [{ id: "routes:a", source: "event:a", target: "agent:a@1", kind: "routes" }],
+    };
+    const legend = legendEntries(graph);
+    expect(legend.nodes.map((n) => n.key)).toEqual(["eventType", "agentReadOnly"]);
+    expect(legend.edges.map((e) => e.kind)).toEqual(["routes"]);
+  });
+
+  test("full graph advertises every style, carrying the shared constants", () => {
+    const graph: CapabilityGraph = {
+      nodes: [
+        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null },
+        agent("a@1", false),
+        agent("b@1", true),
+        { id: "terminal:b@1", kind: "terminal", label: "chain ends", reason: "done" },
+      ],
+      edges: [
+        { id: "routes:a", source: "event:a", target: "agent:a@1", kind: "routes" },
+        { id: "rec:b@1:x", source: "agent:b@1", target: "event:a", kind: "recommends" },
+      ],
+    };
+    const legend = legendEntries(graph);
+    expect(legend.nodes).toEqual([
+      { key: "eventType", ...NODE_STYLES.eventType },
+      { key: "agentReadOnly", ...NODE_STYLES.agentReadOnly },
+      { key: "agentMutating", ...NODE_STYLES.agentMutating },
+      { key: "terminal", ...NODE_STYLES.terminal },
+    ]);
+    expect(legend.edges).toEqual([
+      { kind: "routes", ...EDGE_STYLES.routes },
+      { kind: "recommends", ...EDGE_STYLES.recommends },
+    ]);
+  });
+
+  test("empty graph yields an empty legend", () => {
+    expect(legendEntries({ nodes: [], edges: [] })).toEqual({ nodes: [], edges: [] });
+  });
+});

--- a/event-runtime/web/src/graph/style.ts
+++ b/event-runtime/web/src/graph/style.ts
@@ -1,0 +1,47 @@
+import type { CapabilityGraph, GraphEdge, GraphNode } from "./model";
+
+// The single source of truth for what node/edge colors and dashes *mean*
+// (WM-99). Node components, edge mapping, and the legend all read from here,
+// so the legend can never drift from what the canvas actually draws.
+
+export type NodeStyleKey = "eventType" | "agentReadOnly" | "agentMutating" | "terminal";
+
+export const NODE_STYLES: Record<NodeStyleKey, { label: string; accent: string; dashed: boolean }> = {
+  eventType: { label: "event type", accent: "var(--hue-info)", dashed: false },
+  agentReadOnly: { label: "agent · read-only", accent: "var(--hue-ok)", dashed: false },
+  agentMutating: { label: "agent · mutating", accent: "var(--hue-warn)", dashed: false },
+  terminal: { label: "chain ends", accent: "var(--hue-idle)", dashed: true },
+};
+
+export const nodeStyleKey = (node: GraphNode): NodeStyleKey =>
+  node.kind === "agent" ? (node.mutating ? "agentMutating" : "agentReadOnly") : node.kind;
+
+export const EDGE_STYLES: Record<
+  GraphEdge["kind"],
+  { label: string; stroke: string; strokeDasharray?: string }
+> = {
+  routes: { label: "routes to agent", stroke: "var(--border-strong)" },
+  recommends: { label: "recommendation", stroke: "var(--accent)", strokeDasharray: "4 3" },
+};
+
+export interface LegendEntries {
+  nodes: Array<{ key: NodeStyleKey } & (typeof NODE_STYLES)[NodeStyleKey]>;
+  edges: Array<{ kind: GraphEdge["kind"] } & (typeof EDGE_STYLES)[GraphEdge["kind"]]>;
+}
+
+/**
+ * Legend entries for the styles this graph actually uses — a map with no
+ * mutating agents does not advertise the mutating color.
+ */
+export function legendEntries(graph: CapabilityGraph): LegendEntries {
+  const usedNodes = new Set(graph.nodes.map(nodeStyleKey));
+  const usedEdges = new Set(graph.edges.map((e) => e.kind));
+  return {
+    nodes: (Object.keys(NODE_STYLES) as NodeStyleKey[])
+      .filter((key) => usedNodes.has(key))
+      .map((key) => ({ key, ...NODE_STYLES[key] })),
+    edges: (Object.keys(EDGE_STYLES) as GraphEdge["kind"][])
+      .filter((kind) => usedEdges.has(kind))
+      .map((kind) => ({ kind, ...EDGE_STYLES[kind] })),
+  };
+}

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -13,10 +13,17 @@ import { api } from "../api";
 import { keyGuard } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
+import { largestComponentIds, matchNodes } from "../graph/search";
+import { EDGE_STYLES, legendEntries } from "../graph/style";
 import type { EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import { Button, DetailPane, JsonBlock, JumpLink, KV, Section, copyText, copyLink } from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
+
+// Fit-all on a large graph lands at ~0.1–0.3 zoom where labels are unreadable
+// (WM-99). The initial fit centers on the largest component and never goes
+// below this floor — the minimap covers "where is everything else".
+const INITIAL_FIT_MIN_ZOOM = 0.65;
 
 /**
  * Graph (webui roadmap / OPS-224 phase 1, chrome OPS-230): the capability map
@@ -93,9 +100,9 @@ export function Graph({
                     label: edge.label,
                     animated: false,
                     style: {
-                      stroke: edge.kind === "recommends" ? "var(--accent)" : "var(--border-strong)",
+                      stroke: EDGE_STYLES[edge.kind].stroke,
                       strokeWidth: 1.5,
-                      strokeDasharray: edge.kind === "recommends" ? "4 3" : undefined,
+                      strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
                     },
                     labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
                     labelBgStyle: { fill: "var(--surface-0)" },
@@ -123,9 +130,26 @@ export function Graph({
     };
   }, [graph]);
 
+  // Node search (WM-99): case-insensitive substring on label/id, matches
+  // highlighted on canvas, Enter cycles through them.
+  const [query, setQuery] = useState("");
+  const [matchIdx, setMatchIdx] = useState(0);
+  const matches = useMemo(() => (graph ? matchNodes(graph.nodes, query) : []), [graph, query]);
+  const matchSet = useMemo(() => new Set(matches), [matches]);
+  const safeMatchIdx = matches.length ? matchIdx % matches.length : 0;
+  const currentMatch = matches[safeMatchIdx] ?? null;
+  const legend = useMemo(() => (graph ? legendEntries(graph) : null), [graph]);
+
   const nodes = useMemo(
-    () => (positioned ? positioned.nodes.map((n) => ({ ...n, selected: n.id === focusNodeId })) : []),
-    [positioned, focusNodeId],
+    () =>
+      positioned
+        ? positioned.nodes.map((n) => ({
+            ...n,
+            selected: n.id === focusNodeId,
+            data: { ...n.data, searchHit: matchSet.has(n.id) },
+          }))
+        : [],
+    [positioned, focusNodeId, matchSet],
   );
 
   const selected: GraphNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
@@ -179,10 +203,44 @@ export function Graph({
     });
   };
 
+  // Initial view (WM-99): fit the largest connected component with a zoom
+  // floor instead of squeezing every island on screen at label-illegible zoom.
+  // Runs once per mount; refetches must not yank the viewport afterwards.
+  const didInitialFit = useRef(false);
+  useEffect(() => {
+    if (didInitialFit.current || !flowRef.current || !positioned || !graph || graph.nodes.length === 0)
+      return;
+    didInitialFit.current = true;
+    flowRef.current.fitView({
+      nodes: largestComponentIds(graph).map((id) => ({ id })),
+      padding: 0.25,
+      minZoom: INITIAL_FIT_MIN_ZOOM,
+      maxZoom: 1,
+    });
+  }, [graph, positioned, flowReady]);
+
   useEffect(() => {
     revealSelected();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusNodeId, flowReady, positioned]);
+
+  // Center the current search match at the operator's zoom; `currentMatch` is
+  // a stable string, so background refetches do not re-center the viewport.
+  useEffect(() => {
+    setMatchIdx(0);
+  }, [query]);
+  useEffect(() => {
+    if (!currentMatch || !flowRef.current) return;
+    const zoom = Math.max(flowRef.current.getZoom(), INITIAL_FIT_MIN_ZOOM);
+    flowRef.current.fitView({
+      nodes: [{ id: currentMatch }],
+      padding: 0.45,
+      duration: 180,
+      minZoom: zoom,
+      maxZoom: zoom,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentMatch, flowReady]);
 
   const emptyCopy = registry.isPending
     ? "Loading the capability map…"
@@ -208,6 +266,73 @@ export function Graph({
           </div>
           <ScopeCaption context={context} surface="graph" />
         </div>
+        {positioned && graph && graph.nodes.length > 0 && (
+          <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+            <div className="flex items-center gap-2">
+              {query.trim() && (
+                <span className="text-[11px] text-(--text-faint)">
+                  {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
+                </span>
+              )}
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && matches.length) {
+                    e.preventDefault();
+                    setMatchIdx((i) => (i + 1) % matches.length);
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    if (query) setQuery("");
+                    else e.currentTarget.blur();
+                  }
+                }}
+                placeholder="Search nodes…"
+                aria-label="Search graph nodes"
+                spellCheck={false}
+                className="w-52 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+              />
+            </div>
+            {legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
+              <div
+                className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
+                role="img"
+                aria-label="Graph legend"
+              >
+                {legend.nodes.map((entry) => (
+                  <div key={entry.key} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
+                    <span
+                      aria-hidden
+                      className="inline-block shrink-0 rounded-xs"
+                      style={{
+                        width: 14,
+                        height: 11,
+                        background: "var(--surface-0)",
+                        border: `1px ${entry.dashed ? "dashed" : "solid"} var(--border)`,
+                        borderLeft: `3px solid ${entry.accent}`,
+                      }}
+                    />
+                    {entry.label}
+                  </div>
+                ))}
+                {legend.edges.map((entry) => (
+                  <div key={entry.kind} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
+                    <span
+                      aria-hidden
+                      className="inline-block shrink-0"
+                      style={{
+                        width: 14,
+                        borderTop: `2px ${entry.strokeDasharray ? "dashed" : "solid"} ${entry.stroke}`,
+                      }}
+                    />
+                    {entry.label}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
         {positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow
             nodes={nodes}
@@ -220,8 +345,6 @@ export function Graph({
               setFlowReady((n) => n + 1);
             }}
             nodesFocusable
-            fitView
-            fitViewOptions={{ padding: 0.25 }}
             proOptions={{ hideAttribution: true }}
             minZoom={0.2}
           >


### PR DESCRIPTION
Fixes WM-99

## Summary

The Graph page fit the whole route graph on screen at initial render, leaving labels at ~4-6px, and the color/dash semantics had no legend. This change:

- **Bounded initial zoom**: replaces the unbounded `fitView` prop with a one-shot fit on the largest connected component (`largestComponentIds`, undirected, ties broken by edge count) with a `minZoom` floor of 0.65 and `maxZoom` 1. Manual zoom range (`minZoom={0.2}`), pan, controls, and minimap are unchanged; background refetches never re-fit.
- **Legend overlay**: compact always-visible legend at top-right, derived from new shared style constants in `graph/style.ts` (`NODE_STYLES`, `EDGE_STYLES`). The node components and edge mapping now consume the same constants, and `legendEntries(graph)` filters to the styles the graph actually uses (e.g. no "mutating" entry when no mutating agent exists).
- **Node search**: input above the legend; case-insensitive substring on node label/id (`matchNodes`). Matches get an accent outline on canvas, the first match is centered at the operator's zoom, Enter cycles through matches, Escape clears then blurs. A counter shows `n / m` or "no matches". The existing global j/k/c/Escape bindings are unaffected (`keyGuard` skips inputs).

New pure helpers live in `graph/search.ts` and `graph/style.ts` with tests; `graph/layout.ts` and `graph/model.ts` are untouched.

## Verification

```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 221 pass
 0 fail
 585 expect() calls
Ran 221 tests across 22 files. [1190.00ms]
```