### PR TITLE
feat(event-runtime): close the loop — GitHub webhook intake, dispatch-completion edge, disabled loop schedules (WM-112)

### DIFF
--- a/docs/event-runtime-schedules.md
+++ b/docs/event-runtime-schedules.md
@@ -1,6 +1,7 @@
 # Event runtime: scheduled clock events
 
-Status: **implemented** (OPS-381). Tracking: OPS-380 (this spec), OPS-381 (implementation).
+Status: **implemented** (OPS-381). Tracking: OPS-380 (this spec), OPS-381
+(implementation), WM-112 (repo loops §12, GitHub webhook intake §13).
 Parent: [event-runtime.md](event-runtime.md) §2 (`clock.tick.<loop>`), §3
 (isolation and capacity), §5.4 (idempotency), §12 (approval).
 
@@ -226,3 +227,143 @@ error, not a surprise at 03:00.
 
 1–3 are the substance; 4 is the one that changes what the runtime is allowed
 to do unattended and deserves its own review.
+
+## 12. Repo loops: work, merge, ship (WM-112)
+
+The chains only make a **loop** once events arrive without a human injecting
+them. The heartbeat half is schedules: for every repo in `config/repos.yaml`
+that is **not** `report_only` (today: `bj29`, `wm-home`, `legalease`,
+`cashsaas` — the dispatch doc's §5 rule keeps report-only repos out), three
+per-repo entries in `schedules.json`:
+
+| Loop | Cadence | Fires | Chain it heads |
+| :--- | :--- | :--- | :--- |
+| `work-<repo>` | `30m` | `factory.work.requested {repo}` | work-scan → dispatch (WM-110/108) |
+| `merge-<repo>` | `30m` | `factory.merge.requested {repo}` | merge-scan → merge-apply / escalate (WM-109) |
+| `ship-<repo>` | `7d` | `factory.ship.requested {repo}` | ship-scan → human-only ship-apply (WM-111) |
+
+Every entry ships `enabled: false`, `approval: "watched"`, `singleton: true`,
+`catchUp: "none"`. Switching a loop on is a deliberate, per-loop operator act
+in a reviewable commit — the §6 earning path applies unchanged, and
+`approval: auto` appears nowhere (the ship chain's apply step could never
+earn it anyway: the registry fails closed on `auto` against a
+`humanApprovalOnly` type, WM-111).
+
+Notes, stated rather than absorbed:
+
+- **There are no offsets.** §8 is intervals only; a slot is the epoch floor,
+  so `work-<repo>` and `merge-<repo>` at `30m` tick on the same boundary.
+  That is safe by construction — each loop is a singleton, each tick is a
+  watched proposal, and merges serialize downstream — so staggering is a
+  cosmetic nicety this mechanism deliberately does not have.
+- **The latency half is the dispatch-completion edge**, not a faster clock:
+  `dispatch@1` outcomes `PR_OPEN` and `NOT_CLAIMED` chain straight back into
+  `factory.work.requested {repo}` (edges.json, WM-112), so a freed slot is
+  re-scanned immediately and the 30-minute tick only catches what no
+  completion re-fired. `FAILED` and `BLOCKED` terminate — a run that needs a
+  human must not spin the scanner.
+- **First-enable precondition (known gap, WM-112).** A tick's payload carries
+  `{loop, slot, cadenceSeconds, skippedSlots}` alongside the static
+  `{repo}`. The loop-native agents accept those fields
+  (`schemas/repo-loop.input.json`); the three scan input schemas
+  (`work-scan`, `merge-scan`, `ship-scan`) do not yet, so an enabled loop's
+  tick currently plans to a typed `human_needed (invalid_input)` instead of a
+  proposal. Extending those schemas means re-pinning the agents' definitions
+  — out of WM-112's scope, filed as follow-up. Until it lands, the loops are
+  registered, visible, and inert even if enabled; webhook and injected
+  events (whose payloads are exactly `{repo}`) are unaffected.
+- **Doctor coverage is automatic.** The §9 silent-loop anomaly
+  (`stoppedSchedules` in `GET /status`) iterates `schedules.json` via
+  `scheduleView`, so the twelve new loops are covered without any change to
+  the doctor.
+
+## 13. GitHub webhook intake (WM-112)
+
+The other half of closing the loop: GitHub deliveries, translated at the
+intake boundary into ordinary `factory.event/v1` envelopes. The design
+decision, made against the code: intake's structure allowed a clean seam
+(option *a* of WM-112), so verification and translation live in
+`lib/intake.mjs` (`verifyGitHubWebhook`, `translateGitHubEvent`) and only the
+route — `POST /github` — sits in `lib/api.mjs`, because intake has no HTTP
+layer. The factory-envelope path on `POST /events` is byte-for-byte
+unchanged.
+
+**The contract:**
+
+- **Path**: `POST /github` (GitHub webhook "Content type:
+  application/json").
+- **Headers**: `X-GitHub-Event` (kind), `X-GitHub-Delivery` (GUID →
+  `eventId`, so at-least-once delivery dedupes on the ordinary
+  `(source="github", eventId)` key), `X-Hub-Signature-256` (GitHub's
+  `sha256=<hex>` HMAC over the raw body).
+- **Secret**: `FACTORY_GITHUB_WEBHOOK_SECRET`, dedicated on purpose — GitHub
+  signs raw-body-only with no timestamp, and one secret across two signature
+  schemes would let a capture from the weaker scheme replay against the
+  stronger. Absent secret disables the route, like the factory path.
+- **No signed timestamp** exists in GitHub's scheme, so there is no staleness
+  window; replay of a captured delivery is bounded by delivery-ID dedup
+  instead (a replay answers `duplicate: true` and admits nothing).
+
+**Translations** — minimal and typed; anything else refuses:
+
+| Delivery | Condition | Envelope |
+| :--- | :--- | :--- |
+| `pull_request` | action `opened`/`synchronize`/`ready_for_review`, base ref = the configured repo's `base`, repo not `report_only` | `factory.merge.requested`, subject + payload `{repo}` (short name) |
+| `workflow_run` | action `completed`, conclusion `failure`, repo configured (`report_only` included) | `github.workflow-run.failed`, subject `ci`, payload `{repo: owner/name slug, runId}` — the existing shape ci-log-capture consumes |
+
+**Refusal cases**, following intake's typed-refusal conventions:
+
+- `401 {error}` — missing/bad signature, missing secret. Nothing parsed,
+  nothing written.
+- `200 {admitted: false, ignored: true, reason}` — benign non-events, so
+  GitHub never marks the hook failing: `unhandled_event` (ping and every
+  other kind), `unhandled_action` (closed PRs, green runs),
+  `unconfigured_repo` (no `github:` match in repos.yaml),
+  `not_base_branch`, `repo_report_only` (CI failures still flow for
+  report-only repos; merge requests never do).
+- `422 {errors}` — malformed deliveries that deserve a failure:
+  `missing_delivery_id`, `malformed_payload`, invalid JSON.
+
+**Replay-CLI parity.** Every webhook kind has an injected equivalent through
+`cli.mjs inject` (same intake, no signature, loopback only) — which is also
+the offline test rig:
+
+```jsonc
+// pull_request → merge chain          // workflow_run failure → CI chain
+{                                      {
+  "schemaVersion": "factory.event/v1",   "schemaVersion": "factory.event/v1",
+  "eventId": "gh-replay-1",              "eventId": "gh-replay-2",
+  "type": "factory.merge.requested",     "type": "github.workflow-run.failed",
+  "source": "github",                    "source": "github",
+  "subject": "bj29",                     "subject": "ci",
+  "occurredAt": "<now>",                 "occurredAt": "<now>",
+  "correlationId": "gh-replay-1",        "correlationId": "gh-replay-2",
+  "payload": { "repo": "bj29" }          "payload": { "repo": "watt-mind/bakonszegi-coaching", "runId": 12345 }
+}                                      }
+```
+
+## 14. The loop, end to end (demo walkthrough)
+
+The whole circuit, on the local fake-adapter runtime (`event-runtime/demo/`,
+port 7522 — a demo, never a test dependency), or any watched environment:
+
+1. **Ticket becomes ready** → inject `factory.work.requested {repo}` (or let
+   an enabled `work-<repo>` slot fire it; a finished dispatch re-fires it by
+   itself via the completion edge).
+2. **work-scan proposal** appears in the inbox — the typed DISPATCH plan with
+   its Owned Paths evidence. **Approve.**
+3. **(fake) dispatch** runs: claim → worktree by delegation → PR → the
+   `factory.dispatch-result/v1` artifact. Its `PR_OPEN` outcome chains
+   `factory.work.requested` again — the queue is re-scanned without anyone
+   asking.
+4. **PR webhook arrives** — GitHub's `pull_request` delivery on the repo's
+   base branch through `POST /github` (or its injected equivalent above) —
+   and admits `factory.merge.requested {repo}`, deduped on the delivery ID.
+5. **merge proposal**: merge-scan reviews the open PRs cold and its MERGE
+   verdict chains a head-SHA-pinned `merge-apply` plan into a watched
+   proposal. Approving *that* is the merge.
+
+Ship is the same shape on a weekly clock, with one permanent difference: the
+`ship-apply` approval is structurally human-only (WM-111) — that watched
+approval *is* the master-merge decision, and no schedule, chain, or earned
+policy can ever make it `auto`.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -111,6 +111,23 @@
       }
     }
   },
