### PR TITLE
fix(event-runtime): scan input schemas accept clock-tick payloads (WM-123)

### DIFF
--- a/docs/event-runtime-schedules.md
+++ b/docs/event-runtime-schedules.md
@@ -262,16 +262,15 @@ Notes, stated rather than absorbed:
   re-scanned immediately and the 30-minute tick only catches what no
   completion re-fired. `FAILED` and `BLOCKED` terminate — a run that needs a
   human must not spin the scanner.
-- **First-enable precondition (known gap, WM-112).** A tick's payload carries
-  `{loop, slot, cadenceSeconds, skippedSlots}` alongside the static
-  `{repo}`. The loop-native agents accept those fields
-  (`schemas/repo-loop.input.json`); the three scan input schemas
-  (`work-scan`, `merge-scan`, `ship-scan`) do not yet, so an enabled loop's
-  tick currently plans to a typed `human_needed (invalid_input)` instead of a
-  proposal. Extending those schemas means re-pinning the agents' definitions
-  — out of WM-112's scope, filed as follow-up. Until it lands, the loops are
-  registered, visible, and inert even if enabled; webhook and injected
-  events (whose payloads are exactly `{repo}`) are unaffected.
+- **Tick payloads validate (WM-112's known gap, fixed by WM-123).** A tick's
+  payload carries `{loop, slot, cadenceSeconds, skippedSlots}` alongside the
+  static `{repo}`. Every loop-target input schema whitelists those
+  bookkeeping fields the way `schemas/repo-loop.input.json` always did — the
+  three scan schemas (`work-scan`, `merge-scan`, `ship-scan`) gained them in
+  WM-123, with the agents' definitions re-pinned — so an enabled loop's tick
+  plans an ordinary watched proposal (`loop.test.mjs` proves one real run per
+  loop head). Webhook and injected events (whose payloads are exactly
+  `{repo}`) validate unchanged.
 - **Doctor coverage is automatic.** The §9 silent-loop anomaly
   (`stoppedSchedules` in `GET /status`) iterates `schedules.json` via
   `scheduleView`, so the twelve new loops are covered without any change to

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -23,7 +23,7 @@
   "mutating": false,
   "pins": {
     "agents/merge-scan.md": "sha256:f29375b1efa61e88550ef951ca8be7a5928833f8d5601ec5ad8b02ab9a10e30b",
-    "schemas/merge-scan.input.json": "sha256:b24950b7d9c5cdd07b0af6d2f0179f6ceea30af004c2299cd6efa60b163affa8",
+    "schemas/merge-scan.input.json": "sha256:f41fcfbbaee8423923b9ee5c213bfa92d03ce711d271c5a65a893f08b5af873e",
     "schemas/merge-scan.output.json": "sha256:f2d098a07e56fc68ba5d3781d42abe271292fbae9ff0913e2934fab14d7799c7"
   }
 }

