### PR TITLE
fix(web): disambiguate schedule enabled vs runtime state wording (WM-101)

### DIFF
--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -1,0 +1,168 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Schedules, scheduleFilterTokens, type ScheduleItem } from "./Schedules";
+import { api } from "../api";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const noop = () => {};
+
+function schedule(overrides: Partial<ScheduleItem> & Pick<ScheduleItem, "loop">): ScheduleItem {
+  return {
+    every: "5m",
+    cadenceSeconds: 300,
+    eventType: "tick.test",
+    approval: "watched",
+    catchUp: "none",
+    singleton: false,
+    enabled: true,
+    lastSlot: null,
+    lastCompletedSlot: null,
+    neverCompleted: true,
+    nextDue: null,
+    intervalsLate: null,
+    stopped: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+/** The four enabled × stopped combinations (WM-101). */
+const rows: ScheduleItem[] = [
+  schedule({ loop: "loop-enabled-running", enabled: true, stopped: false }),
+  schedule({ loop: "loop-enabled-stopped", enabled: true, stopped: true, intervalsLate: 3 }),
+  schedule({ loop: "loop-disabled-idle", enabled: false, stopped: false }),
+  schedule({ loop: "loop-disabled-stopped", enabled: false, stopped: true, intervalsLate: 7 }),
+];
+
+const origFetch = globalThis.fetch;
+const origAgents = api.agents;
+const origEvents = api.events;
+
+beforeEach(() => {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.startsWith("/api/schedules")) {
+      return new Response(JSON.stringify({ schedules: rows }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return origFetch(input, init);
+  }) as typeof fetch;
+  api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
+  api.events = async () => ({ events: [] });
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  api.agents = origAgents;
+  api.events = origEvents;
+});
+
+function renderSchedules() {
+  return renderWithClient(
+    <Schedules
+      context={{ kind: "all" }}
+      focusScheduleLoop={null}
+      onSelectSchedule={noop}
+      onJumpProposal={noop}
+      onJumpRun={noop}
+      onJumpEvent={noop}
+      onJumpAgent={noop}
+    />,
+  );
+}
+
+describe("Schedules enabled/state wording (WM-101)", () => {
+  test("enabled + not stopped renders 'enabled' and 'running' with semantic tooltips", async () => {
+    const { getByText, getAllByText, queryByText } = renderSchedules();
+
+    await waitFor(() => getByText("loop-enabled-running"));
+
+    const enabledCells = getAllByText("enabled");
+    expect(enabledCells.length).toBe(2); // the two enabled rows
+    expect(enabledCells[0]!.title).toContain("enabled: true in event-runtime/schedules.json");
+
+    const running = getByText("running");
+    expect(running.title).toContain("scheduler loop is ticking");
+
+    // The ambiguous old wording is gone entirely.
+    expect(queryByText("off")).toBeNull();
+    expect(queryByText("ok")).toBeNull();
+  });
+
+  test("enabled + stopped renders 'stopped (N late)' with the stalled-clock tooltip", async () => {
+    const { getByText } = renderSchedules();
+
+    await waitFor(() => getByText("loop-enabled-stopped"));
+
+    const stopped = getByText("stopped (3 late)");
+    expect(stopped.title).toContain("enabled: true but the scheduler loop is not ticking");
+    expect(stopped.title).toContain("3 intervals");
+  });
+
+  test("disabled + not stopped renders 'disabled' and 'not scheduled' pointing at schedules.json", async () => {
+    const { getByText, getAllByText } = renderSchedules();
+
+    await waitFor(() => getByText("loop-disabled-idle"));
+
+    const disabledCells = getAllByText("disabled");
+    expect(disabledCells.length).toBe(2); // the two disabled rows
+    expect(disabledCells[0]!.title).toContain("enabled: false in event-runtime/schedules.json");
+
+    const notScheduled = getAllByText("not scheduled");
+    expect(notScheduled[0]!.title).toContain("enabled: false in event-runtime/schedules.json");
+  });
+
+  test("disabled + stopped still renders 'not scheduled' (a disabled loop cannot be a stalled clock)", async () => {
+    const { getByText, getAllByText, queryByText } = renderSchedules();
+
+    await waitFor(() => getByText("loop-disabled-stopped"));
+
+    // Both disabled rows collapse to "not scheduled"; the stopped flag on a
+    // disabled row never surfaces as a stalled-clock alarm.
+    expect(getAllByText("not scheduled").length).toBe(2);
+    expect(queryByText("stopped (7 late)")).toBeNull();
+  });
+
+  test("column headers and footer say where enable/disable lives", async () => {
+    const { getByText } = renderSchedules();
+
+    await waitFor(() => getByText("loop-enabled-running"));
+
+    expect(getByText("Enabled").title).toContain("event-runtime/schedules.json");
+    expect(getByText("State").title).toContain("Runtime health");
+    expect(getByText(/there is no.*toggle here/s)).toBeTruthy();
+  });
+
+  test("filter tokens match the visible enabled/state words for all four combinations", () => {
+    // enabled + running
+    expect(scheduleFilterTokens(rows[0]!)).toContain("enabled");
+    expect(scheduleFilterTokens(rows[0]!)).toContain("running");
+    // enabled + stopped
+    expect(scheduleFilterTokens(rows[1]!)).toContain("enabled");
+    expect(scheduleFilterTokens(rows[1]!)).toContain("stopped");
+    // disabled rows expose "disabled" and "not scheduled", never the old "off"/"ok"
+    for (const s of [rows[2]!, rows[3]!]) {
+      const tokens = scheduleFilterTokens(s);
+      expect(tokens).toContain("disabled");
+      expect(tokens).toContain("not scheduled");
+      expect(tokens).not.toContain("off");
+      expect(tokens).not.toContain("ok");
+    }
+    // error wins the state token
+    expect(scheduleFilterTokens(schedule({ loop: "l", error: "bad cadence" }))).toContain("error");
+  });
+});

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -55,6 +55,23 @@ export interface TriggerOutcome {
   loop: string;
 }
 
+/**
+ * Free-text filter tokens for a schedule row (WM-101). The enabled/state
+ * tokens must match the words rendered in the Enabled and State cells so
+ * filtering by what the operator sees works.
+ */
+export function scheduleFilterTokens(s: ScheduleItem): string[] {
+  return [
+    s.loop,
+    s.every,
+    s.eventType,
+    s.approval,
+    s.catchUp,
+    s.enabled ? "enabled" : "disabled",
+    s.error ? "error" : !s.enabled ? "not scheduled" : s.stopped ? "stopped" : "running",
+  ];
+}
+
 async function fetchSchedules(): Promise<{ schedules: ScheduleItem[] }> {
   const res = await fetch("/api/schedules");
   if (!res.ok) {
@@ -129,9 +146,7 @@ export function Schedules({
     const q = filter.trim().toLowerCase();
     if (!q) return rows;
     return rows.filter((s) =>
-      [s.loop, s.every, s.eventType, s.approval, s.catchUp, s.enabled ? "enabled" : "off", s.stopped ? "stopped" : "ok"].some(
-        (v) => (v ?? "").toLowerCase().includes(q),
-      ),
+      scheduleFilterTokens(s).some((v) => (v ?? "").toLowerCase().includes(q)),
     );
   }, [rows, filter]);
 
@@ -235,12 +250,22 @@ export function Schedules({
             <tr className="text-left text-[11px] text-(--text-faint)">
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Loop</th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Cadence</th>
-              <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Enabled</th>
+              <th
+                className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium"
+                title="Config flag from event-runtime/schedules.json — edit that file (or use the CLI) to enable/disable; there is no toggle in this UI"
+              >
+                Enabled
+              </th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Approval</th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Catch-up</th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Last fire</th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">Next due</th>
-              <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium">State</th>
+              <th
+                className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 font-medium"
+                title="Runtime health of the scheduler loop: running, stopped (no ticks), not scheduled (disabled), or error"
+              >
+                State
+              </th>
               <th className="sticky top-0 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1.5 text-right font-medium">Action</th>
             </tr>
           </thead>
@@ -264,9 +289,19 @@ export function Schedules({
                   </td>
                   <td className="border-b border-(--border) px-3 py-2">
                     {s.enabled ? (
-                      <span className="mono text-[11px] text-(--hue-ok)">enabled</span>
+                      <span
+                        className="mono text-[11px] text-(--hue-ok)"
+                        title="enabled: true in event-runtime/schedules.json — the scheduler will fire this loop on cadence"
+                      >
+                        enabled
+                      </span>
                     ) : (
-                      <span className="mono text-[11px] text-(--text-faint)">off</span>
+                      <span
+                        className="mono text-[11px] text-(--text-faint)"
+                        title="enabled: false in event-runtime/schedules.json — edit that file (or use the CLI) to re-enable"
+                      >
+                        disabled
+                      </span>
                     )}
                   </td>
                   <td className="border-b border-(--border) px-3 py-2">
@@ -317,27 +352,29 @@ export function Schedules({
                       >
                         error
                       </span>
-                    ) : s.stopped ? (
-                      <span
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
-                        style={{ background: "color-mix(in oklch, var(--hue-err) 14%, transparent)" }}
-                        title={`No ticks for ${s.intervalsLate} intervals`}
-                      >
-                        STOPPED ({s.intervalsLate} late)
-                      </span>
                     ) : !s.enabled ? (
                       <span
                         className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--text-faint)"
                         style={{ background: "var(--surface-2)" }}
+                        title="Not scheduled: enabled: false in event-runtime/schedules.json, so the scheduler loop is not running for this schedule"
                       >
-                        off
+                        not scheduled
+                      </span>
+                    ) : s.stopped ? (
+                      <span
+                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
+                        style={{ background: "color-mix(in oklch, var(--hue-err) 14%, transparent)" }}
+                        title={`Stopped: enabled: true but the scheduler loop is not ticking — no ticks for ${s.intervalsLate} intervals. Check the event runtime serve process.`}
+                      >
+                        stopped ({s.intervalsLate} late)
                       </span>
                     ) : (
                       <span
                         className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-ok)"
                         style={{ background: "color-mix(in oklch, var(--hue-ok) 14%, transparent)" }}
+                        title="Running: enabled: true and the scheduler loop is ticking on cadence"
                       >
-                        ok
+                        running
                       </span>
                     )}
                   </td>
@@ -362,6 +399,11 @@ export function Schedules({
             )}
           </tbody>
         </table>
+        <div className="px-3 py-2 text-[11px] text-(--text-faint)">
+          Enable or disable schedules in{" "}
+          <code className="mono">event-runtime/schedules.json</code> (or via the CLI) — there is no
+          toggle here.
+        </div>
       </ListPane>
 
       {sel && (
@@ -479,7 +521,9 @@ export function Schedules({
                   sel.enabled ? (
                     <span className="text-(--hue-ok)">true</span>
                   ) : (
-                    <span className="text-(--text-faint)">false (disabled)</span>
+                    <span className="text-(--text-faint)">
+                      false (disabled — re-enable in event-runtime/schedules.json or via the CLI)
+                    </span>
                   )
                 }
               />
@@ -662,8 +706,9 @@ export function Schedules({
                 })()}
                 {!confirmLoop.enabled && (
                   <div className="mt-2 rounded bg-(--surface-3) p-2 text-[12px] text-(--hue-warn)">
-                    Note: This schedule is marked <code className="mono">enabled: false</code> in
-                    registry. Triggering ad-hoc will evaluate the loop once.
+                    Note: This schedule is disabled (<code className="mono">enabled: false</code> in{" "}
+                    <code className="mono">event-runtime/schedules.json</code>), so it is not
+                    scheduled to run on its own. Triggering ad-hoc will evaluate the loop once.
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Fixes WM-101

## Summary

The Schedules view rendered an **Enabled** column (config `enabled` flag) and a **State** column (runtime `stopped` flag) that both displayed the word `off` for a disabled schedule — two different dimensions, indistinguishable wording, and no hint where enabling actually lives.

- **Enabled cell** now renders `enabled` / `disabled`, each with a `title` tooltip spelling out the config semantics (`enabled: true|false in event-runtime/schedules.json`) and pointing at the file/CLI for changes.
- **State cell** now renders `running` / `stopped (N late)` / `not scheduled` (disabled rows) / `error`, each with a semantic tooltip. Disabled rows always show `not scheduled` — the `stopped` flag never surfaces as a stalled-clock alarm on a loop that is not supposed to tick.
- **Column-header tooltips** on Enabled/State plus a **footer note** under the table say that enable/disable lives in `event-runtime/schedules.json` / the CLI (no toggle built, per ticket).
- **Trigger dialog** disabled-schedule note and the detail-pane `enabled` KV updated to the same wording.
- **Filter tokens** extracted into an exported pure `scheduleFilterTokens()` and kept in sync with the visible words (`enabled`/`disabled`/`running`/`stopped`/`not scheduled`/`error`).
- New `Schedules.test.tsx` covers the four enabled×stopped rendering combinations, tooltip semantics, the header/footer hints, absence of the old `off`/`ok` wording, and the filter tokens.

Note: a DOM-level typing test for the filter was attempted but React's `onChange` does not fire from dispatched events under bun + happy-dom in this repo (verified with a minimal controlled input), hence the exported pure token function instead.

## Verification

```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 214 pass
 0 fail
 595 expect() calls
Ran 214 tests across 21 files. [1329.00ms]
```