### PR TITLE
fix(event-runtime): classify only harness-authored tool refusals, not command stderr (WM-127)

### DIFF
--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -122,6 +122,30 @@ function clip(text) {
   return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
 }
 
+/**
+ * Harness-authored refusal shapes only (WM-127). An error tool_result carries
+ * arbitrary command output — `git@ssh.github.com: Permission denied
+ * (publickey)`, `sudo: a password is required`, EACCES traces — and matching
+ * any of that produced receipts blaming the harness for denials it never
+ * issued (run_38deabb4). Each pattern here is anchored to the start of a
+ * message Claude Code itself writes into the tool_result when its policy
+ * layer refuses the call. The trade-off is deliberate: a missed shape
+ * degrades to a truthful generic `agent_exit_*`; a false positive lies about
+ * causality. Extend only with strings confirmed from the CLI.
+ */
+export const HARNESS_DENIAL_PATTERNS = [
+  // -p + --allowedTools: call to a tool the run never granted (CLI 2.1.232).
+  /^\s*Claude requested permissions to use .{1,120}, but you haven't granted it yet/,
+  // A permissions.deny rule (the generated settings policy) refusing a tool.
+  /^\s*Permission to use .{1,120} has been denied/,
+  // The generated sandbox policy blocking an operation.
+  /^\s*Sandbox denied/,
+];
+
+export function isHarnessDenial(content) {
+  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+}
+
 /** Flatten a tool_result content value (string or content-block array) to text. */
 function contentText(content) {
   if (typeof content === "string") return content;
@@ -251,7 +275,7 @@ export async function execute({
             }
             onTrace?.(event.kind, event.payload);
             const content = typeof event.payload?.content === "string" ? event.payload.content : "";
-            if (event.kind === "tool_result" && event.payload?.isError && /(?:permission|sandbox).{0,80}(?:denied|blocked)|(?:denied|blocked).{0,80}(?:permission|sandbox)/i.test(content)) {
+            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
               const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
               policyDenials.push(denial);
               // Keep the registry's closed trace-kind set. The payload turns
@@ -301,7 +325,12 @@ export async function execute({
       clearTimeout(termTimer);
       if (killTimer) clearTimeout(killTimer);
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
-      resolve({ exitCode, timedOut, policyDenials });
+      // A denial observed mid-run is evidence, not a verdict: the model can
+      // recover (run_38deabb4 retried a failed push over gh auth, opened its
+      // PR, and exited clean). A clean exit outranks the observation — report
+      // denials to the worker only when the run also failed; the lifecycle
+      // trace events above keep the evidence visible either way.
+      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
     });
   });
 }

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -7,12 +7,33 @@ import {
   buildClaudeSettings,
   deriveAllowedTools,
   execute,
+  isHarnessDenial,
   KILL_GRACE_MS,
   mapStreamEvent,
   PROMPT_SUFFIX,
   READ_ONLY_TOOLS,
   WRITE_TOOLS,
 } from "./claude.mjs";
