### PR TITLE
fix(web): workers page state tabs — live first, stopped de-emphasized (WM-98)

### DIFF
--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -1,0 +1,120 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Workers, defaultWorkerTab, isLive, partitionWorkers } from "./Workers";
+import { api } from "../api";
+import type { Worker, WorkerState } from "../types";
+
+afterEach(() => {
+  cleanup();
+});
+
+const NOW = new Date().toISOString();
+
+function stubWorker(workerId: string, state: WorkerState, stale = false): Worker {
+  return {
+    workerId,
+    host: "lab-1",
+    pid: 4242,
+    labels: {},
+    adapters: ["claude-code"],
+    state,
+    currentRun: null,
+    lastSeen: NOW,
+    stale,
+    startedAt: NOW,
+    stoppedAt: state === "stopped" ? NOW : null,
+  };
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const noop = () => {};
+
+function renderWorkers() {
+  return renderWithClient(
+    <Workers context={{ kind: "all" }} focusWorkerId={null} onSelectWorker={noop} />,
+  );
+}
+
+function withWorkers(workers: Worker[], fn: () => Promise<void>) {
+  const orig = api.workers;
+  api.workers = async () => ({ workers });
+  return fn().finally(() => {
+    api.workers = orig;
+  });
+}
+
+describe("worker live/stopped partition (WM-98)", () => {
+  test("idle and busy workers are live; cleanly stopped ones are not", () => {
+    expect(isLive(stubWorker("w_idle", "idle"))).toBe(true);
+    expect(isLive(stubWorker("w_busy", "busy"))).toBe(true);
+    expect(isLive(stubWorker("w_stopped", "stopped"))).toBe(false);
+  });
+
+  test("a stale worker is live — it may still hold a run, whatever it last reported", () => {
+    expect(isLive(stubWorker("w_stale", "busy", true))).toBe(true);
+  });
+
+  test("partitionWorkers splits the registry and preserves order within each group", () => {
+    const rows = [
+      stubWorker("w_stopped_1", "stopped"),
+      stubWorker("w_idle", "idle"),
+      stubWorker("w_stopped_2", "stopped"),
+      stubWorker("w_stale", "idle", true),
+    ];
+    const { live, stopped } = partitionWorkers(rows);
+    expect(live.map((w) => w.workerId)).toEqual(["w_idle", "w_stale"]);
+    expect(stopped.map((w) => w.workerId)).toEqual(["w_stopped_1", "w_stopped_2"]);
+  });
+});
+
+describe("default worker tab (WM-98)", () => {
+  test("opens on Live when at least one worker is live", () => {
+    expect(defaultWorkerTab([stubWorker("w_stopped", "stopped"), stubWorker("w_idle", "idle")])).toBe(
+      "LIVE",
+    );
+  });
+
+  test("opens on All when every worker is stopped, and when the registry is empty", () => {
+    expect(defaultWorkerTab([stubWorker("w_stopped", "stopped")])).toBe("ALL");
+    expect(defaultWorkerTab([])).toBe("ALL");
+  });
+});
+
+describe("Workers view default visibility (WM-98)", () => {
+  test("stopped workers are hidden by default when a live worker exists", async () => {
+    const workers = [
+      stubWorker("w_stopped_old", "stopped"),
+      stubWorker("w_idle_live", "idle"),
+      stubWorker("w_stopped_new", "stopped"),
+    ];
+    await withWorkers(workers, async () => {
+      const { getByText, queryByText, getByRole } = renderWorkers();
+      await waitFor(() => {
+        expect(getByText("w_idle_live")).toBeTruthy();
+      });
+      expect(queryByText("w_stopped_old")).toBeNull();
+      expect(queryByText("w_stopped_new")).toBeNull();
+      expect(getByRole("tab", { selected: true }).textContent).toContain("Live");
+    });
+  });
+
+  test("an all-stopped registry opens on All so the page is not blank", async () => {
+    const workers = [stubWorker("w_stopped_1", "stopped"), stubWorker("w_stopped_2", "stopped")];
+    await withWorkers(workers, async () => {
+      const { getByText, getByRole } = renderWorkers();
+      await waitFor(() => {
+        expect(getByText("w_stopped_1")).toBeTruthy();
+      });
+      expect(getByText("w_stopped_2")).toBeTruthy();
+      expect(getByRole("tab", { selected: true }).textContent).toContain("All");
+    });
+  });
+});

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { useDisplayOptions, useListKeys, useNow } from "../hooks";
+import { useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
 import {
   buildSections,
   cycleColumnSort,
@@ -56,6 +56,32 @@ const WORKER_HUES: Record<string, string> = {
  * these four are disjoint.
  */
 const health = (w: Worker) => (w.stale ? "stale" : w.state);
+
+export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
+export type WorkerTab = (typeof WORKER_TABS)[number];
+
+/**
+ * Live = anything that could still be holding or claiming work: idle, busy, or
+ * stale. Stale belongs here, not with stopped — a stale worker is a problem to
+ * look at, while a cleanly stopped one is history.
+ */
+export const isLive = (w: Worker) => health(w) !== "stopped";
+
+/** Split the registry into live and stopped, preserving order within each group. */
+export function partitionWorkers(rows: Worker[]): { live: Worker[]; stopped: Worker[] } {
+  const live: Worker[] = [];
+  const stopped: Worker[] = [];
+  for (const w of rows) (isLive(w) ? live : stopped).push(w);
+  return { live, stopped };
+}
+
+/**
+ * The list opens on the workers that matter: live ones when any exist. A fleet
+ * that is all history (or empty) opens on All, so the page never looks blank
+ * while stopped workers hide behind a tab.
+ */
+export const defaultWorkerTab = (rows: Worker[]): WorkerTab =>
+  rows.some(isLive) ? "LIVE" : "ALL";
 
 /** Grouping/ordering/columns for the fleet table (OPS-493). */
 const WORKERS_DISPLAY: DisplayConfig<Worker> = {
@@ -201,16 +227,33 @@ export function Workers({
     [rows],
   );
 
+  const parts = useMemo(() => partitionWorkers(rows), [rows]);
+
+  // `null` = no explicit choice yet: follow the data (live when any worker is
+  // live). The first click pins the tab and the default stops moving under it.
+  const [tabChoice, setTabChoice] = useState<WorkerTab | null>(null);
+  const tab = tabChoice ?? defaultWorkerTab(rows);
+  useTabKeys(WORKER_TABS, tab, setTabChoice);
+
+  // Live before stopped regardless of recency; within a group the registry's
+  // own order stands. Display Options grouping/sorting (OPS-493) applies on
+  // top of whatever the active tab lets through.
+  const byTab = useMemo(
+    () =>
+      tab === "ALL" ? [...parts.live, ...parts.stopped] : tab === "LIVE" ? parts.live : parts.stopped,
+    [tab, parts],
+  );
+
   const [filter, setFilter] = useState("");
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((w) =>
+    if (!q) return byTab;
+    return byTab.filter((w) =>
       [w.workerId, w.host, String(w.pid), health(w), labelText(w.labels), w.adapters.join(","), w.currentRun].some(
         (v) => (v ?? "").toLowerCase().includes(q),
       ),
     );
-  }, [rows, filter]);
+  }, [byTab, filter]);
 
   // Display options (OPS-493): partition into sections, order inside them,
   // and feed keyboard navigation only the rows of open sections.
@@ -246,6 +289,17 @@ export function Workers({
   useEffect(() => {
     if (focusWorkerId) setFilter("");
   }, [focusWorkerId]);
+
+  // Deep link / jump: reveal a focused worker the active tab hides, once per
+  // focus id, so the jump lands without overriding a tab the operator picks later.
+  const jumpedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!focusWorkerId || jumpedFor.current === focusWorkerId) return;
+    const w = rows.find((r) => r.workerId === focusWorkerId);
+    if (!w) return;
+    jumpedFor.current = focusWorkerId;
+    if (tab !== "ALL" && (tab === "LIVE") !== isLive(w)) setTabChoice("ALL");
+  }, [focusWorkerId, rows, tab]);
 
   useListKeys({
     count: flat.length,
@@ -285,6 +339,28 @@ export function Workers({
             <h1 className="display mb-4 text-lg font-semibold">Workers</h1>
             <ScopeCaption context={context} surface="fleet" />
             <div className="mb-3 flex flex-wrap items-center gap-2">
+              <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto" role="tablist" aria-label="Worker state">
+                {WORKER_TABS.map((t) => {
+                  const count =
+                    t === "ALL" ? rows.length : t === "LIVE" ? parts.live.length : parts.stopped.length;
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      role="tab"
+                      aria-selected={tab === t}
+                      onClick={() => setTabChoice(t)}
+                      title={t === "LIVE" ? "idle, busy, or stale" : t === "STOPPED" ? "cleanly stopped — history" : undefined}
+                      className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                        tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                      }`}
+                    >
+                      {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"}
+                      {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
+                    </button>
+                  );
+                })}
+              </div>
               <span className="ml-auto">
                 <DisplayOptions config={WORKERS_DISPLAY} state={display} onChange={setDisplay} />
               </span>
@@ -344,8 +420,8 @@ export function Workers({
                   onClick={() => onSelectWorker(w.workerId)}
                   aria-selected={w.workerId === selectedId}
                   className={`cursor-pointer hover:bg-(--surface-1) ${w.stale ? "row-wash-err" : ""} ${
-                    w.workerId === selectedId ? "row-selected" : ""
-                  }`}
+                    !isLive(w) ? "opacity-55" : ""
+                  } ${w.workerId === selectedId ? "row-selected" : ""}`}
                 >
                   <td
                     className={`mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 ${


### PR DESCRIPTION
Fixes WM-98

## Summary

The Workers page listed every worker ever seen with equal weight — stopped workers dominated the list. This adds state tabs consistent with the other list pages and puts live workers first.

- **All / Live / Stopped tabs with counts**, styled like the Runs page tab strip, with `[`/`]` cycling via `useTabKeys`. Live = idle, busy, or stale (a stale worker may still hold a run; a cleanly stopped one is history).
- **Default view is Live** when at least one live worker exists; an all-stopped (or empty) registry opens on All so the page is never blank.
- **Live workers sort before stopped** on the All tab regardless of recency; order within each group preserves the registry's own order.
- **Stopped rows are dimmed** (`opacity-55`) when shown.
- The free-text filter applies to whichever tab is visible.
- Deep links / jumps to a worker hidden by the active tab reveal it by switching to All once per focus id, without overriding a tab the operator picks later.
- Partition logic is a pure exported helper (`isLive`, `partitionWorkers`, `defaultWorkerTab`) covered by the new `Workers.test.tsx`, plus render tests for default visibility in both regimes.

Only `event-runtime/web/src/views/Workers.tsx` and the new `Workers.test.tsx` are touched; `components/ui.tsx` is reused as-is.

## Verification

```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 220 pass
 0 fail
 623 expect() calls
Ran 220 tests across 23 files. [1.51s]
```