### PR TITLE
fix(web): truncation pass — short run ids, full-value tooltips, no clipped tabs (WM-96)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, Countdown, DetailPane, notify, ToastContainer } from "./ui";
+import { Button, Countdown, DetailPane, notify, shortId, ToastContainer } from "./ui";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
   const parent = r.getByRole("status").parentElement;
@@ -25,6 +25,23 @@ afterEach(() => {
   });
   jest.useRealTimers();
   cleanup();
+});
+
+describe("shortId (WM-96)", () => {
+  test("shortens a prefixed UUID id to the prefix plus the first 8 body characters", () => {
+    expect(shortId("run_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d")).toBe("run_ec9c87f9");
+    expect(shortId("worker_0f3b2a1c-9e8d-4b7a-8c6d-5e4f3a2b1c0d")).toBe("worker_0f3b2a1c");
+  });
+
+  test("returns ids whose body is already 8 characters or fewer unchanged", () => {
+    expect(shortId("run_failed_1")).toBe("run_failed_1");
+    expect(shortId("run_a")).toBe("run_a");
+  });
+
+  test("returns ids without a prefix unchanged", () => {
+    expect(shortId("plainid-with-no-underscore")).toBe("plainid-with-no-underscore");
+    expect(shortId("")).toBe("");
+  });
 });
 
 describe("ToastContainer", () => {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -51,6 +51,21 @@ export const DECISION_HUES: Record<string, string> = {
   noop: "var(--hue-idle)",
 };
 
+/**
+ * Short display form of a prefixed id: `run_ec9c87f9-…` → `run_ec9c87f9`
+ * (WM-96). Keeps the type prefix up to the first `_` plus the first 8
+ * characters of the body — enough to tell runs apart at a glance. Ids without
+ * a prefix, or already at most 8 characters past it, come back unchanged, so
+ * short human-written ids never lose information. Callers must carry the full
+ * id in a `title` (and keep copy/open verbs on the full id).
+ */
+export function shortId(id: string): string {
+  const sep = id.indexOf("_");
+  if (sep === -1) return id;
+  const body = id.slice(sep + 1);
+  return body.length <= 8 ? id : id.slice(0, sep + 1) + body.slice(0, 8);
+}
+
 export function copyText(text: string, label: string) {
   navigator.clipboard.writeText(text);
   notify(`Copied ${label}`, "info");

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -21,6 +21,7 @@ import {
   ago,
   copyText,
   notify,
+  shortId,
 } from "../components/ui";
 
 const FEED_CAP = 50;
@@ -529,13 +530,16 @@ export function Overview({
                     title={g.runId}
                     className="max-w-36 shrink-0 truncate"
                   >
-                    {g.runId}
+                    {shortId(g.runId)}
                   </JumpLink>
                   <span className="shrink-0">
                     {g.from ?? "·"} → {g.count > 1 ? "… → " : ""}
                     <StateBadge state={g.to} />
                   </span>
-                  <span className="truncate text-(--text-faint)">
+                  <span
+                    className="truncate text-(--text-faint)"
+                    title={`by ${g.actor}${g.reason ? ` (${g.reason})` : ""}${g.count > 1 ? ` · ${g.count} transitions` : ""}`}
+                  >
                     by {g.actor}
                     {g.reason ? ` (${g.reason})` : ""}
                     {g.count > 1 ? ` · ${g.count} transitions` : ""}
@@ -568,13 +572,15 @@ export function Overview({
                       return source && eventId ? (
                         <JumpLink
                           onClick={() => onJumpEvents({ source, eventId })}
-                          title="Open origin event"
+                          title={`Open origin event — ${type}`}
                           className="max-w-[70%] truncate"
                         >
                           {type}
                         </JumpLink>
                       ) : (
-                        <span className="truncate text-(--text-dim)">{type}</span>
+                        <span className="truncate text-(--text-dim)" title={type}>
+                          {type}
+                        </span>
                       );
                     })()}
                     {o.published_at ? (

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -129,6 +129,24 @@ function withApi(runs: RunListItem[], detail: RunDetail, fn: () => Promise<void>
   });
 }
 
+describe("Runs table short run ids (WM-96)", () => {
+  test("run id cell displays the short form and carries the full id as title", async () => {
+    const runId = "run_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d";
+    const detail = stubDetail(runId, "COMPLETED", [transition(1, runId, null, "QUEUED", null)]);
+    await withApi([stubListItem(runId, "COMPLETED")], detail, async () => {
+      const { container } = renderRuns(runId);
+
+      const cell = await waitFor(() => {
+        const el = container.querySelector(`td[title="${runId}"]`);
+        if (!el) throw new Error("run id cell with full-id title is missing");
+        return el;
+      });
+      // Short form shown; the full id never rendered as text, only as title.
+      expect(cell.textContent).toBe("run_ec9c87f9");
+    });
+  });
+});
+
 describe("Runs detail failure banner (WM-93)", () => {
   test("FAILED run renders the terminal transition's reason as a banner with a copy affordance", async () => {
     const runId = "run_failed_1";

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -44,6 +44,7 @@ import {
   VerbError,
   copyText,
   copyLink,
+  shortId,
 } from "../components/ui";
 
 const STATE_TABS: (RunState | "ALL")[] = [
@@ -678,7 +679,9 @@ export function Runs({
         {/* `flex-wrap`: the token chips are a full-width item, so they take
             their own line under the tabs and the box instead of squeezing them. */}
         <div className="mb-3 flex flex-wrap items-center gap-2">
-          <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto" role="tablist" aria-label="Run state">
+          {/* Wrap, never scroll or clip: at 1280px the strip used to run out of
+              width at CANCELLED with no scrollbar affordance (WM-96). */}
+          <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Run state">
             {STATE_TABS.map((t) => {
               const byState = statusQ.data?.runs.byState ?? {};
               const count = fetchAll
@@ -746,7 +749,9 @@ export function Runs({
                   aria-selected={r.runId === selectedId}
                   className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
                 >
-                  <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{r.runId}</td>
+                  <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5" title={r.runId}>
+                    {shortId(r.runId)}
+                  </td>
                   {show.has("state") && (
                     <td className="border-b border-(--border) px-3 py-1.5">
                       <StateBadge state={r.state} />
@@ -772,14 +777,23 @@ export function Runs({
                     </td>
                   )}
                   {show.has("reason") && (
-                    <td className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                    <td
+                      className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                      title={r.reasonCode ?? undefined}
+                    >
                       {r.reasonCode ?? "-"}
                     </td>
                   )}
                   {show.has("origin") && (
-                    <td className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                    <td
+                      className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                      title={r.eventId ?? undefined}
+                    >
                       {r.eventId && r.eventSource ? (
-                        <JumpLink onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title="Open origin event">
+                        <JumpLink
+                          onClick={() => onJumpEvent(r.eventSource!, r.eventId!)}
+                          title={`Open origin event ${r.eventId}`}
+                        >
                           {r.eventId}
                         </JumpLink>
                       ) : (
@@ -872,7 +886,7 @@ export function Runs({
                 title={`Open ${sel.runId}`}
                 className="truncate"
               >
-                {sel.runId}
+                {shortId(sel.runId)}
               </JumpLink>
             </span>
           }

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -40,6 +40,7 @@ import {
   Th,
   copyLink,
   copyText,
+  shortId,
 } from "../components/ui";
 
 /** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector. */
@@ -427,6 +428,7 @@ export function Workers({
                     className={`mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 ${
                       w.state === "stopped" && !w.stale ? "text-(--text-faint)" : ""
                     }`}
+                    title={w.workerId}
                   >
                     {w.workerId}
                   </td>
@@ -454,15 +456,18 @@ export function Workers({
                     </td>
                   )}
                   {show.has("adapters") && (
-                    <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                    <td
+                      className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                      title={w.adapters.length > 0 ? w.adapters.join(", ") : undefined}
+                    >
                       {w.adapters.join(", ") || "-"}
                     </td>
                   )}
                   {show.has("run") && (
                     <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
                       {w.currentRun ? (
-                        <JumpLink onClick={() => openRun(w.currentRun!)} title="Open this run">
-                          {w.currentRun}
+                        <JumpLink onClick={() => openRun(w.currentRun!)} title={`Open ${w.currentRun}`}>
+                          {shortId(w.currentRun)}
                         </JumpLink>
                       ) : (
                         "-"
@@ -589,8 +594,8 @@ export function Workers({
               k="currentRun"
               v={
                 sel.currentRun ? (
-                  <JumpLink onClick={() => openRun(sel.currentRun!)} title="Open this run">
-                    {sel.currentRun}
+                  <JumpLink onClick={() => openRun(sel.currentRun!)} title={`Open ${sel.currentRun}`}>
+                    {shortId(sel.currentRun)}
                   </JumpLink>
                 ) : (
                   "-"


### PR DESCRIPTION
Fixes WM-96

Final cross-cutting truncation pass over the Runs / Workers / Overview views, re-verified against develop after WM-91/92/93/94/95/97/98/100/101 + OPS-493 landed.

## Already fixed by intervening merges (skipped)
- **Events state tab strip** — already `flex-wrap` (wraps at 1280px, counts visible); no change needed.
- **Overview grouped feed run-id tooltip** (WM-100) — the feed's run-id `JumpLink` already carried `title={runId}`; only the displayed text needed shortening here.
- **Workers Labels cell** — already carried a full-value `title`.
- **Anomaly deck proposal id / anomaly text** (WM-95) — already carry `title` tooltips.

## Fixed here
- **`shortId` helper** in `components/ui.tsx`: `run_ec9c87f9-…` → `run_ec9c87f9` (prefix + first 8 body chars; short/unprefixed ids pass through unchanged). Unit tests in `ui.test.tsx`; usage-site test (short text + full id in `title`) in `Runs.test.tsx`.
- **Runs table** run-id cell: displays `shortId`, full id as `title`; row click/copy verbs unchanged (they always used the full id).
- **Runs detail pane title**: short id displayed; `title` already carried the full id.
- **Runs Reason cell**: full `reasonCode` as `title`.
- **Runs Origin cell**: full event id as `title` on the cell and in the JumpLink tooltip.
- **Runs state tab strip**: `overflow-x-auto` → `flex-wrap`, so CANCELLED can no longer sit clipped/off-screen at 1280px; counts stay visible.
- **Overview activity feed**: run id displayed short (tooltip already full); actor/reason span gets a full-value `title`; outbox event-type row gets full-value tooltips.
- **Workers table**: worker-id cell gets full-value `title`; Adapters cell gets full-value `title`; Current run cell displays `shortId` with full id in the tooltip (table and detail pane).

## Verification
```
$ bunx tsc --noEmit        # clean
$ bun test src
 271 pass
 0 fail
 746 expect() calls
Ran 271 tests across 28 files. [1132.00ms]
```