### PR TITLE
docs(event-runtime): dispatch coordination design — shared claim, capacity, owned paths, approval (WM-107)

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -1,0 +1,334 @@
+# Event runtime: dispatch coordination for repository-mutating runs
+
+Status: **design — operator-ratified, nothing built**. Tracking: WM-107 (this
+design); implementation lands through the work/merge/ship chains
+(WM-108..WM-112). Companion to [event-runtime.md](event-runtime.md) §3, which
+names the boundary this moves, and
+[event-runtime-workers.md](event-runtime-workers.md) §5a, which held tier-2
+worktrees until this document existed.
+
+The last row of event-runtime.md §2's table — repository-mutating events —
+was deliberately last: before an event run may claim a ticket or modify code,
+the runtime and the orchestrator's ticket dispatcher must share **one** claim
+mechanism, **one** capacity budget, **one** Owned Paths check, **one**
+workspace lifecycle, and **one** approval authority. Two independent mutation
+coordinators race even when their source trees are separate. This document
+records how each of those five is shared, with the alternatives that were
+rejected and why.
+
+---
+
+## 1. What this moves, said out loud
+
+§3's MVP rules forbid the runtime to "create worktrees, mutate repository
+source, or merge code". Building this moves that boundary — the third such
+move, after timers and Linear writes — so, like those, it is stated rather
+than absorbed:
+
+- An event run may **claim a ticket, build a worktree, mutate source, and
+  merge to `develop`** — but only through the coordination rules below, every
+  one of which is shared with the ticket dispatcher rather than duplicated
+  beside it.
+- The rest of §3 stands unchanged (§8 restates it item by item). In
+  particular: agents still never spawn agents, every mutation still flows
+  through intake → planner → watched proposal, and the ship chain's
+  deploy-branch merge is **permanently** a human approval (§7).
+
+The failure this prevents is the one §3 names: two mutation coordinators
+that each obey their own rules perfectly and still put two agents in one
+file, four agents in a three-slot cap, or an unattended merge on a deploy
+branch.
+
+---
+
+## 2. Claim: the Linear `assignee` stays the only ticket lock
+
+**Decision.** The Linear `assignee` field remains the single distributed lock
+for tickets, for both paths. The runtime's `BEGIN IMMEDIATE` claim
+(event-runtime.md §10) governs **runs** — which worker executes an approved
+RunSpec — and says nothing about tickets. An event run that finds its target
+ticket already assigned refuses with a typed NOOP (`ticket_assigned`); it
+never steals, and it never queues behind the holder.
+
+**Rejected: a ticket lock in the runtime database.** The runtime's ledger is
+authoritative for event facts only (§10); Linear is the authority for
+business work, and architecture.md §1 is explicit that two agents cannot
+disagree about ownership when there is one authority. A second lock is a
+second authority, and the interesting failure is precisely the moment they
+disagree.
+
+**The claim protocol is the dispatcher's, verbatim.** `tick.mjs` claims by
+writing the assignee and reading it back — Linear has no compare-and-swap, so
+the read-back *is* the concurrency control — and serializes the
+read-decide-claim window through a machine-local lock file
+(`~/.factory/locks/<repo>.dispatch.lock`), because every local supervisor
+authenticates as the same Linear user (OPS-40) and the read-back cannot tell
+them apart. The runtime's executor is exactly such a supervisor: it must take
+the **same lock file** for its read-refuse-claim window, then claim, then
+read back. A runtime-private lock would be correct against foreign agents and
+blind against the dispatcher — the one collision this design exists to
+prevent.
+
+Order follows architecture.md §2.4: **claim → worktree → spawn**. A
+`worktree_up` takes minutes; an unclaimed ticket is one another agent may
+take, and holding a claim for minutes is harmless against the reaper's
+45-minute threshold. A failed run must not keep its claim: the executor
+applies the dispatcher's un-claim rule — roll back to Todo with a comment
+only when the ticket still looks like our claim (In Progress, assigned to us,
+`ai:in-progress` present); a run that legitimately moved its ticket to
+Blocked or In Review keeps that state.
+
+**A recorded asymmetry, not a contradiction.** `tick.mjs` deliberately does
+*not* treat an assignee on a Todo ticket as a gate — with one shared Linear
+identity, "has an assignee" is indistinguishable from "was claimed and never
+cleared", and skipping such tickets forever is the reaper's failure to fix,
+not dispatch's to avoid. The event run's rule is stricter: assigned →
+refuse. That is the safe direction for an automated path with no operator in
+the loop at plan time — a false refusal costs one typed NOOP and the reaper
+clears the stale claim; a false steal puts two agents in one worktree. The
+asymmetry collapses when per-agent Linear identities land (OPS-40); until
+then it is stated here so nobody "fixes" either side to match the other. See
+§9.
+
+---
+
+## 3. Capacity: one budget, checked at plan and again at execute
+
+**Decision.** One per-repo in-flight cap, shared by both paths: the repo's
+`max_in_flight` in `config/repos.yaml`, falling back to
+`concurrency.max_in_flight_per_repo` in `config/policy.yaml`. The ledger that
+counts against it is the existing one — `lib/worker-leases.mjs`: files under
+`~/.factory/worker-leases/` that independent supervisors already share, live
+only while heartbeating and backed by a real pid. A tier-2 mutating run
+writes, renews, and releases a lease exactly as a dispatched ticket process
+does, so `tick.mjs`'s `cap - liveWorkerLeases(repo)` arithmetic counts event
+runs without learning anything new.
+
+**Rejected: a runtime-private cap.** Two caps that each hold individually sum
+to more than the machine's true limit — that is the §3 event-storm scenario
+verbatim: an event burst that starves ticket dispatch without violating a
+single rule.
+
+**Checked twice, deliberately.** At plan time, a proposal is refused
+(`capacity_full`) when the repo is at cap — proposing a run that cannot start
+wastes an approval, the same reason the planner refuses on a missing artifact
+before the operator decides rather than after. And re-checked at execute:
+an approval may sit for its whole TTL, and within the TTL it executes as-is
+(event-runtime.md §12) — the world the operator approved against has had
+minutes to fill the cap. The plan-time check keeps the inbox honest; the
+execute-time check is the one that holds.
+
+**The usage window: a static split, not dynamic observation.** Every
+claude-adapter run draws on the same subscription usage window as interactive
+sessions and dispatched tickets, and architecture.md §2.9 is blunt that
+nothing can observe that window. A coordinator "allocating" an unobservable
+resource is guessing with extra steps. So v1 keeps the existing static
+protections and calls them the answer for now: **at most one event worker**
+(§3's standing rule — a deployment choice since OPS-233, re-affirmed here)
+and **singleton scheduled loops** (event-runtime-schedules.md §5). One event
+worker means at most one event-side agent run at a time, which bounds the
+event path's window draw the same way `--max` bounds a tick's. Dynamic
+coordination of the window between the two paths remains the open problem §3
+says it is — for the unattended stage, not this design.
+
+---
+
+## 4. Owned Paths: one collision oracle, imported
+
+**Decision.** The planner reuses `orchestrator/owned-paths.mjs` as a library
+— `effectiveOwnedPaths`, `pathsCollide`, the same glob algebra, the same
+biases. Before proposing a mutating run for a ticket, the planner reads the
+in-flight set from Linear (In Progress tickets for the repo's team/project —
+the same query shape `tick.mjs` uses) plus its own leased mutating runs, and
+**refuses to propose** (`owned_paths_overlap`) on any collision, whichever
+path the in-flight ticket belongs to. Re-checked at execute alongside
+capacity, for the same TTL reason.
+
+Both of the module's safety biases carry over unchanged: a ticket with no
+parseable `Owned Paths` owns everything (dispatchable, but alone), and
+ambiguous glob overlap errs toward collision — a false positive serializes
+two tickets, a false negative puts two agents in one file.
+
+**Rejected: a second overlap implementation inside the runtime.** The
+existing parser has already bitten once — architecture.md §2.3's CLNT-616,
+where a correctly specced ticket parsed as empty and dispatch refused it —
+and the fix landed in one place. Two parsers drift, and drift here is not
+cosmetic: the moment the runtime's parser accepts a format the dispatcher's
+rejects (or vice versa), the two paths compute different in-flight scopes
+from the same tickets and the collision check silently stops meaning
+anything.
+
+**Importing is not modifying.** §3's rule that the runtime never changes
+orchestrator code stands (§8). `owned-paths.mjs` is deliberately
+dependency-free and side-effect-free; the runtime reads it the way it reads
+`config/repos.yaml` — as the single source of truth it must not fork.
+
+---
+
+## 5. Workspace: tier 2 delegates to the repo's own scripts
+
+**Decision.** The tier-2 mutating workspace provider shells out to the
+`worktree_up` / `worktree_down` each repo declares in `config/repos.yaml`,
+and the repo's declared `verify` command is the §9 repository verification —
+executed by the verifier as ordinary code, outside and after the implementing
+agent, never trusted from the agent's own report. This is §5a rule 1
+satisfied, not relaxed: **delegate, never reimplement**. Git isolates
+branches, not ports or databases (architecture.md §2.5); the ports,
+per-ticket databases, and seeded templates live in the repo-owned scripts,
+and a second worktree implementation inside the runtime would drift until it
+collided with a dev server.
+
+Consequences, all inherited from the dispatcher's rules rather than invented:
+
+- **`report_only` repos are never tier-2 targets.** A repo without the
+  scripts has a safe concurrency of one human; `tick.mjs` refuses to
+  dispatch there and the planner refuses to propose there
+  (`repo_report_only`), for the same reason.
+- **One run, one worktree.** The workspace is never shared with interactive
+  or ticket agents (§3, unchanged); `worktree_down` tears it down, with
+  retain-on-failure per policy like every other workspace type (§7).
+- **The runtime stays a reader of `config/repos.yaml`** (`lib/repos.mjs`
+  already reads the `worktree_*` and `verify` fields, unused until now). A
+  second repo registry is the same drift argument as §4, applied to ports.
+
+---
+
+## 6. Execution form: the `claude` adapter, `mutating: true`
+
+**Decision.** The ticket workflow runs as an **ordinary registered agent**
+through the runtime's existing `claude` adapter
+(`lib/adapters/claude.mjs`) with `mutating: true` capabilities, over the
+tier-2 workspace from §5. Same registry, same conformance bar, same
+lifecycle, same receipts as every other run — repository mutation is a
+capability and a workspace type, not a parallel execution path.
+
+**Rejected: a closed command template shelling to `runners/run-agent.sh`.**
+It looks like less work — the runner already spawns ticket-shaped sessions —
+and it is the wrong shape three ways:
+
+- **A second spawn path the runtime cannot trace.** The adapter streams
+  `factory.trace/v1` events (assistant text, tool use, usage) and captures
+  the transcript as a run artifact; a shelled runner collapses all of that
+  into an opaque exit code. No trace, no usage, no transcript artifact, no
+  verified result contract — the run would be *less* observable than a
+  read-only status report, on the one run class that mutates code.
+- **Duplicated machinery.** The adapter already owns the timeout discipline
+  (TERM, then KILL), subscription auth (strips `ANTHROPIC_API_KEY`,
+  architecture.md §2.9), strict MCP config, and tool confinement. The runner
+  owns its own copies for the interactive path. Shelling one from the other
+  stacks two timeout layers, two auth strips, and two MCP configs, and the
+  first disagreement between them is a debugging session with no owner.
+- **§5a's delegation rule does not apply.** Delegate-never-reimplement is
+  about **repo-owned isolation scripts** — ports and databases the runtime
+  cannot know. `run-agent.sh` is not repo-owned isolation; it is the
+  orchestrator's own harness spawn, and the runtime already has one of
+  those, tested, with a result contract. Delegation covers the worktree
+  scripts (§5), not the harness spawn.
+
+**Knowingly deferred, with triggers named** (§2's rule):
+
+- **Multi-harness dispatch.** codex, pi, and agy remain on `run-agent.sh` /
+  `tick.mjs --harness` until each has a conformant adapter — the registry
+  admits only adapters with a passing conformance test (§6), and none of the
+  three has one. The second-provider capacity they add is an orchestrator
+  feature until then.
+- **`--max-budget-usd` passthrough (WM-108).** `tick.mjs` passes the policy
+  budget to every ticket process; the adapter does not yet pass it at all. A
+  mutating run without the runaway guard is not acceptable, so the adapter
+  gains the flag **before** the first tier-2 run, not after.
+
+---
+
+## 7. Approval authority: earned for dispatch and develop, never for deploy
+
+**Decision.** Watched proposals gate every mutation — §12 is unchanged as the
+centerpiece. On top of that gate, `approval: auto` follows the earned-per-edge
+model the schedules and chains already use (event-runtime-schedules.md §6,
+event-runtime-workers.md §5), with one permanent exception:
+
+- **Dispatch of a `Todo` + `ai:agent-ready` + unassigned ticket may
+  eventually earn `auto`.** The queue itself is the reviewed artifact:
+  triage wrote the spec to the agent-ready template, and the operator's
+  curation of the queue — what got promoted, what got held — is the review.
+  A watched approval of such a proposal restates a decision already made,
+  and 24 restatements a day teach an operator to click approve without
+  reading (the schedules doc's argument, applied to dispatch). Earned means
+  earned: watched first, then flipped in a reviewable registry commit with
+  the run history as evidence, `actor` recording the truth.
+- **The develop-targeting merge chain may eventually earn `auto`.** This is
+  autonomy the orchestrator path already has — `policy.yaml`'s
+  `auto_merge_base: [develop]` with green CI — so the runtime earning it is
+  parity on a track record, not new ground. Escalation rules
+  (`escalate_paths`, the judgment list) apply identically; an escalated PR
+  is `human_needed`, never `auto`.
+- **The ship chain's deploy-branch merge is PERMANENTLY `watched`.** That
+  watched approval **is** the human master-merge decision — policy.yaml:
+  master/main always goes through a human, on every repo. It is not an
+  approval *about* the decision; it is the decision, relocated into the
+  runtime's inbox. Because §2's earned-automation ratchet only ever loosens,
+  this one must be enforced **structurally (WM-111), not by convention**:
+  registry validation fails closed on `approval: auto` for any agent whose
+  edge merges a deploy branch — a load error, exactly like `approval: auto`
+  on a disabled loop — so the config that would delete the human decision
+  cannot load, whoever writes it and however good the track record looks.
+
+The failure this prevents: earned-automation creep quietly consuming the one
+decision the whole factory routes through a human. Every other gate here may
+someday relax on evidence; this one may not, and the place that says so is a
+validator, not a paragraph.
+
+---
+
+## 8. The §3 boundary, restated item by item
+
+Moved by this design — permitted only through §§2–7 above:
+
+- create worktrees (§5, via the repo's own scripts);
+- mutate repository source (§6, the `claude` adapter with `mutating: true`);
+- merge code (§7 — `develop` on an earned record, deploy branches never
+  without the human approval that constitutes the decision).
+
+Standing, unchanged:
+
+- **agents never spawn agents** — a ticket run that discovers follow-up work
+  files a ticket or emits a typed recommendation; chains go through the
+  planner and a proposal, like everything since OPS-223;
+- **everything flows intake → planner → watched proposal** — there is no
+  express lane for mutations; `auto`, where earned, is a recorded approval
+  policy on that same path, not a bypass of it;
+- **never share mutable workspaces** with interactive or ticket agents;
+- **never modify** `shared/commands/`, `shared/skills/`, their generated
+  copies, `build/emit.mjs`, `orchestrator/run.mjs`, `orchestrator/tick.mjs`,
+  `config/schedule.yaml`, or the launchd state — importing
+  `orchestrator/owned-paths.mjs` as a library (§4) reads orchestrator code
+  and changes none of it;
+- **never feed a result into the existing dispatcher automatically** — the
+  runtime's mutating runs are its own, coordinated with the dispatcher
+  through the shared lock, ledger, and oracle above, not injected into it.
+
+---
+
+## 9. Open questions
+
+Recorded, not silently decided:
+
+- **Shared Linear identity (OPS-40) is the load-bearing weakness in §2.**
+  The assignee read-back cannot distinguish the two paths, so the
+  machine-local dispatch lock file is the real mutual exclusion — and it is
+  machine-local by construction. The moment a tier-2 mutating worker runs on
+  another node (event-runtime-workers.md stage 2), both the claim window and
+  the §3 capacity ledger (also `~/.factory` files) stop covering it.
+  **Precondition, stated now:** no remote mutating worker before either
+  per-agent Linear identities make the read-back honest, or the lock and
+  lease ledgers move to a shared substrate. Deterministic-command remote
+  workers (slice 2's remediation class) are unaffected — they touch no
+  tickets.
+- **The claim asymmetry in §2** — dispatch does not hard-skip assigned Todo
+  tickets, event runs refuse on any assignee — is deliberate today and
+  should collapse into one rule when OPS-40 lands. Whoever closes OPS-40
+  should revisit both sides together, not either alone.
+- **The usage window remains unobservable.** §3's static split (one event
+  worker, singleton loops) is a stopgap this design re-affirms, not an
+  answer. Raising event-side parallelism, or scheduling LLM loops beyond
+  singletons, waits on the unattended-stage answer §3 already demands — it
+  is not unlocked by anything here.

--- a/docs/event-runtime-workers.md
+++ b/docs/event-runtime-workers.md
@@ -170,20 +170,31 @@ registry. The operator's live checkout is never used: it holds uncommitted
 work an agent would read as truth, concurrent runs would race in it, and even
 a read-only run wants `git fetch`, which writes to `.git`.
 
-**Tier 2 — full worktree (held, deliberately).** Branch, install, ports,
-per-ticket database. Two rules when it is built:
+**Tier 2 — full worktree (designed, WM-107; unbuilt).** Branch, install,
+ports, per-ticket database. This tier was held while its blocker was
+unresolved; the coordination design now exists —
+[event-runtime-dispatch.md](event-runtime-dispatch.md) — and the two rules
+stand as the rules that design satisfies:
 
 1. **Delegate, never reimplement.** `config/repos.yaml` already declares
    `worktree_up`/`worktree_down`/`verify` per repo; the provider shells out to
-   them. Git isolates branches, not ports or databases — a second worktree
-   implementation inside the runtime would drift and eventually collide with a
-   dev server.
-2. **The blocker is coordination, not workspaces.** Per event-runtime.md §3,
-   before an event run may claim a ticket or mutate code, both paths must
-   share one claim, capacity, Owned Paths, and approval authority with the
-   ticket dispatcher. Two independent mutation coordinators race even with
-   separate source trees, and both draw on the same unobservable subscription
-   usage window. That is the work to do first — not a workspace provider.
+   them (dispatch design §5). Git isolates branches, not ports or databases —
+   a second worktree implementation inside the runtime would drift and
+   eventually collide with a dev server. Delegation covers the repo-owned
+   worktree scripts, **not** the harness spawn: the run itself goes through
+   the runtime's own `claude` adapter, never by shelling to `run-agent.sh`
+   (dispatch design §6).
+2. **Coordination first, workspaces second.** Per event-runtime.md §3, before
+   an event run may claim a ticket or mutate code, both paths must share one
+   claim, capacity, Owned Paths, and approval authority with the ticket
+   dispatcher. Two independent mutation coordinators race even with separate
+   source trees, and both draw on the same unobservable subscription usage
+   window. The dispatch design answers each: the Linear assignee stays the
+   only ticket lock, the dispatcher's cap and worker-lease ledger count both
+   paths, `orchestrator/owned-paths.mjs` is imported as the one collision
+   oracle, and watched proposals gate every mutation — with the deploy-branch
+   merge permanently human. Building the provider before those land would
+   recreate the race this rule exists to prevent.
 
 ## 6. Ticket cut-lines (when the operator says go)
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -63,7 +63,7 @@ machinery it earns. Anything no listed event type needs stays unbuilt.
 | `github.workflow-run.failed` | GitHub webhook / replay CLI | first discovered chain (OPS-223): typed `ci-doctor` diagnosis → recommendation edges → watched closed-command follow-ups (`gh run rerun`, notify); command adapter and edge registry | shipped |
 | `sentry.issue.created` | Sentry webhook | *(dropped as a slice — Sentry already feeds Linear directly, so classifying here validates nothing operationally new; revisit only if that intake moves)* | — |
 | `clock.tick.<loop>` | scheduler | admitted, audited timer events; per-loop migration of the standing loops — **[event-runtime-schedules.md](event-runtime-schedules.md)** (OPS-380/OPS-381) | shipped, loops off by default |
-| repository-mutating events | GitHub / Linear | shared claim, capacity, Owned Paths, and approval authority with the ticket dispatcher (§3) | last |
+| repository-mutating events | GitHub / Linear | shared claim, capacity, Owned Paths, and approval authority with the ticket dispatcher (§3, designed in [event-runtime-dispatch.md](event-runtime-dispatch.md)) | last |
 
 Clock events are called out deliberately. [architecture.md](architecture.md)
 §2.7 keeps every timer in `config/schedule.yaml` disabled until a loop earns its
@@ -116,17 +116,23 @@ The MVP must not:
 - change `build/emit.mjs` or participate in the emit pipeline;
 - change `orchestrator/run.mjs`, `orchestrator/tick.mjs`, or their schedules;
 - change `config/schedule.yaml` or the launchd state;
-- create worktrees, mutate repository source, or merge code;
 - share mutable workspaces with interactive or ticket agents; or
 - feed a result into the existing dispatcher automatically.
 
-Two boundaries have moved deliberately since this was written, and are stated
+Three boundaries have moved deliberately since this was written, and are stated
 rather than absorbed. **Timers:** the runtime has its own in-process scheduler
 ([event-runtime-schedules.md](event-runtime-schedules.md)); it touches neither
 launchd nor `config/schedule.yaml`, and every loop ships `enabled: false`.
 **Linear writes:** `triage-apply@1` and the scheduled `reaper@1` mutate ticket
 state through closed action registries, so the runtime now writes to the same
-control plane the dispatcher reads.
+control plane the dispatcher reads. **Repository mutation:** this list
+originally also forbade "create worktrees, mutate repository source, or merge
+code"; that rule is replaced — by design, not yet by code — with the
+coordination rules in
+[event-runtime-dispatch.md](event-runtime-dispatch.md): one ticket claim
+(the Linear assignee), one capacity budget, one Owned Paths oracle, and one
+approval authority shared with the ticket dispatcher, with the ship chain's
+deploy-branch merge permanently a human approval.
 
 Starting the API, planner, or worker is always explicit. Stopping all three has
 no effect on skill invocation, emit checks, queue scans, or ticket dispatch.
@@ -135,6 +141,10 @@ This isolation is safe while event runs are read-only. Before an event run may
 claim a ticket or modify code, both paths must share one distributed claim,
 capacity, Owned Paths, workspace, and approval authority. Two independent
 mutation coordinators would race even if their source trees were separate.
+That sharing is now designed —
+[event-runtime-dispatch.md](event-runtime-dispatch.md) (WM-107) records each
+decision with its rejected alternatives — and unbuilt until the WM-108..WM-112
+chains land it.
 
 **Capacity is shared even when state is not.** The moment both paths run, their
 agent processes draw on the same machine and the same subscription usage
@@ -394,7 +404,7 @@ Every run has an execution directory. It does not necessarily have source code.
 | :--- | :--- | :---: |
 | `ephemeral` | Empty directory populated only with declared inputs | yes |
 | `artifacts` | Declared prior artifacts materialized by content hash, read-only (OPS-372) | yes |
-| `repository` | Read-only checkout pinned to a SHA, from a per-repo bare mirror (tier 1, OPS-228); full worktrees for repo-mutating work are tier 2 and held | tier 1 |
+| `repository` | Read-only checkout pinned to a SHA, from a per-repo bare mirror (tier 1, OPS-228); full worktrees for repo-mutating work are tier 2 — designed ([event-runtime-dispatch.md](event-runtime-dispatch.md)), unbuilt | tier 1 |
 | `mounted` | Explicit existing directory, normally read-only | later |
 | `container` | Isolated filesystem/volume in Docker or Kubernetes | later |
 | `persistent` | Named, versioned workspace protected by a single-writer lease | later |


### PR DESCRIPTION
Fixes WM-107

Design doc moving the event runtime's §3 repository-mutation boundary deliberately: new `docs/event-runtime-dispatch.md` (claim = Linear assignee as the single ticket lock; shared per-repo capacity checked at plan and execute; `orchestrator/owned-paths.mjs` reused as a library; tier-2 workspace delegating to per-repo worktree scripts; execution via the runtime's claude adapter with `mutating: true` — run-agent.sh command template rejected as a second untraceable spawn path; approval: watched everywhere, deploy-branch merge permanently human). Updates `docs/event-runtime.md` §3 (three moved boundaries) and `docs/event-runtime-workers.md` §5a (tier 2: designed, unbuilt).

Docs only — no behavior change. Verification: `bun test` 968 pass (1 pre-existing environment-dependent port test, fails identically on develop), `bun build/emit.mjs --check` exit 0.