### PR TITLE
feat(event-runtime): ship chain — RC assembly, human-only ship-apply approval, closed release actions (WM-111)

### DIFF
--- a/event-runtime/agents/ship-apply.json
+++ b/event-runtime/agents/ship-apply.json
@@ -1,0 +1,74 @@
+{
+  "id": "ship-apply",
+  "version": 1,
+  "prompt": "agents/ship-apply.md",
+  "input_schema": "schemas/ship-apply.input.json",
+  "output_schema": "schemas/ship-applied.output.json",
+  "output_contract": "factory.ship-applied/v1",
+  "itemsField": "plan",
+  "itemKey": "action",
+  "actionRegistry": {
+    "open_rc_pr": {
+      "argv": [
+        "sh",
+        "-c",
+        "set -eu\nactual=\"$(gh api \"repos/$1/branches/$2\" --jq .commit.sha)\"\nif [ \"$actual\" != \"$3\" ]; then\n  echo \"refusing open_rc_pr: base $2 head is $actual, not the scanned $3 — a moved base needs a fresh ship scan, not a release PR\" >&2\n  exit 1\nfi\nexisting=\"$(gh pr list --repo \"$1\" --base \"$4\" --head \"$2\" --state open --json number --jq length)\"\nif [ \"$existing\" != \"0\" ]; then\n  echo \"reusing the existing open release PR ($2 -> $4)\"\n  exit 0\nfi\nexec gh pr create --repo \"$1\" --base \"$4\" --head \"$2\" --title \"$5\" --body \"$6\"",
+        "open_rc_pr",
+        "{github}",
+        "{base}",
+        "{headSha}",
+        "{deployBranch}",
+        "{title}",
+        "{body}"
+      ]
+    },
+    "merge_rc_pr": {
+      "argv": [
+        "sh",
+        "-c",
+        "set -eu\ndeploy_actual=\"$(gh api \"repos/$1/branches/$2\" --jq .commit.sha)\"\nif [ \"$deploy_actual\" != \"$3\" ]; then\n  echo \"refusing merge_rc_pr: deploy branch $2 head is $deploy_actual, not the scanned $3 — the deploy branch moved since the scan; re-scan, never merge blind\" >&2\n  exit 1\nfi\npr=\"$(gh pr list --repo \"$1\" --base \"$2\" --head \"$4\" --state open --json number --jq \".[0].number // empty\")\"\nif [ -z \"$pr\" ]; then\n  echo \"refusing merge_rc_pr: no open release PR $4 -> $2 on $1\" >&2\n  exit 1\nfi\npr_head=\"$(gh pr view \"$pr\" --repo \"$1\" --json headRefOid --jq .headRefOid)\"\nif [ \"$pr_head\" != \"$5\" ]; then\n  echo \"refusing release PR #$pr: head $pr_head is not the scanned $5 — a moved head needs a fresh ship scan, not a merge\" >&2\n  exit 1\nfi\ngh pr checks \"$pr\" --repo \"$1\" --watch --fail-fast\nexec gh pr merge \"$pr\" --repo \"$1\" --merge",
+        "merge_rc_pr",
+        "{github}",
+        "{deployBranch}",
+        "{deployHeadSha}",
+        "{base}",
+        "{headSha}"
+      ]
+    },
+    "smoke_check": {
+      "argv": [
+        "sh",
+        "-c",
+        "set -eu\nexpected=\"$(gh api \"repos/$1/branches/$2\" --jq .commit.sha)\"\ndeadline=$(( $(date +%s) + ${SHIP_SMOKE_DEADLINE_SECONDS:-600} ))\ndeployed=\"\"\nwhile :; do\n  deployed=\"$(SMOKE_URL=\"$3\" SMOKE_REVISION_FIELD=\"$6\" FACTORY_ROOT_DIR=\"$4\" bun -e 'const { deployedRevision, metadataUrl } = await import(process.env.FACTORY_ROOT_DIR + \"/lib/repo-status.mjs\"); const res = await fetch(metadataUrl(process.env.SMOKE_URL), { headers: { accept: \"application/json\" } }); if (!res.ok) { console.error(\"endpoint answered \" + res.status); process.exit(1); } const rev = deployedRevision(await res.json(), process.env.SMOKE_REVISION_FIELD || null); if (!rev) { console.error(\"endpoint did not expose a revision\"); process.exit(1); } console.log(rev.value);')\" || deployed=\"\"\n  if [ -n \"$deployed\" ] && [ \"${#deployed}\" -ge 7 ]; then\n    case \"$expected\" in\n      \"$deployed\"*) echo \"smoke green: $2 serves $deployed\"; exit 0 ;;\n    esac\n  fi\n  if [ \"$(date +%s)\" -ge \"$deadline\" ]; then break; fi\n  sleep 15\ndone\nfactory notify \"SMOKE RED $5: $3 serves ${deployed:-no revision}, expected $2@$expected — deploy did not verify; never auto-revert, the human decides\"\necho \"smoke red: $3 serves ${deployed:-no revision}, expected $expected\" >&2\nexit 1",
+        "smoke_check",
+        "{github}",
+        "{smokeBranch}",
+        "{url}",
+        "{factoryRoot}",
+        "{repo}",
+        "{revisionField}"
+      ]
+    }
+  },
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:write",
+      "notify:telegram"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 3600,
+    "attempts": 1
+  },
+  "mutating": true,
+  "pins": {
+    "agents/ship-apply.md": "sha256:0c3d40d2b6b6dbe9b3cb27b8ec85017b7bba4c0b71f92845899df8d51a24caa3",
+    "schemas/ship-apply.input.json": "sha256:34c7691643e63e88e4bf68e3f42bba19012be0dc061cda38bfabcda3c4dd17d3",
+    "schemas/ship-applied.output.json": "sha256:e73f513f50197b344ff320f2f881464028991c6dfb7689790fe3039456ce821b"
+  }
+}