+
+describe("isHarnessDenial (WM-127)", () => {
+  test("matches the harness's own refusal shapes", () => {
+    expect(isHarnessDenial("Claude requested permissions to use Bash, but you haven't granted it yet.")).toBe(true);
+    expect(isHarnessDenial("Claude requested permissions to use mcp__linear__create_issue, but you haven't granted it yet.")).toBe(true);
+    expect(isHarnessDenial("Permission to use Bash has been denied.")).toBe(true);
+    expect(isHarnessDenial("Sandbox denied write to /tmp/run-a1/repo/x")).toBe(true);
+  });
+
+  test("does not match permission-flavored stderr from commands the harness allowed", () => {
+    // The run_38deabb4 misclassification: git push over SSH without agent access.
+    expect(isHarnessDenial("git@ssh.github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.")).toBe(false);
+    expect(isHarnessDenial("bash: /etc/hosts: Permission denied")).toBe(false);
+    expect(isHarnessDenial("sudo: a terminal is required to read the password; permission denied")).toBe(false);
+    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
+    expect(isHarnessDenial("remote: Write access to repository not granted.\nfatal: unable to access: The requested URL returned error: 403")).toBe(false);
+    expect(isHarnessDenial("curl: (22) The requested URL returned error: 403 Forbidden — request blocked by firewall permissions")).toBe(false);
+    expect(isHarnessDenial(null)).toBe(false);
+  });
+});
 
 describe("mapStreamEvent", () => {
   test("assistant text block → assistant_text", () => {
@@ -279,10 +300,68 @@ if (behavior === "emit_policy_denial") {
   process.stdout.write(
     JSON.stringify({
       type: "user",
-      message: { content: [{ type: "tool_result", tool_use_id: "toolu_1", is_error: true, content: "Sandbox denied write to repo/nope" }] },
+      message: { content: [{ type: "tool_result", tool_use_id: "toolu_1", is_error: true, content: "Claude requested permissions to use Bash, but you haven't granted it yet." }] },
     }) + "\\n",
   );
   process.exit(1);
+}
+
+// run_38deabb4's transcript shape: git push fails with SSH publickey stderr in
+// an error tool_result, the agent retries over gh auth and finishes clean.
+if (behavior === "emit_ssh_denied" || behavior === "emit_ssh_denied_then_recovery") {
+  process.stdout.write(
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_push", name: "Bash", input: { command: "git push -u origin HEAD" } }],
+      },
+    }) + "\\n",
+  );
+  process.stdout.write(
+    JSON.stringify({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "toolu_push", is_error: true, content: "git@ssh.github.com: Permission denied (publickey).\\r\\nfatal: Could not read from remote repository.\\n\\nPlease make sure you have the correct access rights\\nand the repository exists." }] },
+    }) + "\\n",
+  );
+  if (behavior === "emit_ssh_denied") process.exit(1);
+  process.stdout.write(
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_retry", name: "Bash", input: { command: "git -c credential.helper='!gh auth git-credential' push -u origin HEAD" } }],
+      },
+    }) + "\\n",
+  );
+  process.stdout.write(
+    JSON.stringify({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "toolu_retry", content: "branch pushed" }] },
+    }) + "\\n",
+  );
+  process.stdout.write(JSON.stringify({ type: "result", subtype: "success", is_error: false, usage: {} }) + "\\n");
+  process.exit(0);
+}
+
+if (behavior === "emit_denial_then_recovery") {
+  process.stdout.write(
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_1", name: "WebFetch", input: { url: "https://example.com" } }],
+      },
+    }) + "\\n",
+  );
+  process.stdout.write(
+    JSON.stringify({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "toolu_1", is_error: true, content: "Claude requested permissions to use WebFetch, but you haven't granted it yet." }] },
+    }) + "\\n",
+  );
+  process.stdout.write(JSON.stringify({ type: "result", subtype: "success", is_error: false, usage: {} }) + "\\n");
+  process.exit(0);
 }
 `;
   writeFileSync(stubClaudePath, stubScript, { mode: 0o755 });
@@ -499,9 +578,64 @@ if (behavior === "emit_policy_denial") {
     expect(outcome).toEqual({
       exitCode: 1,
       timedOut: false,
-      policyDenials: [{ tool: "Bash", rule: "Sandbox denied write to repo/nope" }],
+      policyDenials: [{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }],
     });
     expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial" && e.payload.tool === "Bash")).toBe(true);
+  });
+
+  test("SSH publickey stderr in an error tool_result is not a policy denial (WM-127)", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_ssh_denied",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    // The harness allowed and executed the push; the command failed on its
+    // own. The run must fail as an ordinary agent exit, never policy_denied.
+    expect(outcome).toEqual({ exitCode: 1, timedOut: false, policyDenials: [] });
+    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+  });
+
+  test("SSH publickey stderr followed by a recovered push and clean exit completes (WM-127, run_38deabb4)", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_ssh_denied_then_recovery",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+  });
+
+  test("a genuine denial the model recovers from does not fail a clean exit; trace keeps the evidence (WM-127)", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_denial_then_recovery",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    // Evidence, not verdict: the observation stays in the lifecycle trace,
+    // but a run that ends exit 0 with a valid result is not failed for it.
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial" && e.payload.tool === "WebFetch")).toBe(true);
   });
 
   test("returns a policy denial even when no trace sink is attached", async () => {
@@ -515,7 +649,7 @@ if (behavior === "emit_policy_denial") {
         FACTORY_TEST_BEHAVIOR: "emit_policy_denial",
       },
     });
-    expect(outcome.policyDenials).toEqual([{ tool: "Bash", rule: "Sandbox denied write to repo/nope" }]);
+    expect(outcome.policyDenials).toEqual([{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }]);
   });
 
   test("spawn error (e.g. claude not on PATH) rejects promise", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -150,11 +150,12 @@ describe("worker", () => {
     const spec = queueRun(db, makeSpec({ adapter: "policy" }));
     const policyAdapter = {
       execute: async () => ({
-        // A model could recover after the denial; accepting its output would
-        // erase evidence of a policy breach, so exit 0 must still fail.
-        exitCode: 0,
+        // Adapters report policyDenials only when they are the verdict — the
+        // claude adapter suppresses them on a clean exit (WM-127), so a
+        // non-empty list here means the run failed at a refused tool call.
+        exitCode: 1,
         timedOut: false,
-        policyDenials: [{ tool: "Bash", rule: "Sandbox denied write" }],
+        policyDenials: [{ tool: "Bash", rule: "Claude requested permissions to use Bash, but you haven't granted it yet." }],
       }),
     };
 


### PR DESCRIPTION
Fixes WM-127

Narrows the claude adapter's policy-denial classifier to the harness's own refusal shapes (auto-mode classifier / permission-rule refusals) instead of regex-matching arbitrary tool stderr — git/SSH "Permission denied (publickey)", file modes, sudo etc. no longer produce `policy_denied:*`. A denial observed mid-run is evidence, not an automatic verdict: a run that recovers and exits 0 with a valid result contract completes. Regression fixtures derived from the two live false-FAILED runs (run_38deabb4 / WM-64, run_d56701f5 / WM-65).

Provenance note: implemented by dispatch run run_627ffb73 (the runtime's own agent); the run was cancelled after Claude Code's auto-mode classifier blocked its `bun test`/`git commit`/Linear-comment commands — plausibly because editing denial-detection code pattern-matches to weakening security controls. Work rescued, verified (901 tests, 0 fail), and landed by the operator session; the classifier-vs-unattended-dispatch problem is filed separately.

Verification: `bun test event-runtime/` → 901 pass, 0 fail.