### PR TITLE
feat(event-runtime): push notification when an event parks human_needed or a watched proposal nears TTL expiry (WM-65)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -674,10 +674,23 @@ originally proposed: `cli.mjs`, a one-shot verb CLI (`proposals`, `approve
 are **clients, not the runtime**: every read and every verb goes through the
 same control API the runtime exposes, never directly into the database. That keeps a future web app a second client of
 identical endpoints, with the same audit trail, rather than a reimplementation.
-There is no push notification in watched mode — the operator is, by
-definition, watching. A notification channel (the existing `notify.py`
-convention) belongs to the later unattended stage, where `HUMAN_NEEDED`
-outcomes must reach an absent operator.
+
+**Push notifications (WM-65).** For the operator who is *not* watching, the
+serve tick carries a push channel (`lib/notify.mjs`) over the existing
+`notify.py` convention, covering exactly the two states that wait on a human:
+an event parked `human_needed` pushes `BLOCKED <event-type> <eventId>:
+<reason>`, and an open watched proposal pushes `DECISION NEEDED proposal <id>
+(<agent>): expires in <n>m` once it crosses 50% of its TTL undecided, plus one
+final `expired undecided` push if it expires. Each push fires once per subject
+— dedup markers persist in the module-owned `notify_log` table, so serve
+restarts never re-notify. The channel is **off by default**: set
+`FACTORY_EVENT_NOTIFY=1` to enable it, and `FACTORY_EVENT_NOTIFY_CMD` to
+replace the transport (default `python3 ~/Develop/hdkiller/scripts/notify.py`;
+the message is appended as the final argument). Deliveries are fire-and-forget
+with a 30s kill timeout; a notifier failure is recorded on `notify_log` and
+the serve log, never thrown — the notify step is an isolated tick subsystem
+like GC and chains (OPS-412). Routine flow (admissions, approvals, clean
+completions) never notifies; a channel that pings on everything gets muted.
 
 **What the operator sees.** The full `RunSpec`, plus the planner's evidence:
 the admitted event, the authoritative-state read that produced the proposal and

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -31,6 +31,7 @@ import { pruneArtifacts } from "./lib/artifacts.mjs";
 import { publishOutbox } from "./lib/outbox.mjs";
 import { autoApproveScheduled, emitDueTicks, scheduleView } from "./lib/schedules.mjs";
 import { resolveChains } from "./lib/chain.mjs";
+import { notifyPending } from "./lib/notify.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
 import { approveProposal } from "./lib/proposals.mjs";
@@ -108,7 +109,7 @@ async function withClient(fn) {
 // cannot hitch every 1s tick.
 export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
-export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "outbox", "GC", "chains"];
+export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "notify", "outbox", "GC", "chains"];
 
 /**
  * One serve-loop pass (OPS-412). Each named subsystem is caught on its own
@@ -165,6 +166,13 @@ export async function tick({
   await runStep("announce", () => {
     announceProposals();
     announceTransitions();
+  });
+
+  // Push channel for states awaiting a human (WM-65): human_needed parks and
+  // aging watched proposals. Off unless FACTORY_EVENT_NOTIFY=1; deliveries
+  // are fire-and-forget so a slow or broken notifier cannot delay the tick.
+  await runStep("notify", () => {
+    notifyPending(db, { now, log: logLine });
   });
 
   await runStep("reap", () => {

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -277,6 +277,81 @@ describe("cli", () => {
     verifyDb.close();
   });
 
+  test("tick runs notify as an isolated subsystem (WM-65): a throwing notifier step cannot break the tick", async () => {
+    const { tick, TICK_SUBSYSTEMS } = await import("./cli.mjs");
+    const { loadRegistry } = await import("./lib/registry.mjs");
+    expect(TICK_SUBSYSTEMS).toContain("notify");
+
+    const db = openDb(":memory:");
+    const logs = [];
+    let chainsRan = false;
+    await tick({
+      db,
+      registry: loadRegistry(),
+      policyVersion: "git:test",
+      log: (l) => logs.push(l),
+      subsystems: {
+        notify: () => {
+          throw new Error("notifier exploded");
+        },
+        chains: () => {
+          chainsRan = true;
+        },
+      },
+    });
+    expect(logs.some((l) => l.includes("tick notify: notifier exploded"))).toBe(true);
+    expect(chainsRan).toBe(true);
+  });
+
+  test("tick with FACTORY_EVENT_NOTIFY=1 pushes a human_needed park through the stub notifier exactly once", async () => {
+    const { tick } = await import("./cli.mjs");
+    const { loadRegistry } = await import("./lib/registry.mjs");
+    const { chmodSync, readFileSync, writeFileSync, existsSync } = await import("node:fs");
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tick-notify-"));
+    const outFile = path.join(dir, "pushes.txt");
+    const stub = path.join(dir, "notify-stub.sh");
+    writeFileSync(stub, `#!/bin/sh\nprintf '%s\\n' "$1" >> ${outFile}\n`);
+    chmodSync(stub, 0o755);
+
+    const db = openDb(path.join(dir, "runtime.db"));
+    const at = new Date().toISOString();
+    db.query(
+      `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at)
+       VALUES ('test', 'evt-tick', 'linear.ticket.agent_ready', ?, ?, '{}', 'sha256:x', 'human_needed', ?)`,
+    ).run(at, at, at);
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, reason, created_at, ttl_seconds)
+       VALUES ('prop-tick', 'test', 'evt-tick', 'human_needed', 'open', 'no_worktree_scripts', ?, 1800)`,
+    ).run(at);
+
+    const saved = { N: process.env.FACTORY_EVENT_NOTIFY, C: process.env.FACTORY_EVENT_NOTIFY_CMD };
+    process.env.FACTORY_EVENT_NOTIFY = "1";
+    process.env.FACTORY_EVENT_NOTIFY_CMD = stub;
+    const logs = [];
+    try {
+      await tick({ db, registry: loadRegistry(), policyVersion: "git:test", log: (l) => logs.push(l) });
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline && !existsSync(outFile)) {
+        await Bun.sleep(50);
+      }
+      expect(readFileSync(outFile, "utf8").trim()).toBe(
+        "BLOCKED linear.ticket.agent_ready evt-tick: no_worktree_scripts",
+      );
+      expect(logs.some((l) => l.includes("notify human_needed test/evt-tick"))).toBe(true);
+      // A second tick pushes nothing new.
+      await tick({ db, registry: loadRegistry(), policyVersion: "git:test", log: () => {} });
+      await Bun.sleep(200);
+      expect(readFileSync(outFile, "utf8").trim().split("\n")).toHaveLength(1);
+    } finally {
+      if (saved.N === undefined) delete process.env.FACTORY_EVENT_NOTIFY;
+      else process.env.FACTORY_EVENT_NOTIFY = saved.N;
+      if (saved.C === undefined) delete process.env.FACTORY_EVENT_NOTIFY_CMD;
+      else process.env.FACTORY_EVENT_NOTIFY_CMD = saved.C;
+      db.close();
+    }
+  });
+
   test("doctor against a dead port says serve is not running, non-zero exit", () => {
     const r = runCli(["doctor"], { FACTORY_EVENT_PORT: DEAD_PORT });
     expect(r.status).not.toBe(0);

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -1,0 +1,226 @@
+/**
+ * Push notifications for runtime states that are waiting on a human (WM-65).
+ *
+ * The watched runtime fails silently for an operator who is not looking at
+ * the web UI: an event parked `human_needed` sits invisibly, and a watched
+ * proposal nobody decides just expires at TTL. This module wires the serve
+ * tick to the existing `notify.py` Telegram transport for exactly those two
+ * states — and nothing else. Routine flow (admissions, approvals, clean
+ * completions) never notifies: the channel is only for things awaiting a
+ * human, or it gets muted.
+ *
+ * Design (ticket WM-65):
+ *   - Off by default; FACTORY_EVENT_NOTIFY=1 enables, FACTORY_EVENT_NOTIFY_CMD
+ *     replaces the transport (tests point it at a stub binary).
+ *   - Once, not per tick: dedup markers live in the module-owned `notify_log`
+ *     table so they survive serve restarts. The marker is written *before*
+ *     the spawn — exactly-once beats at-least-once for a push channel; a
+ *     failing notifier must not re-push on every subsequent 1s tick.
+ *   - A notify failure never breaks the tick (OPS-412 isolation): the spawn
+ *     is fire-and-forget with a kill timeout; a non-zero exit, spawn error,
+ *     or hang is recorded on the notify_log row and logged, never thrown.
+ */
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hdkiller", "scripts", "notify.py")}`;
+
+/** A notifier that has not exited by then is killed and recorded as failed. */
+export const NOTIFY_TIMEOUT_MS = 30_000;
+
+export function notifyEnabled(env = process.env) {
+  return env.FACTORY_EVENT_NOTIFY === "1" || env.FACTORY_EVENT_NOTIFY === "true";
+}
+
+/**
+ * The notifier command, split on whitespace; the message is appended as one
+ * final argv entry (no shell involved, so no quoting pitfalls).
+ */
+export function notifyCommand(env = process.env) {
+  return env.FACTORY_EVENT_NOTIFY_CMD || DEFAULT_NOTIFY_CMD;
+}
+
+/**
+ * Dedup ledger, owned by this module (Owned Paths exclude db.mjs, and an
+ * auxiliary marker table is not core schema). Idempotent by construction;
+ * one row per (kind, target) is the once-only guarantee.
+ */
+export function ensureNotifyLog(db) {
+  db.exec(`CREATE TABLE IF NOT EXISTS notify_log (
+    kind      TEXT NOT NULL,
+    target    TEXT NOT NULL,
+    message   TEXT NOT NULL,
+    sent_at   TEXT NOT NULL,
+    exit_code INTEGER,
+    error     TEXT,
+    PRIMARY KEY (kind, target)
+  );`);
+}
+
+const KIND_HUMAN_NEEDED = "human_needed";
+const KIND_PROPOSAL_TTL = "proposal_ttl";
+const KIND_PROPOSAL_EXPIRED = "proposal_expired";
+
+function alreadyNotified(db, kind, target) {
+  return !!db.query(`SELECT 1 FROM notify_log WHERE kind = ? AND target = ?`).get(kind, target);
+}
+
+/**
+ * What should be pushed right now, given DB state and the dedup ledger:
+ *
+ *   - every `human_needed` event not yet notified —
+ *     `BLOCKED <event-type> <eventId>: <reason>`
+ *   - every open watched 'run' proposal past 50% of its TTL —
+ *     `DECISION NEEDED proposal <id> (<agent>): expires in <n>m`
+ *   - every open watched 'run' proposal past its full TTL, once more —
+ *     `DECISION NEEDED proposal <id> (<agent>): expired undecided`
+ *
+ * A proposal decided before the 50% threshold is no longer `status = 'open'`
+ * and never appears here. Scheduled auto-approved proposals are decided
+ * within a tick of creation, so they never age into either threshold.
+ *
+ * @returns {Array<{ kind: string, target: string, message: string }>}
+ */
+export function pendingNotifications(db, { now = Date.now() } = {}) {
+  ensureNotifyLog(db);
+  const pending = [];
+
+  const parked = db
+    .query(
+      `SELECT e.source, e.event_id AS eventId, e.type, e.last_plan_error AS lastPlanError,
+              (SELECT p.reason FROM proposals p
+                WHERE p.event_source = e.source AND p.event_id = e.event_id
+                  AND p.decision = 'human_needed'
+                ORDER BY p.rowid DESC LIMIT 1) AS reason
+       FROM events e
+       WHERE e.status = 'human_needed'
+       ORDER BY e.admitted_at, e.rowid`,
+    )
+    .all();
+  for (const e of parked) {
+    const target = `${e.source}/${e.eventId}`;
+    if (alreadyNotified(db, KIND_HUMAN_NEEDED, target)) continue;
+    pending.push({
+      kind: KIND_HUMAN_NEEDED,
+      target,
+      message: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
+    });
+  }
+
+  const open = db
+    .query(`SELECT * FROM proposals WHERE status = 'open' AND decision = 'run' ORDER BY created_at, rowid`)
+    .all();
+  for (const p of open) {
+    const ageMs = now - Date.parse(p.created_at);
+    const ttlMs = p.ttl_seconds * 1000;
+    if (ageMs < ttlMs / 2) continue;
+    const spec = p.spec_json ? JSON.parse(p.spec_json) : null;
+    const agent = spec?.agent ?? "?";
+    if (ageMs > ttlMs) {
+      if (!alreadyNotified(db, KIND_PROPOSAL_EXPIRED, p.id)) {
+        pending.push({
+          kind: KIND_PROPOSAL_EXPIRED,
+          target: p.id,
+          message: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
+        });
+      }
+    } else if (!alreadyNotified(db, KIND_PROPOSAL_TTL, p.id)) {
+      const minutesLeft = Math.max(1, Math.ceil((ttlMs - ageMs) / 60_000));
+      pending.push({
+        kind: KIND_PROPOSAL_TTL,
+        target: p.id,
+        message: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
+      });
+    }
+  }
+
+  return pending;
+}
+
+/**
+ * Spawn the notifier once with `message` as its final argument. Resolves —
+ * never rejects — with the delivery outcome; a notifier still running after
+ * `timeoutMs` is killed and reported as failed.
+ *
+ * @returns {Promise<{ ok: boolean, exitCode: number|null, error: string|null }>}
+ */
+export function sendNotification(command, message, { timeoutMs = NOTIFY_TIMEOUT_MS } = {}) {
+  return new Promise((resolve) => {
+    const argv = String(command).trim().split(/\s+/).filter(Boolean);
+    let child;
+    try {
+      child = spawn(argv[0], [...argv.slice(1), message], { stdio: ["ignore", "ignore", "ignore"] });
+    } catch (err) {
+      resolve({ ok: false, exitCode: null, error: err.message });
+      return;
+    }
+    let settled = false;
+    const settle = (outcome) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(outcome);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+      settle({ ok: false, exitCode: null, error: `notifier timed out after ${timeoutMs}ms` });
+    }, timeoutMs);
+    timer.unref?.();
+    child.on("error", (err) => settle({ ok: false, exitCode: null, error: err.message }));
+    child.on("exit", (code, signal) => {
+      settle({
+        ok: code === 0,
+        exitCode: code,
+        error: code === 0 ? null : `notifier exited ${code ?? `on signal ${signal}`}`,
+      });
+    });
+  });
+}
+
+/**
+ * The tick subsystem: compute pending pushes, mark them notified, and fire
+ * the notifier for each without awaiting delivery. Returns synchronously as
+ * far as the tick is concerned; `deliveries` is only there so tests (and
+ * curious callers) can await the actual outcomes.
+ *
+ * With the feature disabled (the default) this returns before touching the
+ * database or spawning anything.
+ *
+ * @returns {{ sent: Array<{kind, target, message}>, deliveries: Promise<Array> }}
+ */
+export function notifyPending(db, {
+  now = Date.now(),
+  enabled = notifyEnabled(),
+  command = notifyCommand(),
+  log = () => {},
+  send = sendNotification,
+} = {}) {
+  if (!enabled) return { sent: [], deliveries: Promise.resolve([]) };
+
+  const pending = pendingNotifications(db, { now });
+  const at = new Date(now).toISOString();
+  const deliveries = [];
+  for (const n of pending) {
+    db.query(`INSERT OR IGNORE INTO notify_log (kind, target, message, sent_at) VALUES (?, ?, ?, ?)`)
+      .run(n.kind, n.target, n.message, at);
+    log(`notify ${n.kind} ${n.target}: ${n.message}`);
+    deliveries.push(
+      send(command, n.message).then((outcome) => {
+        try {
+          db.query(`UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`)
+            .run(outcome.exitCode, outcome.error, n.kind, n.target);
+        } catch {
+          // db already closed (shutdown mid-delivery) — the log line below is the record
+        }
+        if (!outcome.ok) log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
+        return { ...n, ...outcome };
+      }),
+    );
+  }
+  return { sent: pending, deliveries: Promise.all(deliveries) };
+}

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openDb } from "./db.mjs";
+import {
+  DEFAULT_NOTIFY_CMD,
+  notifyCommand,
+  notifyEnabled,
+  notifyPending,
+  pendingNotifications,
+  sendNotification,
+} from "./notify.mjs";
+
+const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+/** A stub notifier that appends its message argument to `outFile`. */
+function stubNotifier(dir, { exitCode = 0 } = {}) {
+  const outFile = path.join(dir, "pushes.txt");
+  const bin = path.join(dir, "notify-stub.sh");
+  writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$1" >> ${outFile}\nexit ${exitCode}\n`);
+  chmodSync(bin, 0o755);
+  return { bin, outFile, pushes: () => (Bun.file(outFile).size > 0 ? readFileSync(outFile, "utf8").trim().split("\n") : []) };
+}
+
+function insertEvent(db, { source = "test", eventId, type = "linear.ticket.agent_ready", status = "admitted", lastPlanError = null }) {
+  const at = new Date().toISOString();
+  db.query(
+    `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, last_plan_error, admitted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(source, eventId, type, at, at, "{}", "sha256:x", status, lastPlanError, at);
+}
+
+function insertProposal(db, {
+  id, eventId, decision = "run", status = "open", reason = null,
+  agent = "worktree-ticket@1", createdAt, ttlSeconds = 1800,
+}) {
+  db.query(
+    `INSERT INTO proposals (id, event_source, event_id, run_id, decision, spec_json, spec_hash, status, reason, created_at, ttl_seconds)
+     VALUES (?, 'test', ?, ?, ?, ?, 'sha256:x', ?, ?, ?, ?)`,
+  ).run(
+    id, eventId, decision === "run" ? `run_${id}` : null, decision,
+    decision === "run" ? JSON.stringify({ agent }) : null,
+    status, reason, createdAt ?? new Date().toISOString(), ttlSeconds,
+  );
+}
+
+describe("notify (WM-65)", () => {
+  test("config: off by default, FACTORY_EVENT_NOTIFY=1 enables, CMD overrides the notify.py default", () => {
+    expect(notifyEnabled({})).toBe(false);
+    expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "0" })).toBe(false);
+    expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "1" })).toBe(true);
+    expect(notifyEnabled({ FACTORY_EVENT_NOTIFY: "true" })).toBe(true);
+    expect(notifyCommand({})).toBe(DEFAULT_NOTIFY_CMD);
+    expect(DEFAULT_NOTIFY_CMD).toContain("python3 ");
+    expect(DEFAULT_NOTIFY_CMD).toContain("scripts/notify.py");
+    expect(notifyCommand({ FACTORY_EVENT_NOTIFY_CMD: "/x/stub" })).toBe("/x/stub");
+  });
+
+  test("disabled (the default): no notifier is ever spawned, nothing is queried or marked", () => {
+    const db = openDb(":memory:");
+    insertEvent(db, { eventId: "evt-1", status: "human_needed" });
+    insertProposal(db, { id: "prop-hn-1", eventId: "evt-1", decision: "human_needed", reason: "repo_unknown" });
+    const spawned = [];
+    const out = notifyPending(db, { enabled: false, send: (cmd, msg) => (spawned.push(msg), Promise.resolve({ ok: true, exitCode: 0, error: null })) });
+    expect(out.sent).toEqual([]);
+    expect(spawned).toEqual([]);
+    // No dedup ledger was even created — the disabled path touches nothing.
+    const tables = db.query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'notify_log'`).all();
+    expect(tables).toEqual([]);
+  });
+
+  test("a human_needed park pushes exactly once — with event type, id, and reason — and never again, across restarts", async () => {
+    const dir = tmp("evrt-notify-");
+    const dbFile = path.join(dir, "runtime.db");
+    const stub = stubNotifier(dir);
+
+    let db = openDb(dbFile);
+    insertEvent(db, { eventId: "evt-park", type: "linear.ticket.agent_ready", status: "human_needed" });
+    insertProposal(db, { id: "prop-park", eventId: "evt-park", decision: "human_needed", reason: "repo_report_only" });
+
+    const first = notifyPending(db, { enabled: true, command: stub.bin });
+    expect(first.sent).toHaveLength(1);
+    expect(first.sent[0].message).toBe("BLOCKED linear.ticket.agent_ready evt-park: repo_report_only");
+    await first.deliveries;
+    expect(stub.pushes()).toEqual(["BLOCKED linear.ticket.agent_ready evt-park: repo_report_only"]);
+
+    // Same serve process, next tick: nothing new.
+    const second = notifyPending(db, { enabled: true, command: stub.bin });
+    expect(second.sent).toEqual([]);
+
+    // Serve restart: the marker is in the database, not in process memory.
+    db.close();
+    db = openDb(dbFile);
+    const afterRestart = notifyPending(db, { enabled: true, command: stub.bin });
+    expect(afterRestart.sent).toEqual([]);
+    await afterRestart.deliveries;
+    expect(stub.pushes()).toHaveLength(1);
+    db.close();
+  });
+
+  test("an open watched proposal notifies once at 50% TTL and once more on expiry; a young one not at all", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    const ttlSeconds = 1800;
+    insertEvent(db, { eventId: "evt-p" });
+    // 16 of 30 minutes gone → past 50%, 14m left.
+    insertProposal(db, {
+      id: "prop-aging", eventId: "evt-p", agent: "ci-doctor@2",
+      createdAt: new Date(now - 16 * 60_000).toISOString(), ttlSeconds,
+    });
+    // 5 of 30 minutes gone → below threshold.
+    insertProposal(db, {
+      id: "prop-young", eventId: "evt-p",
+      createdAt: new Date(now - 5 * 60_000).toISOString(), ttlSeconds,
+    });
+
+    const sent = (at) => notifyPending(db, { now: at, enabled: true, send: () => Promise.resolve({ ok: true, exitCode: 0, error: null }) }).sent;
+
+    const first = sent(now);
+    expect(first).toHaveLength(1);
+    expect(first[0].message).toBe("DECISION NEEDED proposal prop-aging (ci-doctor@2): expires in 14m");
+
+    // Later ticks before expiry: silent.
+    expect(sent(now + 60_000)).toEqual([]);
+
+    // prop-young is decided before it ever reaches 50%: no push, ever.
+    db.query(`UPDATE proposals SET status = 'approved' WHERE id = 'prop-young'`).run();
+
+    // Past TTL: one final push, then silence.
+    const expired = sent(now + 15 * 60_000);
+    expect(expired).toHaveLength(1);
+    expect(expired[0].message).toBe("DECISION NEEDED proposal prop-aging (ci-doctor@2): expired undecided");
+    expect(sent(now + 16 * 60_000)).toEqual([]);
+    expect(sent(now + 60 * 60_000)).toEqual([]);
+  });
+
+  test("a proposal approved or rejected before the threshold never notifies", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    insertEvent(db, { eventId: "evt-d" });
+    insertProposal(db, { id: "prop-approved", eventId: "evt-d", status: "approved", createdAt: new Date(now - 60 * 60_000).toISOString() });
+    insertProposal(db, { id: "prop-rejected", eventId: "evt-d", status: "rejected", createdAt: new Date(now - 60 * 60_000).toISOString() });
+    expect(pendingNotifications(db, { now })).toEqual([]);
+  });
+
+  test("a notifier that exits non-zero is recorded on notify_log and logged, not thrown", async () => {
+    const dir = tmp("evrt-notify-fail-");
+    const stub = stubNotifier(dir, { exitCode: 3 });
+    const db = openDb(":memory:");
+    insertEvent(db, { eventId: "evt-f", status: "human_needed", lastPlanError: "plan exploded" });
+
+    const logs = [];
+    const out = notifyPending(db, { enabled: true, command: stub.bin, log: (l) => logs.push(l) });
+    expect(out.sent).toHaveLength(1);
+    const results = await out.deliveries;
+    expect(results[0].ok).toBe(false);
+    expect(results[0].exitCode).toBe(3);
+    const row = db.query(`SELECT exit_code, error FROM notify_log WHERE kind = 'human_needed'`).get();
+    expect(row.exit_code).toBe(3);
+    expect(row.error).toContain("exited 3");
+    expect(logs.some((l) => l.includes("notify human_needed test/evt-f failed: notifier exited 3"))).toBe(true);
+
+    // Failed delivery does NOT retry: once means once.
+    expect(notifyPending(db, { enabled: true, command: stub.bin }).sent).toEqual([]);
+  });
+
+  test("a hanging notifier is killed at the timeout and never delays the caller", async () => {
+    const dir = tmp("evrt-notify-hang-");
+    const bin = path.join(dir, "hang.sh");
+    writeFileSync(bin, "#!/bin/sh\nsleep 60\n");
+    chmodSync(bin, 0o755);
+
+    const before = Date.now();
+    const delivery = sendNotification(bin, "msg", { timeoutMs: 250 });
+    // The spawn call itself returns immediately — the tick is never blocked.
+    expect(Date.now() - before).toBeLessThan(200);
+    const outcome = await delivery;
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toContain("timed out after 250ms");
+  });
+
+  test("a missing notifier binary resolves as a failure instead of throwing", async () => {
+    const outcome = await sendNotification("/nonexistent/notifier-binary", "msg", { timeoutMs: 2000 });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes WM-65

## What

Wires the serve loop to the existing `notify.py` Telegram transport for the two states that wait on an absent operator — no new transport, no new agent:

- **human_needed park** → exactly one push per event: `BLOCKED <event-type> <eventId>: <reason>` (reason from the latest human_needed proposal, falling back to `last_plan_error`).
- **Open watched proposal** → one push when it crosses 50% of its TTL undecided (`DECISION NEEDED proposal <id> (<agent>): expires in <n>m`), one final push if it expires undecided. Approving/rejecting before the threshold produces none (decided proposals are no longer `status='open'`).

## How

- New `event-runtime/lib/notify.mjs`: `notifyPending(db, ...)` computes pending pushes and fires the notifier fire-and-forget (30s kill timeout). Non-zero exit, spawn error, or hang is recorded on the dedup row and logged — never thrown, never awaited by the tick.
- **Dedup survives restarts**: module-owned `notify_log` table (`CREATE TABLE IF NOT EXISTS`, one row per kind+target), marker written before the spawn — exactly-once beats at-least-once for a push channel. Owned Paths exclude `db.mjs`, so the module owns its marker table instead of a core migration; flagging for review.
- **Off by default**: `FACTORY_EVENT_NOTIFY=1` enables; `FACTORY_EVENT_NOTIFY_CMD` overrides the transport (default `python3 ~/Develop/hdkiller/scripts/notify.py`, message appended as final argv). Disabled → returns before touching the DB or spawning anything (test asserts `notify_log` is never even created).
- `cli.mjs`: `notify` added as an isolated tick subsystem (OPS-412 pattern, in `TICK_SUBSYSTEMS`), running after announce.
- `docs/event-runtime.md` §12 updated from 'deferred to the unattended stage' to the shipped mechanism and its defaults. (Doc file is required by the AC but was missing from the ticket's Owned Paths — treated the AC as authoritative.)

## Verification

```
bun test event-runtime/   # 907 pass, 0 fail
bun build/emit.mjs --check  # ok — 90 generated files match shared/
```

Full-repo `bun test` has 3 pre-existing failures in `bin/worktree-checkout.test.mjs` (`could not fetch origin/develop` — environmental, fails identically on an untouched checkout; unrelated to this diff).