--- a/event-runtime/agents/ship-apply.md
+++ b/event-runtime/agents/ship-apply.md
@@ -1,0 +1,48 @@
+# ship-apply — closed action-list executor for the approved release plan
+
+Not a prompt: this definition applies an **approved release plan** via the
+deterministic actions adapter in item-list mode (`lib/adapters/actions.mjs`).
+No model runs.
+
+**Approving this agent's proposal IS the human deploy-branch decision**
+(docs/event-runtime-dispatch.md §7). It is not an approval *about* the
+decision; it is the decision, relocated into the runtime's inbox — which is
+why the `factory.ship-apply.requested` event type is `humanApprovalOnly`:
+`approval: auto` on a schedule targeting it fails registry load, and a
+non-operator actor's approval attempt is rejected fail-closed
+(`human_approval_only`) in `lib/proposals.mjs`. Every other gate in the
+runtime may someday relax on evidence; this one may not (WM-111).
+
+Registered actions — each resolves to one fixed argv:
+
+| action id | effect |
+| :--- | :--- |
+| `open_rc_pr` | probe, then `gh pr create` base=deploy branch, head=base — reuses an existing open release PR instead of stacking a second |
+| `merge_rc_pr` | probe both pins, wait on the PR's checks (`gh pr checks --watch --fail-fast`, /factory-ship §3 — never sleep-and-poll), then `gh pr merge --merge` |
+| `smoke_check` | poll the deployment's revision endpoint until it serves the deployed branch's live tip; on timeout push `factory notify "SMOKE RED <repo>: ..."` and fail |
+
+Probes, the way merge-apply and disk-remediate probe:
+
+- `open_rc_pr` reads the **current** base head and compares it to the plan's
+  pinned `headSha`. A moved base is a **refusal** (exit 1, nothing later in
+  the plan runs) — a fresh scan produces a fresh pin, never a blind release.
+- `merge_rc_pr` refuses if the deploy branch head moved off the scanned
+  `deployHeadSha` (someone committed to the deploy branch directly — surface
+  it, don't resolve it by merging), or if the release PR's head is not the
+  scanned `headSha`.
+
+The release PR merges with a **merge commit** (`gh pr merge --merge`), never
+squash and never `--delete-branch`: squashing the integration branch into the
+deploy branch makes every later release PR re-show shipped commits as
+conflicts and wrecks `git log deploy..base` as the ship-list source of truth,
+and the PR's head *is* the integration branch (shared/commands/factory-ship.md
+§4). `smoke_check` reuses `lib/repo-status.mjs` — the exact metadata-URL and
+revision-field logic `factory status` uses for deployment freshness — via a
+fixed `bun -e` one-liner inside the constant script. A red smoke **never
+auto-reverts**: the action notifies and fails the attempt; what happens next
+is the human's call.
+
+Every script substitutes values only as trailing positional arguments
+(`$1`…), each anchored by the input schema — values are never spliced into
+the script text. An action ID outside this table refuses before applying
+anything — including the legitimate items alongside it.

--- a/event-runtime/agents/ship-scan.json
+++ b/event-runtime/agents/ship-scan.json
@@ -1,0 +1,28 @@
+{
+  "id": "ship-scan",
+  "version": 1,
+  "prompt": "agents/ship-scan.md",
+  "input_schema": "schemas/ship-scan.input.json",
+  "output_schema": "schemas/ship-scan.output.json",
+  "output_contract": "factory.ship-plan/v1",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [
+      "gh:read"
+    ]
+  },
+  "limits": {
+    "timeout_seconds": 900,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/ship-scan.md": "sha256:857d96ee7610f26f7fa1f931ef3bc479b8d7c0d0dbaf0c7b5ee98dc4bd714bd0",
+    "schemas/ship-scan.input.json": "sha256:605e1ecf5f1a122b0d9e79ab2c7957b37b571617658c3db323c096f609f63937",
+    "schemas/ship-scan.output.json": "sha256:b5d997d51db38988a35744294f8def899ec05482875a46a6c602497dc6dcb0c8"
+  }
+}

--- a/event-runtime/agents/ship-scan.md
+++ b/event-runtime/agents/ship-scan.md
@@ -1,0 +1,99 @@
+# ship-scan — assemble the release candidate: ahead, green, and ready for the human deploy decision
+
+You assemble evidence; you decide nothing. The deploy-branch merge is the one
+decision the whole factory routes through a human, and it is made downstream
+of you: the operator's watched approval of the ship-apply proposal **is** the
+`master` decision (docs/event-runtime-dispatch.md §7). Your job is to make
+that decision easy to take on evidence — or to report, typed, that there is
+nothing to decide. `./input.json` names one repo:
+
+```json
+{ "repo": "bj29" }
+```
+
+There is no source checkout: you read branches and CI through `gh`, never a
+local tree. Resolve the repo's GitHub `owner/name` slug, its `base` branch,
+its `deploy_branch`, and its optional `deployment` block (`url`, `branch`,
+`revision_field`) from `$FACTORY_ROOT/config/repos.yaml`. Write
+`./result.json`. Work only inside this directory. You are read-only: you
+never open PRs, merge, push, comment, or notify.
+
+## Method
+
+1. **Deploy config.** The repo must be in `config/repos.yaml` — if it is not,
+   or `gh` is unreachable, refuse (`needs_human`). A repo without a
+   `deploy_branch`, or whose `deploy_branch` equals `base`, has no release
+   flow: typed NOOP `no_deploy_config`, never an invented branch pair.
+2. **Heads.** Read both branch tips:
+   `gh api repos/<owner/name>/branches/<branch> --jq .commit.sha` for `base`
+   and `deploy_branch`. Record them as `headSha` (what ships) and
+   `deployHeadSha` (what it lands on). Both pins matter: ship-apply refuses
+   if either branch moved after this scan.
+3. **Ahead?** `gh api repos/<owner/name>/compare/<deploy_branch>...<base>`.
+   `ahead_by` of 0 means there is nothing to ship: typed NOOP `not_ahead`.
+   (A `diverged` status means someone committed to the deploy branch
+   directly — say so in the summary; the comparison still ships base's
+   commits, and the human sees the divergence before approving.)
+4. **Base CI green — real checks on the head commit.**
+   `gh api repos/<owner/name>/commits/<headSha>/check-runs`. Zero check runs
+   is NOT green — that is typed NOOP `no_checks`, never a pass. Any latest
+   check-run red/failed: typed NOOP `ci_red`. Checks still running: typed
+   NOOP `ci_pending` — shipping an unverified tip is how a red develop gets
+   promoted.
+5. **Changelog.** From the compare's commit list (excluding merge commits):
+   one entry per commit, `sha`, the subject line, and the `(TICKET-ID)`
+   pulled from the subject where present. This is the ship-list the human
+   reads before approving.
+6. **Plan — the closed set, in order.**
+
+   | action | effect downstream (ship-apply) |
+   | :--- | :--- |
+   | `open_rc_pr` | probe base head still equals `headSha`, then `gh pr create` base=`deploy_branch` head=`base` (reuses an existing open release PR) |
+   | `merge_rc_pr` | probe deploy head still equals `deployHeadSha` and the PR head equals `headSha`, wait for the PR's checks, then merge with a **merge commit** |
+   | `smoke_check` | poll the deployment's revision endpoint until it serves the deployed branch's tip; red pushes `SMOKE RED` and fails |
+
+   `open_rc_pr` carries `title` — `release: <base> → <deploy_branch> (<YYYY-MM-DD>)`
+   — and `body`: the changelog, with each Linear ticket ID on its own line so
+   the integration links every shipped ticket. Never `Fixes <ID>` — these
+   tickets are already Done; a release PR references, it doesn't close.
+   Include `smoke_check` only when the repo has a `deployment` block with a
+   `url`; its `smokeBranch` is `deployment.branch` (default `deploy_branch`)
+   and `revisionField` is `deployment.revision_field` (default `""`). Never
+   invent an action id.
+
+## Output
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "SHIP",
+    "repo": "bj29",
+    "github": "watt-mind/bakonszegi-coaching",
+    "base": "develop",
+    "deployBranch": "master",
+    "headSha": "<40-hex base tip>",
+    "deployHeadSha": "<40-hex deploy tip>",
+    "changelog": [
+      { "sha": "<40-hex>", "subject": "fix(app): guard null session (CLNT-123)", "ticket": "CLNT-123" }
+    ],
+    "plan": [
+      { "action": "open_rc_pr", "title": "release: develop → master (2026-08-14)", "body": "..." },
+      { "action": "merge_rc_pr" },
+      { "action": "smoke_check", "url": "https://bj29-dev.projects.watt-mind.com", "smokeBranch": "develop", "revisionField": "" }
+    ],
+    "summary": "one line the human reads before taking the deploy decision"
+  },
+  "evidence": { "commands": ["the gh reads this rests on"], "aheadBy": 3 }
+}
+```
+
+`recommendation` is `SHIP` only when the base is ahead, its head commit's
+checks exist and are all green, and the plan is complete; otherwise `NOOP`
+with empty `plan` and a typed `noopReason` (`not_ahead`, `ci_red`,
+`ci_pending`, `no_checks`, `no_deploy_config`). A NOOP is a good outcome,
+not a failure. If `gh` is unreachable or the repo is not in
+`config/repos.yaml`, refuse:
+`{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -68,6 +68,24 @@
       }
     }
   },
