### PR TITLE
feat(event-runtime): dispatch executor — worktree workspace by delegation, claude-adapter ticket runs (WM-108)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -1,0 +1,40 @@
+{
+  "id": "dispatch",
+  "version": 1,
+  "prompt": "agents/dispatch.md",
+  "input_schema": "schemas/dispatch.input.json",
+  "output_schema": "schemas/dispatch.output.json",
+  "output_contract": "factory.dispatch-result/v1",
+  "workspace": {
+    "type": "worktree",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:write",
+      "repo:write",
+      "github:write"
+    ],
+    "tools": [
+      "Bash",
+      "Read",
+      "Write",
+      "Edit",
+      "Grep",
+      "Glob"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 2700,
+    "attempts": 1,
+    "budget_usd": 15
+  },
+  "mutating": true,
+  "pins": {
+    "agents/dispatch.md": "sha256:cf84c0cc41ce4ed84cd179f8bc8f52f73919e8187073254b86ee58c27a7e0828",
+    "schemas/dispatch.input.json": "sha256:66898f48608fff53f07f2b59e9df9d41c15aae69615c2383c22d3978ca9807b2",
+    "schemas/dispatch.output.json": "sha256:56ea5a82df4bce92d5f22b60d173a03bbb9e139491abeff3c01a96524ef49a4d"
+  }
+}

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -1,0 +1,96 @@
+# dispatch — implement exactly one Linear ticket in a delegated worktree
+
+You are a ticket agent. `./input.json` names one repo and one ticket:
+
+```json
+{ "repo": "bj29", "ticket": "CLNT-123" }
+```
+
+The repo's source is at `./repo` — a full worktree the repo's **own**
+`worktree_up` script built for this ticket, with its own branch, ports, and
+database. Do not create another worktree, do not touch any sibling worktree,
+and do not work anything except this one ticket. Write `./result.json` before
+you finish. Work only inside this directory (the `./repo` worktree included).
+
+## 1. Claim
+
+The planner verified the ticket was `Todo` + `ai:agent-ready` + unassigned
+when this run was proposed; the world may have moved since. Claim it now:
+
+```
+bun "$FACTORY_ROOT/tools/linear.mjs" claim <TICKET>
+```
+
+The claim verb enforces the read-back — if it reports a lost race, or the
+ticket is no longer in a dispatchable state, **stop**: write `./result.json`
+with `outcome: "NOT_CLAIMED"` and a summary naming who holds it. That is a
+good, typed outcome (docs/event-runtime-dispatch.md §2), not a failure. Never
+steal a claim, never queue behind the holder.
+
+## 2. Implement
+
+1. **Read the ticket** (`bun "$FACTORY_ROOT/tools/linear.mjs" get <TICKET>`)
+   and restate your approach as a comment on it.
+2. **Implement in `./repo`**, touching only files matching the ticket's
+   `Owned Paths`. Work discovered outside that set becomes a new `Triage`
+   issue (`tools/linear.mjs file`) — never a widening of this one.
+3. **Verify** with the ticket's exact `Verification Command`, run inside
+   `./repo`. Never proceed past failing output; never weaken a test to get
+   green. The runtime re-runs the repo's declared verify command after you —
+   your report is not the evidence, the output is.
+4. **Never `sleep` to wait for anything.** Poll a condition with a real
+   command (`gh pr checks <PR> --watch --fail-fast` for CI); a fixed sleep
+   wedges the run until the timeout kills it.
+5. **Push and open a PR** against the repo's base branch with
+   `Fixes <TICKET>` in the body. Post the structured `## Handoff` comment on
+   the ticket (PR link, verification command + one-line result, files
+   touched, risks), then move it to `In Review` + `ai:needs-review`, removing
+   `ai:in-progress`.
+
+**Never merge.** The merge stage reviews and lands PRs; a ticket agent that
+merges its own work bypasses the review gate entirely.
+
+If the work turns out to touch auth/authz, payments, secrets, destructive
+migrations, or production infra: stop without pushing, comment the finding on
+the ticket, and refuse (`reasonCode: "needs_human"`). Those diffs are never
+landed without a human.
+
+## 3. When it goes wrong
+
+Do not open a PR on a guess. Comment the ticket with the specific decision,
+credential, or missing piece you need — phrased so one reply unblocks it —
+move it to `Blocked` + `ai:blocked`, and report `outcome: "BLOCKED"`. If you
+attempted the work and cannot produce a shippable diff, roll the ticket back
+to `Todo` with a comment saying why (the dispatcher's un-claim rule) and
+report `outcome: "FAILED"`.
+
+## Output
+
+`./result.json`, per factory.agent-result/v1:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "outcome": "PR_OPEN",
+    "repo": "bj29",
+    "ticket": "CLNT-123",
+    "prUrl": "https://github.com/owner/name/pull/42",
+    "verification": {
+      "command": "cd app && npm run lint && npm run typecheck",
+      "passed": true,
+      "output": "the last lines of the verification run"
+    },
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the commands this rests on"] }
+}
+```
+
+`BLOCKED`, `FAILED`, and `NOT_CLAIMED` are still `terminalState:
+"completed"` — the run determined a typed outcome; `prUrl` is null and
+`verification.command` is null when nothing ran. If Linear itself is
+unreachable, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -161,6 +161,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.dispatch.requested": {
+    "agent": "dispatch@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.ticket.dispatched": {
     "observe": true
   },

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -60,13 +60,21 @@ export function deriveAllowedTools(def) {
 }
 
 /**
- * Build argv for spawning claude (OPS-407, WM-62).
+ * Build argv for spawning claude (OPS-407, WM-62, WM-108).
  * Enforces --allowedTools and --strict-mcp-config with the repo's declared MCP servers.
+ * A definition declaring `limits.budget_usd` gets `--max-budget-usd` — the
+ * runaway guard tick.mjs passes every ticket process (policy.yaml `budget`:
+ * notional API-equivalent units on subscription auth, not money). The
+ * dispatch design (§6) requires it before the first tier-2 mutating run.
  */
 export function buildClaudeArgv({ prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig }) {
   const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
   if (allowedTools && allowedTools.length > 0) {
     args.push("--allowedTools", allowedTools.join(","));
+  }
+  const budget = def?.limits?.budget_usd;
+  if (typeof budget === "number" && Number.isFinite(budget) && budget > 0) {
+    args.push("--max-budget-usd", String(budget));
   }
   if (mcpConfig) {
     args.push("--mcp-config", mcpConfig);

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -168,6 +168,17 @@ describe("buildClaudeArgv (OPS-407, WM-62)", () => {
     expect(argv).toContain("/path/to/mcp.json");
     expect(argv).toContain("--strict-mcp-config");
   });
+
+  test("limits.budget_usd → --max-budget-usd; absent or invalid → no flag (WM-108)", () => {
+    const withBudget = buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: 15 } } });
+    const i = withBudget.indexOf("--max-budget-usd");
+    expect(i).toBeGreaterThan(-1);
+    expect(withBudget[i + 1]).toBe("15");
+
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false } })).not.toContain("--max-budget-usd");
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: 0 } } })).not.toContain("--max-budget-usd");
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: "15" } } })).not.toContain("--max-budget-usd");
+  });
 });
 
 describe("execute conformance (OPS-427, docs/event-runtime.md §6)", () => {

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -1,0 +1,315 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeWorkerLease } from "../../lib/worker-leases.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents, planEvent, worktreeDispatchGate } from "./planner.mjs";
+import { approveProposal, openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+import { runOnce } from "./worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+
+// Hermetic fixtures: repos.yaml + policy.yaml under a temp FACTORY_REPOS_ROOT,
+// fake worktree scripts that log every call (the tier-2 provider delegates to
+// them, docs/event-runtime-dispatch.md §5), and injected Linear readers — the
+// gate's transport is tools/linear.mjs in production, never exercised here.
+const fixtures = [];
+let repoDir;
+let wtRoot;
+let callsLog;
+let previousReposRoot;
+let previousEventHome;
+
+const calls = () => (existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : []);
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-factory-"));
+  fixtures.push(root);
+  repoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-repo-")));
+  wtRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-trees-")));
+  fixtures.push(repoDir, wtRoot);
+  callsLog = path.join(repoDir, "calls.log");
+
+  mkdirSync(path.join(repoDir, "bin"), { recursive: true });
+  writeFileSync(
+    path.join(repoDir, "bin", "worktree-up.sh"),
+    `#!/bin/bash\nset -e\necho "up $1" >> "${callsLog}"\nmkdir -p "${wtRoot}/$1"\n`,
+  );
+  writeFileSync(
+    path.join(repoDir, "bin", "worktree-down.sh"),
+    `#!/bin/bash\nset -e\necho "down $1" >> "${callsLog}"\nrm -rf "${wtRoot}/$1"\n`,
+  );
+
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: wt29\n    path: ${repoDir}\n    github: watt-mind/wt29\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    max_in_flight: 1\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n` +
+      `  - name: watched\n    path: ${repoDir}\n    team: OPS\n    project: Watched\n    report_only: true\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n` +
+      `  - name: uncapped\n    path: ${repoDir}\n    team: WM\n    project: Factory\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n`,
+  );
+  writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
+
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  previousEventHome = process.env.FACTORY_EVENT_HOME;
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-home-"));
+  fixtures.push(process.env.FACTORY_EVENT_HOME);
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+  else process.env.FACTORY_EVENT_HOME = previousEventHome;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A ticket exactly as `tools/linear.mjs get --json` reports one. */
+const readyTicket = (overrides = {}) => ({
+  identifier: "WM-500",
+  title: "a fully specified ticket",
+  state: { name: "Todo" },
+  assignee: null,
+  labels: { nodes: [{ name: "ai:agent-ready" }] },
+  description: "## Owned Paths\n- src/feature-a/**\n",
+  ...overrides,
+});
+
+/** Gate injection where the world is wide open — override per test. */
+const openWorld = (overrides = {}) => ({
+  fetchTicket: () => readyTicket(),
+  fetchInFlight: () => [],
+  countLeases: () => 0,
+  ...overrides,
+});
+
+const dispatchEnvelope = (payload, eventId = "dispatch-1") => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.dispatch.requested",
+  source: "operator",
+  subject: payload.ticket ?? null,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload,
+});
+
+function plan(payload, dispatch, eventId = `d-${Math.random().toString(36).slice(2)}`) {
+  const db = openDb(":memory:");
+  const admitted = admitEvent(db, registry, dispatchEnvelope(payload, eventId));
+  expect(admitted.admitted).toBe(true);
+  const outcome = planEvent(db, registry, { source: admitted.event.source, eventId: admitted.event.event_id }, {
+    policyVersion: PV,
+    dispatch,
+  });
+  return { db, outcome };
+}
+
+describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
+  test("report_only repo → human_needed repo_report_only, no run", () => {
+    const { db, outcome } = plan({ repo: "watched", ticket: "WM-500" }, openWorld());
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toBe("repo_report_only");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+  });
+
+  test("per-repo cap reached → typed NOOP capacity_full, refusal carries its reason", () => {
+    const { db, outcome } = plan({ repo: "wt29", ticket: "WM-500" }, openWorld({ countLeases: () => 1 }));
+    expect(outcome.decision).toBe("noop");
+    expect(outcome.reason).toBe("capacity_full");
+    expect(outcome.proposal.status).toBe("resolved");
+    expect(db.query(`SELECT status FROM events`).get().status).toBe("noop");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+  });
+
+  test("the cap counts the dispatcher's own live lease ledger (shared budget, §3)", () => {
+    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-leases-"));
+    fixtures.push(leaseDir);
+    writeWorkerLease({ repo: "wt29", ticket: "WM-400", owner: "tick-test", pid: process.pid, dir: leaseDir });
+    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
+      countLeases: (name) => (name === "wt29" ? 1 : 0),
+    }));
+    expect(refusal).toEqual({ decision: "noop", reason: "capacity_full" });
+  });
+
+  test("no max_in_flight on the repo → policy.yaml fallback holds (cap 2)", () => {
+    const twoLeases = openWorld({ countLeases: () => 2 });
+    expect(worktreeDispatchGate({ repo: "uncapped", ticket: "WM-500" }, twoLeases))
+      .toEqual({ decision: "noop", reason: "capacity_full" });
+    expect(worktreeDispatchGate({ repo: "uncapped", ticket: "WM-500" }, openWorld({ countLeases: () => 1 })))
+      .toBeNull();
+  });
+
+  test("assigned ticket → typed NOOP ticket_assigned; never stolen, never queued behind", () => {
+    const { outcome } = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({ fetchTicket: () => readyTicket({ assignee: { id: "u1", name: "someone" } }) }),
+    );
+    expect(outcome.decision).toBe("noop");
+    expect(outcome.reason).toBe("ticket_assigned");
+  });
+
+  test("ticket not in Todo → NOOP ticket_not_todo; missing ai:agent-ready → NOOP ticket_not_agent_ready", () => {
+    const inReview = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({ fetchTicket: () => readyTicket({ state: { name: "In Review" } }) }),
+    );
+    expect(inReview.outcome).toMatchObject({ decision: "noop", reason: "ticket_not_todo" });
+
+    const unlabelled = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({ fetchTicket: () => readyTicket({ labels: { nodes: [] } }) }),
+    );
+    expect(unlabelled.outcome).toMatchObject({ decision: "noop", reason: "ticket_not_agent_ready" });
+  });
+
+  test("vanished ticket → human_needed ticket_not_found", () => {
+    const { outcome } = plan({ repo: "wt29", ticket: "WM-500" }, openWorld({ fetchTicket: () => null }));
+    expect(outcome).toMatchObject({ decision: "human_needed", reason: "ticket_not_found" });
+  });
+
+  test("Owned Paths overlap with any in-flight ticket → NOOP owned_paths_overlap", () => {
+    const { outcome } = plan(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        fetchInFlight: () => [
+          { identifier: "WM-400", description: "## Owned Paths\n- src/feature-a/api.ts\n" },
+        ],
+      }),
+    );
+    expect(outcome).toMatchObject({ decision: "noop", reason: "owned_paths_overlap" });
+  });
+
+  test("an in-flight ticket with NO parseable Owned Paths owns everything (imported bias, §4)", () => {
+    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
+      fetchInFlight: () => [{ identifier: "WM-400", description: "no owned paths section at all" }],
+    }));
+    expect(refusal).toEqual({ decision: "noop", reason: "owned_paths_overlap" });
+  });
+
+  test("disjoint Owned Paths do not refuse; the ticket's own In Progress row is ignored", () => {
+    const refusal = worktreeDispatchGate({ repo: "wt29", ticket: "WM-500" }, openWorld({
+      fetchInFlight: () => [
+        { identifier: "WM-401", description: "## Owned Paths\n- src/feature-b/**\n" },
+        { identifier: "WM-500", description: "" }, // itself — never self-colliding
+      ],
+    }));
+    expect(refusal).toBeNull();
+  });
+
+  test("a Linear transport failure throws — plan_failures/dead-letter own retries, not a one-shot refusal", () => {
+    const db = openDb(":memory:");
+    const admitted = admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-500" }, "d-outage"));
+    expect(() =>
+      planEvent(db, registry, { source: admitted.event.source, eventId: admitted.event.event_id }, {
+        policyVersion: PV,
+        dispatch: openWorld({ fetchTicket: () => { throw new Error("linear_read_failed: HTTP 503"); } }),
+      }),
+    ).toThrow(/linear_read_failed/);
+    expect(db.query(`SELECT status FROM events`).get().status).toBe("admitted");
+  });
+});
+
+describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", () => {
+  // A local contract-shaped fake for the claude adapter: the run's value here
+  // is the pipeline around it — worktree delegation, verification, receipt —
+  // not the model. It proves the delegated tree is reachable where the prompt
+  // says (./repo) before reporting success.
+  const dispatchFake = {
+    async execute({ spec, workspaceDir }) {
+      writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"dispatch transcript"}\n`, "utf8");
+      const treeVisible = existsSync(path.join(workspaceDir, "repo"));
+      writeFileSync(
+        path.join(workspaceDir, "result.json"),
+        `${JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "completed",
+          reasonCode: "ok",
+          artifact: {
+            outcome: "PR_OPEN",
+            repo: spec.input.repo,
+            ticket: spec.input.ticket,
+            prUrl: "https://github.com/watt-mind/wt29/pull/42",
+            verification: { command: "echo verified", passed: true, output: "verified" },
+            summary: `fake dispatch of ${spec.input.ticket} (tree visible: ${treeVisible})`,
+          },
+          evidence: { commands: ["fake"], treeVisible },
+        }, null, 2)}\n`,
+        "utf8",
+      );
+      return { exitCode: 0, timedOut: false };
+    },
+  };
+
+  test("an approved dispatch run builds the worktree by delegation, completes, and tears it down", async () => {
+    const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-db-")), "runtime.db"));
+    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
+
+    admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-501" }, "d-e2e"));
+    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld() });
+
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
+    expect(proposal).toBeTruthy();
+    expect(proposal.status).toBe("open"); // watched: nothing mutates without approval
+    expect(proposal.spec.workspace).toEqual({ type: "worktree", checkoutDir: "repo", retainOnFailure: true });
+    expect(proposal.spec.input).toEqual({ repo: "wt29", ticket: "WM-501" });
+    expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
+
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, { claude: dispatchFake }, {
+      workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+    });
+
+    expect(summary.terminalState).toBe("COMPLETED");
+    expect(summary.reasonCode).toBe("ok");
+    expect(summary.receipt).toBeTruthy();
+    expect(calls()).toContain("up WM-501");
+    expect(calls()).toContain("down WM-501"); // torn down on completion
+    expect(existsSync(path.join(wtRoot, "WM-501"))).toBe(false);
+
+    const row = db.query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`).get(approved.runId);
+    const result = JSON.parse(row.result_json);
+    expect(result.artifact.outcome).toBe("PR_OPEN");
+    expect(result.artifact.prUrl).toContain("/pull/42");
+    expect(result.artifact.verification.passed).toBe(true);
+    expect(result.evidence.treeVisible).toBe(true);
+    expect(JSON.parse(row.receipt_json).runId).toBe(approved.runId);
+  });
+
+  test("a failing run without retain still tears the worktree down (down-on-failure)", async () => {
+    const db = openDb(":memory:");
+    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    fixtures.push(workspaces);
+
+    admitEvent(db, registry, dispatchEnvelope({ repo: "wt29", ticket: "WM-502" }, "d-fail"));
+    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld() });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
+    // dispatch@1 declares retainOnFailure: true; override to prove the
+    // non-retained failure path runs worktree_down (WM-108 stage 1 contract).
+    const crashing = { async execute() { return { exitCode: 1, timedOut: false }; } };
+    approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    // After approval (which re-verifies the spec hash), flip retainOnFailure
+    // off for the claim below — the worker reads the run's spec at claim time.
+    const spec = { ...proposal.spec, workspace: { ...proposal.spec.workspace, retainOnFailure: false } };
+    db.query(`UPDATE runs SET spec_json = ? WHERE run_id = ?`).run(JSON.stringify(spec), proposal.run_id);
+
+    const summary = await runOnce(db, registry, { claude: crashing }, {
+      workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+    });
+    expect(summary.terminalState).toBe("FAILED");
+    expect(calls()).toContain("up WM-502");
+    expect(calls()).toContain("down WM-502");
+    expect(existsSync(path.join(wtRoot, "WM-502"))).toBe(false);
+  });
+});

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -8,14 +8,22 @@
  * returns the recorded outcome — and a poison event that keeps throwing is
  * dead-lettered instead of wedging the sweep or silently vanishing.
  */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
+// Imported as a library, never copied (docs/event-runtime-dispatch.md §4):
+// one collision oracle for both mutation paths, with its safety biases —
+// missing Owned Paths owns everything, ambiguous overlap errs to collision.
+import { effectiveOwnedPaths, pathsCollide } from "../../orchestrator/owned-paths.mjs";
 import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
-import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
+import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS, FACTORY_ROOT } from "./config.mjs";
 import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun, resolveIdempotency } from "./lifecycle.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
-import { getRepo, loadRepos } from "./repos.mjs";
+import { getRepo, loadRepos, reposRoot } from "./repos.mjs";
 import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
 import { loopInFlight } from "./schedules.mjs";
@@ -83,6 +91,133 @@ export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion
   };
 }
 
+/** policy.yaml's per-repo cap fallback, read from the same root as repos.yaml. */
+export const DEFAULT_MAX_IN_FLIGHT = 3;
+
+function policyMaxInFlight(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return DEFAULT_MAX_IN_FLIGHT;
+  try {
+    const n = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_in_flight_per_repo;
+    return typeof n === "number" && Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_IN_FLIGHT;
+  } catch {
+    return DEFAULT_MAX_IN_FLIGHT;
+  }
+}
+
+/**
+ * Plan-time Linear reads for the dispatch gate, through the factory's own
+ * Linear surface (tools/linear.mjs — gql retries, backoff, and key loading
+ * live there; a second client would be a second set of bugs). Synchronous
+ * subprocesses because the planner is synchronous code; planEvent calls the
+ * gate BEFORE its write transaction so these round trips never hold the
+ * SQLite write lock. A transport failure throws — planAdmittedEvents turns
+ * that into plan_failures with retry and eventual dead-letter (§13), which is
+ * the right shape for a transient outage, unlike a one-shot refusal.
+ */
+const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
+
+function fetchTicketDefault(ticketId) {
+  try {
+    return JSON.parse(
+      execFileSync("bun", [linearCli(), "get", ticketId, "--json"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+    );
+  } catch (err) {
+    const stderr = String(err?.stderr ?? "");
+    if (stderr.includes("no such issue")) return null;
+    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`);
+  }
+}
+
+// The same query shape tick.mjs uses for its in-flight set (dispatch doc §4).
+const IN_FLIGHT_QUERY =
+  `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
+
+function fetchInFlightDefault(repoConfig) {
+  try {
+    const out = execFileSync(
+      "bun",
+      [linearCli(), "raw", IN_FLIGHT_QUERY, "--var", `t=${repoConfig.team}`, "--var", `p=${repoConfig.project}`],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return JSON.parse(out)?.issues?.nodes ?? [];
+  } catch (err) {
+    const stderr = String(err?.stderr ?? "");
+    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`);
+  }
+}
+
+/**
+ * The dispatch gate (docs/event-runtime-dispatch.md §§2–5, WM-108): may a
+ * tier-2 mutating run for {repo, ticket} be PROPOSED right now? Checked
+ * cheapest-first — repo config, then the shared lease ledger, then Linear.
+ *
+ * Refusal semantics follow the doc: durable config states an operator must
+ * change (unknown repo, report_only, missing worktree scripts, missing
+ * team/project, vanished ticket) are `human_needed` — visible in the inbox
+ * and requeue-able after the fix. Transient world states (claimed ticket,
+ * full cap, Owned Paths overlap) are typed NOOPs — a false refusal costs one
+ * NOOP and the next request re-reads a fresh world; parking them as inbox
+ * asks would train the operator to approve stale facts.
+ *
+ * This is the plan-time half of the doc's "checked twice" rule; the
+ * execute-time re-check (claim lock file, lease write, cap and overlap under
+ * the approval TTL) belongs to the executor and is NOT implemented here.
+ *
+ * @returns {null | { decision: "noop" | "human_needed", reason: string }}
+ */
+export function worktreeDispatchGate(payload, {
+  fetchTicket = fetchTicketDefault,
+  fetchInFlight = fetchInFlightDefault,
+  countLeases = (repoName) => liveWorkerLeases(repoName).length,
+  maxInFlightFallback,
+} = {}) {
+  let repo;
+  try {
+    repo = getRepo(loadRepos(), payload?.repo);
+  } catch (err) {
+    return { decision: "human_needed", reason: `repo_unknown: ${err.message}` };
+  }
+  // report_only repos are never tier-2 targets (dispatch doc §5): safe
+  // concurrency of one human, same refusal as tick.mjs.
+  if (repo.reportOnly) return { decision: "human_needed", reason: "repo_report_only" };
+  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) {
+    return { decision: "human_needed", reason: "no_worktree_scripts" };
+  }
+
+  // One budget for both paths (§3): the repo's cap against the dispatcher's
+  // own lease ledger — files under ~/.factory/worker-leases that count every
+  // live ticket worker, whichever coordinator started it.
+  const cap = repo.maxInFlight ?? maxInFlightFallback ?? policyMaxInFlight();
+  if (countLeases(repo.name) >= cap) return { decision: "noop", reason: "capacity_full" };
+
+  // The Linear assignee stays the only ticket lock (§2). Stricter than
+  // tick.mjs on purpose — any assignee refuses; the asymmetry is recorded in
+  // the doc (§2, §9) and collapses when OPS-40 lands. Do not "fix" either
+  // side to match the other.
+  const ticket = fetchTicket(payload.ticket);
+  if (!ticket) return { decision: "human_needed", reason: "ticket_not_found" };
+  if (ticket.assignee) return { decision: "noop", reason: "ticket_assigned" };
+  if (ticket.state?.name !== "Todo") return { decision: "noop", reason: "ticket_not_todo" };
+  if (!(ticket.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready")) {
+    return { decision: "noop", reason: "ticket_not_agent_ready" };
+  }
+
+  // One collision oracle (§4): the in-flight set is Linear's In Progress
+  // tickets for the repo's team/project, whichever path claimed them.
+  if (!repo.team || !repo.project) {
+    return { decision: "human_needed", reason: "repo_unconfigured: team/project missing for the in-flight query" };
+  }
+  const inFlight = fetchInFlight(repo);
+  const busy = inFlight
+    .filter((i) => i.identifier !== payload.ticket)
+    .flatMap((i) => effectiveOwnedPaths(i.description ?? ""));
+  if (pathsCollide(effectiveOwnedPaths(ticket.description ?? ""), busy)) {
+    return { decision: "noop", reason: "owned_paths_overlap" };
+  }
+  return null;
+}
+
 function insertProposal(db, { id, event, runId = null, decision, specJson = null, specHash = null, idempotencyKey = null, status, reason = null, at, ttlSeconds }) {
   db.query(
     `INSERT INTO proposals
@@ -125,7 +260,28 @@ function existingOutcome(db, event) {
  *
  * @returns {{ decision: string, proposal?: object, runId?: string, reason?: string }}
  */
-export function planEvent(db, registry, { source, eventId }, { now = Date.now(), policyVersion = "unknown", adapterOverride, artifactStore = artifactsRoot() } = {}) {
+export function planEvent(db, registry, { source, eventId }, { now = Date.now(), policyVersion = "unknown", adapterOverride, artifactStore = artifactsRoot(), dispatch = {} } = {}) {
+  // Dispatch gate for tier-2 worktree agents (WM-108), evaluated BEFORE the
+  // write transaction: its Linear and lease reads must never hold the SQLite
+  // write lock across a network round trip. The verdict is applied inside the
+  // transaction only when the event is still admitted there — a raced plan
+  // simply discards it via the idempotent early return.
+  let worktreeRefusal = null;
+  {
+    const row = db.query(`SELECT status, envelope_json FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
+    if (row?.status === "admitted") {
+      const preEnvelope = JSON.parse(row.envelope_json);
+      const preMapping = getEventType(registry, preEnvelope.type);
+      const preDef = preMapping && preMapping.observe !== true ? registry.agents.get(preMapping.agent) : null;
+      if (
+        preDef?.workspace?.type === "worktree" &&
+        typeof preEnvelope.payload?.repo === "string" &&
+        typeof preEnvelope.payload?.ticket === "string"
+      ) {
+        worktreeRefusal = worktreeDispatchGate(preEnvelope.payload, dispatch);
+      }
+    }
+  }
   return txImmediate(db, () => {
     const event = db.query(`SELECT * FROM events WHERE source = ? AND event_id = ?`).get(source, eventId);
     if (!event) throw new Error(`no admitted event (${source}, ${eventId})`);
@@ -169,22 +325,20 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const input = validate(def.inputSchema, envelope.payload);
     if (!input.valid) return humanNeeded(db, event, `invalid_input: ${input.errors[0]}`, at, ttlSeconds);
 
-    // §5 tier 2 (docs/event-runtime-dispatch.md, WM-108): a worktree
-    // workspace delegates to the repo's own scripts, so a repo that declares
-    // none cannot host a mutating run — a typed refusal now, while the
-    // operator can still see why, never a crash at execute. Both reasons are
-    // config states a human must change, hence human_needed (requeue-able
-    // after the fix, like unregistered_event_type) rather than a NOOP.
-    if (def.workspace?.type === "worktree") {
-      let repoConfig;
-      try {
-        repoConfig = getRepo(loadRepos(), envelope.payload?.repo);
-      } catch (err) {
-        return humanNeeded(db, event, `repo_unknown: ${err.message}`, at, ttlSeconds);
+    // Tier-2 dispatch gate verdict (docs/event-runtime-dispatch.md §§2–5,
+    // WM-108), computed above outside this transaction. Refusals are typed
+    // and carry their reason; a null verdict means every check passed at the
+    // moment of the read — the doc's execute-time re-check owns the TTL gap.
+    if (def.workspace?.type === "worktree" && worktreeRefusal) {
+      if (worktreeRefusal.decision === "human_needed") {
+        return humanNeeded(db, event, worktreeRefusal.reason, at, ttlSeconds);
       }
-      if (!repoConfig.worktreeUp || !repoConfig.worktreeDown || !repoConfig.worktreeRoot) {
-        return humanNeeded(db, event, "no_worktree_scripts", at, ttlSeconds);
-      }
+      const proposal = insertProposal(db, {
+        id: newProposalId(), event, decision: "noop", status: "resolved",
+        reason: worktreeRefusal.reason, at, ttlSeconds,
+      });
+      setEventStatus(db, event, "noop");
+      return { decision: "noop", proposal, reason: worktreeRefusal.reason };
     }
 
     // §7 tier 1 (OPS-228): a repository workspace resolves its ref to an

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -15,6 +15,7 @@ import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun, resolveIdempotency } from "./lifecycle.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
+import { getRepo, loadRepos } from "./repos.mjs";
 import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
 import { loopInFlight } from "./schedules.mjs";
@@ -167,6 +168,24 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
 
     const input = validate(def.inputSchema, envelope.payload);
     if (!input.valid) return humanNeeded(db, event, `invalid_input: ${input.errors[0]}`, at, ttlSeconds);
+
+    // §5 tier 2 (docs/event-runtime-dispatch.md, WM-108): a worktree
+    // workspace delegates to the repo's own scripts, so a repo that declares
+    // none cannot host a mutating run — a typed refusal now, while the
+    // operator can still see why, never a crash at execute. Both reasons are
+    // config states a human must change, hence human_needed (requeue-able
+    // after the fix, like unregistered_event_type) rather than a NOOP.
+    if (def.workspace?.type === "worktree") {
+      let repoConfig;
+      try {
+        repoConfig = getRepo(loadRepos(), envelope.payload?.repo);
+      } catch (err) {
+        return humanNeeded(db, event, `repo_unknown: ${err.message}`, at, ttlSeconds);
+      }
+      if (!repoConfig.worktreeUp || !repoConfig.worktreeDown || !repoConfig.worktreeRoot) {
+        return humanNeeded(db, event, "no_worktree_scripts", at, ttlSeconds);
+      }
+    }
 
     // §7 tier 1 (OPS-228): a repository workspace resolves its ref to an
     // immutable SHA *now*, so the pin is inside the spec's input (and its

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -222,6 +222,76 @@ describe("planEvent", () => {
   });
 });
 
+describe("planEvent worktree gate (WM-108)", () => {
+  // A synthetic worktree-workspace agent: the real dispatch@1 lands with its
+  // own tests; this proves the gate itself, independent of any one agent.
+  function syntheticRegistry() {
+    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    synthetic.eventTypes["test.worktree.requested"] = {
+      agent: "test-worktree@1",
+      adapter: "claude",
+      idempotencyScope: ["inputHash"],
+    };
+    synthetic.agents.set("test-worktree@1", {
+      id: "test-worktree",
+      version: 1,
+      ref: "test-worktree@1",
+      output_contract: "factory.test/v1",
+      workspace: { type: "worktree" },
+      capabilities: { services: [] },
+      limits: { timeout_seconds: 60, attempts: 1 },
+      mutating: true,
+      inputSchema: { type: "object", required: ["repo", "ticket"], properties: { repo: { type: "string" }, ticket: { type: "string" } } },
+    });
+    return synthetic;
+  }
+
+  function withReposRoot(yaml, fn) {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-plan-wt-"));
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+    }
+  }
+
+  const dispatchEnvelope = (payload) => ({
+    type: "test.worktree.requested",
+    eventId: `wt-${JSON.stringify(payload)}`,
+    correlationId: null,
+    payload,
+  });
+
+  test("a repo with no worktree scripts declared → typed human_needed at plan time, no run", () => {
+    withReposRoot(`repos:\n  - name: noscripts\n    path: /tmp/nowhere\n    base: develop\n`, () => {
+      const synthetic = syntheticRegistry();
+      const db = openDb(":memory:");
+      const ref = admit(db, dispatchEnvelope({ repo: "noscripts", ticket: "WM-1" }));
+      const outcome = planEvent(db, synthetic, ref, { now: NOW });
+      expect(outcome.decision).toBe("human_needed");
+      expect(outcome.reason).toBe("no_worktree_scripts");
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+
+  test("a repo missing from config/repos.yaml → human_needed repo_unknown", () => {
+    withReposRoot(`repos:\n  - name: real\n    path: /tmp/nowhere\n    base: develop\n`, () => {
+      const synthetic = syntheticRegistry();
+      const db = openDb(":memory:");
+      const ref = admit(db, dispatchEnvelope({ repo: "ghost", ticket: "WM-1" }));
+      const outcome = planEvent(db, synthetic, ref, { now: NOW });
+      expect(outcome.decision).toBe("human_needed");
+      expect(outcome.reason).toMatch(/^repo_unknown: /);
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+});
+
 describe("buildRunSpec", () => {
   test("is pure and honors adapterOverride", () => {
     const mapping = registry.eventTypes["factory.status-report.requested"];

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -30,8 +30,13 @@ function loadAgentDef(root, file) {
   }
   // §14 enforcement path: a mutating definition is admitted only when it is
   // enforceable by construction — a fixed argv template (the closed action
-  // registry), never a model. LLM agents stay read-only in the MVP (§3).
+  // registry), never a model. LLM agents stay read-only in the MVP (§3),
+  // with one boundary move stated in docs/event-runtime-dispatch.md §6
+  // (WM-107/WM-108): a mutating LLM agent over a tier-2 `worktree` workspace,
+  // whose enforcement is the coordination design itself — watched proposals,
+  // the shared claim/capacity/Owned Paths gates, and the repo's own scripts.
   if (def.mutating !== false) {
+    const tier2Worktree = def.workspace?.type === "worktree";
     const closedArgv =
       Array.isArray(def.command) && def.command.length > 0 && def.command.every((e) => typeof e === "string");
     const closedActionRegistry =
@@ -49,9 +54,9 @@ function loadAgentDef(root, file) {
       Object.values(def.actionRegistry).every(
         (a) => Array.isArray(a?.argv) && a.argv.length > 0 && a.argv.every((e) => typeof e === "string"),
       );
-    if (!closedArgv && !closedActionRegistry && !closedItemList) {
+    if (!closedArgv && !closedActionRegistry && !closedItemList && !tier2Worktree) {
       throw new RegistryError(
-        `${file}: mutating agents are admitted only as closed command templates or closed action registries (docs/event-runtime.md §14; OPS-223/OPS-208)`,
+        `${file}: mutating agents are admitted only as closed command templates, closed action registries, or tier-2 worktree agents (docs/event-runtime.md §14; docs/event-runtime-dispatch.md §6; OPS-223/OPS-208/WM-108)`,
       );
     }
   }

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -42,6 +42,21 @@ describe("registry", () => {
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
   });
 
+  test("a mutating LLM agent over a tier-2 worktree workspace is admitted (dispatch design §6, WM-108)", () => {
+    const registry = loadRegistry();
+    const def = getAgent(registry, "dispatch@1");
+    expect(def.mutating).toBe(true);
+    expect(def.workspace.type).toBe("worktree");
+    expect(getEventType(registry, "factory.dispatch.requested").agent).toBe("dispatch@1");
+    // The carve-out is the workspace type, nothing wider: the same def on an
+    // ephemeral workspace must still fail closed.
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "dispatch.json");
+    const raw = JSON.parse(readFileSync(defFile, "utf8"));
+    writeFileSync(defFile, JSON.stringify({ ...raw, workspace: { type: "ephemeral" } }));
+    expect(() => loadRegistry({ root })).toThrow(/mutating/);
+  });
+
   test("schedule payload must be a plain object without reserved tick fields (WM-72)", () => {
     const root = tempRegistry();
     const withPayload = (payload) =>

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -8,11 +8,13 @@
  * enforcement, not a security sandbox (§7): safeJoin exists so a declared
  * artifact path can never name a file outside the workspace, failing closed.
  */
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson } from "./canonical.mjs";
 import { materializeArtifact } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
+import { getRepo, loadRepos } from "./repos.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 
 export class PathViolation extends Error {
@@ -21,6 +23,14 @@ export class PathViolation extends Error {
     this.name = "PathViolation";
     this.workspaceDir = workspaceDir;
     this.relPath = relPath;
+  }
+}
+
+/** Tier-2 worktree delegation failure — always typed, never a bare throw. */
+export class WorktreeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "WorktreeError";
   }
 }
 
@@ -64,6 +74,60 @@ export function resolveInputRef(input, expr) {
   return value;
 }
 
+/**
+ * Marker recording a delegated worktree inside its workspace, so teardown can
+ * find the repo's own `worktree_down` without the caller re-plumbing repo
+ * facts through every destroy path. Durable on disk (not module state): a
+ * worker that dies and restarts must still know what to tear down.
+ */
+const WORKTREE_MARKER = ".worktree.json";
+
+/**
+ * Tier-2 mutating workspace (docs/event-runtime-dispatch.md §5, WM-108):
+ * delegate to the `worktree_up` the repo declares in config/repos.yaml —
+ * the runtime NEVER implements worktrees itself (event-runtime-workers.md
+ * §5a rule 1). Git isolates branches, not ports or databases; those live in
+ * the repo-owned script. The planner refuses `no_worktree_scripts` before
+ * proposing, so reaching this without the scripts is a bypassed gate — it
+ * still fails typed, not with a crash mid-spawn.
+ *
+ * The tree lands at `worktree_root/<ticket>` (the dispatcher's convention,
+ * orchestrator/tick.mjs) and is reachable from the workspace at
+ * `./<checkoutDir>` via symlink, mirroring tier 1's `./repo` layout. The
+ * repo's declared `verify` command rides along in the returned record — the
+ * §9 verifier runs it as ordinary code, never trusting the agent's report.
+ */
+function materializeWorktree({ workspaceDir, input, checkoutDir }) {
+  const repoName = input?.repo;
+  const ticket = input?.ticket;
+  if (!repoName || !ticket) {
+    throw new WorktreeError("a worktree workspace needs input.repo and input.ticket");
+  }
+  const repo = getRepo(loadRepos(), repoName);
+  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) {
+    throw new WorktreeError(
+      `repo "${repoName}" declares no worktree lifecycle in config/repos.yaml (worktree_up/worktree_down/worktree_root) — the planner should have refused this`,
+    );
+  }
+  const up = spawnSync("/bin/bash", [repo.worktreeUp, ticket], { cwd: repo.path, encoding: "utf8" });
+  if (up.status !== 0) {
+    const why = (up.stderr || up.stdout || "").trim().split("\n").pop() || `exit ${up.status}`;
+    throw new WorktreeError(`worktree_up failed for ${repoName}/${ticket}: ${why}`);
+  }
+  const worktreePath = path.join(repo.worktreeRoot, ticket);
+  symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
+  const record = {
+    repo: repoName,
+    ticket,
+    path: worktreePath,
+    repoPath: repo.path,
+    down: repo.worktreeDown,
+    verify: repo.verify,
+  };
+  writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+  return record;
+}
+
 export function createWorkspace({ root, runId, attempt, input, workspace = {}, artifactStore = artifactsRoot() }) {
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
@@ -98,7 +162,12 @@ export function createWorkspace({ root, runId, attempt, input, workspace = {}, a
       subdir,
     });
   }
-  return { dir, checkout, materialized };
+
+  let worktree = null;
+  if (workspace.type === "worktree") {
+    worktree = materializeWorktree({ workspaceDir: dir, input, checkoutDir: workspace.checkoutDir ?? "repo" });
+  }
+  return { dir, checkout, materialized, worktree };
 }
 
 /**
@@ -110,6 +179,26 @@ export function destroyWorkspace(dir, { retain = false, checkout = null, repoNam
   // a mirror that keeps stale worktree registrations refuses future adds.
   if (checkout) releaseCheckout({ checkoutPath: checkout, repoName });
   if (retain) return false;
+
+  // Delegated worktree teardown (WM-108): run the repo's own `worktree_down`
+  // on every non-retained path, completion and failure alike. The script owns
+  // the safety property — it refuses dirty trees, and the runtime never adds
+  // `--force` (lib/client.mjs carries the same rule). A refusal or failure
+  // retains the whole workspace, marker included, so the leak is visible to
+  // the janitor instead of an rm quietly orphaning a live dev server.
+  const marker = path.join(dir, WORKTREE_MARKER);
+  if (existsSync(marker)) {
+    let record = null;
+    try {
+      record = JSON.parse(readFileSync(marker, "utf8"));
+    } catch {
+      record = null;
+    }
+    if (!record?.down || !record?.ticket) return false;
+    const down = spawnSync("/bin/bash", [record.down, record.ticket], { cwd: record.repoPath, encoding: "utf8" });
+    if (down.status !== 0) return false;
+  }
+
   rmSync(dir, { recursive: true, force: true });
   return true;
 }

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -1,8 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { PathViolation, createWorkspace, destroyWorkspace, safeJoin } from "./workspace.mjs";
+import { PathViolation, WorktreeError, createWorkspace, destroyWorkspace, safeJoin } from "./workspace.mjs";
 
 function tmpRoot() {
   return mkdtempSync(path.join(os.tmpdir(), "evrt-ws-"));
@@ -47,5 +47,136 @@ describe("createWorkspace / destroyWorkspace", () => {
     expect(existsSync(dir)).toBe(true);
     expect(destroyWorkspace(dir)).toBe(true);
     expect(existsSync(dir)).toBe(false);
+  });
+});
+
+// Tier-2 delegation (docs/event-runtime-dispatch.md §5, WM-108): the runtime
+// never implements worktrees — it shells to the scripts each repo declares in
+// config/repos.yaml. These fixtures stand in fake scripts that log every call,
+// so the tests prove exactly when up/down ran and when they deliberately did not.
+describe("worktree workspaces (WM-108)", () => {
+  let factoryRoot;
+  let repoDir;
+  let wtRoot;
+  let callsLog;
+  let previousReposRoot;
+
+  const calls = () => (existsSync(callsLog) ? readFileSync(callsLog, "utf8").trim().split("\n") : []);
+
+  beforeAll(() => {
+    factoryRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-wt-factory-"));
+    repoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-wt-repo-")));
+    wtRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "evrt-wt-trees-")));
+    callsLog = path.join(repoDir, "calls.log");
+
+    mkdirSync(path.join(repoDir, "bin"), { recursive: true });
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up.sh"),
+      `#!/bin/bash\nset -e\necho "up $1 cwd=$PWD" >> "${callsLog}"\nmkdir -p "${wtRoot}/$1"\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-down.sh"),
+      `#!/bin/bash\nset -e\necho "down $1" >> "${callsLog}"\nrm -rf "${wtRoot}/$1"\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-broken.sh"),
+      `#!/bin/bash\necho "template failed to build" >&2\nexit 7\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-down-refuse.sh"),
+      `#!/bin/bash\necho "refusing: dirty tree" >&2\nexit 1\n`,
+    );
+
+    mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(factoryRoot, "config", "repos.yaml"),
+      `repos:\n` +
+        `  - name: wtrepo\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo verified\n` +
+        `  - name: broken-up\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up-broken.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n` +
+        `  - name: refusing-down\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down-refuse.sh\n` +
+        `    worktree_root: ${wtRoot}\n` +
+        `  - name: noscripts\n    path: ${repoDir}\n    base: develop\n`,
+    );
+    previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = factoryRoot;
+  });
+
+  afterAll(() => {
+    if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  });
+
+  const make = (repo, ticket, runId) =>
+    createWorkspace({
+      root: tmpRoot(),
+      runId,
+      attempt: 1,
+      input: { repo, ticket },
+      workspace: { type: "worktree" },
+    });
+
+  test("up is delegated to the repo's script; the tree is reachable at ./repo; verify rides along", () => {
+    const { dir, worktree } = make("wtrepo", "WM-1", "run_wt1");
+    expect(calls()).toContainEqual(`up WM-1 cwd=${repoDir}`);
+    expect(worktree).toEqual({
+      repo: "wtrepo",
+      ticket: "WM-1",
+      path: path.join(wtRoot, "WM-1"),
+      repoPath: repoDir,
+      down: "bin/worktree-down.sh",
+      verify: "echo verified",
+    });
+    const link = path.join(dir, "repo");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(realpathSync(link)).toBe(path.join(wtRoot, "WM-1"));
+    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).ticket).toBe("WM-1");
+    expect(destroyWorkspace(dir)).toBe(true);
+  });
+
+  test("destroy runs worktree_down, then removes the workspace — completion and failure teardown are the same path", () => {
+    const { dir } = make("wtrepo", "WM-2", "run_wt2");
+    expect(existsSync(path.join(wtRoot, "WM-2"))).toBe(true);
+    expect(destroyWorkspace(dir)).toBe(true);
+    expect(calls()).toContain("down WM-2");
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(path.join(wtRoot, "WM-2"))).toBe(false);
+  });
+
+  test("retainOnFailure: retain skips worktree_down and keeps workspace AND worktree for inspection", () => {
+    const { dir } = make("wtrepo", "WM-3", "run_wt3");
+    expect(destroyWorkspace(dir, { retain: true })).toBe(false);
+    expect(calls()).not.toContain("down WM-3");
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(path.join(wtRoot, "WM-3"))).toBe(true);
+    expect(destroyWorkspace(dir)).toBe(true); // operator finishing the inspection
+    expect(calls()).toContain("down WM-3");
+  });
+
+  test("a refusing worktree_down (dirty tree) retains everything and never forces", () => {
+    const { dir } = make("refusing-down", "WM-4", "run_wt4");
+    expect(destroyWorkspace(dir)).toBe(false);
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(path.join(wtRoot, "WM-4"))).toBe(true);
+  });
+
+  test("a failing worktree_up is a typed error carrying the script's last line", () => {
+    expect(() => make("broken-up", "WM-5", "run_wt5")).toThrow(WorktreeError);
+    expect(() => make("broken-up", "WM-5", "run_wt5")).toThrow(/template failed to build/);
+  });
+
+  test("a repo with no declared scripts fails typed, not with a crash mid-spawn", () => {
+    expect(() => make("noscripts", "WM-6", "run_wt6")).toThrow(WorktreeError);
+    expect(() => make("noscripts", "WM-6", "run_wt6")).toThrow(/declares no worktree lifecycle/);
+  });
+
+  test("missing input.repo or input.ticket is a typed error", () => {
+    expect(() =>
+      createWorkspace({ root: tmpRoot(), runId: "run_wt7", attempt: 1, input: { repo: "wtrepo" }, workspace: { type: "worktree" } }),
+    ).toThrow(/input.repo and input.ticket/);
   });
 });

--- a/event-runtime/schemas/dispatch.input.json
+++ b/event-runtime/schemas/dispatch.input.json
@@ -1,0 +1,53 @@
+{
+  "title": "dispatch input — one repo, one already-queued ticket (WM-108)",
+  "type": "object",
+  "required": [
+    "repo",
+    "ticket"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    },
+    "ticket": {
+      "type": "string",
+      "pattern": "^[A-Z]+-[0-9]+$",
+      "description": "Linear issue identifier to implement; must be Todo + ai:agent-ready + unassigned at plan time (docs/event-runtime-dispatch.md §2)"
+    },
+    "repoPin": {
+      "type": "object",
+      "required": [
+        "repo",
+        "sha"
+      ],
+      "additionalProperties": false,
+      "description": "Optional provenance pin recording the base-branch SHA the request was made against; the worktree itself branches from the repo's live base via its own worktree_up, so this is a record, not a checkout instruction",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Echo of the pinned short repo name"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Ref the pin was resolved from, when one was requested"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Commit SHA of the repo's base branch at request time"
+        },
+        "github": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/dispatch.output.json
+++ b/event-runtime/schemas/dispatch.output.json
@@ -1,0 +1,73 @@
+{
+  "title": "factory.dispatch-result/v1 output artifact — one ticket run's terminal outcome (WM-108)",
+  "type": "object",
+  "required": [
+    "outcome",
+    "repo",
+    "ticket",
+    "prUrl",
+    "verification",
+    "summary"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "outcome": {
+      "enum": [
+        "PR_OPEN",
+        "BLOCKED",
+        "FAILED",
+        "NOT_CLAIMED"
+      ],
+      "description": "Terminal state of the ticket run: PR_OPEN (verified, PR opened, ticket In Review), BLOCKED (typed question posted, ticket Blocked), FAILED (work attempted but no shippable diff), NOT_CLAIMED (claim lost or ticket no longer dispatchable at claim time — the typed NOOP of docs/event-runtime-dispatch.md §2)"
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name the run worked in, echoed from the input"
+    },
+    "ticket": {
+      "type": "string",
+      "pattern": "^[A-Z]+-[0-9]+$",
+      "description": "Linear issue identifier this run implemented, echoed from the input"
+    },
+    "prUrl": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "URL of the opened pull request when outcome is PR_OPEN; null for every other outcome"
+    },
+    "verification": {
+      "type": "object",
+      "required": [
+        "command",
+        "passed",
+        "output"
+      ],
+      "additionalProperties": false,
+      "description": "The ticket's own Verification Command as actually run in the worktree — never a claim without output",
+      "properties": {
+        "command": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Exact verification command executed, or null when the run never reached verification (BLOCKED/NOT_CLAIMED)"
+        },
+        "passed": {
+          "type": "boolean",
+          "description": "Whether the verification command exited zero; must be true for outcome PR_OPEN"
+        },
+        "output": {
+          "type": "string",
+          "description": "Tail of the verification command's output (last lines, enough for a reviewer to see the pass/fail evidence); empty when no command ran"
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One line an operator can act on: what shipped, what blocked, or why nothing happened"
+    }
+  }
+}


### PR DESCRIPTION
Fixes WM-108

Implements the dispatch executor per docs/event-runtime-dispatch.md (WM-107), in four staged commits:

1. **Worktree workspace provider** (`workspace.type: "worktree"`) — delegates to each repo's declared `worktree_up`/`worktree_down` from config/repos.yaml; down runs on completion and failure, `retainOnFailure` honored; a refusing `worktree_down` retains visibly (never `--force`), the janitor owns the leak.
2. **`--max-budget-usd` passthrough** in the claude adapter from the definition's limits.
3. **`dispatch@1` agent + `factory.dispatch.requested`** (`{repo, ticket}`, idempotent on inputHash) — claude adapter, `mutating: true`, prompt adapted from shared/commands/factory-ticket.md; schemas with per-field descriptions; pins via update-pins. Includes the narrowest registry carve-out so a mutating claude agent is admissible only on a worktree workspace (dispatch doc §6; test proves ephemeral-workspace defs still fail closed).
4. **Planner refusals** — plan-time gate hoisted before the write transaction (no network under SQLite's write lock): durable config states → `human_needed`; transient world states (`ticket_assigned`, `ticket_not_todo`, `ticket_not_agent_ready`, `capacity_full`, `owned_paths_overlap`) → typed resolved NOOP. Claim state read through `tools/linear.mjs` (the factory's one Linear client); capacity from policy.yaml against the worker-lease ledger; Owned Paths via `orchestrator/owned-paths.mjs` imported as a library. Transport failure throws → plan_failures → retry → dead-letter, never a silent refusal.

Verification: `bun test` → 1034 pass, 0 fail (94 files). Execute-side hardening (lock-file claim window, execute-time re-checks, consuming the repo's `verify`) is deliberately out of scope — follow-up filed.