### PR TITLE
fix(web): keep detail-panel Close reachable — wrap/collapse toolbar actions (WM-97)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
-import { act, cleanup, render } from "@testing-library/react";
-import { Countdown, notify, ToastContainer } from "./ui";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { Button, Countdown, DetailPane, notify, ToastContainer } from "./ui";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
   const parent = r.getByRole("status").parentElement;
@@ -121,5 +121,68 @@ describe("Countdown", () => {
     if (!el) throw new Error("Countdown span is missing");
     expect(el.textContent).toBe("expired 2h ago");
     expect(el.getAttribute("title")).toBe(new Date(new Date(createdAt).getTime() + ttlSeconds * 1000).toISOString());
+  });
+});
+
+describe("DetailPane", () => {
+  // WM-97: with six actions in the Runs toolbar the old single-row header
+  // grew past the panel edge and clipped Close off entirely. Close now rides
+  // a dedicated non-wrapping slot next to the title; the other actions live
+  // in a row that is allowed to wrap. jsdom does no layout, so these assert
+  // the structure that produces that behavior, plus that Close stays wired.
+
+  function renderPane(onClose: () => void) {
+    return render(
+      <DetailPane
+        widthClass="w-[460px]"
+        title={<span>run_0000</span>}
+        actions={
+          <>
+            <Button onClick={() => {}}>Open in tab</Button>
+            <Button onClick={() => {}}>Expand</Button>
+            <Button onClick={() => {}}>Copy id</Button>
+            <Button onClick={() => {}}>Copy CLI</Button>
+            <Button onClick={() => {}}>Copy link</Button>
+          </>
+        }
+        close={<Button onClick={onClose}>Close</Button>}
+      >
+        <div>body</div>
+      </DetailPane>,
+    );
+  }
+
+  test("renders Close and fires its handler even with many actions present", () => {
+    const onClose = jest.fn();
+    const r = renderPane(onClose);
+    const close = r.getByText("Close");
+    fireEvent.click(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("pins Close outside the wrapping action row, in a non-shrinking slot", () => {
+    const r = renderPane(() => {});
+    const close = r.getByText("Close");
+    const actionRow = r.getByText("Copy link").parentElement;
+    if (!actionRow) throw new Error("action row is missing");
+    // Close must not be a sibling inside the wrapping row, or wrapping order
+    // could push it below the fold with everything else.
+    expect(actionRow.contains(close)).toBe(false);
+    expect(classes(actionRow)).toContain("flex-wrap");
+    // shrink-0 on the row is what defeated flex-wrap originally: the row then
+    // keeps its max-content width and overflows instead of wrapping.
+    expect(classes(actionRow)).not.toContain("shrink-0");
+    const closeSlot = close.parentElement;
+    if (!closeSlot) throw new Error("close slot is missing");
+    expect(classes(closeSlot)).toContain("shrink-0");
+  });
+
+  test("omits the close slot when no close action is given", () => {
+    const r = render(
+      <DetailPane widthClass="w-[440px]" title="t" actions={<Button onClick={() => {}}>Copy id</Button>}>
+        <div>body</div>
+      </DetailPane>,
+    );
+    expect(r.queryByText("Close")).toBeNull();
   });
 });

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -235,18 +235,29 @@ export function DetailPane({
   widthClass,
   title,
   actions,
+  close,
   children,
 }: {
   widthClass: string;
   title: ReactNode;
   actions: ReactNode;
+  /** Escape hatch pinned at the top-right, outside the wrapping action row,
+   *  so it stays visible and clickable no matter how many actions the view
+   *  stacks up or how narrow the panel gets (WM-97). */
+  close?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <aside className={`${widthClass} flex min-h-0 shrink-0 flex-col border-l border-(--border) bg-(--surface-1)`}>
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-(--border) px-4 py-3">
-        <div className="display min-w-0 truncate text-[14px] font-semibold">{title}</div>
-        <div className="flex shrink-0 flex-wrap justify-end gap-1.5">{actions}</div>
+      <div className="shrink-0 border-b border-(--border) px-4 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">{title}</div>
+          {close != null && <div className="shrink-0">{close}</div>}
+        </div>
+        {/* Own row under the title, and no shrink-0: the actions must be free
+            to wrap when the panel is narrower than the button row, instead of
+            crushing the title or clipping past the panel edge (WM-97). */}
+        <div className="mt-2 flex flex-wrap justify-end gap-1.5">{actions}</div>
       </div>
       <div className="min-h-0 flex-1 overflow-auto p-4">{children}</div>
     </aside>

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -533,9 +533,9 @@ export function Events({
             <>
               <Button onClick={() => copyText(sel.eventId, "event id")}>Copy id</Button>
               <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectEvent(null)}>Close</Button>
             </>
           }
+          close={<Button onClick={() => onSelectEvent(null)}>Close</Button>}
         >
 
           <Section title="Event">

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -514,9 +514,9 @@ export function Proposals({
             <>
               <Button onClick={() => copyText(sel.id, "proposal id")}>Copy id</Button>
               <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectProposal(null)}>Close</Button>
             </>
           }
+          close={<Button onClick={() => onSelectProposal(null)}>Close</Button>}
         >
 
           <Section title="Proposal">

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -746,9 +746,9 @@ export function Runs({
                 Copy CLI
               </Button>
               <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectRun(null)}>Close</Button>
             </>
           }
+          close={<Button onClick={() => onSelectRun(null)}>Close</Button>}
         >
 
           {!d && (


### PR DESCRIPTION
Fixes WM-97

## Summary

The detail-panel header put all actions (Runs: Open in tab · Expand · Copy id · Copy CLI · Copy link · Close) in one row whose container was `shrink-0` — which defeats its own `flex-wrap`, so the row kept max-content width and clipped Close past the panel edge at ~1280px viewports.

`DetailPane` (event-runtime/web/src/components/ui.tsx) now renders:

- Row 1: title (`min-w-0 flex-1 truncate`) + a new pinned `close` slot (`shrink-0`, top-right) — Close stays visible and clickable at any panel width.
- Row 2: the remaining actions, right-aligned, free to wrap (`flex-wrap`, no `shrink-0`).

Runs, Events, and Proposals pass Close via the new slot. **All three views shared the pattern** via the same `DetailPane` primitive, so one fix covers them (ticket asked to state what was found). Five other views (Workers, Schedules, Agents, Projects, Graph) also use `DetailPane` and still pass Close inside `actions`; they compile unchanged (`close` is optional) and strictly improve — their actions now wrap instead of clipping.

**Wheel scroll over metadata:** verified in the live seeded app that the panel body is the single `overflow-auto` container covering the entire panel content (metadata KV rows included), there are no wheel handlers anywhere in `src`, the scroll-ancestor chain at three probe points over the metadata is clean, and the container scrolls. The two-row header removes the horizontally-overflowed toolbar state that accompanied the report.

Verified live at 1280x800 and at a forced 360px panel width: Close fully on-screen and hit-testable (elementFromPoint returns the button), actions wrap to two rows, title truncates.

## Verification

```
$ cd event-runtime/web && bunx tsc --noEmit && bun test src
bun test v1.3.14 (0d9b296a)

 213 pass
 0 fail
 577 expect() calls
Ran 213 tests across 21 files. [1325.00ms]
```

New colocated tests in `ui.test.tsx`: Close renders and fires with many actions present; Close is pinned outside the wrapping action row in a non-shrinking slot (and the row is wrappable, not `shrink-0`); the close slot is omitted when unused.