### PR TITLE
feat(event-runtime): work-scan agent — queue scan to a typed DISPATCH plan chained into dispatch (WM-110)

### DIFF
--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -1,0 +1,30 @@
+{
+  "id": "work-scan",
+  "version": 1,
+  "prompt": "agents/work-scan.md",
+  "input_schema": "schemas/work-scan.input.json",
+  "output_schema": "schemas/work-scan.output.json",
+  "output_contract": "factory.work-plan/v1",
+  "workspace": {
+    "type": "repository",
+    "checkoutDir": "repo",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "linear:read",
+      "repo:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/work-scan.md": "sha256:fc801eff175731093b473930fc6c24a4c7914ec7514a6d047e67780486022659",
+    "schemas/work-scan.input.json": "sha256:9932614918892f8ad90e0ef2e89145ef41a2bad79050a3dc6298ac88aff30e4c",
+    "schemas/work-scan.output.json": "sha256:fc3d7d8de8ca4c892f6be6effe6e3f89edd8ea68e6a0cbc0b5d17d469d4cb188"
+  }
+}

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -1,0 +1,94 @@
+# work-scan — read a repo's agent-ready queue, propose a typed dispatch plan
+
+You are a dispatch planner. `./input.json` names one repo and the exact source
+tree to read it against:
+
+```json
+{
+  "repo": "bj29",
+  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+}
+```
+
+`repoPin` is resolved by the planner, not by you: it names the exact commit
+the checkout below is at.
+
+The repo's source is checked out **read-only** at `./repo` (that exact SHA).
+You never modify it, never run its build, never install anything. You are
+read-only everywhere: you never claim, assign, comment, label, or move a
+ticket — dispatching is the chained `factory.dispatch.requested` run's job
+(WM-108), not yours. Write `./result.json`. Work only inside this directory.
+
+## Method
+
+1. **Enumerate candidates**: the repo's `Todo` + `ai:agent-ready` +
+   **unassigned** tickets (`bun "$FACTORY_ROOT/tools/linear.mjs"`). The
+   `assignee` field is the ticket lock (docs/event-runtime-dispatch.md §2) —
+   check the actual field on each ticket; an `agent:*` or `ai:*` label proves
+   nothing either way. Any assignee at all excludes the ticket.
+2. **Order them**: priority ascending (urgent first), then `createdAt`
+   ascending — the same queue order the orchestrator dispatches in.
+3. **Count the cap**: the repo's `max_in_flight` from
+   `$FACTORY_ROOT/config/repos.yaml`, falling back to
+   `concurrency.max_in_flight_per_repo` in `config/policy.yaml`, else 3. The
+   in-flight count against it is the repo team/project's `In Progress`
+   tickets — the same set the dispatch gate reads. Free slots = cap minus
+   in-flight; zero or fewer → NOOP `cap_full`.
+4. **Pin each candidate's Owned Paths**: parse its `## Owned Paths` section
+   and check the globs against the real tree at `./repo`. A glob matching
+   nothing that exists is only a smell (new files legitimately match
+   nothing) — note it in the item's `reason`, don't disqualify. A ticket with
+   no parseable section owns **everything** (`["**"]`): still plannable, but
+   only alone, with nothing in flight. Ambiguous overlap is overlap — the
+   same biases as `orchestrator/owned-paths.mjs`, always toward collision.
+5. **Select the plan**: walk the ordered queue; take each ticket whose Owned
+   Paths are disjoint from every in-flight ticket's paths AND from every
+   ticket already selected; skip colliding ones (they wait for a later scan);
+   stop when the free slots are full. Selected in order, each item pinning
+   `{ticket, ownedPaths, reason}`.
+
+## What you cannot see — say so, never pretend
+
+You cannot see the runtime's own ledger: a ticket with an open (not yet
+approved) dispatch proposal, or an approved-but-unclaimed run, still reads as
+unassigned in Linear. Excluding assigned tickets is the whole dedup you can
+enforce from your inputs. The rest is closed downstream, by design: every
+chained `factory.dispatch.requested` is re-gated by WM-108's plan-time checks
+(assignee, cap, Owned Paths — a stale scan cannot force a dispatch), and the
+dispatch run's claim read-back refuses a lost race as `NOT_CLAIMED`. Your
+plan is advisory input to that gate, not a reservation.
+
+Only the **first** plan item chains into a dispatch this run (one chain event
+per run); list every later item's ticket id in `deferred`. Rolling dispatch
+comes from re-firing `factory.work.requested` after each completion, which
+re-plans the deferred tickets against a fresh world.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "DISPATCH",
+    "repo": "bj29",
+    "ticket": "CLNT-123",
+    "plan": [
+      { "ticket": "CLNT-123", "ownedPaths": ["src/feature-a/**"], "reason": "priority 1, paths disjoint from all in-flight" },
+      { "ticket": "CLNT-124", "ownedPaths": ["src/feature-b/**"], "reason": "priority 2, disjoint from CLNT-123 and in-flight" }
+    ],
+    "deferred": ["CLNT-124"],
+    "summary": "one line an operator can act on"
+  },
+  "evidence": { "commands": ["the linear reads this rests on"], "candidatesSeen": 5, "inFlightSeen": 1 }
+}
+```
+
+`ticket` is always `plan[0].ticket`. No dispatchable ticket, cap already
+full, or everything colliding → `recommendation: "NOOP"` with an empty
+`plan`, empty `deferred`, `ticket: null`, and a typed `noopReason`
+(`queue_empty`, `cap_full`, `all_overlapping`). A NOOP is a good outcome, not
+a failure. If Linear is unreachable, or the repo has no team/project in
+`config/repos.yaml`, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -81,6 +81,18 @@
       }
     }
   },
+  "work-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "DISPATCH": {
+        "eventType": "factory.dispatch.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "ticket": "$.artifact.ticket"
+        }
+      }
+    }
+  },
   "ci-doctor@2": {
     "recommendationField": "verdict",
     "edges": {

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -193,6 +193,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.work.requested": {
+    "agent": "work-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.ticket.dispatched": {
     "observe": true
   },

--- a/event-runtime/schemas/work-scan.input.json
+++ b/event-runtime/schemas/work-scan.input.json
@@ -1,0 +1,51 @@
+{
+  "title": "work-scan input — one repo queue to scan; repoPin is resolved by the planner (WM-110)",
+  "type": "object",
+  "required": [
+    "repo"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    },
+    "ref": {
+      "type": "string",
+      "description": "Optional git ref to scan instead of the repo's configured base branch"
+    },
+    "repoPin": {
+      "type": "object",
+      "required": [
+        "repo",
+        "sha"
+      ],
+      "additionalProperties": false,
+      "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Echo of the pinned short repo name"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Ref the pin was resolved from, when one was requested"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Commit SHA the scan runs against"
+        },
+        "github": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/work-scan.output.json
+++ b/event-runtime/schemas/work-scan.output.json
@@ -1,0 +1,71 @@
+{
+  "title": "factory.work-plan/v1 output artifact — ordered dispatchable-ticket plan with one chained dispatch target (WM-110)",
+  "type": "object",
+  "required": ["recommendation", "repo", "ticket", "plan", "deferred", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": {
+      "enum": ["DISPATCH", "NOOP"],
+      "description": "DISPATCH when at least one Todo + ai:agent-ready + unassigned ticket fits the per-repo in-flight cap with Owned Paths disjoint from all in-flight work; NOOP otherwise, with a typed noopReason"
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Echo of the short repo name from the input"
+    },
+    "ticket": {
+      "type": ["string", "null"],
+      "pattern": "^[A-Z]+-[0-9]+$",
+      "description": "The plan's first ticket — the single target the chain edge feeds into factory.dispatch.requested (chain.mjs emits exactly one chain event per run); must equal plan[0].ticket, null on NOOP"
+    },
+    "plan": {
+      "type": "array",
+      "description": "Queue-ordered (priority asc, then createdAt asc) tickets that are dispatchable right now: Todo + ai:agent-ready + unassigned, within the per-repo in-flight cap, Owned Paths mutually disjoint and disjoint from every in-flight ticket's paths. Item order is dispatch order; only the first item chains this run",
+      "items": {
+        "type": "object",
+        "required": ["ticket", "ownedPaths", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear issue identifier, dispatchable at scan time (assignee field checked, not just labels)"
+          },
+          "ownedPaths": {
+            "type": "array",
+            "minItems": 1,
+            "description": "The ticket's Owned Paths globs as parsed at scan time — the disjointness evidence this plan rests on; a ticket with no parseable section owns everything ([\"**\"]) and can only ever be planned alone",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "description": "One Owned Paths glob, verified against the pinned tree at ./repo"
+            }
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "One line of why this ticket made the plan at this position (priority, age, path disjointness)"
+          }
+        }
+      }
+    },
+    "deferred": {
+      "type": "array",
+      "description": "Tickets after the first plan item: selected but NOT chained this run — chain.mjs emits one chain event per run, so only plan[0] becomes a factory.dispatch.requested; rolling dispatch re-fires the scan after each completion and re-plans these against a fresh world",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]+-[0-9]+$",
+        "description": "Linear issue identifier of a planned-but-deferred ticket (echo of a plan[1..] item's ticket)"
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One line an operator can act on"
+    },
+    "noopReason": {
+      "enum": ["queue_empty", "cap_full", "all_overlapping"],
+      "description": "Typed reason accompanying a NOOP — no Todo + ai:agent-ready + unassigned tickets exist, the per-repo in-flight cap is already full, or every dispatchable ticket's Owned Paths collide with in-flight work or with each other"
+    }
+  }
+}

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -1,0 +1,309 @@
+/**
+ * Work chain (WM-110): work-scan@1 reads a repo's agent-ready Linear queue
+ * against a pinned tree and emits a typed DISPATCH plan; the chain edge feeds
+ * the FIRST planned ticket into factory.dispatch.requested, where WM-108's
+ * plan-time gate re-checks the world — a stale scan cannot force a dispatch.
+ * chain.mjs emits exactly one chain event per run (eventId chain-<runId>), so
+ * the rest of the plan rides in the artifact as `deferred`; rolling dispatch
+ * comes from re-firing the scan event, never a long-lived loop. Follows the
+ * triage-scan (OPS-229) and merge-scan (WM-109) precedents.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fake from "./lib/adapters/fake.mjs";
+import { resolveChains } from "./lib/chain.mjs";
+import { openDb } from "./lib/db.mjs";
+import { admitEvent } from "./lib/intake.mjs";
+import { planAdmittedEvents } from "./lib/planner.mjs";
+import { approveProposal, openProposals } from "./lib/proposals.mjs";
+import { loadRegistry } from "./lib/registry.mjs";
+import { runOnce } from "./lib/worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+// See repository.test.mjs: neutralise the operator's global git config so a
+// signing key or a global hooks path cannot hang the fixture (OPS-441).
+const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
+const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+
+// Hermetic repo fixtures: a real git repo (the scan's repository workspace
+// pins a SHA) whose config also carries the worktree scripts and team/project
+// the chained dispatch plan is gated on. Linear and the lease ledger are
+// injected — no test here touches the network or ~/.factory.
+const fixtures = [];
+let previousReposRoot;
+let previousEventHome;
+
+function makeGitRepo(name) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), `evrt-work-${name}-`));
+  fixtures.push(dir);
+  git(["init", "--quiet", "--initial-branch=develop"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(path.join(dir, "README.md"), `${name}\n`);
+  git(["add", "."], dir);
+  git(["commit", "--quiet", "-m", "init"], dir);
+  return dir;
+}
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-work-factory-"));
+  fixtures.push(root);
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  const wm29 = makeGitRepo("wm29");
+  const clean = makeGitRepo("clean");
+  const wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-work-trees-"));
+  fixtures.push(wtRoot);
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: wm29\n    path: ${wm29}\n    github: watt-mind/wm29\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n` +
+      `  - name: clean\n    path: ${clean}\n    github: watt-mind/clean\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+      `    worktree_root: ${wtRoot}\n`,
+  );
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  previousEventHome = process.env.FACTORY_EVENT_HOME;
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-work-home-"));
+  fixtures.push(process.env.FACTORY_EVENT_HOME);
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+  else process.env.FACTORY_EVENT_HOME = previousEventHome;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+const FIRST = "WM-601";
+const SECOND = "WM-602";
+
+// ---------------------------------------------------------------------------
+// Chain e2e on the fake adapter. The shared fake (lib/adapters/fake.mjs) does
+// not know the work-plan contract, so a local wrapper answers it the same way
+// the fake answers triage/sweep — repo-keyed, contract-shaped — and delegates
+// everything else to the fake.
+// ---------------------------------------------------------------------------
+
+function workScanArtifact(repo) {
+  if (repo === "clean") {
+    return {
+      recommendation: "NOOP",
+      repo,
+      ticket: null,
+      plan: [],
+      deferred: [],
+      summary: "fake: no dispatchable tickets",
+      noopReason: "queue_empty",
+    };
+  }
+  return {
+    recommendation: "DISPATCH",
+    repo,
+    ticket: FIRST,
+    plan: [
+      { ticket: FIRST, ownedPaths: ["src/feature-a/**"], reason: "fake: priority 1, disjoint" },
+      { ticket: SECOND, ownedPaths: ["src/feature-b/**"], reason: "fake: priority 2, disjoint" },
+    ],
+    deferred: [SECOND],
+    summary: `fake work plan for ${repo}`,
+  };
+}
+
+const workFake = {
+  async execute(opts) {
+    const { spec, workspaceDir } = opts;
+    if (spec.outputContract === "factory.work-plan/v1") {
+      writeFileSync(
+        path.join(workspaceDir, "result.json"),
+        `${JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "completed",
+          reasonCode: "ok",
+          artifact: workScanArtifact(spec.input.repo),
+          evidence: { commands: ["fake"], candidatesSeen: 2, inFlightSeen: 0 },
+        }, null, 2)}\n`,
+        "utf8",
+      );
+      return { exitCode: 0, timedOut: false };
+    }
+    return fake.execute(opts);
+  },
+};
+
+/**
+ * Injected dispatch-gate world for planning the CHAINED event: the planner's
+ * worktree gate re-reads Linear and the lease ledger (dispatch doc §§2–4);
+ * here both say "wide open" so the chained proposal is planned, proving the
+ * re-gate ran without a network read. dispatch.test.mjs owns the refusal
+ * matrix — not re-proven here.
+ */
+const openWorld = {
+  fetchTicket: () => ({
+    identifier: FIRST,
+    title: "a fully specified ticket",
+    state: { name: "Todo" },
+    assignee: null,
+    labels: { nodes: [{ name: "ai:agent-ready" }] },
+    description: "## Owned Paths\n- src/feature-a/**\n",
+  }),
+  fetchInFlight: () => [],
+  countLeases: () => 0,
+};
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-work-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-work-ws-"));
+  const adapters = { claude: workFake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  const planAll = () => planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld });
+
+  async function approveNext(agentRef) {
+    planAll();
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, planAll, approveNext };
+}
+
+const workEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.work.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("work-scan registration (WM-110)", () => {
+  test("work-scan@1 is a read-only claude agent over a repository workspace, like triage-scan", () => {
+    const def = registry.agents.get("work-scan@1");
+    expect(def.mutating).toBe(false);
+    // It verifies Owned Paths globs against real paths, so it reads the
+    // pinned tree — repository checkout, never a mutable worktree.
+    expect(def.workspace).toEqual({ type: "repository", checkoutDir: "repo", retainOnFailure: true });
+    expect(def.output_contract).toBe("factory.work-plan/v1");
+    expect(def.capabilities.services).toEqual(["linear:read", "repo:read"]);
+  });
+
+  test("factory.work.requested maps to work-scan@1 on the claude adapter, deduped by inputHash", () => {
+    expect(registry.eventTypes["factory.work.requested"]).toEqual({
+      agent: "work-scan@1",
+      adapter: "claude",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+    });
+  });
+
+  test("the plan item shape pins {ticket, ownedPaths, reason}; NOOP reasons are the closed set", () => {
+    const schema = registry.agents.get("work-scan@1").outputSchema;
+    expect(schema.properties.plan.items.required).toEqual(["ticket", "ownedPaths", "reason"]);
+    expect(schema.properties.plan.items.properties.ticket.pattern).toBe("^[A-Z]+-[0-9]+$");
+    expect(schema.properties.noopReason.enum).toEqual(["queue_empty", "cap_full", "all_overlapping"]);
+  });
+
+  test("the DISPATCH edge is single-emit by construction: one {repo, ticket} into factory.dispatch.requested", () => {
+    // chain.mjs derives eventId chain-<runId> — one chain event per run, ever
+    // — so the edge carries exactly the artifact's single dispatch target and
+    // the rest of the plan stays in `deferred`.
+    expect(registry.edges["work-scan@1"]).toEqual({
+      recommendationField: "recommendation",
+      edges: {
+        DISPATCH: {
+          eventType: "factory.dispatch.requested",
+          input: { repo: "$.artifact.repo", ticket: "$.artifact.ticket" },
+        },
+      },
+    });
+  });
+});
+
+describe("work chain: scan → chained dispatch proposal (WM-110)", () => {
+  test("a DISPATCH plan chains its first ticket into a watched, re-gated dispatch proposal", async () => {
+    const { db, planAll, approveNext } = harness();
+    admitEvent(db, registry, workEnvelope("wm29", "work-1"));
+
+    const scan = await approveNext("work-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+    // The scan run's spec pins an immutable SHA (OPS-228): reproducible, and
+    // dedup distinguishes "same repo, new commit".
+    expect(scan.proposal.spec.input.repoPin).toMatchObject({ repo: "wm29", ref: "develop" });
+    expect(scan.proposal.spec.input.repoPin.sha).toMatch(/^[0-9a-f]{40}$/);
+
+    // The single-emit shape: only plan[0] chains; the rest is recorded, typed.
+    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    expect(result.artifact.ticket).toBe(FIRST);
+    expect(result.artifact.deferred).toEqual([SECOND]);
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${scan.runId}`);
+    expect(chainEvent.type).toBe("factory.dispatch.requested");
+    expect(chainEvent.correlation_id).toBe("work-1"); // inherited from the scan's event
+    expect(chainEvent.causation_id).toBe(scan.runId);
+
+    // The chained event is planned through WM-108's gate (injected world) and
+    // lands as its own watched proposal with exactly the dispatch input shape.
+    planAll();
+    const dispatch = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
+    expect(dispatch).toBeTruthy();
+    expect(dispatch.status).toBe("open"); // watched: nothing mutates without approval
+    expect(dispatch.spec.input).toEqual({ repo: "wm29", ticket: FIRST });
+    expect(dispatch.spec.workspace.type).toBe("worktree");
+
+    // One chain event per run, ever: re-resolving emits nothing new.
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+  });
+
+  test("a NOOP scan chains to nothing — no dispatch proposal exists", async () => {
+    const { db, planAll, approveNext } = harness();
+    admitEvent(db, registry, workEnvelope("clean", "work-2"));
+    const scan = await approveNext("work-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAll();
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1")).toBeUndefined();
+  });
+
+  test("re-injecting the same envelope converges: one event, one scan proposal", async () => {
+    const { db, planAll } = harness();
+    expect(admitEvent(db, registry, workEnvelope("wm29", "work-3")).admitted).toBe(true);
+    expect(admitEvent(db, registry, workEnvelope("wm29", "work-3")).duplicate).toBe(true);
+    planAll();
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(1);
+    expect(openProposals(db, {}).filter((p) => p.spec?.agent === "work-scan@1")).toHaveLength(1);
+  });
+
+  test("a re-fired scan (new eventId, same repo) plans a NEW run — rolling re-fires are not deduped away", async () => {
+    const { db, planAll, approveNext } = harness();
+    admitEvent(db, registry, workEnvelope("wm29", "work-4"));
+    await approveNext("work-scan@1");
+
+    // Same payload, same pinned SHA — but the idempotency key carries the
+    // correlation (planner.mjs suffixes it when the scope omits it), so each
+    // re-fire re-reads the queue instead of resolving as duplicate_run.
+    admitEvent(db, registry, workEnvelope("wm29", "work-5"));
+    planAll();
+    const again = openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1" && p.decision === "run");
+    expect(again).toBeTruthy();
+    expect(again.reason).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes WM-110

The scan half of /factory-work:

1. **`work-scan@1`** (claude, `mutating: false`, repository workspace + `linear:read`) — enumerates `Todo` + `ai:agent-ready` + unassigned tickets for the repo, orders by priority then age, respects the per-repo in-flight cap, selects the greedy maximal prefix with mutually non-overlapping Owned Paths (matching `nextDispatchable`'s semantics). Typed NOOP with reason otherwise. `factory.work.requested {repo}` registered.
2. **Chain edge** — `DISPATCH` → `factory.dispatch.requested {repo, ticket}`. `chain.mjs` is single-emit by construction (`chain-<runId>`, one chain event per run), so the edge emits `plan[0]` and the artifact records `plan[1..]` as `deferred` with the constraint documented in the schema — rolling dispatch is the re-fire of the scan event, and every chained dispatch is re-gated by WM-108's plan-time checks (assignee/cap/Owned Paths), so a stale scan cannot force a dispatch.
3. **Dedup, honestly**: the agent excludes any ticket with a non-null assignee; what it cannot see (open unapproved dispatch proposals) is stated in the prompt and artifact contract rather than pretended away — the structural backstops are the dispatch gate, chain/intake dedup, and the dispatch agent's claim read-back (`NOT_CLAIMED`).

Fake-adapter e2e: scan → chained dispatch proposal (exact input, correlation/causation inherited), NOOP path, re-inject idempotency, re-fire plans a new run.

Verification: `bun test event-runtime/` → 765 pass, 0 fail; full `bun test` → 1074 pass, 0 fail (98 files).