+  "dispatch@1": {
+    "recommendationField": "outcome",
+    "edges": {
+      "PR_OPEN": {
+        "eventType": "factory.work.requested",
+        "input": {
+          "repo": "$.input.repo"
+        }
+      },
+      "NOT_CLAIMED": {
+        "eventType": "factory.work.requested",
+        "input": {
+          "repo": "$.input.repo"
+        }
+      }
+    }
+  },
   "ci-doctor@2": {
     "recommendationField": "verdict",
     "edges": {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -15,7 +15,7 @@ import http from "node:http";
 import path from "node:path";
 import { findArtifact } from "./artifacts.mjs";
 import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
-import { admitEvent, verifyWebhook } from "./intake.mjs";
+import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { planEvent, requeueEvent } from "./planner.mjs";
@@ -483,6 +483,7 @@ export function createApi({
   db,
   registry,
   secret = webhookSecret(),
+  githubSecret = githubWebhookSecret(),
   now = () => Date.now(),
   policyVersion = "unknown",
   env = { name: environmentName(), home: runtimeHome(), adapter: null },
@@ -550,6 +551,50 @@ export function createApi({
         // Fail closed: nothing is parsed, nothing is written (§14).
         if (!verdict.ok) return send(res, 401, { error: verdict.reason });
         return admit(db, registry, res, raw, nowMs, onEvent);
+      }
+
+      // GitHub webhook intake (WM-112). The route seam lives here because
+      // intake.mjs has no HTTP layer; verification and translation are
+      // intake's. GitHub signs the raw body only (no timestamp) with its own
+      // header, so this is a separate path with a dedicated secret — the
+      // factory-envelope path above is byte-for-byte unchanged. Benign
+      // non-events answer 2xx `ignored` so GitHub does not disable the hook.
+      if (route === "POST /github") {
+        const raw = await readBody(req);
+        const verdict = verifyGitHubWebhook({
+          rawBody: raw,
+          signature: req.headers["x-hub-signature-256"],
+          secret: githubSecret,
+        });
+        if (!verdict.ok) return send(res, 401, { error: verdict.reason });
+        const parsed = parseJson(raw);
+        if (parsed.error) return send(res, 422, { errors: [parsed.error] });
+        let repoRegistry;
+        try {
+          repoRegistry = repos();
+        } catch (err) {
+          if (err instanceof RepoError) return send(res, 500, { error: err.message });
+          throw err;
+        }
+        const translated = translateGitHubEvent({
+          event: req.headers["x-github-event"],
+          deliveryId: req.headers["x-github-delivery"],
+          payload: parsed.value,
+          repos: repoRegistry,
+          now: nowMs,
+        });
+        if (!translated.ok) {
+          if (translated.ignored) return send(res, 200, { admitted: false, ignored: true, reason: translated.reason });
+          return send(res, 422, { errors: [translated.reason] });
+        }
+        const outcome = admitEvent(db, registry, translated.envelope, { now: nowMs });
+        if (!outcome.admitted && !outcome.duplicate) return send(res, 422, { errors: outcome.errors });
+        if (outcome.admitted) onEvent("admitted");
+        return send(res, 200, {
+          admitted: outcome.admitted,
+          duplicate: outcome.duplicate,
+          eventId: outcome.event.event_id,
+        });
       }
 
       if (route === "POST /replay") {

--- a/event-runtime/lib/intake-github.test.mjs
+++ b/event-runtime/lib/intake-github.test.mjs
@@ -1,0 +1,338 @@
+/**
+ * GitHub webhook intake (WM-112): GitHub's raw-body HMAC verified with a
+ * dedicated secret, deliveries translated into `factory.event/v1` envelopes
+ * at the intake boundary, deduped on the delivery GUID — and the existing
+ * factory-envelope path on POST /events byte-for-byte unchanged beside it.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { startApi } from "./api.mjs";
+import { openDb } from "./db.mjs";
+import { githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook } from "./intake.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const registry = loadRegistry();
+const SECRET = "test-factory-secret";
+const GH_SECRET = "test-github-secret";
+const NOW = Date.parse("2026-08-14T10:30:00Z");
+const PV = "git:test-pv";
+
+/** Exactly GitHub's scheme: HMAC-SHA256 hex of the raw body, no timestamp. */
+const ghSign = (rawBody, secret = GH_SECRET) =>
+  `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+
+/** The factory scheme, for the unchanged-path assertions. */
+const factorySign = (rawBody, timestamp, secret = SECRET) =>
+  `sha256=${createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")}`;
+
+/** Repos as lib/repos.mjs loads them — only the fields translation reads. */
+const REPOS = new Map([
+  ["wt29", { name: "wt29", github: "watt-mind/wt29", base: "develop", reportOnly: false }],
+  ["watched", { name: "watched", github: "watt-mind/watched", base: "develop", reportOnly: true }],
+]);
+
+const prPayload = (overrides = {}) => ({
+  action: "opened",
+  pull_request: { number: 7, base: { ref: "develop" }, ...overrides.pull_request },
+  repository: { full_name: "watt-mind/wt29" },
+  ...overrides,
+});
+
+const workflowRunPayload = (overrides = {}) => ({
+  action: "completed",
+  workflow_run: { id: 12345, conclusion: "failure", ...overrides.workflow_run },
+  repository: { full_name: "watt-mind/watched" },
+  ...overrides,
+});
+
+const translate = (event, payload, overrides = {}) =>
+  translateGitHubEvent({ event, deliveryId: "gh-delivery-1", payload, repos: REPOS, now: NOW, ...overrides });
+
+describe("verifyGitHubWebhook (WM-112)", () => {
+  const rawBody = JSON.stringify(prPayload());
+
+  test("valid signature over the raw body passes", () => {
+    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody), secret: GH_SECRET })).toEqual({ ok: true });
+  });
+
+  test("wrong secret and tampered body each fail as bad_signature", () => {
+    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody, "other"), secret: GH_SECRET })).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+    expect(
+      verifyGitHubWebhook({ rawBody: rawBody.replace("wt29", "evil"), signature: ghSign(rawBody), secret: GH_SECRET }),
+    ).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  test("missing secret and missing signature fail closed", () => {
+    expect(verifyGitHubWebhook({ rawBody, signature: ghSign(rawBody), secret: null })).toEqual({
+      ok: false,
+      reason: "missing_secret",
+    });
+    expect(verifyGitHubWebhook({ rawBody, secret: GH_SECRET })).toEqual({ ok: false, reason: "missing_signature" });
+  });
+
+  test("malformed signature never throws", () => {
+    for (const signature of ["nonsense", "sha256=", "sha256=zzzz", "sha1=abc"]) {
+      expect(verifyGitHubWebhook({ rawBody, signature, secret: GH_SECRET })).toEqual({
+        ok: false,
+        reason: "bad_signature",
+      });
+    }
+  });
+
+  test("the dedicated secret env is read, never FACTORY_EVENT_SECRET", () => {
+    const previous = process.env.FACTORY_GITHUB_WEBHOOK_SECRET;
+    delete process.env.FACTORY_GITHUB_WEBHOOK_SECRET;
+    expect(githubWebhookSecret()).toBeNull();
+    process.env.FACTORY_GITHUB_WEBHOOK_SECRET = "gh-s";
+    expect(githubWebhookSecret()).toBe("gh-s");
+    if (previous === undefined) delete process.env.FACTORY_GITHUB_WEBHOOK_SECRET;
+    else process.env.FACTORY_GITHUB_WEBHOOK_SECRET = previous;
+  });
+});
+
+describe("translateGitHubEvent (WM-112)", () => {
+  test("pull_request opened|synchronize|ready_for_review against base → factory.merge.requested {repo}", () => {
+    for (const action of ["opened", "synchronize", "ready_for_review"]) {
+      const outcome = translate("pull_request", prPayload({ action }));
+      expect(outcome.ok).toBe(true);
+      expect(outcome.envelope).toEqual({
+        schemaVersion: "factory.event/v1",
+        eventId: "gh-delivery-1",
+        type: "factory.merge.requested",
+        source: "github",
+        subject: "wt29",
+        occurredAt: new Date(NOW).toISOString(),
+        correlationId: "gh-delivery-1",
+        causationId: null,
+        payload: { repo: "wt29" },
+      });
+    }
+  });
+
+  test("other pull_request actions are typed benign refusals", () => {
+    for (const action of ["closed", "labeled", "converted_to_draft"]) {
+      expect(translate("pull_request", prPayload({ action }))).toEqual({
+        ok: false,
+        ignored: true,
+        reason: "unhandled_action",
+      });
+    }
+  });
+
+  test("a PR not targeting the configured base branch is ignored", () => {
+    const payload = prPayload({ pull_request: { number: 7, base: { ref: "feature/x" } } });
+    expect(translate("pull_request", payload)).toEqual({ ok: false, ignored: true, reason: "not_base_branch" });
+  });
+
+  test("a report_only repo never yields factory.merge.requested", () => {
+    const payload = prPayload({ repository: { full_name: "watt-mind/watched" } });
+    expect(translate("pull_request", payload)).toEqual({ ok: false, ignored: true, reason: "repo_report_only" });
+  });
+
+  test("an unconfigured repo is a typed benign refusal on both kinds", () => {
+    expect(translate("pull_request", prPayload({ repository: { full_name: "someone/else" } }))).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unconfigured_repo",
+    });
+    expect(translate("workflow_run", workflowRunPayload({ repository: { full_name: "someone/else" } }))).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unconfigured_repo",
+    });
+  });
+
+  test("workflow_run completed+failure → the EXISTING github.workflow-run.failed shape, slug not short name", () => {
+    const outcome = translate("workflow_run", workflowRunPayload());
+    expect(outcome.ok).toBe(true);
+    expect(outcome.envelope).toEqual({
+      schemaVersion: "factory.event/v1",
+      eventId: "gh-delivery-1",
+      type: "github.workflow-run.failed",
+      source: "github",
+      subject: "ci",
+      occurredAt: new Date(NOW).toISOString(),
+      correlationId: "gh-delivery-1",
+      causationId: null,
+      // ci-log-capture consumes the owner/name slug (schemas/ci-log-capture.input.json).
+      payload: { repo: "watt-mind/watched", runId: 12345 },
+    });
+    // report_only repos DO get CI-failure events — only merge.requested is withheld.
+  });
+
+  test("a successful or in-progress workflow_run is ignored", () => {
+    expect(translate("workflow_run", workflowRunPayload({ workflow_run: { id: 1, conclusion: "success" } }))).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unhandled_action",
+    });
+    expect(translate("workflow_run", workflowRunPayload({ action: "requested" }))).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unhandled_action",
+    });
+  });
+
+  test("unknown event kinds (ping and friends) are typed benign refusals", () => {
+    expect(translate("ping", { zen: "Design for failure." })).toEqual({
+      ok: false,
+      ignored: true,
+      reason: "unhandled_event",
+    });
+    expect(translate(undefined, prPayload())).toEqual({ ok: false, ignored: true, reason: "unhandled_event" });
+  });
+
+  test("missing delivery id and malformed payloads fail closed, not ignored", () => {
+    expect(translate("pull_request", prPayload(), { deliveryId: undefined })).toEqual({
+      ok: false,
+      ignored: false,
+      reason: "missing_delivery_id",
+    });
+    for (const junk of [null, "string", ["array"]]) {
+      expect(translate("pull_request", junk)).toEqual({ ok: false, ignored: false, reason: "malformed_payload" });
+    }
+    expect(translate("pull_request", { action: "opened", repository: { full_name: "watt-mind/wt29" } })).toEqual({
+      ok: false,
+      ignored: false,
+      reason: "malformed_payload",
+    });
+    expect(
+      translate("workflow_run", workflowRunPayload({ workflow_run: { conclusion: "failure" } })),
+    ).toEqual({ ok: false, ignored: false, reason: "malformed_payload" });
+  });
+});
+
+describe("POST /github route (WM-112)", () => {
+  let s;
+  beforeAll(async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-gh-api-"));
+    const db = openDb(path.join(dir, "runtime.db"));
+    const onEvents = [];
+    const server = startApi({
+      db, registry, secret: SECRET, githubSecret: GH_SECRET, policyVersion: PV, port: 0,
+      onEvent: (kind) => onEvents.push(kind),
+      repos: () => REPOS,
+    });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const port = server.address().port;
+    s = {
+      db, server, onEvents,
+      url: (p) => `http://127.0.0.1:${port}${p}`,
+      close: () => { server.close(); db.close(); },
+    };
+  });
+  afterAll(() => s.close());
+
+  const deliver = (payload, { deliveryId = "d-1", event = "pull_request", signature } = {}) => {
+    const body = JSON.stringify(payload);
+    return fetch(s.url("/github"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": event,
+        "x-github-delivery": deliveryId,
+        "x-hub-signature-256": signature ?? ghSign(body),
+      },
+      body,
+    });
+  };
+
+  test("a valid delivery admits and the SAME delivery id again is a duplicate", async () => {
+    const first = await deliver(prPayload(), { deliveryId: "d-admit-1" });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ admitted: true, duplicate: false, eventId: "d-admit-1" });
+    expect(s.onEvents).toEqual(["admitted"]);
+
+    const again = await deliver(prPayload(), { deliveryId: "d-admit-1" });
+    expect(again.status).toBe(200);
+    expect(await again.json()).toEqual({ admitted: false, duplicate: true, eventId: "d-admit-1" });
+    expect(s.onEvents).toEqual(["admitted"]); // dedup planned nothing new
+
+    const row = s.db.query(`SELECT * FROM events WHERE source = 'github' AND event_id = 'd-admit-1'`).get();
+    expect(row.type).toBe("factory.merge.requested");
+    expect(JSON.parse(row.envelope_json).payload).toEqual({ repo: "wt29" });
+  });
+
+  test("a bad signature is refused before anything is parsed or written", async () => {
+    const body = JSON.stringify(prPayload());
+    const res = await deliver(prPayload(), { deliveryId: "d-bad-sig", signature: ghSign(body, "wrong") });
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("bad_signature");
+    expect(s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-bad-sig'`).get().n).toBe(0);
+  });
+
+  test("ignored kinds answer 2xx so GitHub keeps the hook healthy; nothing is written", async () => {
+    const res = await deliver({ zen: "Keep it logically awesome." }, { deliveryId: "d-ping", event: "ping" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ admitted: false, ignored: true, reason: "unhandled_event" });
+    expect(s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = 'd-ping'`).get().n).toBe(0);
+  });
+
+  test("a report_only repo's PR is 2xx-ignored — merge.requested never admitted", async () => {
+    const res = await deliver(prPayload({ repository: { full_name: "watt-mind/watched" } }), { deliveryId: "d-ro" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ admitted: false, ignored: true, reason: "repo_report_only" });
+    expect(
+      s.db.query(`SELECT COUNT(*) AS n FROM events WHERE type = 'factory.merge.requested' AND event_id = 'd-ro'`).get().n,
+    ).toBe(0);
+  });
+
+  test("a missing delivery id is a 422, per intake's fail-closed convention", async () => {
+    const body = JSON.stringify(prPayload());
+    const res = await fetch(s.url("/github"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": ghSign(body),
+      },
+      body,
+    });
+    expect(res.status).toBe(422);
+    expect((await res.json()).errors).toEqual(["missing_delivery_id"]);
+  });
+
+  test("the factory-envelope path is unchanged: /events still wants the factory scheme, not GitHub's", async () => {
+    const envelope = {
+      schemaVersion: "factory.event/v1",
+      eventId: "factory-evt-1",
+      type: "factory.status-report.requested",
+      source: "operator-webhook",
+      subject: "factory",
+      occurredAt: new Date().toISOString(),
+      correlationId: "factory-evt-1",
+      causationId: null,
+      payload: { repos: ["wt29"] },
+    };
+    const body = JSON.stringify(envelope);
+    const ts = String(Date.now());
+
+    // The existing fixture behaves exactly as before the GitHub seam landed.
+    const ok = await fetch(s.url("/events"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-factory-timestamp": ts,
+        "x-factory-signature": factorySign(body, ts),
+      },
+      body,
+    });
+    expect(ok.status).toBe(200);
+    expect(await ok.json()).toEqual({ admitted: true, duplicate: false, eventId: "factory-evt-1" });
+
+    // A GitHub-signed request to /events is refused: two schemes, two paths.
+    const cross = await fetch(s.url("/events"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-hub-signature-256": ghSign(body) },
+      body,
+    });
+    expect(cross.status).toBe(401);
+    expect((await cross.json()).error).toBe("missing_signature");
+  });
+});

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -1,12 +1,15 @@
 /**
  * Authenticated event intake (docs/event-runtime.md §5.1, §14).
  *
- * The webhook boundary is the runtime's outermost trust surface, so both
- * functions fail closed: a missing secret, missing header, stale timestamp,
- * or malformed anything is a typed refusal, never an exception and never an
- * admission. Verification runs over the raw body bytes before parsing, and
- * admission dedupes on (source, eventId) so an at-least-once delivery can
- * only ever produce one admitted row — a retry gets the original record back.
+ * The webhook boundary is the runtime's outermost trust surface, so every
+ * function here fails closed: a missing secret, missing header, stale
+ * timestamp, or malformed anything is a typed refusal, never an exception and
+ * never an admission. Verification runs over the raw body bytes before
+ * parsing, and admission dedupes on (source, eventId) so an at-least-once
+ * delivery can only ever produce one admitted row — a retry gets the original
+ * record back. GitHub deliveries are verified with GitHub's own signature
+ * scheme and translated into `factory.event/v1` envelopes at this same
+ * boundary (WM-112); the factory-envelope path is untouched by that seam.
  */
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { canonicalJson, hashJson } from "./canonical.mjs";
@@ -54,6 +57,131 @@ export function verifyWebhook({ rawBody, signature, timestamp, secret, now = Dat
     return { ok: false, reason: "bad_signature" };
   }
   return { ok: true };
+}
+
+/**
+ * Dedicated secret for GitHub webhook deliveries (WM-112). Deliberately not
+ * FACTORY_EVENT_SECRET: GitHub signs raw-body-only with its own scheme, and
+ * sharing one secret across two signature schemes would let a capture from
+ * the weaker scheme (no signed timestamp) be replayed against the stronger
+ * one. Absent secret means GitHub intake is disabled, like the factory path.
+ */
+export function githubWebhookSecret() {
+  return process.env.FACTORY_GITHUB_WEBHOOK_SECRET || null;
+}
+
+/**
+ * Verify GitHub's `X-Hub-Signature-256: sha256=<hex>` where <hex> is
+ * HMAC-SHA256(secret, rawBody) — GitHub's scheme, which signs no timestamp.
+ * Replay is bounded by delivery-ID dedup at admission instead (WM-112).
+ * Fail closed on anything missing or malformed; never throws on bad input.
+ *
+ * @returns {{ ok: true } | { ok: false, reason: string }}
+ */
+export function verifyGitHubWebhook({ rawBody, signature, secret }) {
+  if (!secret) return { ok: false, reason: "missing_secret" };
+  if (!signature || typeof signature !== "string") return { ok: false, reason: "missing_signature" };
+  if (!signature.startsWith("sha256=")) return { ok: false, reason: "bad_signature" };
+  try {
+    const presented = Buffer.from(signature.slice("sha256=".length).toLowerCase(), "utf8");
+    const expected = Buffer.from(
+      createHmac("sha256", secret)
+        .update(rawBody ?? "")
+        .digest("hex"),
+      "utf8",
+    );
+    if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) {
+      return { ok: false, reason: "bad_signature" };
+    }
+  } catch {
+    return { ok: false, reason: "bad_signature" };
+  }
+  return { ok: true };
+}
+
+/** PR lifecycle moments that mean "the merge queue may have changed" (WM-112). */
+const PR_ACTIONS = ["opened", "synchronize", "ready_for_review"];
+
+/** The repos.yaml entry whose `github` slug matches, or null when unconfigured. */
+function repoForSlug(repos, slug) {
+  if (typeof slug !== "string" || slug === "") return null;
+  for (const repo of repos.values()) {
+    if (repo.github === slug) return repo;
+  }
+  return null;
+}
+
+/**
+ * Translate a verified GitHub webhook delivery into a `factory.event/v1`
+ * envelope (WM-112). Minimal and typed, on purpose:
+ *
+ *   pull_request  opened|synchronize|ready_for_review against a configured
+ *                 repo's base branch → `factory.merge.requested {repo}`
+ *                 (short name); `report_only` repos never yield it.
+ *   workflow_run  completed + failure on a configured repo → the EXISTING
+ *                 `github.workflow-run.failed` shape ci-log-capture consumes
+ *                 ({repo: owner/name slug, runId}); report_only repos included.
+ *
+ * eventId is GitHub's delivery GUID, so at-least-once delivery dedupes on the
+ * (source, eventId) key like every other admission. Anything else is a typed
+ * refusal: `ignored: true` for benign non-events (the route answers 2xx so
+ * GitHub does not mark the hook failing), `ignored: false` for malformed
+ * deliveries that deserve a 4xx.
+ *
+ * @returns {{ ok: true, envelope: object }
+ *         | { ok: false, ignored: boolean, reason: string }}
+ */
+export function translateGitHubEvent({ event, deliveryId, payload, repos, now = Date.now() }) {
+  if (!deliveryId || typeof deliveryId !== "string") {
+    return { ok: false, ignored: false, reason: "missing_delivery_id" };
+  }
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return { ok: false, ignored: false, reason: "malformed_payload" };
+  }
+  const occurredAt = new Date(typeof now === "number" ? now : Date.now()).toISOString();
+  const base = {
+    schemaVersion: "factory.event/v1",
+    eventId: deliveryId,
+    source: "github",
+    occurredAt,
+    correlationId: deliveryId,
+    causationId: null,
+  };
+
+  if (event === "pull_request") {
+    if (!PR_ACTIONS.includes(payload.action)) return { ok: false, ignored: true, reason: "unhandled_action" };
+    const pr = payload.pull_request;
+    if (!pr || typeof pr !== "object") return { ok: false, ignored: false, reason: "malformed_payload" };
+    const repo = repoForSlug(repos, payload.repository?.full_name);
+    if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
+    if (pr.base?.ref !== repo.base) return { ok: false, ignored: true, reason: "not_base_branch" };
+    // A repo without industrialized worktrees has a safe concurrency of one
+    // human (dispatch doc §5) — CI facts still flow, merge requests never do.
+    if (repo.reportOnly) return { ok: false, ignored: true, reason: "repo_report_only" };
+    return {
+      ok: true,
+      envelope: { ...base, type: "factory.merge.requested", subject: repo.name, payload: { repo: repo.name } },
+    };
+  }
+
+  if (event === "workflow_run") {
+    const run = payload.workflow_run;
+    if (payload.action !== "completed" || run?.conclusion !== "failure") {
+      return { ok: false, ignored: true, reason: "unhandled_action" };
+    }
+    const slug = payload.repository?.full_name;
+    const repo = repoForSlug(repos, slug);
+    if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
+    if (run.id === undefined || run.id === null) return { ok: false, ignored: false, reason: "malformed_payload" };
+    return {
+      ok: true,
+      // The existing shape ci-log-capture@1 consumes: the GitHub slug, not the
+      // short name — see schemas/ci-log-capture.input.json.
+      envelope: { ...base, type: "github.workflow-run.failed", subject: "ci", payload: { repo: slug, runId: run.id } },
+    };
+  }
+
+  return { ok: false, ignored: true, reason: "unhandled_event" };
 }
 
 /**

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -1,0 +1,217 @@
+/**
+ * Closing the loop (WM-112): a finished dispatch re-fires the work-scan —
+ * dispatch@1 outcomes PR_OPEN and NOT_CLAIMED chain into
+ * factory.work.requested {repo}, so the queue is re-read the moment a slot
+ * frees (the latency half of rolling dispatch; the disabled schedules are the
+ * heartbeat half). FAILED and BLOCKED terminate: a run that needs a human
+ * must not spin the scanner.
+ *
+ * Follows the ci-doctor precedent (OPS-223) for mapping two verdicts onto one
+ * target, and the dispatch e2e harness (WM-108) for the fixtures.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveChains } from "./lib/chain.mjs";
+import { openDb } from "./lib/db.mjs";
+import { admitEvent } from "./lib/intake.mjs";
+import { planAdmittedEvents } from "./lib/planner.mjs";
+import { approveProposal, openProposals } from "./lib/proposals.mjs";
+import { loadRegistry } from "./lib/registry.mjs";
+import { runOnce } from "./lib/worker.mjs";
+
+const registry = loadRegistry();
+const PV = "git:test-pv";
+// See repository.test.mjs: neutralise the operator's global git config so a
+// signing key or a global hooks path cannot hang the fixture (OPS-441).
+const HERMETIC = ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", "-c", "commit.template="];
+const git = (args, cwd) => execFileSync("git", [...HERMETIC, ...args], { cwd, encoding: "utf8" }).trim();
+
+// Hermetic fixtures: a real git repo (the chained work-scan's repository
+// workspace pins a SHA) that also carries the worktree scripts the dispatch
+// run delegates to. Linear and the lease ledger are injected — nothing here
+// touches the network or ~/.factory.
+const fixtures = [];
+let previousReposRoot;
+let previousEventHome;
+
+beforeAll(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-factory-"));
+  fixtures.push(root);
+  const repoDir = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-repo-"));
+  const wtRoot = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-trees-"));
+  fixtures.push(repoDir, wtRoot);
+
+  git(["init", "--quiet", "--initial-branch=develop"], repoDir);
+  git(["config", "user.email", "test@example.com"], repoDir);
+  git(["config", "user.name", "Test"], repoDir);
+  writeFileSync(path.join(repoDir, "README.md"), "loop fixture\n");
+  git(["add", "."], repoDir);
+  git(["commit", "--quiet", "-m", "init"], repoDir);
+
+  mkdirSync(path.join(repoDir, "bin"), { recursive: true });
+  writeFileSync(path.join(repoDir, "bin", "worktree-up.sh"), `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\n`);
+  writeFileSync(path.join(repoDir, "bin", "worktree-down.sh"), `#!/bin/bash\nset -e\nrm -rf "${wtRoot}/$1"\n`);
+
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n` +
+      `  - name: wt29\n    path: ${repoDir}\n    github: watt-mind/wt29\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n`,
+  );
+  writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
+
+  previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  previousEventHome = process.env.FACTORY_EVENT_HOME;
+  process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-home-"));
+  fixtures.push(process.env.FACTORY_EVENT_HOME);
+});
+
+afterAll(() => {
+  if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+  else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+  if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+  else process.env.FACTORY_EVENT_HOME = previousEventHome;
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Gate injection where the world is wide open — dispatch.test.mjs owns the refusal matrix. */
+const openWorld = {
+  fetchTicket: () => ({
+    identifier: "WM-600",
+    title: "a fully specified ticket",
+    state: { name: "Todo" },
+    assignee: null,
+    labels: { nodes: [{ name: "ai:agent-ready" }] },
+    description: "## Owned Paths\n- src/feature-a/**\n",
+  }),
+  fetchInFlight: () => [],
+  countLeases: () => 0,
+};
+
+/** A contract-shaped dispatch result for one terminal outcome (dispatch.output.json). */
+const dispatchArtifact = (outcome, { repo, ticket }) => ({
+  outcome,
+  repo,
+  ticket,
+  prUrl: outcome === "PR_OPEN" ? "https://github.com/watt-mind/wt29/pull/42" : null,
+  verification:
+    outcome === "PR_OPEN"
+      ? { command: "echo verified", passed: true, output: "verified" }
+      : { command: null, passed: false, output: "" },
+  summary: `fake dispatch terminal ${outcome}`,
+});
+
+const dispatchFake = (outcome) => ({
+  async execute({ spec, workspaceDir }) {
+    writeFileSync(
+      path.join(workspaceDir, "result.json"),
+      `${JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: dispatchArtifact(outcome, spec.input),
+        evidence: { commands: ["fake"] },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    return { exitCode: 0, timedOut: false };
+  },
+});
+
+/** Admit → plan → approve → execute one dispatch run ending in `outcome`. */
+async function dispatchTo(outcome, eventId, ticket) {
+  const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-loop-db-")), "runtime.db"));
+  const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-loop-ws-"));
+  fixtures.push(workspaces);
+  const planAll = () => planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld });
+
+  admitEvent(db, registry, {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type: "factory.dispatch.requested",
+    source: "operator",
+    subject: ticket,
+    occurredAt: "2026-08-14T09:00:00Z",
+    correlationId: eventId,
+    causationId: null,
+    payload: { repo: "wt29", ticket },
+  });
+  planAll();
+  const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
+  expect(proposal).toBeTruthy();
+  const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
+  const summary = await runOnce(db, registry, { claude: dispatchFake(outcome) }, {
+    workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+  });
+  expect(summary.terminalState).toBe("COMPLETED");
+  return { db, planAll, runId: approved.runId };
+}
+
+describe("dispatch-completion edge registration (WM-112)", () => {
+  test("PR_OPEN and NOT_CLAIMED both map onto factory.work.requested {repo} — ci-doctor's two-verdicts-one-target shape", () => {
+    expect(registry.edges["dispatch@1"]).toEqual({
+      recommendationField: "outcome",
+      edges: {
+        PR_OPEN: { eventType: "factory.work.requested", input: { repo: "$.input.repo" } },
+        NOT_CLAIMED: { eventType: "factory.work.requested", input: { repo: "$.input.repo" } },
+      },
+    });
+  });
+});
+
+describe("dispatch-completion edge: a finished dispatch re-fires the work-scan (WM-112)", () => {
+  test("PR_OPEN chains to work.requested with inherited correlation — and plans a fresh watched scan", async () => {
+    const { db, planAll, runId } = await dispatchTo("PR_OPEN", "loop-pr-open", "WM-601");
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${runId}`);
+    expect(chainEvent.type).toBe("factory.work.requested");
+    expect(chainEvent.correlation_id).toBe("loop-pr-open"); // inherited from the dispatch's event
+    expect(chainEvent.causation_id).toBe(runId);
+    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({ repo: "wt29" });
+
+    // The latency half of rolling dispatch: the freed slot is re-scanned NOW,
+    // through the ordinary planner, as a watched proposal — never auto.
+    planAll();
+    const scan = openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1");
+    expect(scan).toBeTruthy();
+    expect(scan.status).toBe("open");
+
+    // One chain event per run, ever.
+    expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 0, errors: [] });
+  });
+
+  test("NOT_CLAIMED chains the same way — a lost claim frees the slot just as a PR does", async () => {
+    const { db, runId } = await dispatchTo("NOT_CLAIMED", "loop-not-claimed", "WM-602");
+
+    expect(resolveChains(db, registry)).toEqual({ emitted: 1, skipped: 0, errors: [] });
+    const chainEvent = db
+      .query(`SELECT * FROM events WHERE source = 'chain' AND event_id = ?`)
+      .get(`chain-${runId}`);
+    expect(chainEvent.type).toBe("factory.work.requested");
+    expect(chainEvent.correlation_id).toBe("loop-not-claimed");
+    expect(JSON.parse(chainEvent.envelope_json).payload).toEqual({ repo: "wt29" });
+  });
+
+  test("FAILED and BLOCKED terminate: no chain, no work.requested, no scanner spin", async () => {
+    for (const [outcome, eventId, ticket] of [
+      ["FAILED", "loop-failed", "WM-603"],
+      ["BLOCKED", "loop-blocked", "WM-604"],
+    ]) {
+      const { db, planAll } = await dispatchTo(outcome, eventId, ticket);
+      expect(resolveChains(db, registry)).toEqual({ emitted: 0, skipped: 1, errors: [] });
+      planAll();
+      expect(db.query(`SELECT COUNT(*) AS n FROM events WHERE type = 'factory.work.requested'`).get().n).toBe(0);
+      expect(openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1")).toBeUndefined();
+    }
+  });
+});

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -20,6 +20,7 @@ import { admitEvent } from "./lib/intake.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { approveProposal, openProposals } from "./lib/proposals.mjs";
 import { loadRegistry } from "./lib/registry.mjs";
+import { emitDueTicks } from "./lib/schedules.mjs";
 import { runOnce } from "./lib/worker.mjs";
 
 const registry = loadRegistry();
@@ -213,5 +214,86 @@ describe("dispatch-completion edge: a finished dispatch re-fires the work-scan (
       expect(db.query(`SELECT COUNT(*) AS n FROM events WHERE type = 'factory.work.requested'`).get().n).toBe(0);
       expect(openProposals(db, {}).find((p) => p.spec?.agent === "work-scan@1")).toBeUndefined();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The heartbeat half (WM-112): work/merge/ship loop schedules per dispatchable
+// repo, every one shipped disabled — switching a loop on stays a deliberate
+// operator act, and `approval: auto` appears nowhere (WM-107 §7).
+// ---------------------------------------------------------------------------
+
+/** The repos in config/repos.yaml that are NOT report_only, enumerated by hand
+ *  from the actual file — dispatch doc §5: report_only repos are never loop
+ *  targets. Everything else there (coach-wattz, watts-mobile, proxies,
+ *  hdkiller, eslint-config, factory) is report_only. */
+const DISPATCHABLE = ["bj29", "wm-home", "legalease", "cashsaas"];
+
+const loopEntry = (eventType, repo, every) => ({
+  every,
+  eventType,
+  payload: { repo },
+  catchUp: "none",
+  singleton: true,
+  approval: "watched",
+  enabled: false,
+});
+
+describe("loop schedules ship disabled (WM-112)", () => {
+  test("every dispatchable repo gets work/merge every 30m and ship weekly — all off, all watched, all singleton", () => {
+    for (const repo of DISPATCHABLE) {
+      expect(registry.schedules[`work-${repo}`]).toEqual(loopEntry("factory.work.requested", repo, "30m"));
+      expect(registry.schedules[`merge-${repo}`]).toEqual(loopEntry("factory.merge.requested", repo, "30m"));
+      expect(registry.schedules[`ship-${repo}`]).toEqual(loopEntry("factory.ship.requested", repo, "7d"));
+    }
+  });
+
+  test("no loop targets a report_only repo, and no loop anywhere declares approval auto", () => {
+    for (const repo of ["coach-wattz", "watts-mobile", "proxies", "hdkiller", "eslint-config", "factory"]) {
+      expect(registry.schedules[`work-${repo}`]).toBeUndefined();
+      expect(registry.schedules[`merge-${repo}`]).toBeUndefined();
+      expect(registry.schedules[`ship-${repo}`]).toBeUndefined();
+    }
+    for (const [loop, schedule] of Object.entries(registry.schedules)) {
+      expect({ loop, approval: schedule.approval }).toEqual({ loop, approval: "watched" });
+      expect({ loop, enabled: schedule.enabled }).toEqual({ loop, enabled: false });
+    }
+  });
+
+  test("enabling a loop in a fixture registry fires exactly its event type with its repo payload", () => {
+    const cases = [
+      ["work-bj29", "factory.work.requested", "bj29"],
+      ["merge-wm-home", "factory.merge.requested", "wm-home"],
+      ["ship-legalease", "factory.ship.requested", "legalease"],
+    ];
+    for (const [loop, eventType, repo] of cases) {
+      const db = openDb(":memory:");
+      const fixture = { ...registry, schedules: { [loop]: { ...registry.schedules[loop], enabled: true } } };
+      const outcome = emitDueTicks(db, fixture, { now: Date.parse("2026-08-14T10:05:00Z") });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.emitted).toHaveLength(1);
+      expect(outcome.emitted[0].loop).toBe(loop);
+
+      const row = db.query(`SELECT envelope_json FROM events`).get();
+      const envelope = JSON.parse(row.envelope_json);
+      expect(envelope.type).toBe(eventType);
+      expect(envelope.source).toBe("schedule");
+      expect(envelope.payload).toMatchObject({ repo, loop });
+      db.close();
+    }
+    // Known first-enable precondition, recorded rather than silently shipped:
+    // the tick payload carries {loop, slot, cadenceSeconds, skippedSlots}
+    // alongside the static {repo}, and the three scan input schemas do not yet
+    // whitelist those fields the way repo-loop.input.json does — so a planned
+    // tick lands as a typed human_needed(invalid_input), never a run. Fixing
+    // it means re-pinning agents' definitions, out of this ticket's scope; see
+    // docs/event-runtime-schedules.md §"Repo loops" and the WM-112 report.
+  });
+
+  test("a disabled loop never fires — the shipped default is silence", () => {
+    const db = openDb(":memory:");
+    expect(emitDueTicks(db, registry, { now: Date.now() }).emitted).toEqual([]);
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+    db.close();
   });
 });

--- a/event-runtime/schedules.json
+++ b/event-runtime/schedules.json
@@ -42,5 +42,113 @@
     "singleton": true,
     "approval": "watched",
     "enabled": false
+  },
+  "work-bj29": {
+    "every": "30m",
+    "eventType": "factory.work.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "merge-bj29": {
+    "every": "30m",
+    "eventType": "factory.merge.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "ship-bj29": {
+    "every": "7d",
+    "eventType": "factory.ship.requested",
+    "payload": { "repo": "bj29" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "work-wm-home": {
+    "every": "30m",
+    "eventType": "factory.work.requested",
+    "payload": { "repo": "wm-home" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "merge-wm-home": {
+    "every": "30m",
+    "eventType": "factory.merge.requested",
+    "payload": { "repo": "wm-home" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "ship-wm-home": {
+    "every": "7d",
+    "eventType": "factory.ship.requested",
+    "payload": { "repo": "wm-home" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "work-legalease": {
+    "every": "30m",
+    "eventType": "factory.work.requested",
+    "payload": { "repo": "legalease" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "merge-legalease": {
+    "every": "30m",
+    "eventType": "factory.merge.requested",
+    "payload": { "repo": "legalease" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "ship-legalease": {
+    "every": "7d",
+    "eventType": "factory.ship.requested",
+    "payload": { "repo": "legalease" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "work-cashsaas": {
+    "every": "30m",
+    "eventType": "factory.work.requested",
+    "payload": { "repo": "cashsaas" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "merge-cashsaas": {
+    "every": "30m",
+    "eventType": "factory.merge.requested",
+    "payload": { "repo": "cashsaas" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
+  },
+  "ship-cashsaas": {
+    "every": "7d",
+    "eventType": "factory.ship.requested",
+    "payload": { "repo": "cashsaas" },
+    "catchUp": "none",
+    "singleton": true,
+    "approval": "watched",
+    "enabled": false
   }
 }


### PR DESCRIPTION
Fixes WM-112

Closes the triage → work → merge → ship loop's wiring:

1. **GitHub webhook translation** — verification + translation as pure functions in `lib/intake.mjs`, admission through the existing `admitEvent`; only the `POST /github` route lives in `lib/api.mjs` (intake has no route layer — the narrow out-of-Owned-Paths change the ticket anticipated, cited inline). Dedicated `FACTORY_GITHUB_WEBHOOK_SECRET` (GitHub signs raw-body-only with no timestamp — sharing the factory secret would let the weaker scheme's captures replay against the stronger). Delivery-ID dedup; PR events on a configured repo's base branch → `factory.merge.requested`; failed workflow runs → the EXISTING `github.workflow-run.failed` shape; benign non-events 200-ignored, malformed 422, bad signature 401. `POST /events` byte-for-byte unchanged (tested).
2. **Dispatch-completion edge** — `dispatch@1` `PR_OPEN`/`NOT_CLAIMED` → `factory.work.requested {repo}`: a finished dispatch immediately re-scans the queue (latency half; schedules are the heartbeat half). No chain on FAILED/BLOCKED.
3. **Loop schedules** — `work-*`/`merge-*` 30m + `ship-*` 7d for the four non-report_only repos (bj29, wm-home, legalease, cashsaas); ALL `enabled: false`, watched, singleton, no catch-up. `approval: auto` appears nowhere. Doctor's silent-loop anomaly covers them automatically.
4. **Docs** — schedules doc gains the loop table, the webhook contract + replay-CLI parity, and the end-to-end demo walkthrough.

**Known gap, recorded in §12 rather than hidden:** an *enabled* loop's tick would today fail the three scan agents' `additionalProperties: false` input schemas (tick bookkeeping fields) → typed `human_needed`, never a run. Fixing needs schema edits + re-pinning, forbidden inside this ticket's constraints — filed as the first-enable precondition ticket. Webhook/injected events are unaffected.

Verification: `bun test event-runtime/` → 811 pass, 0 fail; full `bun test` → 1120 pass, 0 fail (101 files).