### PR TITLE
feat(event-runtime): per-agent repo scoping — definitions declare an allowed repo set, enforced at plan time (WM-64)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -358,6 +358,22 @@ mutating: false
 A definition is admitted only when its adapter can prove the required
 capabilities. Adapter support is a contract, not a hopeful command-line flag.
 
+**Per-agent repo scoping (`repos`, WM-64).** A definition may declare an
+optional top-level `"repos": ["bj29", "cw-app"]` — a closed set of repos the
+agent may run over, the repo analogue of the actions adapter's per-definition
+host allowlist. Absent field = unrestricted (backward compatible). The
+registry validates only the field's shape at load (non-empty array of
+non-empty strings; an empty array is refused as a half-finished edit);
+membership against `config/repos.yaml` is deliberately not checked at load,
+because repos.yaml is external config that may legitimately change — the
+planner's plan-time check is the authority. The planner refuses any event
+whose `payload.repo` falls outside the declared set, whatever the workspace or
+adapter: the event parks `human_needed` with reason
+`repo_not_allowed: <agent> may not run over <repo> (allowed: …)`, before any
+repo pin, mirror fetch, or worktree materialization happens. The declared
+scope rides in the RunSpec (so the proposal an operator approves names it) and
+is readable in `GET /registry`.
+
 **Adapters are a registry, not a flag.** `"adapter": "claude"` in the run spec
 names an entry in a small adapter registry, one per harness the runtime has
 actually tested. The emit pipeline targets several harnesses (Claude Code,
@@ -752,7 +768,20 @@ a minimal runtime environment instead of copying the worker environment. That
 does not yet turn declarations such as `linear:read` into network authority:
 those still answer *what was authorized*, not *what was possible*. The
 declaration is validated at admission, recorded immutably in the `RunSpec`, and
-auditable after the fact. The remaining enforcement path, in order:
+auditable after the fact.
+
+Two per-definition allowlists ARE enforced by construction today, in contrast
+to the audited-not-enforced service capabilities: the actions adapter's **host
+allowlist** (`def.hosts` — an action naming a host outside the set fails the
+attempt before anything executes) and the planner's **repo scoping**
+(`def.repos`, WM-64 — an event naming a repo outside the set parks
+`human_needed` at plan time, before any repo pin or mirror fetch, so a
+`repository`/`worktree` workspace for an out-of-scope repo is never even
+materialized). Both are closed sets in the registered definition, checked in
+deterministic code on the refusal path, not policies a model is asked to
+respect.
+
+The remaining enforcement path, in order:
 
 1. **A worker-local egress proxy** that permits only declared services — for
    `linear:read`, a GraphQL proxy that forwards queries and rejects mutations.

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -342,6 +342,9 @@ function agentsView(registry) {
       command: def.command ?? null,
       actionRegistry: def.actionRegistry ?? null,
       hosts: def.hosts ? Object.keys(def.hosts) : null,
+      // Per-agent repo scope (WM-64), the repo analogue of hosts. Null means
+      // unrestricted.
+      repos: def.repos ?? null,
       eventTypes: Object.entries(registry.eventTypes)
         .filter(([, mapping]) => mapping.agent === def.ref)
         .map(([type, mapping]) => ({

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -51,6 +51,19 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
 }
 
 /**
+ * Per-agent repo scoping (WM-64), the repo analogue of the actions adapter's
+ * host allowlist: a definition that declares `repos` may only run over those
+ * repos. Applies to any input carrying a `repo` field, whatever the workspace
+ * or adapter. Returns the typed refusal reason, or null when in scope (no
+ * `repos` declared, or no `repo` in the payload, or a member of the set).
+ */
+export function repoNotAllowed(def, payload) {
+  if (!Array.isArray(def.repos) || typeof payload?.repo !== "string") return null;
+  if (def.repos.includes(payload.repo)) return null;
+  return `repo_not_allowed: ${def.ref} may not run over ${payload.repo} (allowed: ${def.repos.join(", ")})`;
+}
+
+/**
  * Pure assembly of the §5.2 RunSpec from a registered mapping. No I/O, no
  * clock reads beyond the injected `now` — same inputs, same spec, always.
  */
@@ -84,6 +97,9 @@ export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion
     policyVersion,
     outputContract: def.output_contract,
     capabilities: def.capabilities.services,
+    // Declared repo scope (WM-64) rides in the spec so the proposal the
+    // operator approves names it, same as capabilities.
+    ...(def.repos ? { repos: def.repos } : {}),
     timeoutSeconds: def.limits.timeout_seconds,
     maxAttempts: def.limits.attempts,
     idempotencyKey,
@@ -273,10 +289,14 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       const preEnvelope = JSON.parse(row.envelope_json);
       const preMapping = getEventType(registry, preEnvelope.type);
       const preDef = preMapping && preMapping.observe !== true ? registry.agents.get(preMapping.agent) : null;
+      // An event already outside the definition's repo scope (WM-64) skips
+      // the gate's Linear/lease reads entirely — the transaction below parks
+      // it repo_not_allowed before anything else happens.
       if (
         preDef?.workspace?.type === "worktree" &&
         typeof preEnvelope.payload?.repo === "string" &&
-        typeof preEnvelope.payload?.ticket === "string"
+        typeof preEnvelope.payload?.ticket === "string" &&
+        !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
         worktreeRefusal = worktreeDispatchGate(preEnvelope.payload, dispatch);
       }
@@ -307,6 +327,13 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     }
 
     const def = getAgent(registry, mapping.agent);
+
+    // Per-agent repo scoping (WM-64): checked before anything else the plan
+    // would do for the run — no repo pin, no mirror fetch, no worktree
+    // materialization for a repo the definition may never touch. Same idea as
+    // the actions adapter's host allowlist, enforced at plan time.
+    const scopeRefusal = repoNotAllowed(def, envelope.payload);
+    if (scopeRefusal) return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
 
     // §5 singleton: a scheduled loop whose previous run is still in flight
     // plans a typed NOOP, never a second queued run. A reaper that takes 70

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -292,6 +292,104 @@ describe("planEvent worktree gate (WM-108)", () => {
   });
 });
 
+describe("planEvent repo scoping (WM-64)", () => {
+  // A synthetic agent per test keeps the check independent of any one real
+  // definition (same approach as the worktree gate tests above).
+  function scopedRegistry({ repos, workspace = { type: "ephemeral" } } = {}) {
+    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    synthetic.eventTypes["test.scoped.requested"] = {
+      agent: "test-scoped@1",
+      adapter: "claude",
+      idempotencyScope: ["inputHash"],
+    };
+    synthetic.agents.set("test-scoped@1", {
+      id: "test-scoped",
+      version: 1,
+      ref: "test-scoped@1",
+      output_contract: "factory.test/v1",
+      workspace,
+      capabilities: { services: [] },
+      limits: { timeout_seconds: 60, attempts: 1 },
+      ...(repos ? { repos } : {}),
+      inputSchema: {
+        type: "object",
+        required: ["repo", "ticket"],
+        properties: { repo: { type: "string" }, ticket: { type: "string" } },
+      },
+    });
+    return synthetic;
+  }
+
+  const scopedEnvelope = (payload) => ({
+    type: "test.scoped.requested",
+    eventId: `scoped-${JSON.stringify(payload)}`,
+    correlationId: null,
+    payload,
+  });
+
+  test("payload.repo inside the declared set plans a run, and the spec carries the scope", () => {
+    const synthetic = scopedRegistry({ repos: ["bj29", "cw-app"] });
+    const db = openDb(":memory:");
+    const ref = admit(db, scopedEnvelope({ repo: "bj29", ticket: "WM-1" }));
+    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    expect(outcome.decision).toBe("run");
+    // The proposal the operator approves names the scope (WM-64).
+    expect(JSON.parse(outcome.proposal.spec_json).repos).toEqual(["bj29", "cw-app"]);
+  });
+
+  test("payload.repo outside the declared set parks human_needed with the named reason, no run", () => {
+    const synthetic = scopedRegistry({ repos: ["bj29", "cw-app"] });
+    const db = openDb(":memory:");
+    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
+    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toBe("repo_not_allowed: test-scoped@1 may not run over coach-wattz (allowed: bj29, cw-app)");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    const event = db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId);
+    expect(event.status).toBe("human_needed");
+  });
+
+  test("a definition without repos is unrestricted — behaves exactly as today (regression)", () => {
+    const synthetic = scopedRegistry();
+    const db = openDb(":memory:");
+    const ref = admit(db, scopedEnvelope({ repo: "anything-at-all", ticket: "WM-1" }));
+    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    expect(outcome.decision).toBe("run");
+    expect(JSON.parse(outcome.proposal.spec_json).repos).toBeUndefined();
+  });
+
+  test("scope refusal precedes the repo pin: repository workspace parks repo_not_allowed, never touches the mirror", () => {
+    // No FACTORY_REPOS_ROOT setup at all — if the planner reached pinRepo it
+    // would fail as repo_pin_failed; the scope check must win first, so no
+    // mirror fetch happens for a refused run.
+    const synthetic = scopedRegistry({ repos: ["bj29"], workspace: { type: "repository" } });
+    const db = openDb(":memory:");
+    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
+    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test" });
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toMatch(/^repo_not_allowed: /);
+    const stored = db.query(`SELECT envelope_json FROM events WHERE event_id = ?`).get(ref.eventId);
+    expect(JSON.parse(stored.envelope_json).payload.repoPin).toBeUndefined();
+  });
+
+  test("scope refusal precedes the worktree dispatch gate: no Linear or lease reads for an out-of-scope repo", () => {
+    const synthetic = scopedRegistry({ repos: ["bj29"], workspace: { type: "worktree" } });
+    const db = openDb(":memory:");
+    const ref = admit(db, scopedEnvelope({ repo: "coach-wattz", ticket: "WM-1" }));
+    const dispatch = {
+      fetchTicket: () => {
+        throw new Error("gate consulted Linear for an out-of-scope repo");
+      },
+      fetchInFlight: () => {
+        throw new Error("gate consulted Linear for an out-of-scope repo");
+      },
+    };
+    const outcome = planEvent(db, synthetic, ref, { now: NOW, policyVersion: "git:test", dispatch });
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toMatch(/^repo_not_allowed: /);
+  });
+});
+
 describe("buildRunSpec", () => {
   test("is pure and honors adapterOverride", () => {
     const mapping = registry.eventTypes["factory.status-report.requested"];

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -60,6 +60,22 @@ function loadAgentDef(root, file) {
       );
     }
   }
+  // Per-agent repo scoping (WM-64), the repo analogue of the actions adapter's
+  // host allowlist: an optional closed set of repos the definition may run
+  // over. Only the shape is checked here — membership against config/repos.yaml
+  // is deliberately NOT validated at load, because repos.yaml is external
+  // config that may legitimately change; the planner's plan-time check is the
+  // authority. Absent field = unrestricted. An empty array is refused as a
+  // half-finished edit: write the set or delete the field.
+  if (def.repos !== undefined) {
+    const wellFormed =
+      Array.isArray(def.repos) && def.repos.length > 0 && def.repos.every((r) => typeof r === "string" && r.trim() !== "");
+    if (!wellFormed) {
+      throw new RegistryError(
+        `${file}: "repos" must be a non-empty array of non-empty repo names (WM-64) — omit the field for an unrestricted agent`,
+      );
+    }
+  }
   const pins = def.pins ?? {};
   for (const field of PINNED_FIELDS) {
     const rel = def[field];

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -74,6 +74,28 @@ describe("registry", () => {
     expect(() => loadRegistry({ root })).not.toThrow();
   });
 
+  test("repos scope: malformed values fail closed at load, well-formed ones load (WM-64)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "factory-status-report.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    const withRepos = (repos) => writeFileSync(defFile, JSON.stringify({ ...def, repos }));
+
+    withRepos("bj29"); // not an array
+    expect(() => loadRegistry({ root })).toThrow(/"repos"/);
+    withRepos([]); // half-finished edit, not a deny-all
+    expect(() => loadRegistry({ root })).toThrow(/"repos"/);
+    withRepos(["bj29", ""]); // empty string member
+    expect(() => loadRegistry({ root })).toThrow(/"repos"/);
+    withRepos(["bj29", 7]); // non-string member
+    expect(() => loadRegistry({ root })).toThrow(/"repos"/);
+
+    // Well-formed loads, and membership is deliberately NOT checked against
+    // config/repos.yaml here — the planner owns that at plan time.
+    withRepos(["bj29", "not-in-repos-yaml"]);
+    const registry = loadRegistry({ root });
+    expect(getAgent(registry, "factory-status-report@1").repos).toEqual(["bj29", "not-in-repos-yaml"]);
+  });
+
   test("event type mapped to an unregistered agent fails closed", () => {
     const root = tempRegistry();
     writeFileSync(


### PR DESCRIPTION
Fixes WM-64

Per-agent repo scoping, the repo analogue of the actions adapter's per-definition host allowlist:

- **`lib/registry.mjs`** — a definition may declare optional top-level `"repos": [...]`; the shape (non-empty array of non-empty strings) is validated fail-closed at load. Membership against `config/repos.yaml` is deliberately NOT checked at load (external config may change) — the planner is the authority.
- **`lib/planner.mjs`** — new exported `repoNotAllowed(def, payload)`; `planEvent` parks any event whose `payload.repo` falls outside the definition's set as `human_needed` with `repo_not_allowed: <agent> may not run over <repo> (allowed: …)`, before any repo pin / mirror fetch / worktree materialization. The pre-transaction worktree dispatch gate is skipped for out-of-scope events, so no Linear/lease reads happen either. `buildRunSpec` carries `repos` in the spec so the proposal the operator approves names the scope. Applies to any input carrying `repo`, whatever the workspace or adapter. Absent field = unrestricted (regression-tested).
- **`lib/api.mjs`** — `GET /registry` agents view includes `repos` (null = unrestricted).
- **`docs/event-runtime.md`** — §6 documents the field; §14 lists repo scoping alongside the host allowlist as enforced-by-construction, contrasted with the audited-not-enforced service capabilities.
- Tests: allowed repo plans a run with the scope in the spec; disallowed parks with the named reason and no run; absent field unrestricted; scope check ordering vs repo pin and vs the dispatch gate; malformed `repos` rejected at registry load.

Out of scope: the one-line `cli.mjs agents` display of the field — `event-runtime/cli.mjs` is not in WM-64's Owned Paths, filed as WM-126. No existing agent definition declares `repos` yet (behavior-preserving by design).

Verification: `bun test event-runtime/` — 896 pass, 0 fail.