### PR TITLE
feat(event-runtime): merge chain — merge-scan verdicts, closed merge/notify actions, chain edges (WM-109)

### DIFF
--- a/event-runtime/agents/merge-apply.json
+++ b/event-runtime/agents/merge-apply.json
@@ -1,0 +1,67 @@
+{
+  "id": "merge-apply",
+  "version": 1,
+  "prompt": "agents/merge-apply.md",
+  "input_schema": "schemas/merge-apply.input.json",
+  "output_schema": "schemas/merge-applied.output.json",
+  "output_contract": "factory.merge-applied/v1",
+  "itemsField": "plan",
+  "itemKey": "ticket",
+  "actionRegistry": {
+    "merge_pr": {
+      "argv": [
+        "sh",
+        "-c",
+        "set -eu\nactual=\"$(gh pr view \"$1\" --repo \"$2\" --json headRefOid -q .headRefOid)\"\nif [ \"$actual\" != \"$3\" ]; then\n  echo \"refusing PR #$1: head $actual is not the reviewed $3 — a moved head needs a fresh scan, not a merge\" >&2\n  exit 1\nfi\nexec gh pr merge \"$1\" --repo \"$2\" --squash --delete-branch",
+        "merge_pr",
+        "{pr}",
+        "{github}",
+        "{headSha}"
+      ]
+    },
+    "ticket_done": {
+      "argv": [
+        "bun",
+        "{factoryRoot}/tools/linear.mjs",
+        "state",
+        "{ticket}",
+        "Done",
+        "--remove",
+        "ai:needs-review",
+        "--remove",
+        "ai:escalated",
+        "--remove",
+        "ai:blocked"
+      ]
+    },
+    "notify_escalate": {
+      "argv": [
+        "factory",
+        "notify",
+        "ESCALATED PR#{pr} ({ticket}): {reason}"
+      ]
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:write",
+      "linear:write",
+      "notify:telegram"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/merge-apply.md": "sha256:3f4a7b02c8cf0d492536b2c21cfbda136aa3d8fcd773ee835158b6f7569eb116",
+    "schemas/merge-apply.input.json": "sha256:299af3cd5b0c171805345ddf81a2663a28c33a1a402b09082a7b78fb443913cc",
+    "schemas/merge-applied.output.json": "sha256:799c2d6cbd896720bcb78c3987e7499761ec4368016fa2841f631448d038a066"
+  }
+}

--- a/event-runtime/agents/merge-apply.md
+++ b/event-runtime/agents/merge-apply.md
@@ -1,0 +1,28 @@
+# merge-apply — closed action-list executor for the approved merge plan
+
+Not a prompt: this definition applies an **approved per-PR action list** via
+the deterministic actions adapter in item-list mode
+(`lib/adapters/actions.mjs`). No model runs.
+
+Registered actions — each resolves to one fixed argv:
+
+| action id | effect |
+| :--- | :--- |
+| `merge_pr` | probe, then `gh pr merge <pr> --repo <owner/name> --squash --delete-branch` |
+| `ticket_done` | `tools/linear.mjs state {ticket} "Done" --remove ai:needs-review --remove ai:escalated --remove ai:blocked` — the full merge-protocol Done transition |
+| `notify_escalate` | `factory notify "ESCALATED PR#{pr} ({ticket}): {reason}"` — the notification protocol's ESCALATED push, same invocation shape as ci-notify |
+
+`merge_pr` probes before it merges, the way disk-remediate probes `df`: it
+reads the PR's **current** head (`gh pr view --json headRefOid`) and compares
+it to the plan's pinned `headSha`. A moved head is a **refusal** (the item
+exits 1, the attempt fails, nothing later in the plan runs) — never a
+re-review; a fresh scan produces a fresh pin. The probe and the merge live in
+one fixed `sh` template whose only substitutions are trailing positional
+arguments (`$1`=pr, `$2`=github slug, `$3`=headSha), each anchored by the
+input schema — values are never spliced into the script text.
+
+An action ID outside this table refuses before applying anything — including
+the legitimate items alongside it. Deploy-branch-targeting PRs never reach
+this agent: merge-scan refuses them at scan time, and the deploy-branch merge
+belongs permanently to the ship chain's human approval (WM-111,
+docs/event-runtime-dispatch.md §7).