+  "ship-scan@1": {
+    "recommendationField": "recommendation",
+    "edges": {
+      "SHIP": {
+        "eventType": "factory.ship-apply.requested",
+        "input": {
+          "repo": "$.artifact.repo",
+          "github": "$.artifact.github",
+          "base": "$.artifact.base",
+          "deployBranch": "$.artifact.deployBranch",
+          "headSha": "$.artifact.headSha",
+          "deployHeadSha": "$.artifact.deployHeadSha",
+          "changelog": "$.artifact.changelog",
+          "plan": "$.artifact.plan"
+        }
+      }
+    }
+  },
   "ci-log-capture@1": {
     "recommendationField": "exitCode",
     "edges": {

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -209,6 +209,15 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.ship-apply.requested": {
+    "agent": "ship-apply@1",
+    "adapter": "actions",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800,
+    "humanApprovalOnly": true
+  },
   "factory.ticket.dispatched": {
     "observe": true
   },

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -201,6 +201,14 @@
     ],
     "proposalTtlSeconds": 1800
   },
+  "factory.ship.requested": {
+    "agent": "ship-scan@1",
+    "adapter": "claude",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
+  },
   "factory.ticket.dispatched": {
     "observe": true
   },

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -16,6 +16,15 @@ import { runState, transition } from "./lifecycle.mjs";
 import { buildRunSpec } from "./planner.mjs";
 import { getEventType } from "./registry.mjs";
 
+/**
+ * The one human actor in the MVP (lib/api.mjs §14). An event type flagged
+ * `humanApprovalOnly` (docs/event-runtime-dispatch.md §7, WM-111) accepts an
+ * approval from this actor and no other — the ship chain's deploy-branch
+ * decision is permanently the human's, and the earned-automation ratchet must
+ * not be able to consume it.
+ */
+const HUMAN_ACTOR = "operator";
+
 function isExpired(proposal, now) {
   return now - Date.parse(proposal.created_at) > proposal.ttl_seconds * 1000;
 }
@@ -98,12 +107,25 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
     if (proposal.decision !== "run") throw new Error(`proposal ${id} decision is '${proposal.decision}' — only 'run' proposals are approvable`);
 
     const envelope = loadEnvelope(db, proposal);
+    // Structural no-auto-approval (docs/event-runtime-dispatch.md §7, WM-111):
+    // a humanApprovalOnly event type rejects every non-operator actor —
+    // schedule auto-approval included — fail-closed, before any state moves.
+    // This is the single choke point every approval path goes through
+    // (operator API/CLI and autoApproveScheduled both call approveProposal),
+    // so there is no code path that approves around it.
+    const mapping = getEventType(registry, envelope.type);
+    if (mapping?.humanApprovalOnly === true && actor !== HUMAN_ACTOR) {
+      const err = new Error(
+        `proposal ${id}: event type ${envelope.type} is humanApprovalOnly — actor "${actor}" cannot approve it; this watched approval IS the human deploy-branch decision (human_approval_only; docs/event-runtime-dispatch.md §7, WM-111)`,
+      );
+      err.code = "human_approval_only";
+      throw err;
+    }
     if (!isExpired(proposal, now)) {
       return approveRun(db, proposal, envelope, { actor, now, policyVersion, reason: "approved" });
     }
 
     // Expired: re-plan against current registry state, reusing the runId.