--- a/event-runtime/agents/ship-scan.json
+++ b/event-runtime/agents/ship-scan.json
@@ -22,7 +22,7 @@
   "mutating": false,
   "pins": {
     "agents/ship-scan.md": "sha256:857d96ee7610f26f7fa1f931ef3bc479b8d7c0d0dbaf0c7b5ee98dc4bd714bd0",
-    "schemas/ship-scan.input.json": "sha256:605e1ecf5f1a122b0d9e79ab2c7957b37b571617658c3db323c096f609f63937",
+    "schemas/ship-scan.input.json": "sha256:78ca9a5df1148baf509348b7a492f7d299c2d519df2c9adc0c875e969db067da",
     "schemas/ship-scan.output.json": "sha256:b5d997d51db38988a35744294f8def899ec05482875a46a6c602497dc6dcb0c8"
   }
 }

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -24,7 +24,7 @@
   "mutating": false,
   "pins": {
     "agents/work-scan.md": "sha256:fc801eff175731093b473930fc6c24a4c7914ec7514a6d047e67780486022659",
-    "schemas/work-scan.input.json": "sha256:9932614918892f8ad90e0ef2e89145ef41a2bad79050a3dc6298ac88aff30e4c",
+    "schemas/work-scan.input.json": "sha256:3d596ece1e34c9d3a8711596076df67357d8eeec3d29bc5bfb64e02ed4f32c10",
     "schemas/work-scan.output.json": "sha256:fc3d7d8de8ca4c892f6be6effe6e3f89edd8ea68e6a0cbc0b5d17d469d4cb188"
   }
 }

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -281,13 +281,10 @@ describe("loop schedules ship disabled (WM-112)", () => {
       expect(envelope.payload).toMatchObject({ repo, loop });
       db.close();
     }
-    // Known first-enable precondition, recorded rather than silently shipped:
-    // the tick payload carries {loop, slot, cadenceSeconds, skippedSlots}
-    // alongside the static {repo}, and the three scan input schemas do not yet
-    // whitelist those fields the way repo-loop.input.json does — so a planned
-    // tick lands as a typed human_needed(invalid_input), never a run. Fixing
-    // it means re-pinning agents' definitions, out of this ticket's scope; see
-    // docs/event-runtime-schedules.md §"Repo loops" and the WM-112 report.
+    // WM-112 shipped these loops inert: the scan input schemas rejected the
+    // tick bookkeeping fields, parking every tick as human_needed. WM-123
+    // whitelisted the fields (repo-loop.input.json's approach) — the describe
+    // below proves each tick now plans a real run.
   });
 
   test("a disabled loop never fires — the shipped default is silence", () => {
@@ -295,5 +292,76 @@ describe("loop schedules ship disabled (WM-112)", () => {
     expect(emitDueTicks(db, registry, { now: Date.now() }).emitted).toEqual([]);
     expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
     db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First-enable gap closed (WM-123): a real clock tick — payload assembled by
+// emitDueTicks itself, never hand-written here — must plan an actual scan run
+// for each of the three loop heads, not park as human_needed(invalid_input).
+// The scan input schemas whitelist the tick bookkeeping fields exactly the way
+// repo-loop.input.json does.
+// ---------------------------------------------------------------------------
+
+describe("an enabled loop's tick plans a real scan run (WM-123)", () => {
+  /** A fixture registry with exactly one enabled loop for the wt29 test repo. */
+  const oneLoop = (loop, eventType) => ({
+    ...registry,
+    schedules: {
+      [loop]: {
+        every: "30m", eventType, payload: { repo: "wt29" },
+        catchUp: "none", singleton: true, approval: "watched", enabled: true,
+      },
+    },
+  });
+
+  const cases = [
+    ["work-wt29", "factory.work.requested", "work-scan@1"],
+    ["merge-wt29", "factory.merge.requested", "merge-scan@1"],
+    ["ship-wt29", "factory.ship.requested", "ship-scan@1"],
+  ];
+
+  for (const [loop, eventType, agent] of cases) {
+    test(`${eventType} tick carries {repo, loop, slot, cadenceSeconds, skippedSlots} and plans a watched ${agent} run`, () => {
+      const db = openDb(":memory:");
+      const fixture = oneLoop(loop, eventType);
+      const ticks = emitDueTicks(db, fixture, { now: Date.parse("2026-08-14T10:05:00Z") });
+      expect(ticks.errors).toEqual([]);
+      expect(ticks.emitted).toHaveLength(1);
+
+      // Pin the payload shape to what the scheduler actually emits — if
+      // emitDueTicks ever grows a field, this fails before the schema does.
+      const envelope = JSON.parse(db.query(`SELECT envelope_json FROM events`).get().envelope_json);
+      expect(Object.keys(envelope.payload).sort()).toEqual(["cadenceSeconds", "loop", "repo", "skippedSlots", "slot"]);
+
+      expect(planAdmittedEvents(db, fixture, { policyVersion: PV })).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
+      const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agent);
+      expect(proposal).toBeTruthy();
+      expect(proposal.decision).toBe("run");
+      expect(db.query(`SELECT status FROM events`).get().status).toBe("planned");
+      db.close();
+    });
+  }
+
+  test("plain {repo} payloads (webhook / injected) still plan unchanged", () => {
+    for (const [, eventType, agent] of cases) {
+      const db = openDb(":memory:");
+      admitEvent(db, registry, {
+        schemaVersion: "factory.event/v1",
+        eventId: `inject-${agent}`,
+        type: eventType,
+        source: "operator",
+        subject: "wt29",
+        occurredAt: "2026-08-14T09:00:00Z",
+        correlationId: `inject-${agent}`,
+        causationId: null,
+        payload: { repo: "wt29" },
+      });
+      expect(planAdmittedEvents(db, registry, { policyVersion: PV })).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
+      const proposal = openProposals(db, {}).find((p) => p.spec?.agent === agent);
+      expect(proposal).toBeTruthy();
+      expect(proposal.decision).toBe("run");
+      db.close();
+    }
   });
 });

--- a/event-runtime/schemas/merge-scan.input.json
+++ b/event-runtime/schemas/merge-scan.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "merge-scan input — one repo whose open PRs to review for merging",
+  "title": "merge-scan input — one repo whose open PRs to review for merging. A clock tick adds {loop, slot, cadenceSeconds, skippedSlots} bookkeeping to the schedule's static {repo} payload — whitelisted here as in repo-loop.input.json (WM-123)",
   "type": "object",
   "required": ["repo"],
   "additionalProperties": false,
@@ -8,6 +8,10 @@
       "type": "string",
       "minLength": 1,
       "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
-    }
+    },
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
   }
 }

