### PR TITLE
refactor(event-runtime-web): share Workers health() with command palette (OPS-291)

### DIFF
--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { api } from "../api";
 import { GO_CHORD_MS, goPrefix, goSequence } from "../goSequence";
 import { keyGuard, modal } from "../hooks";
 import { useContextActions } from "../palette";
+import { health } from "../workerHealth";
 
 export interface PaletteAction {
   label: string;
@@ -223,9 +224,7 @@ export function CommandPalette({
           {(workers.data?.workers ?? []).length > 0 && (
             <Command.Group heading="Workers">
           {(workers.data?.workers ?? []).map((w) => {
-            // A stale heartbeat outranks what the worker last reported, same
-            // as the Workers view — the palette must not call a dead process busy.
-            const state = w.stale ? "stale" : w.state;
+            const state = health(w);
             return (
             <Command.Item
               key={w.workerId}

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -42,21 +42,7 @@ import {
   copyText,
   shortId,
 } from "../components/ui";
-
-/** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector. */
-const WORKER_HUES: Record<string, string> = {
-  idle: "var(--hue-ok)",
-  busy: "var(--hue-warn)",
-  stopped: "var(--hue-idle)",
-  stale: "var(--hue-err)",
-};
-
-/**
- * A stale heartbeat outranks whatever the row claims: a stale busy worker is
- * gone, not busy. `listWorkers` never marks a cleanly stopped worker stale, so
- * these four are disjoint.
- */
-const health = (w: Worker) => (w.stale ? "stale" : w.state);
+import { health, WORKER_HUES } from "../workerHealth";
 
 export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
 export type WorkerTab = (typeof WORKER_TABS)[number];

--- a/event-runtime/web/src/workerHealth.ts
+++ b/event-runtime/web/src/workerHealth.ts
@@ -1,0 +1,18 @@
+import type { Worker, WorkerState } from "./types";
+
+export type WorkerHealth = WorkerState | "stale";
+
+/** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector. */
+export const WORKER_HUES: Record<WorkerHealth, string> = {
+  idle: "var(--hue-ok)",
+  busy: "var(--hue-warn)",
+  stopped: "var(--hue-idle)",
+  stale: "var(--hue-err)",
+};
+
+/**
+ * A stale heartbeat outranks whatever the row claims: a stale busy worker is
+ * gone, not busy. `listWorkers` never marks a cleanly stopped worker stale, so
+ * these four are disjoint.
+ */
+export const health = (w: Worker): WorkerHealth => (w.stale ? "stale" : w.state);


### PR DESCRIPTION
Fixes OPS-291