-    const mapping = getEventType(registry, envelope.type);
     if (!mapping) throw new Error(`proposal ${id} expired and event type ${envelope.type} is no longer registered`);
     const fresh = buildRunSpec(registry, envelope, mapping, {
       runId: proposal.run_id, policyVersion, adapterOverride, now,

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -172,6 +172,15 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
       if (approval === "auto" && !schedule.enabled) {
         throw new RegistryError(`schedules.json: ${loop} declares approval "auto" but is not enabled — decide one`);
       }
+      // The ship chain's deploy-branch merge is PERMANENTLY watched: that
+      // approval IS the human master decision, so the config that would
+      // delete it cannot load, whoever writes it and however good the track
+      // record looks (docs/event-runtime-dispatch.md §7, WM-111).
+      if (approval === "auto" && eventTypes[schedule.eventType]?.humanApprovalOnly === true) {
+        throw new RegistryError(
+          `schedules.json: ${loop} declares approval "auto" but ${schedule.eventType} is humanApprovalOnly — the deploy-branch decision is permanently the human's watched approval (docs/event-runtime-dispatch.md §7, WM-111)`,
+        );
+      }
       // A static payload rides along on every tick (repo-scoped loops need
       // {repo}). Tick fields always win the merge, so a payload claiming
       // loop/slot identity is a config error, not a spoofing vector.

--- a/event-runtime/schemas/ship-applied.output.json
+++ b/event-runtime/schemas/ship-applied.output.json
@@ -1,0 +1,33 @@
+{
+  "title": "factory.ship-applied/v1 output artifact — which release steps actually ran",
+  "type": "object",
+  "required": ["repo", "applied"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Echo of the short repo name from the input"
+    },
+    "applied": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Every release step that actually ran, in order — a failed step ends the list and fails the attempt (a red smoke is a failed attempt, never a silent success)",
+      "items": {
+        "type": "object",
+        "required": ["issueId", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "issueId": {
+            "enum": ["open_rc_pr", "merge_rc_pr", "smoke_check"],
+            "description": "The item-list adapter records the item key under the fixed name issueId (lib/adapters/actions.mjs); ship-apply's itemKey is the action itself — a release plan has one step per action, not one per ticket"
+          },
+          "action": {
+            "enum": ["open_rc_pr", "merge_rc_pr", "smoke_check"],
+            "description": "Registered action id that ran for this step"
+          }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/ship-apply.input.json
+++ b/event-runtime/schemas/ship-apply.input.json
@@ -1,0 +1,104 @@
+{
+  "title": "ship-apply input — the approved, double-SHA-pinned release plan whose watched approval IS the human deploy-branch decision",
+  "type": "object",
+  "required": ["repo", "github", "base", "deployBranch", "headSha", "deployHeadSha", "changelog", "plan"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — substituted into the SMOKE RED notification"
+    },
+    "github": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub owner/name slug the release commands run against — anchored so it substitutes safely into the closed argv templates"
+    },
+    "base": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+      "description": "Integration branch (the release PR's head) — anchored branch name"
+    },
+    "deployBranch": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+      "description": "Deploy branch (the release PR's base) — anchored branch name. Merging it is permanently the human's watched approval (docs/event-runtime-dispatch.md §7)"
+    },
+    "headSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Base tip the scan reviewed — open_rc_pr and merge_rc_pr probe the live heads and refuse if this pin no longer matches"
+    },
+    "deployHeadSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Deploy tip at scan time — merge_rc_pr refuses if the deploy branch moved off this pin since the scan"
+    },
+    "changelog": {
+      "type": "array",
+      "description": "The scan's ship-list, carried along so the approved spec records exactly what the human agreed to ship",
+      "items": {
+        "type": "object",
+        "required": ["sha", "subject"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{7,40}$",
+            "description": "Commit SHA (full or abbreviated)"
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Commit subject line"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket pulled from the subject, when present"
+          }
+        }
+      }
+    },
+    "plan": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Approved release actions from the ship-scan proposal, applied in order — a failed item stops the plan",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": ["open_rc_pr", "merge_rc_pr", "smoke_check"],
+            "description": "Closed-registry action to apply — anything else refuses the whole plan before executing any item"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "open_rc_pr: release PR title — passed as a single argv element, never spliced into script text"
+          },
+          "body": {
+            "type": "string",
+            "description": "open_rc_pr: release PR body (the changelog; ticket IDs on their own lines, never Fixes)"
+          },
+          "url": {
+            "type": "string",
+            "pattern": "^https?://[^\\s]+$",
+            "description": "smoke_check: deployment metadata endpoint or origin (an origin is queried at /version.json, exactly as factory status does)"
+          },
+          "smokeBranch": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+            "description": "smoke_check: branch the deployment tracks — the endpoint must serve this branch's live tip"
+          },
+          "revisionField": {
+            "type": "string",
+            "pattern": "^[A-Za-z_]*$",
+            "description": "smoke_check: configured deployment.revision_field, or empty for the default candidates"
+          }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/ship-scan.input.json
+++ b/event-runtime/schemas/ship-scan.input.json
@@ -1,0 +1,13 @@
+{
+  "title": "ship-scan input — one repo whose release candidate to assemble",
+  "type": "object",
+  "required": ["repo"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
+    }
+  }
+}