--- a/event-runtime/schemas/ship-scan.input.json
+++ b/event-runtime/schemas/ship-scan.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "ship-scan input — one repo whose release candidate to assemble",
+  "title": "ship-scan input — one repo whose release candidate to assemble. A clock tick adds {loop, slot, cadenceSeconds, skippedSlots} bookkeeping to the schedule's static {repo} payload — whitelisted here as in repo-loop.input.json (WM-123)",
   "type": "object",
   "required": ["repo"],
   "additionalProperties": false,
@@ -8,6 +8,10 @@
       "type": "string",
       "minLength": 1,
       "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
-    }
+    },
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
   }
 }

--- a/event-runtime/schemas/work-scan.input.json
+++ b/event-runtime/schemas/work-scan.input.json
@@ -1,5 +1,5 @@
 {
-  "title": "work-scan input — one repo queue to scan; repoPin is resolved by the planner (WM-110)",
+  "title": "work-scan input — one repo queue to scan; repoPin is resolved by the planner (WM-110). A clock tick adds {loop, slot, cadenceSeconds, skippedSlots} bookkeeping to the schedule's static {repo} payload — whitelisted here as in repo-loop.input.json (WM-123)",
   "type": "object",
   "required": [
     "repo"
@@ -46,6 +46,10 @@
           "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
         }
       }
-    }
+    },
+    "loop": { "type": "string", "minLength": 1 },
+    "slot": { "type": "string", "minLength": 1 },
+    "cadenceSeconds": { "type": "integer", "minimum": 1 },
+    "skippedSlots": { "type": "integer", "minimum": 0 }
   }
 }


### PR DESCRIPTION
Fixes WM-123

The first-enable precondition for the work/merge/ship loops: a clock tick's payload carries `{loop, slot, cadenceSeconds, skippedSlots}` alongside `{repo}`, but the three scan input schemas were `additionalProperties: false` without those fields — so enabling any loop parked every tick as `human_needed (invalid_input)`.

Fix — option (a), extend the schemas mirroring `repo-loop.input.json`'s whitelist exactly. Option (b) (strip in planner) rejected on evidence: the validated payload is the same object feeding the run spec, inputHash, and the pinned envelope that `autoApproveScheduled` and the §5 singleton check read `payload.loop` back from — stripping would break both or produce run specs violating their own pinned schemas.

Tests (in loop.test.mjs): per-agent real ticks — payloads assembled by `emitDueTicks` itself, with the emitted key set pinned so a future scheduler field breaks the test before the schema; plain `{repo}` injected events regression-tested unchanged. Pins re-generated for exactly the three scan agents; registry loads clean (28 agents). Docs §12 known-gap bullet rewritten as fixed.

Verification: `bun test event-runtime/` → 854 pass, 0 fail; full `bun test` → 1163 pass, 0 fail (103 files).