### PR TITLE
fix(event-runtime-web): lazy-load Proposals view — entry chunk back under budget (WM-125)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -20,7 +20,6 @@ import { ToastContainer, copyLink, copyText } from "./components/ui";
 import { Agents } from "./views/Agents";
 import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
-import { Proposals } from "./views/Proposals";
 import { RunFull } from "./views/RunFull";
 import { Runs } from "./views/Runs";
 import { Workers } from "./views/Workers";
@@ -36,6 +35,7 @@ type NavBadge = {
 const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph })));
 const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
 const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
+const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
 
 export function App() {
   const [route, navigateRaw] = useHashRoute();
@@ -498,18 +498,20 @@ export function App() {
         )}
         <div className="min-h-0 flex-1">
           {view === "proposals" ? (
-            <Proposals
-              connected={connected}
-              context={context}
-              onRunQueued={jumpToRun}
-              focusProposalId={focusProposalId}
-              onSelectProposal={(id) => navigate(hashPath("proposals", id))}
-              focusExpired={focusExpired}
-              onFocusExpiredConsumed={() => setFocusExpired(false)}
-              onJumpAgent={jumpToAgent}
-              onJumpEvent={jumpToEvent}
-              rejumpEpoch={rejumpEpoch}
-            />
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading proposals…</div>}>
+              <Proposals
+                connected={connected}
+                context={context}
+                onRunQueued={jumpToRun}
+                focusProposalId={focusProposalId}
+                onSelectProposal={(id) => navigate(hashPath("proposals", id))}
+                focusExpired={focusExpired}
+                onFocusExpiredConsumed={() => setFocusExpired(false)}
+                onJumpAgent={jumpToAgent}
+                onJumpEvent={jumpToEvent}
+                rejumpEpoch={rejumpEpoch}
+              />
+            </Suspense>
           ) : view === "run" && fullRunId ? (
             <RunFull
               runId={fullRunId}


### PR DESCRIPTION
Fixes WM-125

develop's web build failed its entry-chunk budget check (498.67 kB > 490 kB), breaking every fresh worktree-up (CI doesn't run the web build, so develop stayed green). Per the check's own triage: xyflow vendor chunk intact → genuine app growth, and the growth source was `src/views/Proposals.tsx` (recently grown by the OPS-375 blast-radius radar) — the one route-level view still eagerly imported while Graph/Projects/Schedules already use `lazy()` + `Suspense`.

Fix: apply the identical lazy pattern to Proposals instead of re-baselining. `ENTRY_CHUNK_BUDGET_BYTES` stays at 490 kB; `vite.config.ts` untouched. **Note:** the ticket's Owned Paths named `vite.config.ts` (anticipating a re-baseline); the actual change is the one-file `App.tsx` split the check's guidance prefers.

Measured: entry 498.67 kB → **477.19 kB** (13 kB headroom); new async `Proposals-*.js` 21.85 kB; xyflow/elk unchanged.

Verification: `cd event-runtime/web && bun run build` → built in 6.01s, exit 0 (only the pre-existing accepted elk warning); `bun test event-runtime/` → 850 pass, 0 fail.