--- a/event-runtime/schemas/ship-scan.output.json
+++ b/event-runtime/schemas/ship-scan.output.json
@@ -1,0 +1,116 @@
+{
+  "title": "factory.ship-plan/v1 output artifact — release-candidate assembly: is base ahead, green, and ready for the human deploy-branch decision?",
+  "type": "object",
+  "required": ["recommendation", "repo", "github", "changelog", "plan", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "recommendation": {
+      "enum": ["SHIP", "NOOP"],
+      "description": "SHIP when base is ahead of the deploy branch, its head commit's real checks are green, and the plan is complete; otherwise NOOP with a typed noopReason. There is no auto path: SHIP only chains into a watched ship-apply proposal, and approving THAT proposal is the human deploy decision (docs/event-runtime-dispatch.md §7, WM-111)"
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Echo of the short repo name from the input"
+    },
+    "github": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "description": "GitHub owner/name slug resolved from config/repos.yaml — the repository the apply actions run against"
+    },
+    "base": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+      "description": "Integration branch from config/repos.yaml (usually develop) — the release PR's head"
+    },
+    "deployBranch": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+      "description": "Deploy branch from config/repos.yaml (usually master) — the release PR's base; merging it is permanently the human's watched approval"
+    },
+    "headSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Base branch tip this scan reviewed — what ships. ship-apply refuses open_rc_pr/merge_rc_pr if the base or PR head moved off this pin"
+    },
+    "deployHeadSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Deploy branch tip at scan time — what it lands on. ship-apply refuses merge_rc_pr if the deploy branch moved off this pin (someone committed to it directly)"
+    },
+    "changelog": {
+      "type": "array",
+      "description": "Commits between the deploy head and the base head (merge commits excluded) — the ship-list the human reads before approving",
+      "items": {
+        "type": "object",
+        "required": ["sha", "subject"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{7,40}$",
+            "description": "Commit SHA (full or abbreviated) as reported by the compare API"
+          },
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Commit subject line, conventionally carrying the (TICKET-ID)"
+          },
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear ticket pulled from the subject's (TICKET-ID), when present"
+          }
+        }
+      }
+    },
+    "plan": {
+      "type": "array",
+      "description": "Ship actions in execution order — open_rc_pr, merge_rc_pr, then smoke_check where the repo has a deployment block. Empty on NOOP",
+      "items": {
+        "type": "object",
+        "required": ["action"],
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": ["open_rc_pr", "merge_rc_pr", "smoke_check"],
+            "description": "Closed ship-apply action id this item resolves to — anything else refuses the whole plan"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "open_rc_pr only: release PR title, release: <base> → <deployBranch> (<date>)"
+          },
+          "body": {
+            "type": "string",
+            "description": "open_rc_pr only: the changelog with each Linear ticket ID on its own line — never a Fixes line; a release PR references, it doesn't close"
+          },
+          "url": {
+            "type": "string",
+            "pattern": "^https?://[^\\s]+$",
+            "description": "smoke_check only: deployment metadata endpoint or origin from the repo's deployment block (an origin is queried at /version.json, same as factory status)"
+          },
+          "smokeBranch": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]*$",
+            "description": "smoke_check only: branch the deployment tracks (deployment.branch, defaulting to the deploy branch) — the endpoint must serve this branch's live tip"
+          },
+          "revisionField": {
+            "type": "string",
+            "pattern": "^[A-Za-z_]*$",
+            "description": "smoke_check only: configured deployment.revision_field, or empty to use the default revision field candidates"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One line the human reads before taking the deploy decision"
+    },
+    "noopReason": {
+      "enum": ["not_ahead", "ci_red", "ci_pending", "no_checks", "no_deploy_config"],
+      "description": "Typed reason accompanying a NOOP — nothing to ship, base CI red, base CI still running, no real checks on the head commit (no checks is not green), or the repo has no deploy branch distinct from base"
+    }
+  }
+}

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * Ship chain (WM-111): ship-scan@1 assembles the release candidate — base
+ * ahead of the deploy branch, real checks green on the head commit, changelog
+ * of shipped tickets — and emits a typed, double-SHA-pinned plan. The watched
+ * approval of the chained ship-apply proposal IS the human deploy-branch
+ * decision (docs/event-runtime-dispatch.md §7): it is permanently watched,
+ * structurally — auto approval of the ship-apply event type cannot load and
+ * cannot execute. Follows the merge chain precedent (WM-109).
+ */
+import { describe, expect, test } from "bun:test";
+import { loadRegistry } from "./lib/registry.mjs";
+
+const registry = loadRegistry();
+
+describe("ship-scan registration (WM-111)", () => {
+  test("ship-scan@1 is a read-only claude agent with no repository workspace", () => {
+    const def = registry.agents.get("ship-scan@1");
+    expect(def.mutating).toBe(false);
+    // It reads branches and CI via gh, not a source tree — ephemeral, like
+    // merge-scan, never a repository checkout.
+    expect(def.workspace.type).toBe("ephemeral");
+    expect(def.output_contract).toBe("factory.ship-plan/v1");
+    expect(def.capabilities.services).toContain("gh:read");
+  });
+
+  test("factory.ship.requested maps to ship-scan@1 on the claude adapter, deduped by inputHash", () => {
+    expect(registry.eventTypes["factory.ship.requested"]).toEqual({
+      agent: "ship-scan@1",
+      adapter: "claude",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+    });
+  });
+
+  test("the artifact pins BOTH branch tips — a moved base or deploy head is detectable at apply time", () => {
+    const props = registry.agents.get("ship-scan@1").outputSchema.properties;
+    expect(props.headSha.pattern).toBe("^[0-9a-f]{40}$");
+    expect(props.deployHeadSha.pattern).toBe("^[0-9a-f]{40}$");
+    expect(props.recommendation.enum).toEqual(["SHIP", "NOOP"]);
+    // The plan is the closed ship set, nothing else nameable.
+    expect(props.plan.items.properties.action.enum).toEqual(["open_rc_pr", "merge_rc_pr", "smoke_check"]);
+    // NOOP is typed: not ahead, CI red/pending, no real checks, or no deploy config.
+    expect(props.noopReason.enum).toEqual(["not_ahead", "ci_red", "ci_pending", "no_checks", "no_deploy_config"]);
+  });
+});

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -13,6 +13,8 @@ import { chmodSync, cpSync, existsSync, mkdtempSync, readFileSync, writeFileSync
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import * as fake from "./lib/adapters/fake.mjs";
+import { resolveChains } from "./lib/chain.mjs";
 import { RUNTIME_ROOT } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { admitEvent } from "./lib/intake.mjs";
@@ -21,6 +23,7 @@ import { approveProposal, getProposal, openProposals } from "./lib/proposals.mjs
 import { RegistryError, loadRegistry } from "./lib/registry.mjs";
 import { runState } from "./lib/lifecycle.mjs";
 import { SCHEDULE_SOURCE } from "./lib/schedules.mjs";
+import { runOnce } from "./lib/worker.mjs";
 
 const registry = loadRegistry();
 
@@ -392,5 +395,167 @@ describe("ship-apply approval is structurally human-only (WM-111)", () => {
     // The human operator's approval — the deploy-branch decision — succeeds.
     const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
     expect(approved).toEqual({ approved: true, runId: proposal.run_id });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain e2e on the fake adapter. The shared fake (lib/adapters/fake.mjs) does
+// not know the ship contracts, so a local wrapper answers them the same way
+// the merge tests answer theirs — repo-keyed, contract-shaped — and delegates
+// everything else to the fake. The local runtime demo (port 7620) plays no
+// part here.
+// ---------------------------------------------------------------------------
+
+const FAKE_HEAD_SHA = "d".repeat(40);
+const FAKE_DEPLOY_HEAD_SHA = "e".repeat(40);
+
+function writeResult(workspaceDir, result) {
+  writeFileSync(path.join(workspaceDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`, "utf8");
+}
+
+function shipScanArtifact(repo) {
+  const base = { repo, github: `watt-mind/${repo}`, changelog: [], plan: [] };
+  if (repo === "clean") {
+    return { ...base, recommendation: "NOOP", summary: "fake: nothing to ship", noopReason: "not_ahead" };
+  }
+  return {
+    ...base,
+    recommendation: "SHIP",
+    base: "develop",
+    deployBranch: "master",
+    headSha: FAKE_HEAD_SHA,
+    deployHeadSha: FAKE_DEPLOY_HEAD_SHA,
+    changelog: [{ sha: FAKE_HEAD_SHA, subject: "feat(app): fake thing (CLNT-901)", ticket: "CLNT-901" }],
+    plan: [
+      { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "- feat(app): fake thing\nCLNT-901" },
+      { action: "merge_rc_pr" },
+      { action: "smoke_check", url: `https://${repo}.projects.watt-mind.com`, smokeBranch: "develop", revisionField: "" },
+    ],
+    summary: `fake release candidate for ${repo}: 1 commit, CI green`,
+  };
+}
+
+const shipFake = {
+  async execute(opts) {
+    const { spec, workspaceDir } = opts;
+    if (spec.outputContract === "factory.ship-plan/v1") {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: shipScanArtifact(spec.input.repo),
+        evidence: { commands: ["fake"], aheadBy: 1 },
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    if (spec.outputContract === "factory.ship-applied/v1") {
+      writeResult(workspaceDir, {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: {
+          repo: spec.input.repo,
+          applied: (spec.input.plan ?? []).map((i) => ({ issueId: i.action, action: i.action })),
+        },
+        evidence: { commands: ["fake"] },
+      });
+      return { exitCode: 0, timedOut: false };
+    }
+    return fake.execute(opts);
+  },
+};
+
+function harness() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-"));
+  const db = openDb(path.join(dir, "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-ws-"));
+  const adapters = { claude: shipFake, actions: shipFake, command: shipFake };
+  const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
+
+  async function approveNext(agentRef) {
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agentRef);
+    expect(proposal).toBeTruthy();
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    return { proposal, runId: approved.runId, summary };
+  }
+  return { db, approveNext };
+}
+
+const shipEnvelope = (repo, eventId) => ({
+  schemaVersion: "factory.event/v1",
+  eventId,
+  type: "factory.ship.requested",
+  source: "operator",
+  subject: repo,
+  occurredAt: "2026-08-14T09:00:00Z",
+  correlationId: eventId,
+  payload: { repo },
+});
+
+describe("ship chain: scan → human-approved apply (WM-111)", () => {
+  test("a SHIP recommendation chains the pinned plan into a watched ship-apply proposal the human approves", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, shipEnvelope("bj29", "ship-1"));
+
+    const scan = await approveNext("ship-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${scan.runId}`);
+    expect(chainEvent.type).toBe("factory.ship-apply.requested");
+    expect(chainEvent.correlation_id).toBe("ship-1"); // inherited from the origin
+    expect(chainEvent.causation_id).toBe(scan.runId); // caused by the scan run
+
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    const apply = openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1");
+    expect(apply.status).toBe("open"); // never applied without the human
+    expect(apply.spec.input).toEqual({
+      repo: "bj29",
+      github: "watt-mind/bj29",
+      base: "develop",
+      deployBranch: "master",
+      headSha: FAKE_HEAD_SHA, // the pin the probes hold the release to
+      deployHeadSha: FAKE_DEPLOY_HEAD_SHA,
+      changelog: [{ sha: FAKE_HEAD_SHA, subject: "feat(app): fake thing (CLNT-901)", ticket: "CLNT-901" }],
+      plan: [
+        { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "- feat(app): fake thing\nCLNT-901" },
+        { action: "merge_rc_pr" },
+        { action: "smoke_check", url: "https://bj29.projects.watt-mind.com", smokeBranch: "develop", revisionField: "" },
+      ],
+    });
+
+    // The chained proposal itself rejects the auto path — this approval IS
+    // the human deploy-branch decision, and no schedule can take it.
+    expect(() =>
+      approveProposal(db, registry, apply.id, { actor: SCHEDULE_SOURCE, policyVersion: PV }),
+    ).toThrow(/human_approval_only/);
+    expect(getProposal(db, apply.id).status).toBe("open");
+
+    const applied = await approveNext("ship-apply@1");
+    expect(applied.summary.terminalState).toBe("COMPLETED");
+    const row = db.query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`).get(applied.runId);
+    expect(JSON.parse(row.result_json).artifact.applied).toEqual([
+      { issueId: "open_rc_pr", action: "open_rc_pr" },
+      { issueId: "merge_rc_pr", action: "merge_rc_pr" },
+      { issueId: "smoke_check", action: "smoke_check" },
+    ]);
+    expect(JSON.parse(row.receipt_json).runId).toBe(applied.runId); // accepted with a receipt
+  });
+
+  test("a NOOP converges quietly — nothing chained, nothing proposed, nothing to approve", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, shipEnvelope("clean", "ship-2"));
+    const scan = await approveNext("ship-scan@1");
+    expect(scan.summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
+    expect(result.artifact.noopReason).toBe("not_ahead");
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1")).toBeUndefined();
   });
 });

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -8,9 +8,26 @@
  * cannot execute. Follows the merge chain precedent (WM-109).
  */
 import { describe, expect, test } from "bun:test";
-import { loadRegistry } from "./lib/registry.mjs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, cpSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { RUNTIME_ROOT } from "./lib/config.mjs";
+import { openDb } from "./lib/db.mjs";
+import { admitEvent } from "./lib/intake.mjs";
+import { planAdmittedEvents } from "./lib/planner.mjs";
+import { approveProposal, getProposal, openProposals } from "./lib/proposals.mjs";
+import { RegistryError, loadRegistry } from "./lib/registry.mjs";
+import { runState } from "./lib/lifecycle.mjs";
+import { SCHEDULE_SOURCE } from "./lib/schedules.mjs";
 
 const registry = loadRegistry();
+
+const PV = "git:test-pv";
+const BASE_SHA = "a".repeat(40);
+const DEPLOY_SHA = "b".repeat(40);
+const MOVED_SHA = "c".repeat(40);
 
 describe("ship-scan registration (WM-111)", () => {
   test("ship-scan@1 is a read-only claude agent with no repository workspace", () => {
@@ -41,5 +58,339 @@ describe("ship-scan registration (WM-111)", () => {
     expect(props.plan.items.properties.action.enum).toEqual(["open_rc_pr", "merge_rc_pr", "smoke_check"]);
     // NOOP is typed: not ahead, CI red/pending, no real checks, or no deploy config.
     expect(props.noopReason.enum).toEqual(["not_ahead", "ci_red", "ci_pending", "no_checks", "no_deploy_config"]);
+  });
+});
+
+/**
+ * Run the REAL ship-apply@1 registry definition against shimmed `gh`,
+ * `factory` (and the real `bun` for the smoke helper): the probe → act flow
+ * executes exactly the registered templates, but nothing reaches GitHub or
+ * Telegram. Branch reads answer from $FAKE_BASE_HEAD / $FAKE_DEPLOY_HEAD, PR
+ * reads from $FAKE_OPEN_PRS / $FAKE_PR_HEAD; every mutating call is appended
+ * to $SHIM_LOG.
+ */
+async function runApply(plan, env = {}) {
+  const shims = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-shims-"));
+  const log = path.join(shims, "shim.log");
+  writeFileSync(
+    path.join(shims, "gh"),
+    `#!/bin/sh
+if [ "$1" = "api" ]; then
+  case "$2" in
+    */branches/develop) echo "$FAKE_BASE_HEAD" ;;
+    */branches/master) echo "$FAKE_DEPLOY_HEAD" ;;
+    *) echo "unexpected gh api $2" >&2; exit 1 ;;
+  esac
+elif [ "$1 $2" = "pr list" ]; then
+  case "$*" in
+    *"--jq length"*) echo "\${FAKE_OPEN_PRS:-0}" ;;
+    *) if [ "\${FAKE_OPEN_PRS:-0}" != "0" ]; then echo "7"; fi ;;
+  esac
+elif [ "$1 $2" = "pr view" ]; then
+  echo "$FAKE_PR_HEAD"
+else
+  echo "gh $*" >> "$SHIM_LOG"
+fi
+`,
+  );
+  writeFileSync(path.join(shims, "factory"), `#!/bin/sh\necho "factory $*" >> "$SHIM_LOG"\n`);
+  chmodSync(path.join(shims, "gh"), 0o755);
+  chmodSync(path.join(shims, "factory"), 0o755);
+
+  const runtimeRoot = path.dirname(fileURLToPath(import.meta.url));
+  const driver = path.join(shims, "driver.mjs");
+  writeFileSync(
+    driver,
+    `import * as actions from ${JSON.stringify(path.join(runtimeRoot, "lib", "adapters", "actions.mjs"))};\n` +
+      `import { loadRegistry } from ${JSON.stringify(path.join(runtimeRoot, "lib", "registry.mjs"))};\n` +
+      `const outcome = await actions.execute({\n` +
+      `  spec: { input: JSON.parse(process.argv[2]) },\n` +
+      `  def: loadRegistry().agents.get("ship-apply@1"),\n` +
+      `  workspaceDir: process.argv[3],\n` +
+      `  timeoutMs: 20_000,\n` +
+      `});\n` +
+      `console.log(JSON.stringify(outcome));\n`,
+  );
+
+  const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-ws-"));
+  const input = {
+    repo: "bj29",
+    github: "watt-mind/bj29",
+    base: "develop",
+    deployBranch: "master",
+    headSha: BASE_SHA,
+    deployHeadSha: DEPLOY_SHA,
+    changelog: [],
+    plan,
+  };
+  const proc = spawnSync("bun", [driver, JSON.stringify(input), workspaceDir], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${shims}:${process.env.PATH}`,
+      FAKE_BASE_HEAD: BASE_SHA,
+      FAKE_DEPLOY_HEAD: DEPLOY_SHA,
+      FAKE_PR_HEAD: BASE_SHA,
+      FAKE_OPEN_PRS: "0",
+      SHIM_LOG: log,
+      SHIP_SMOKE_DEADLINE_SECONDS: "0",
+      ...env,
+    },
+  });
+  expect(proc.status).toBe(0);
+  return { outcome: JSON.parse(proc.stdout.trim().split("\n").at(-1)), workspaceDir, log };
+}
+
+describe("ship-apply is closed by construction (WM-111)", () => {
+  test("the registry admits ship-apply@1 as an item-list definition with exactly the three closed actions", () => {
+    const def = registry.agents.get("ship-apply@1");
+    expect(def.mutating).toBe(true);
+    expect(def.itemsField).toBe("plan");
+    // A release plan has one step per action, not one per ticket — the item
+    // key IS the action id (recorded as issueId by the item-list adapter).
+    expect(def.itemKey).toBe("action");
+    expect(Object.keys(def.actionRegistry).sort()).toEqual(["merge_rc_pr", "open_rc_pr", "smoke_check"]);
+    // Every script substitutes only trailing positional args — never into the script text.
+    expect(def.actionRegistry.open_rc_pr.argv.slice(-6)).toEqual([
+      "{github}", "{base}", "{headSha}", "{deployBranch}", "{title}", "{body}",
+    ]);
+    expect(def.actionRegistry.merge_rc_pr.argv.slice(-5)).toEqual([
+      "{github}", "{deployBranch}", "{deployHeadSha}", "{base}", "{headSha}",
+    ]);
+    expect(def.actionRegistry.smoke_check.argv.slice(-6)).toEqual([
+      "{github}", "{smokeBranch}", "{url}", "{factoryRoot}", "{repo}", "{revisionField}",
+    ]);
+    // A release PR merges with a merge commit — never squash, never
+    // --delete-branch (its head is the integration branch): factory-ship §4.
+    const mergeScript = def.actionRegistry.merge_rc_pr.argv[2];
+    expect(mergeScript).toContain("gh pr merge");
+    expect(mergeScript).toContain("--merge");
+    expect(mergeScript).not.toContain("--squash");
+    expect(mergeScript).not.toContain("--delete-branch");
+    // Smoke reuses the factory-status freshness helpers, and never reverts.
+    expect(def.actionRegistry.smoke_check.argv[2]).toContain("lib/repo-status.mjs");
+    expect(def.actionRegistry.smoke_check.argv[2]).toContain("SMOKE RED");
+  });
+
+  test("factory.ship-apply.requested maps to ship-apply@1 on the actions adapter — and is humanApprovalOnly", () => {
+    expect(registry.eventTypes["factory.ship-apply.requested"]).toEqual({
+      agent: "ship-apply@1",
+      adapter: "actions",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+      humanApprovalOnly: true,
+    });
+  });
+
+  test("open_rc_pr probes the base head and opens the release PR when it matches the pin", async () => {
+    const { outcome, log } = await runApply([
+      { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" },
+    ]);
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const shimLog = readFileSync(log, "utf8");
+    expect(shimLog).toContain(
+      "gh pr create --repo watt-mind/bj29 --base master --head develop --title release: develop → master (2026-08-14) --body the changelog",
+    );
+  });
+
+  test("open_rc_pr reuses an existing open release PR instead of stacking a second", async () => {
+    const { outcome, log } = await runApply(
+      [{ action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" }],
+      { FAKE_OPEN_PRS: "1" },
+    );
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    expect(existsSync(log)).toBe(false); // nothing mutating ran
+  });
+
+  test("a moved base head is a refusal, not a blind release: the PR never opens", async () => {
+    const { outcome, workspaceDir, log } = await runApply(
+      [{ action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" }],
+      { FAKE_BASE_HEAD: MOVED_SHA },
+    );
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false);
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing open_rc_pr");
+  });
+
+  test("merge_rc_pr waits on the PR's checks, then merges with a merge commit", async () => {
+    const { outcome, log } = await runApply([{ action: "merge_rc_pr" }], { FAKE_OPEN_PRS: "1" });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const shimLog = readFileSync(log, "utf8");
+    expect(shimLog).toContain("gh pr checks 7 --repo watt-mind/bj29 --watch --fail-fast");
+    expect(shimLog).toContain("gh pr merge 7 --repo watt-mind/bj29 --merge");
+    expect(shimLog).not.toContain("--squash");
+    expect(shimLog).not.toContain("--delete-branch");
+  });
+
+  test("a deploy branch that moved since the scan refuses the merge — someone committed to it directly", async () => {
+    const { outcome, workspaceDir, log } = await runApply([{ action: "merge_rc_pr" }], {
+      FAKE_OPEN_PRS: "1",
+      FAKE_DEPLOY_HEAD: MOVED_SHA,
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false); // the merge never executed
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing merge_rc_pr");
+  });
+
+  test("a release PR head that is not the scanned pin refuses the merge", async () => {
+    const { outcome, workspaceDir, log } = await runApply([{ action: "merge_rc_pr" }], {
+      FAKE_OPEN_PRS: "1",
+      FAKE_PR_HEAD: MOVED_SHA,
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false);
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("refusing release PR #7");
+  });
+
+  // The endpoint runs as a child process: runApply's spawnSync blocks this
+  // process's event loop, so an in-process Bun.serve could never answer.
+  async function withSmokeServer(payload, fn) {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-smoke-"));
+    const script = path.join(dir, "server.mjs");
+    writeFileSync(
+      script,
+      `const server = Bun.serve({ port: 0, fetch: () => Response.json(${JSON.stringify(payload)}) });\nconsole.log(server.port);\n`,
+    );
+    const proc = Bun.spawn(["bun", script], { stdout: "pipe" });
+    const reader = proc.stdout.getReader();
+    const { value } = await reader.read();
+    const port = Number(new TextDecoder().decode(value).trim());
+    expect(port).toBeGreaterThan(0);
+    try {
+      return await fn(port);
+    } finally {
+      proc.kill();
+    }
+  }
+
+  test("smoke_check goes green when the endpoint serves the deployed branch's tip (factory-status form)", async () => {
+    await withSmokeServer({ revision: BASE_SHA }, async (port) => {
+      const { outcome, workspaceDir } = await runApply([
+        { action: "smoke_check", url: `http://127.0.0.1:${port}`, smokeBranch: "develop", revisionField: "" },
+      ]);
+      expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+      expect(result.artifact).toEqual({ repo: "bj29", applied: [{ issueId: "smoke_check", action: "smoke_check" }] });
+    });
+  }, 20_000);
+
+  test("smoke red pushes SMOKE RED and fails the attempt — never an auto-revert", async () => {
+    await withSmokeServer({ revision: "0123456789abcdef" }, async (port) => {
+      const { outcome, workspaceDir, log } = await runApply([
+        { action: "smoke_check", url: `http://127.0.0.1:${port}`, smokeBranch: "develop", revisionField: "" },
+      ]);
+      expect(outcome.exitCode).toBe(1);
+      expect(readFileSync(log, "utf8")).toContain("factory notify SMOKE RED bj29:");
+      expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain("smoke red");
+      // Never auto-revert: the only mutation a red smoke performs is the push.
+      expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(1);
+    });
+  }, 20_000);
+
+  test("an unregistered action refuses before applying ANY item — including the valid ones", async () => {
+    const { outcome, workspaceDir, log } = await runApply([
+      { action: "merge_rc_pr" },
+      { action: "revert_release" },
+    ]);
+    expect(outcome.exitCode).toBe(1);
+    expect(existsSync(log)).toBe(false);
+    expect(readFileSync(path.join(workspaceDir, ".actions.log"), "utf8")).toContain(
+      "not in the closed action registry",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The structural block (docs/event-runtime-dispatch.md §7, WM-111): the
+// deploy-branch merge decision is PERMANENTLY the human's. Two fail-closed
+// layers, both tested by ATTEMPTING the auto path: config that would delete
+// the decision cannot load, and an approval by any non-operator actor is
+// rejected at the single choke point every approval goes through.
+// ---------------------------------------------------------------------------
+
+const applyPayload = {
+  repo: "bj29",
+  github: "watt-mind/bj29",
+  base: "develop",
+  deployBranch: "master",
+  headSha: BASE_SHA,
+  deployHeadSha: DEPLOY_SHA,
+  changelog: [{ sha: BASE_SHA, subject: "fix(app): guard null session (CLNT-123)", ticket: "CLNT-123" }],
+  plan: [
+    { action: "open_rc_pr", title: "release: develop → master (2026-08-14)", body: "the changelog" },
+    { action: "merge_rc_pr" },
+  ],
+};
+
+function openShipApplyProposal(db) {
+  admitEvent(db, registry, {
+    schemaVersion: "factory.event/v1",
+    eventId: "ship-apply-direct-1",
+    type: "factory.ship-apply.requested",
+    source: "operator",
+    subject: "bj29",
+    occurredAt: "2026-08-14T09:00:00Z",
+    correlationId: "ship-apply-direct-1",
+    payload: applyPayload,
+  });
+  planAdmittedEvents(db, registry, { policyVersion: PV });
+  const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "ship-apply@1");
+  expect(proposal).toBeTruthy();
+  return proposal;
+}
+
+describe("ship-apply approval is structurally human-only (WM-111)", () => {
+  test("schedules.json declaring approval auto on the ship-apply event type cannot load", () => {
+    // Copy the real registry into a temp root so the test can corrupt it safely.
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-registry-"));
+    for (const dir of ["agents", "schemas"]) {
+      cpSync(path.join(RUNTIME_ROOT, dir), path.join(root, dir), { recursive: true });
+    }
+    cpSync(path.join(RUNTIME_ROOT, "event-types.json"), path.join(root, "event-types.json"));
+    const withApproval = (approval) =>
+      writeFileSync(
+        path.join(root, "schedules.json"),
+        JSON.stringify({
+          "ship-apply-creep": { every: "1h", eventType: "factory.ship-apply.requested", approval, enabled: true },
+        }),
+      );
+    withApproval("auto");
+    expect(() => loadRegistry({ root })).toThrow(RegistryError);
+    expect(() => loadRegistry({ root })).toThrow(/humanApprovalOnly/);
+    // Watched is the permanent mode — the same loop loads fine watched.
+    withApproval("watched");
+    expect(() => loadRegistry({ root })).not.toThrow();
+  });
+
+  test("a schedule-actor approval attempt is rejected fail-closed with a typed reason — then the human's still works", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-"));
+    const db = openDb(path.join(dir, "runtime.db"));
+    const proposal = openShipApplyProposal(db);
+
+    // The exact call autoApproveScheduled makes (lib/schedules.mjs): actor
+    // "schedule" through approveProposal. There is no other approval path.
+    let rejection;
+    try {
+      approveProposal(db, registry, proposal.id, { actor: SCHEDULE_SOURCE, policyVersion: PV });
+    } catch (err) {
+      rejection = err;
+    }
+    expect(rejection).toBeTruthy();
+    expect(rejection.code).toBe("human_approval_only");
+    expect(rejection.message).toContain("humanApprovalOnly");
+
+    // Fail-closed means NOTHING moved: proposal still open, run still PROPOSED.
+    expect(getProposal(db, proposal.id).status).toBe("open");
+    expect(runState(db, proposal.run_id)).toBe("PROPOSED");
+
+    // Any other machine actor is rejected identically — the gate allowlists
+    // the human operator; it does not blocklist known robots.
+    expect(() => approveProposal(db, registry, proposal.id, { actor: "chain", policyVersion: PV })).toThrow(
+      /human_approval_only/,
+    );
+
+    // The human operator's approval — the deploy-branch decision — succeeds.
+    const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+    expect(approved).toEqual({ approved: true, runId: proposal.run_id });
   });
 });


### PR DESCRIPTION
Fixes WM-111

Ports /factory-ship into the runtime, with the watched ship-apply approval AS the human deploy-branch decision (design doc §7):

1. **`ship-scan@1`** — confirms base ahead of `deploy_branch`, base CI green on the head commit (real checks), assembles the ticket changelog; typed plan `SHIP {headSha, deployBranch, changelog}` or typed NOOP (`not_ahead` / `ci_red` / `no_deploy_config`).
2. **`ship-apply@1`** (actions adapter, closed registry): `open_rc_pr` (probe: base head must equal pinned SHA), `merge_rc_pr` (`gh pr checks --watch --fail-fast` then `gh pr merge --merge` — NOT squash and NOT --delete-branch, per factory-ship §4: squashing an RC re-shows shipped commits as conflicts and the PR head is develop; both absences tested), `smoke_check` (reuses `lib/repo-status.mjs`'s `metadataUrl`/`deployedRevision` — the same freshness logic as `factory status`; bounded poll; on red fires the one fixed `SMOKE RED` notify and exits 1 — never auto-reverts, tested).
3. **Structural no-auto-approval**: `factory.ship-apply.requested` carries `humanApprovalOnly: true`; `approveProposal` rejects any non-operator actor before any state transition (typed `human_approval_only` error — the single choke point both the CLI and `autoApproveScheduled` go through), and `lib/registry.mjs` fails closed at load on a schedule declaring `approval: auto` for such an event type (doc §7 mandate — the one out-of-Owned-Paths touch, +9 lines, cited inline). Tests attempt auto-approval via both paths and prove rejection.
4. **Chain edge + e2e**: `SHIP` → `factory.ship-apply.requested` (pinned SHA asserted, correlation/causation inherited); e2e covers scan → human-approved apply → receipt, NOOP, and the schedule-actor rejection on the real chained proposal.

Verification: `bun test event-runtime/` → 783 pass, 0 fail; full `bun test` → 1092 pass, 0 fail (99 files).