### PR TITLE
fix(ci): isolate worktree test port band per run; surface+retry git worktree-add lock races (WM-113)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -146,21 +146,30 @@ test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
   const ticket1 = `CONCA-${base}`;
   const ticket2 = `CONCB-${base + 1}`;
 
-  try {
-    const [p1, p2] = await Promise.all([
-      Bun.spawn(["bash", UP, ticket1, "--checkout-only"], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-      }).exited,
-      Bun.spawn(["bash", UP, ticket2, "--checkout-only"], {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-      }).exited,
+  // Keep each child's stderr: a losing `git worktree add` reports the reason
+  // (lock contention, etc.) only there, and a bare exit-1 in the CI log is
+  // undiagnosable (WM-113).
+  const runUp = async (ticket) => {
+    const proc = Bun.spawn(["bash", UP, ticket, "--checkout-only"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    const [stderr, status] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
     ]);
-    expect(p1).toBe(0);
-    expect(p2).toBe(0);
+    return { ticket, status, stderr };
+  };
+
+  try {
+    const [r1, r2] = await Promise.all([runUp(ticket1), runUp(ticket2)]);
+    for (const r of [r1, r2]) {
+      if (r.status !== 0) {
+        console.error(`worktree-up ${r.ticket} exited ${r.status}; stderr:\n${r.stderr}`);
+      }
+      expect(r.status).toBe(0);
+    }
     expect(existsSync(path.join(tempWtRoot, ticket1))).toBe(true);
     expect(existsSync(path.join(tempWtRoot, ticket2))).toBe(true);
 

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -17,8 +17,11 @@ BASE_BRANCH="${FACTORY_BASE_BRANCH:-develop}"
 #                     ticket string (OPS-123 ≠ OPS-123-scratch, OPS-201 ≠
 #                     OPS-401), persisted in .factory/run/ports. Occupied
 #                     slots walk forward. web = API + 1.
-PORT_BASE=7400
-PORT_SPAN=200
+# The band is env-overridable (WM-113) so tests can run in a private range
+# instead of colliding with real runtimes or concurrent CI jobs; defaults
+# are unchanged for real use.
+PORT_BASE="${FACTORY_PORT_BASE:-7400}"
+PORT_SPAN="${FACTORY_PORT_SPAN:-200}"
 HERE_API_PORT=7391
 HERE_WEB_PORT=7392
 
@@ -28,6 +31,9 @@ die() {
 }
 info() { printf '\033[36m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarn:\033[0m %s\n' "$*" >&2; }
+
+[[ "$PORT_BASE" =~ ^[0-9]+$ ]] || die "FACTORY_PORT_BASE must be numeric (got '$PORT_BASE')"
+[[ "$PORT_SPAN" =~ ^[0-9]+$ ]] || die "FACTORY_PORT_SPAN must be numeric (got '$PORT_SPAN')"
 
 repo_root() { git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel; }
 

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -5,12 +5,53 @@ import { expect, test } from "bun:test";
 
 const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
 
+// Private port band for this test run (WM-113). Fixed in-band ports (7752,
+// 7772, …) collide with real runtimes, leftover servers, and concurrent CI
+// jobs — EADDRINUSE before the assertion even runs. Instead, probe random
+// even bases in the ephemeral-ish 20000–60000 range until every offset the
+// fixtures bind is free, and pass the band to the scripts via
+// FACTORY_PORT_BASE / FACTORY_PORT_SPAN. No absolute ports below.
+const PORT_SPAN = 200;
+const FIXTURE_OFFSETS = [352, 360, 362, 364, 366, 372, 374, 396];
+
+function offsetsBindable(base) {
+  for (const off of FIXTURE_OFFSETS) {
+    try {
+      const l = Bun.listen({
+        hostname: "127.0.0.1",
+        port: base + off,
+        socket: { data() {} },
+      });
+      l.stop(true);
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function pickPortBase() {
+  for (let i = 0; i < 50; i++) {
+    // Even base in 20000–59998 so every slot in the band stays even.
+    const candidate = 20000 + 2 * Math.floor(Math.random() * 20000);
+    if (offsetsBindable(candidate)) return candidate;
+  }
+  throw new Error("could not find a free port band for worktree-common tests");
+}
+
+const PORT_BASE = pickPortBase();
+const P = (offset) => PORT_BASE + offset;
+const BAND_ENV = {
+  FACTORY_PORT_BASE: String(PORT_BASE),
+  FACTORY_PORT_SPAN: String(PORT_SPAN),
+};
+
 function sh(body, extraEnv = {}) {
   const result = Bun.spawnSync({
     cmd: ["bash", "-c", `source "${COMMON}"\n${body}`],
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, ...BAND_ENV, ...extraEnv },
   });
   return {
     status: result.exitCode,
@@ -23,7 +64,7 @@ async function shAsync(body, extraEnv = {}) {
   const proc = Bun.spawn(["bash", "-c", `source "${COMMON}"\n${body}`], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, ...BAND_ENV, ...extraEnv },
   });
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -40,8 +81,12 @@ test("ticket_api_port hashes the full id so N and N+200 do not share a slot", ()
   expect(a.status).toBe(0);
   expect(b.status).toBe(0);
   expect(a.stdout).not.toBe(b.stdout);
-  expect(Number(a.stdout) % 2).toBe(0);
-  expect(Number(b.stdout) % 2).toBe(0);
+  for (const port of [Number(a.stdout), Number(b.stdout)]) {
+    expect(port % 2).toBe(0);
+    // Preferred-slot math must follow the overridden base, not the default.
+    expect(port).toBeGreaterThanOrEqual(PORT_BASE);
+    expect(port).toBeLessThan(PORT_BASE + 2 * PORT_SPAN);
+  }
 });
 
 test("ticket_api_port treats OPS-123 and OPS-123-scratch as different tickets", () => {
@@ -55,9 +100,9 @@ test("ticket_api_port treats OPS-123 and OPS-123-scratch as different tickets", 
 test("write_ports / read_ports round-trip", () => {
   const wt = mkdtempSync(path.join(tmpdir(), "ops-460-ports-"));
   try {
-    const written = sh(`write_ports "${wt}" 7752 7753\nread_ports "${wt}"`);
+    const written = sh(`write_ports "${wt}" ${P(352)} ${P(353)}\nread_ports "${wt}"`);
     expect(written.status).toBe(0);
-    expect(written.stdout.trim()).toBe("7752 7753");
+    expect(written.stdout.trim()).toBe(`${P(352)} ${P(353)}`);
   } finally {
     rmSync(wt, { recursive: true, force: true });
   }
@@ -65,7 +110,7 @@ test("write_ports / read_ports round-trip", () => {
 
 test("assert_event_home dies when /health belongs to another checkout", () => {
   const json = JSON.stringify({ env: { home: "/other/.factory/event-runtime" } });
-  const r = sh(`assert_event_home '${json}' '/this/.factory/event-runtime' 7752`);
+  const r = sh(`assert_event_home '${json}' '/this/.factory/event-runtime' ${P(352)}`);
   expect(r.status).not.toBe(0);
   expect(r.stderr).toContain("refusing to seed");
   expect(r.stderr).toContain("/other/.factory/event-runtime");
@@ -74,16 +119,16 @@ test("assert_event_home dies when /health belongs to another checkout", () => {
 test("assert_event_home accepts a matching env.home", () => {
   const home = "/this/.factory/event-runtime";
   const json = JSON.stringify({ env: { home } });
-  const r = sh(`assert_event_home '${json}' '${home}' 7752`);
+  const r = sh(`assert_event_home '${json}' '${home}' ${P(352)}`);
   expect(r.status).toBe(0);
 });
 
 test("assert_event_adapter requires fake unless --live", () => {
   const fake = JSON.stringify({ env: { adapter: "fake" } });
   const live = JSON.stringify({ env: {} });
-  expect(sh(`assert_event_adapter '${fake}' 0 7752`).status).toBe(0);
-  expect(sh(`assert_event_adapter '${live}' 1 7752`).status).toBe(0);
-  const mismatch = sh(`assert_event_adapter '${fake}' 1 7752`);
+  expect(sh(`assert_event_adapter '${fake}' 0 ${P(352)}`).status).toBe(0);
+  expect(sh(`assert_event_adapter '${live}' 1 ${P(352)}`).status).toBe(0);
+  const mismatch = sh(`assert_event_adapter '${fake}' 1 ${P(352)}`);
   expect(mismatch.status).not.toBe(0);
   expect(mismatch.stderr).toContain("--live");
 });
@@ -95,15 +140,15 @@ test("adapter_banner reports the /health adapter, not the local flag", () => {
 });
 
 test("allocate_api_port returns the preferred slot when nothing answers /health", () => {
-  const r = sh('allocate_api_port 7752 /tmp/expected-home');
+  const r = sh(`allocate_api_port ${P(352)} /tmp/expected-home`);
   expect(r.status).toBe(0);
-  expect(r.stdout).toBe("7752");
+  expect(r.stdout).toBe(String(P(352)));
 });
 
 test("allocate_api_port skips port occupied by another runtime", async () => {
   const server = Bun.serve({
     hostname: "127.0.0.1",
-    port: 7760,
+    port: P(360),
     fetch(req) {
       if (new URL(req.url).pathname === "/health") {
         return new Response(JSON.stringify({ ok: true, env: { home: "/other/worktree/.factory/event-runtime" } }), {
@@ -114,9 +159,9 @@ test("allocate_api_port skips port occupied by another runtime", async () => {
     },
   });
   try {
-    const r = await shAsync('allocate_api_port 7760 /this/worktree/.factory/event-runtime');
+    const r = await shAsync(`allocate_api_port ${P(360)} /this/worktree/.factory/event-runtime`);
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe("7762");
+    expect(r.stdout.trim()).toBe(String(P(362)));
   } finally {
     server.stop(true);
   }
@@ -125,24 +170,25 @@ test("allocate_api_port skips port occupied by another runtime", async () => {
 test("allocate_api_port skips port squatted by an alien process that does not answer /health", async () => {
   const server = Bun.serve({
     hostname: "127.0.0.1",
-    port: 7764,
+    port: P(364),
     fetch() {
       return new Response("I am an alien process", { status: 500 });
     },
   });
   try {
-    const r = await shAsync('allocate_api_port 7764 /this/worktree/.factory/event-runtime');
+    const r = await shAsync(`allocate_api_port ${P(364)} /this/worktree/.factory/event-runtime`);
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe("7766");
+    expect(r.stdout.trim()).toBe(String(P(366)));
   } finally {
     server.stop(true);
   }
 });
 
 test("allocate_api_port skips port held by raw TCP listener", async () => {
+  const heldPort = P(372);
   const listener = Bun.listen({
     hostname: "127.0.0.1",
-    port: 7772,
+    port: heldPort,
     socket: {
       data() {},
       open() {},
@@ -150,9 +196,11 @@ test("allocate_api_port skips port held by raw TCP listener", async () => {
     },
   });
   try {
-    const r = await shAsync('allocate_api_port 7772 /this/worktree/.factory/event-runtime');
+    const r = await shAsync(`allocate_api_port ${heldPort} /this/worktree/.factory/event-runtime`);
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe("7774");
+    // The skip property: allocation succeeds and lands off the held slot.
+    expect(r.stdout.trim()).not.toBe(String(heldPort));
+    expect(r.stdout.trim()).toBe(String(P(374)));
   } finally {
     listener.stop(true);
   }
@@ -162,7 +210,7 @@ test("allocate_api_port reuses port when /health reports matching expected home"
   const home = "/this/worktree/.factory/event-runtime";
   const server = Bun.serve({
     hostname: "127.0.0.1",
-    port: 7774,
+    port: P(374),
     fetch(req) {
       if (new URL(req.url).pathname === "/health") {
         return new Response(JSON.stringify({ ok: true, env: { home } }), {
@@ -173,19 +221,19 @@ test("allocate_api_port reuses port when /health reports matching expected home"
     },
   });
   try {
-    const r = await shAsync(`allocate_api_port 7774 '${home}'`);
+    const r = await shAsync(`allocate_api_port ${P(374)} '${home}'`);
     expect(r.status).toBe(0);
-    expect(r.stdout.trim()).toBe("7774");
+    expect(r.stdout.trim()).toBe(String(P(374)));
   } finally {
     server.stop(true);
   }
 });
 
 test("port_listening detects active and closed ports", async () => {
-  expect(sh('port_listening 7796').status).not.toBe(0);
+  expect(sh(`port_listening ${P(396)}`).status).not.toBe(0);
   const listener = Bun.listen({
     hostname: "127.0.0.1",
-    port: 7796,
+    port: P(396),
     socket: {
       data() {},
       open() {},
@@ -193,11 +241,11 @@ test("port_listening detects active and closed ports", async () => {
     },
   });
   try {
-    expect(sh('port_listening 7796').status).toBe(0);
+    expect(sh(`port_listening ${P(396)}`).status).toBe(0);
   } finally {
     listener.stop(true);
   }
-  expect(sh('port_listening 7796').status).not.toBe(0);
+  expect(sh(`port_listening ${P(396)}`).status).not.toBe(0);
 });
 
 test("ticket_number extracts numeric ID from valid ticket strings", () => {

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -59,6 +59,34 @@ done
 
 REPO="$(repo_root)"
 
+# `git worktree add` from concurrent bring-ups contends on git's internal
+# locks and the loser exits 1 with the reason only on stderr (WM-113).
+# Capture stderr so the die names the actual failure, and retry briefly when
+# it looks like lock contention; any other error dies immediately. Branch
+# existence is re-checked per attempt: a lock-interrupted `-b` add can leave
+# the branch created, and a blind `-b` retry would then die on "already
+# exists" instead of finishing the checkout.
+worktree_add() { # <worktree> <branch> <base-ref>
+  local wt="$1" branch="$2" base="$3"
+  local attempt=1 max_attempts=3 err=""
+  local delays=(0.5 1)
+  while :; do
+    if git -C "$REPO" show-ref --verify --quiet "refs/heads/$branch"; then
+      err=$(git -C "$REPO" worktree add --quiet "$wt" "$branch" 2>&1 >/dev/null) && return 0
+    else
+      err=$(git -C "$REPO" worktree add --quiet "$wt" -b "$branch" "$base" 2>&1 >/dev/null) && return 0
+    fi
+    if [[ $attempt -lt $max_attempts ]] \
+      && grep -qiE '\.lock|could not lock|unable to create|another git process' <<<"$err"; then
+      warn "git worktree add hit lock contention (attempt $attempt/$max_attempts) — retrying"
+      sleep "${delays[$((attempt - 1))]}"
+      attempt=$((attempt + 1))
+      continue
+    fi
+    die "git worktree add failed: $err"
+  done
+}
+
 if [[ "$HERE" -eq 1 ]]; then
   [[ -z "$TICKET" ]] || die "--here takes no ticket — it provisions the current checkout"
   WT="$REPO"
@@ -76,11 +104,7 @@ else
     [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
     git -C "$REPO" fetch origin "$BASE_BRANCH" --quiet || die "could not fetch origin/$BASE_BRANCH"
     [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "creating worktree $WT on $BRANCH"
-    if git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
-      git -C "$REPO" worktree add --quiet "$WT" "$BRANCH" >/dev/null 2>&1 || die "git worktree add failed (git worktree list)"
-    else
-      git -C "$REPO" worktree add --quiet "$WT" -b "$BRANCH" "origin/$BASE_BRANCH" >/dev/null 2>&1 || die "git worktree add failed"
-    fi
+    worktree_add "$WT" "$BRANCH" "origin/$BASE_BRANCH"
   fi
 fi
 


### PR DESCRIPTION
Fixes WM-113

Two flake mechanisms behind today's develop/PR CI reds in the worktree test files:

## A. Fixture-port collisions

`bin/worktree-common.test.mjs` bound fixtures at fixed in-band ports (7752/7760/7764/7772/7774/7796) inside the real runtime band (7400–7798). Any concurrent CI job, live runtime, or leftover server on those ports killed the test at `Bun.listen` (EADDRINUSE, observed on 7772) before its assertion ran.

- `bin/worktree-common.sh`: `PORT_BASE`/`PORT_SPAN` are now env-overridable via `FACTORY_PORT_BASE`/`FACTORY_PORT_SPAN` (defaults unchanged: 7400/200; validated numeric at source time).
- The test file probes random even bases in 20000–59998 at startup until every fixture offset binds, passes the band through the `sh`/`shAsync` helpers' env, and derives every fixture port from that base — no fixed absolute ports remain.
- The raw-TCP-listener test still proves the skip property (status 0, allocated port != held port) with assertions relative to the base; the ticket-hash test additionally asserts the preferred slot lands inside the overridden band.

## B. Opaque concurrent `git worktree add` failures

`bin/worktree-up.sh` discarded all `git worktree add` diagnostics (`>/dev/null 2>&1 || die "git worktree add failed"`), so a loser of git's internal lock contention showed up as a bare exit-1 in `concurrent worktree-up --checkout-only succeed in parallel`.

- New `worktree_add` helper captures stderr and includes it in the `die` message; lock-flavored errors (`.lock`, "could not lock", "Unable to create", "another git process") are retried with 0.5s/1s backoff (max 3 attempts); anything else dies immediately with the real error.
- Branch existence is re-checked per attempt: the improved diagnostics exposed that a lock-interrupted `-b` add can leave the branch created, and a blind `-b` retry then died on "a branch named ... already exists" — this was the actual residual flake seen 2/10 in the stress loop before the recheck.
- The concurrent test now captures each child's stderr and prints it via `console.error` before the exit-code assertion, so any future flake is diagnosable straight from the CI log.

## Verification (all from the worktree root)

1. `bun test bin/worktree-common.test.mjs bin/worktree-checkout.test.mjs` — 25 pass, 0 fail.
2. Stress loop (after the per-attempt branch recheck):
```
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [10.02s] (iteration 4)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [10.09s] (iteration 5)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [9.58s] (iteration 6)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [9.08s] (iteration 7)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [10.19s] (iteration 8)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [10.03s] (iteration 9)
25 pass  0 fail  125 expect() calls Ran 25 tests across 2 files. [10.18s] (iteration 10)
```
3. Squatter check: with `bun -e 'Bun.listen({hostname:"127.0.0.1",port:7772,...})'` holding old port 7772 (confirmed via lsof), both test files ran green (25 pass, 0 fail); squatter killed after.
4. Full `bun test bin/` — 41 pass, 0 fail across 4 files (worktree-common, worktree-checkout, worktree-daemons, factory).