--- a/event-runtime/agents/merge-notify.json
+++ b/event-runtime/agents/merge-notify.json
@@ -1,0 +1,33 @@
+{
+  "id": "merge-notify",
+  "version": 1,
+  "prompt": "agents/merge-notify.md",
+  "input_schema": "schemas/merge-notify.input.json",
+  "output_schema": "schemas/command-result.output.json",
+  "output_contract": "factory.command-result/v1",
+  "command": [
+    "factory",
+    "notify",
+    "ESCALATED merge {repo}: {summary}"
+  ],
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "notify:telegram"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 60,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/merge-notify.md": "sha256:08c6b9c75db11728b3959b7f75e15d88f5d38d4dc39009b4c5ff77211011df17",
+    "schemas/merge-notify.input.json": "sha256:cf759d06e47abd5e60335da8881358e82670b09f81e95a7df69e0d9216b30f26",
+    "schemas/command-result.output.json": "sha256:56ef20577453f0162f1a0a22e8214e8c734fc0fbab4f65d1e1dcae9614acc272"
+  }
+}

--- a/event-runtime/agents/merge-notify.md
+++ b/event-runtime/agents/merge-notify.md
@@ -1,0 +1,14 @@
+# merge-notify — closed-registry action
+
+Not a prompt: this definition executes a fixed command template via the
+deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
+
+```
+factory notify "ESCALATED merge {repo}: {summary}"
+```
+
+Pushes the operator notification for an `ESCALATE` recommendation from
+`merge-scan@1` — a PR whose diff changes security-relevant behavior (or
+matches `escalate_paths`) needs the human decision, per the notification
+protocol (escalations only, never routine progress). Same shape as
+`ci-notify@1` for `ci-doctor@2`'s TICKET verdict.

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -1,0 +1,29 @@
+{
+  "id": "merge-scan",
+  "version": 1,
+  "prompt": "agents/merge-scan.md",
+  "input_schema": "schemas/merge-scan.input.json",
+  "output_schema": "schemas/merge-scan.output.json",
+  "output_contract": "factory.merge-plan/v1",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:read",
+      "linear:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/merge-scan.md": "sha256:f29375b1efa61e88550ef951ca8be7a5928833f8d5601ec5ad8b02ab9a10e30b",
+    "schemas/merge-scan.input.json": "sha256:b24950b7d9c5cdd07b0af6d2f0179f6ceea30af004c2299cd6efa60b163affa8",
+    "schemas/merge-scan.output.json": "sha256:f2d098a07e56fc68ba5d3781d42abe271292fbae9ff0913e2934fab14d7799c7"
+  }
+}

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -1,0 +1,98 @@
+# merge-scan — review a repo's open PRs cold, propose a head-SHA-pinned merge plan
+
+You are a cold merge reviewer: you did not write these PRs, you did not
+dispatch them, and you owe them nothing. Green CI is never the bar — you are
+the review that decides whether each diff is fit for a branch that
+auto-deploys. `./input.json` names one repo:
+
+```json
+{ "repo": "bj29" }
+```
+
+There is no source checkout: you read PRs through `gh`, never a local tree.
+Resolve the repo's GitHub `owner/name` slug, its `base` branch, its
+`deploy_branch`, and its `escalate_paths` from
+`$FACTORY_ROOT/config/repos.yaml`. Write `./result.json`. Work only inside
+this directory. You are read-only: you never merge, push, comment, label, or
+touch Linear state.
+
+## Method
+
+1. Enumerate open PRs targeting the repo's `base` branch only:
+   `gh pr list --repo <owner/name> --base <base> --state open --json number,title,headRefOid,body,isDraft,labels,mergeable`.
+   **Deploy-branch-targeting PRs are refused at scan time** — the deploy
+   branch is the ship chain's (WM-111); such a PR never enters the plan or
+   any list, whatever the queue looks like. Drafts and PRs already carrying
+   the `escalated` label are existing holds: leave them out of every list
+   and mention them in the summary.
+2. For each PR, in this order:
+   - **CI, real checks only**: `gh pr checks <pr> --repo <owner/name>`.
+     Verify checks actually exist — "no failures" because the repo has no
+     configured checks is NOT green; that is a FIX finding, not a pass.
+   - **Conflicts and base drift**: the PR's mergeable state against `base`.
+   - **Diff vs ticket**: read the full diff (`gh pr diff <pr>`), find the
+     Linear ticket in the PR body's `Fixes <ISSUE-ID>` line, and read it
+     (`bun "$FACTORY_ROOT/tools/linear.mjs" get <id>`). Review correctness,
+     bugs the tests don't catch, security, whether the diff stays inside the
+     ticket's `Owned Paths`, and quality. A PR whose body names no ticket
+     cannot reach the plan — its `ticket_done` half has no subject; that is
+     a FIX finding.
+3. Verdict per PR — exactly one:
+   - **MERGE** — CI green on real checks, no conflicts, no blocking
+     findings: two plan items pinned at the reviewed head SHA.
+   - **FIX** — red CI, merge conflicts, or a blocking finding that is
+     mechanical to fix: one `fix` entry, specific enough to act on without
+     re-reading the diff.
+   - **ESCALATE** — the diff changes security-relevant behavior (auth/authz,
+     payments, credentials/secrets, destructive migrations, prod infra),
+     matches the repo's `escalate_paths`, or is genuinely ambiguous: one
+     `escalate` entry naming the exact behavior change. The test is
+     behavior, not file-adjacency.
+
+## Plan — the closed set
+
+Each qualifying PR contributes exactly two plan items, in order:
+
+| action | effect downstream |
+| :--- | :--- |
+| `merge_pr` | squash-merge the PR — refused by merge-apply if the head SHA moved since this scan |
+| `ticket_done` | move the PR's Linear ticket to `Done` |
+
+Pin `headSha` at exactly the commit you reviewed. A head that moves between
+scan and apply is a refusal at apply time, never a re-review. Never invent
+an action id.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "MERGE",
+    "repo": "bj29",
+    "github": "watt-mind/bj29",
+    "plan": [
+      { "pr": 42, "headSha": "<40-hex>", "ticket": "CLNT-123", "action": "merge_pr", "reason": "CI green on real checks, clean review" },
+      { "pr": 42, "headSha": "<40-hex>", "ticket": "CLNT-123", "action": "ticket_done", "reason": "CI green on real checks, clean review" }
+    ],
+    "fix": [
+      { "pr": 43, "ticket": "CLNT-124", "finding": "Verify job red: test X fails on null input" }
+    ],
+    "escalate": [
+      { "pr": 44, "ticket": "CLNT-125", "reason": "changes token refresh in auth/session.ts" }
+    ],
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the gh and linear reads this rests on"], "prsSeen": 3 }
+}
+```
+
+`recommendation` precedence: `MERGE` when `plan` is non-empty; else
+`ESCALATE` when `escalate` is non-empty; else `FIX` when `fix` is non-empty;
+else `NOOP` with empty lists and a typed `noopReason` (`no_open_prs`, or
+`all_prs_held` when every open PR is a draft or an existing `escalated`
+hold). A NOOP is a good outcome, not a failure. If `gh` or Linear is
+unreachable, or the repo is not in `config/repos.yaml`, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -48,6 +48,26 @@
       }
     }
   },
+  "merge-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "MERGE": {
+        "eventType": "factory.merge-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "github": "$.artifact.github",
+          "plan": "$.artifact.plan"
+        }
+      },
+      "ESCALATE": {
+        "eventType": "factory.merge-escalate.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "summary": "$.artifact.summary"
+        }
+      }
+    }
+  },
   "ci-log-capture@1": {
     "recommendationField": "exitCode",
     "edges": {

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -161,6 +161,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.merge-apply.requested": {
+    "agent": "merge-apply@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -153,6 +153,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.merge.requested": {
+    "agent": "merge-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -169,6 +169,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.merge-escalate.requested": {
+    "agent": "merge-notify@1",
+    "adapter": "command",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.unblock-digest.requested": {
     "agent": "unblock-digest@1",
     "adapter": "command",

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -6,9 +6,62 @@
  * ci-doctor verdict edges (OPS-223).
  */
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadRegistry } from "./lib/registry.mjs";
 
 const registry = loadRegistry();
+
+const PINNED_SHA = "a".repeat(40);
+const MOVED_SHA = "b".repeat(40);
+
+/**
+ * Run the REAL merge-apply@1 registry definition against shimmed `gh` and
+ * `factory` binaries: the probe → merge flow executes exactly the registered
+ * templates, but nothing reaches GitHub or Telegram. The adapter's spawnSync
+ * inherits the calling process's environ (not mutated process.env), so the
+ * adapter runs in a `bun` child whose env carries the shim PATH. The shim's
+ * `pr view` answers with $FAKE_HEAD_SHA; every mutating call is appended to
+ * $SHIM_LOG.
+ */
+async function runApply(plan, { headSha = PINNED_SHA } = {}) {
+  const shims = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-shims-"));
+  const log = path.join(shims, "shim.log");
+  writeFileSync(
+    path.join(shims, "gh"),
+    `#!/bin/sh\nif [ "$1 $2" = "pr view" ]; then echo "$FAKE_HEAD_SHA"; else echo "gh $*" >> "$SHIM_LOG"; fi\n`,
+  );
+  writeFileSync(path.join(shims, "factory"), `#!/bin/sh\necho "factory $*" >> "$SHIM_LOG"\n`);
+  chmodSync(path.join(shims, "gh"), 0o755);
+  chmodSync(path.join(shims, "factory"), 0o755);
+
+  const runtimeRoot = path.dirname(fileURLToPath(import.meta.url));
+  const driver = path.join(shims, "driver.mjs");
+  writeFileSync(
+    driver,
+    `import * as actions from ${JSON.stringify(path.join(runtimeRoot, "lib", "adapters", "actions.mjs"))};\n` +
+      `import { loadRegistry } from ${JSON.stringify(path.join(runtimeRoot, "lib", "registry.mjs"))};\n` +
+      `const outcome = await actions.execute({\n` +
+      `  spec: { input: JSON.parse(process.argv[2]) },\n` +
+      `  def: loadRegistry().agents.get("merge-apply@1"),\n` +
+      `  workspaceDir: process.argv[3],\n` +
+      `  timeoutMs: 10_000,\n` +
+      `});\n` +
+      `console.log(JSON.stringify(outcome));\n`,
+  );
+
+  const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-ws-"));
+  const input = { repo: "bj29", github: "watt-mind/bj29", plan };
+  const proc = spawnSync("bun", [driver, JSON.stringify(input), workspaceDir], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${shims}:${process.env.PATH}`, FAKE_HEAD_SHA: headSha, SHIM_LOG: log },
+  });
+  expect(proc.status).toBe(0);
+  return { outcome: JSON.parse(proc.stdout.trim().split("\n").at(-1)), workspaceDir, log };
+}
 
 describe("merge-scan registration (WM-109)", () => {
   test("merge-scan@1 is a read-only claude agent with no repository workspace", () => {
@@ -36,5 +89,76 @@ describe("merge-scan registration (WM-109)", () => {
     expect(item.required).toEqual(["pr", "headSha", "ticket", "action", "reason"]);
     expect(item.properties.headSha.pattern).toBe("^[0-9a-f]{40}$");
     expect(item.properties.action.enum).toEqual(["merge_pr", "ticket_done"]);
+  });
+});
+
+describe("merge-apply is closed by construction (WM-109)", () => {
+  test("the registry admits merge-apply@1 as an item-list definition with exactly the three closed actions", () => {
+    const def = registry.agents.get("merge-apply@1");
+    expect(def.mutating).toBe(true);
+    expect(def.itemsField).toBe("plan");
+    expect(def.itemKey).toBe("ticket");
+    expect(Object.keys(def.actionRegistry).sort()).toEqual(["merge_pr", "notify_escalate", "ticket_done"]);
+    // ticket_done is the fixed merge-protocol Done transition, nothing else.
+    expect(def.actionRegistry.ticket_done.argv).toEqual([
+      "bun", "{factoryRoot}/tools/linear.mjs", "state", "{ticket}", "Done",
+      "--remove", "ai:needs-review", "--remove", "ai:escalated", "--remove", "ai:blocked",
+    ]);
+    // notify_escalate follows ci-notify's `factory notify` invocation form.
+    expect(def.actionRegistry.notify_escalate.argv).toEqual([
+      "factory", "notify", "ESCALATED PR#{pr} ({ticket}): {reason}",
+    ]);
+    // merge_pr substitutes only trailing positional args — never into the script.
+    expect(def.actionRegistry.merge_pr.argv.slice(-3)).toEqual(["{pr}", "{github}", "{headSha}"]);
+  });
+
+  test("factory.merge-apply.requested maps to merge-apply@1 on the actions adapter, deduped by inputHash", () => {
+    expect(registry.eventTypes["factory.merge-apply.requested"]).toEqual({
+      agent: "merge-apply@1",
+      adapter: "actions",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+    });
+  });
+
+  test("merge_pr probes the live head first and merges when it matches the pin", async () => {
+    const { outcome, workspaceDir, log } = await runApply([
+      { pr: 101, headSha: PINNED_SHA, ticket: "WM-500", action: "merge_pr", reason: "clean review" },
+      { pr: 102, headSha: PINNED_SHA, ticket: "WM-501", action: "notify_escalate", reason: "touches auth" },
+    ]);
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const shimLog = readFileSync(log, "utf8");
+    expect(shimLog).toContain("gh pr merge 101 --repo watt-mind/bj29 --squash --delete-branch");
+    expect(shimLog).toContain("factory notify ESCALATED PR#102 (WM-501): touches auth");
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact).toEqual({
+      repo: "bj29",
+      applied: [
+        { issueId: "WM-500", action: "merge_pr" },
+        { issueId: "WM-501", action: "notify_escalate" },
+      ],
+    });
+  });
+
+  test("a moved head is a refusal, not a re-review: the merge never executes", async () => {
+    const { outcome, workspaceDir, log } = await runApply(
+      [{ pr: 101, headSha: PINNED_SHA, ticket: "WM-500", action: "merge_pr", reason: "clean review" }],
+      { headSha: MOVED_SHA },
+    );
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false); // no mutating call ever reached the shim
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing PR #101");
+  });
+
+  test("an unregistered action refuses before applying ANY item — including the valid ones", async () => {
+    const { outcome, workspaceDir, log } = await runApply([
+      { pr: 101, headSha: PINNED_SHA, ticket: "WM-500", action: "merge_pr", reason: "clean review" },
+      { pr: 102, headSha: PINNED_SHA, ticket: "WM-501", action: "delete-everything", reason: "nope" },
+    ]);
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false); // the valid merge_pr beside it never ran
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
+      "not in the closed action registry",
+    );
   });
 });

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1,0 +1,40 @@
+/**
+ * Merge chain (WM-109): merge-scan@1 reviews a repo's open PRs cold and emits
+ * a typed, head-SHA-pinned plan; merge-apply@1 executes the approved plan via
+ * the closed actions registry; ESCALATE routes to the merge-notify push.
+ * Follows the triage-scan → triage-apply precedent (OPS-229) and the
+ * ci-doctor verdict edges (OPS-223).
+ */
+import { describe, expect, test } from "bun:test";
+import { loadRegistry } from "./lib/registry.mjs";
+
+const registry = loadRegistry();
+
+describe("merge-scan registration (WM-109)", () => {
+  test("merge-scan@1 is a read-only claude agent with no repository workspace", () => {
+    const def = registry.agents.get("merge-scan@1");
+    expect(def.mutating).toBe(false);
+    // It reads PRs via gh, not a source tree — ephemeral, like the other
+    // pure-CLI readers (factory-status-report), never a repository checkout.
+    expect(def.workspace.type).toBe("ephemeral");
+    expect(def.output_contract).toBe("factory.merge-plan/v1");
+    expect(def.capabilities.services).toContain("gh:read");
+  });
+
+  test("factory.merge.requested maps to merge-scan@1 on the claude adapter, deduped by inputHash", () => {
+    const mapping = registry.eventTypes["factory.merge.requested"];
+    expect(mapping).toEqual({
+      agent: "merge-scan@1",
+      adapter: "claude",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+    });
+  });
+
+  test("the plan item shape pins {pr, headSha, ticket} — a moved head is detectable at apply time", () => {
+    const item = registry.agents.get("merge-scan@1").outputSchema.properties.plan.items;
+    expect(item.required).toEqual(["pr", "headSha", "ticket", "action", "reason"]);
+    expect(item.properties.headSha.pattern).toBe("^[0-9a-f]{40}$");
+    expect(item.properties.action.enum).toEqual(["merge_pr", "ticket_done"]);
+  });
+});

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -11,7 +11,14 @@ import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import * as fake from "./lib/adapters/fake.mjs";
+import { resolveChains } from "./lib/chain.mjs";
+import { openDb } from "./lib/db.mjs";
+import { admitEvent } from "./lib/intake.mjs";
+import { planAdmittedEvents } from "./lib/planner.mjs";
+import { approveProposal, openProposals } from "./lib/proposals.mjs";
 import { loadRegistry } from "./lib/registry.mjs";
+import { runOnce } from "./lib/worker.mjs";
 
 const registry = loadRegistry();
 
@@ -160,5 +167,187 @@ describe("merge-apply is closed by construction (WM-109)", () => {
     expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
       "not in the closed action registry",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain e2e on the fake adapter. The shared fake (lib/adapters/fake.mjs) does
+// not know the merge contracts, so a local wrapper answers them the same way
+// the fake answers triage/sweep — repo-keyed, contract-shaped — and delegates
+// everything else (including merge-notify's command-result) to the fake.
+// ---------------------------------------------------------------------------
+
+const FAKE_PLAN_SHA = "c".repeat(40);
+
+function writeResult(workspaceDir, result) {
+  writeFileSync(path.join(workspaceDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`, "utf8");
+}
+
+function mergeScanArtifact(repo) {
+  const base = { repo, github: `watt-mind/${repo}`, plan: [], fix: [], escalate: [] };
+  if (repo === "clean") {
+    return { ...base, recommendation: "NOOP", summary: "fake: no open PRs", noopReason: "no_open_prs" };
+  }
+  if (repo.endsWith("-esc")) {
+    return {
+      ...base,
+      recommendation: "ESCALATE",
+      escalate: [{ pr: 44, ticket: "CLNT-778", reason: "fake: touches auth" }],
+      summary: `fake: PR #44 on ${repo} changes auth behavior`,
+    };
+  }
+  if (repo.endsWith("-fix")) {
+    return {
+      ...base,
+      recommendation: "FIX",
+      fix: [{ pr: 43, ticket: "CLNT-779", finding: "fake: Verify job red" }],
+      summary: `fake: PR #43 on ${repo} needs a fix`,
+    };
+  }
+  return {
+    ...base,
+    recommendation: "MERGE",
+    plan: [
+      { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "merge_pr", reason: "fake: clean review" },
+      { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "ticket_done", reason: "fake: clean review" },
+    ],
+    summary: `fake merge plan for ${repo}`,
+  };
+}
+
+const mergeFake = {
+  async execute(opts) {
+    const { spec, workspaceDir } = opts;
+    if (spec.outputContract === "factory.merge-plan/v1") {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: mergeScanArtifact(spec.input.repo),
+        evidence: { commands: ["fake"], prsSeen: 1 },
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    if (spec.outputContract === "factory.merge-applied/v1") {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: {
+          repo: spec.input.repo,
+          applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.ticket, action: i.action })),
+        },
+        evidence: { commands: ["fake"] },
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    return fake.execute(opts);
+  },
+};
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-e2e-ws-"));
+  const adapters = { claude: mergeFake, actions: mergeFake, command: mergeFake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+const PV = "git:test-pv";
+
+const mergeEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.merge.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("merge chain: scan → approved apply (WM-109)", () => {
+  test("a MERGE recommendation chains the pinned plan into a watched merge-apply proposal", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, mergeEnvelope("bj29", "merge-1"));
+
+    const scan = await approveNext("merge-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${scan.runId}`);
+    expect(chainEvent.type).toBe("factory.merge-apply.requested");
+    expect(chainEvent.correlation_id).toBe("merge-1");
+    expect(chainEvent.causation_id).toBe(scan.runId);
+
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "merge-apply@1");
+    expect(apply.status).toBe("open"); // never applied without approval
+    expect(apply.spec.input).toEqual({
+      repo: "bj29",
+      github: "watt-mind/bj29",
+      plan: [
+        { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "merge_pr", reason: "fake: clean review" },
+        { pr: 42, headSha: FAKE_PLAN_SHA, ticket: "CLNT-777", action: "ticket_done", reason: "fake: clean review" },
+      ],
+    });
+
+    const applied = await approveNext("merge-apply@1");
+    expect(applied.summary.terminalState).toBe("COMPLETED");
+    const row = db.query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`).get(applied.runId);
+    expect(JSON.parse(row.result_json).artifact.applied).toEqual([
+      { issueId: "CLNT-777", action: "merge_pr" },
+      { issueId: "CLNT-777", action: "ticket_done" },
+    ]);
+    expect(JSON.parse(row.receipt_json).runId).toBe(applied.runId); // accepted with a receipt
+  });
+
+  test("an ESCALATE recommendation routes to the merge-notify push, watched", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, mergeEnvelope("wm-esc", "merge-2"));
+    await approveNext("merge-scan@1");
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const notify = openProposals(db, {}).find((p) => p.spec?.agent === "merge-notify@1");
+    expect(notify.status).toBe("open");
+    expect(notify.spec.adapter).toBe("command");
+    expect(notify.spec.input).toEqual({ repo: "wm-esc", summary: "fake: PR #44 on wm-esc changes auth behavior" });
+
+    const pushed = await approveNext("merge-notify@1");
+    expect(pushed.summary.terminalState).toBe("COMPLETED");
+  });
+
+  test("FIX chains to NOTHING in v1 — the findings stay in the scan artifact for a human", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, mergeEnvelope("wm-fix", "merge-3"));
+    const scan = await approveNext("merge-scan@1");
+    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    expect(result.artifact.fix).toHaveLength(1);
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => ["merge-apply@1", "merge-notify@1"].includes(p.spec?.agent))).toBeUndefined();
+  });
+
+  test("an empty queue converges to NOOP — nothing proposed, nothing applied", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, mergeEnvelope("clean", "merge-4"));
+    await approveNext("merge-scan@1");
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => ["merge-apply@1", "merge-notify@1"].includes(p.spec?.agent))).toBeUndefined();
   });
 });

--- a/event-runtime/schemas/merge-applied.output.json
+++ b/event-runtime/schemas/merge-applied.output.json
@@ -1,0 +1,35 @@
+{
+  "title": "factory.merge-applied/v1 output artifact — what was actually applied",
+  "type": "object",
+  "required": ["repo", "applied"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Echo of the short repo name from the input"
+    },
+    "applied": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Every item that actually ran, in order — a failed item ends the list and fails the attempt, so nothing here claims success it cannot prove",
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "The item's Linear ticket — the item-list adapter records the item key under the fixed name issueId (lib/adapters/actions.mjs), and merge-apply's itemKey is the ticket"
+          },
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Registered action id that ran for this item"
+          }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/merge-apply.input.json
+++ b/event-runtime/schemas/merge-apply.input.json
@@ -1,0 +1,53 @@
+{
+  "title": "merge-apply input — the approved, head-SHA-pinned per-PR action list",
+  "type": "object",
+  "required": ["repo", "github", "plan"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    },
+    "github": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub owner/name slug the merge commands run against — anchored so it substitutes safely into the closed argv templates"
+    },
+    "plan": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Approved per-PR actions from the merge-scan proposal, applied in order",
+      "items": {
+        "type": "object",
+        "required": ["pr", "headSha", "ticket", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "pr": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub pull request number the action applies to"
+          },
+          "headSha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$",
+            "description": "PR head commit the scan reviewed — merge_pr probes the live head and refuses if it moved"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket the PR fixes (the item key in the applied record)"
+          },
+          "action": {
+            "enum": ["merge_pr", "ticket_done", "notify_escalate"],
+            "description": "Closed-registry action to apply — anything else refuses the whole plan before executing any item"
+          },
+          "reason": {
+            "type": "string",
+            "description": "One-line justification kept for the audit trail; notify_escalate substitutes it into the push and refuses without it"
+          }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/merge-notify.input.json
+++ b/event-runtime/schemas/merge-notify.input.json
@@ -1,0 +1,18 @@
+{
+  "title": "merge-notify input — the merge-scan escalation to push to the operator",
+  "type": "object",
+  "required": ["repo", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — names the queue the human needs to look at"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-line scan summary naming the escalated PR(s) and why, pushed verbatim to the operator"
+    }
+  }
+}

--- a/event-runtime/schemas/merge-scan.input.json
+++ b/event-runtime/schemas/merge-scan.input.json
@@ -1,0 +1,13 @@
+{
+  "title": "merge-scan input — one repo whose open PRs to review for merging",
+  "type": "object",
+  "required": ["repo"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    }
+  }
+}

--- a/event-runtime/schemas/merge-scan.output.json
+++ b/event-runtime/schemas/merge-scan.output.json
@@ -1,0 +1,118 @@
+{
+  "title": "factory.merge-plan/v1 output artifact — per-PR MERGE/FIX/ESCALATE verdicts with a head-SHA-pinned merge plan",
+  "type": "object",
+  "required": ["recommendation", "repo", "github", "plan", "fix", "escalate", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": {
+      "enum": ["MERGE", "FIX", "ESCALATE", "NOOP"],
+      "description": "MERGE when at least one PR qualifies (plan is non-empty); else ESCALATE when at least one PR needs the human; else FIX when only fixable findings remain; else NOOP"
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Echo of the short repo name from the input"
+    },
+    "github": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub owner/name slug resolved from config/repos.yaml — the repository the apply actions run against"
+    },
+    "plan": {
+      "type": "array",
+      "description": "Merge actions for qualifying PRs only — two items per PR (merge_pr, then ticket_done), each pinned to the reviewed head SHA. Never a deploy-branch-targeting PR: those are the ship chain's (WM-111), refused at scan time",
+      "items": {
+        "type": "object",
+        "required": ["pr", "headSha", "ticket", "action", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "pr": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub pull request number"
+          },
+          "headSha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$",
+            "description": "PR head commit the verdict was reviewed at — merge-apply refuses the item if the head has moved"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket the PR fixes, from its Fixes line"
+          },
+          "action": {
+            "enum": ["merge_pr", "ticket_done"],
+            "description": "Closed merge-apply action id this item resolves to"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "One-line justification kept for the audit trail"
+          }
+        }
+      }
+    },
+    "fix": {
+      "type": "array",
+      "description": "Per-PR FIX findings — red CI, conflicts, or blocking-but-mechanical review findings. v1 chains these to nothing: they stay in this artifact for a human, never an autonomous fix loop",
+      "items": {
+        "type": "object",
+        "required": ["pr", "finding"],
+        "additionalProperties": false,
+        "properties": {
+          "pr": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub pull request number the finding is about"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket the PR fixes, when its body names one"
+          },
+          "finding": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Specific enough that the caller can act without re-reading the diff"
+          }
+        }
+      }
+    },
+    "escalate": {
+      "type": "array",
+      "description": "Per-PR ESCALATE reasons — security-relevant behavior changes, escalate_paths matches, or genuinely ambiguous diffs that need the human decision",
+      "items": {
+        "type": "object",
+        "required": ["pr", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "pr": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub pull request number being escalated"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket the PR fixes, when its body names one"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The exact behavior change or ambiguity that triggers the escalation"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One line an operator can act on"
+    },
+    "noopReason": {
+      "enum": ["no_open_prs", "all_prs_held"],
+      "description": "Typed reason accompanying a NOOP — the repo has no open base-targeting PRs, or every open PR is an existing hold (draft, or already carrying the escalated label)"
+    }
+  }
+}


### PR DESCRIPTION
Fixes WM-109

Ports /factory-merge into the runtime's scan → watched approval → apply shape, per docs/event-runtime-dispatch.md §7:

1. **`merge-scan@1`** (claude, `mutating: false`, ephemeral workspace) — base-branch PRs only, real required checks ("no checks" ≠ green), conflicts, diff-vs-ticket per the factory-merge-reviewer rubric; per-PR MERGE/FIX/ESCALATE; deploy-branch PRs refused at scan time (ship chain, WM-111). Plan items pin `{pr, headSha, ticket}`.
2. **`merge-apply@1`** (actions adapter, item-list mode) — closed registry: `merge_pr` probes the live head SHA and refuses on mismatch before merging (constant script, schema-anchored positional args only), `ticket_done` (full merge-protocol Linear transition), `notify_escalate` (ci-notify's form). Unregistered action ID refuses the whole plan.
3. **Edges + e2e** — MERGE → `factory.merge-apply.requested` (pinned plan, correlation/causation inherited); ESCALATE → `factory.merge-escalate.requested` → `merge-notify@1`; FIX chains to nothing in v1 (findings stay in the artifact). Fake-adapter e2e covers the full chain plus escalate/fix/noop paths; adapter-level tests execute the real `merge_pr` argv against shimmed `gh`/`factory` binaries.

Every proposal watched; no `approval: auto` anywhere in this chain.

Verification: `bun test event-runtime/` → 757 pass, 0 fail; full `bun test` → 1066 pass, 0 fail (one unrelated worktree-checkout concurrency flake on first run, passes in isolation and on re-run — filed separately).