### PR TITLE
feat(event-runtime): model-tier routing — tiers in definitions, policy map, plan-time pinned model (WM-135)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -49,6 +49,20 @@ budget:
                             # Raised to 1000 on 2026-08-04, then to 2000 same day.
   on_exhausted: drain
 
+models:
+  # Model-tier routing (WM-135). Agent definitions declare INTENT — an
+  # optional "model_tier": strong | standard | light — and this map, keyed per
+  # adapter, decides what each tier means. The planner resolves tier → model
+  # at plan time and pins the value into the RunSpec, so the proposal an
+  # operator approves names the exact model. The literal value "default" is a
+  # sentinel: pass no --model, ride the CLI's own default (today's behavior).
+  # Any other value is passed verbatim as --model. A tier declared by a
+  # definition with no mapping here fails closed at registry load.
+  claude:
+    strong: default        # CLI default — preserves today's dispatch behavior
+    standard: sonnet
+    light: haiku
+
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the
   # harness does about its own timeouts. A harness timeout produces a clean

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -374,6 +374,29 @@ repo pin, mirror fetch, or worktree materialization happens. The declared
 scope rides in the RunSpec (so the proposal an operator approves names it) and
 is readable in `GET /registry`.
 
+**Model-tier routing (`model_tier`, WM-135).** A definition may declare an
+optional `"model_tier": "strong" | "standard" | "light"` — a statement of
+intent, never a concrete model id. What each tier means is operator policy:
+the `models:` block in `config/policy.yaml`, keyed per adapter
+(`models.claude.standard: sonnet`), so retiering the fleet is a one-line
+policy PR instead of an edit fanned across definitions. The literal value
+`default` is a sentinel meaning "pass no model flag — ride the CLI's own
+default"; any other value is passed verbatim as `--model`. The **planner
+resolves tier → model at plan time and pins the result into the RunSpec**
+(`modelTier` + `model`, the same pattern as `repoPin`), so the proposal the
+operator approves, the stored run, and `inspect`/receipt output all name the
+exact model; `GET /agents` and `cli.mjs agents` show the declared tier and the
+per-route resolved value. Resolution order: per-definition `"model"` override
+(the one escape hatch for an exact id — both fields may coexist, the override
+wins) > tier map > adapter default (absent fields = no spec fields = today's
+behavior). A declared tier with no mapping for a routed model-consuming
+adapter is a **load error, fail closed** — never a silent fall-through to the
+adapter default. Only the `claude` adapter consumes models; on
+`command`/`actions`/`fake` routes a declared tier is recorded as not
+applicable (`model: null`), never an error. Tier assignments are intent the
+runtime cannot yet audit: per-run usage observability (WM-66) is what will
+show whether a tier is over- or under-provisioned and inform re-mapping.
+
 **Adapters are a registry, not a flag.** `"adapter": "claude"` in the run spec
 names an entry in a small adapter registry, one per harness the runtime has
 actually tested. The emit pipeline targets several harnesses (Claude Code,

--- a/event-runtime/agents/ci-doctor.json
+++ b/event-runtime/agents/ci-doctor.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/ci-doctor.input.json",
   "output_schema": "schemas/ci-doctor.output.json",
   "output_contract": "factory.ci-doctor/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "artifacts",
     "inputs": [

--- a/event-runtime/agents/disk-diagnose.json
+++ b/event-runtime/agents/disk-diagnose.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/disk-diagnose.input.json",
   "output_schema": "schemas/disk-diagnose.output.json",
   "output_contract": "factory.disk-diagnosis/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/dispatch.input.json",
   "output_schema": "schemas/dispatch.output.json",
   "output_contract": "factory.dispatch-result/v1",
+  "model_tier": "strong",
   "workspace": {
     "type": "worktree",
     "checkoutDir": "repo",

--- a/event-runtime/agents/factory-status-report.json
+++ b/event-runtime/agents/factory-status-report.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/factory-status-report.input.json",
   "output_schema": "schemas/factory-status-report.output.json",
   "output_contract": "factory.status-report/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/merge-scan.input.json",
   "output_schema": "schemas/merge-scan.output.json",
   "output_contract": "factory.merge-plan/v1",
+  "model_tier": "strong",
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true

--- a/event-runtime/agents/run-postmortem.json
+++ b/event-runtime/agents/run-postmortem.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/run-postmortem.input.json",
   "output_schema": "schemas/run-postmortem.output.json",
   "output_contract": "factory.run-postmortem/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "artifacts",
     "inputs": [

--- a/event-runtime/agents/ship-scan.json
+++ b/event-runtime/agents/ship-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/ship-scan.input.json",
   "output_schema": "schemas/ship-scan.output.json",
   "output_contract": "factory.ship-plan/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true

--- a/event-runtime/agents/sweep-scan.json
+++ b/event-runtime/agents/sweep-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/sweep-scan.input.json",
   "output_schema": "schemas/sweep-scan.output.json",
   "output_contract": "factory.sweep-plan/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "repository",
     "checkoutDir": "repo",

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/triage-scan.input.json",
   "output_schema": "schemas/triage-scan.output.json",
   "output_contract": "factory.triage-plan/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "repository",
     "checkoutDir": "repo",

--- a/event-runtime/agents/unblock-scan.json
+++ b/event-runtime/agents/unblock-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/unblock-scan.input.json",
   "output_schema": "schemas/unblock-scan.output.json",
   "output_contract": "factory.unblock-plan/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "repository",
     "checkoutDir": "repo",

--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -5,6 +5,7 @@
   "input_schema": "schemas/work-scan.input.json",
   "output_schema": "schemas/work-scan.output.json",
   "output_contract": "factory.work-plan/v1",
+  "model_tier": "standard",
   "workspace": {
     "type": "repository",
     "checkoutDir": "repo",

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -849,9 +849,18 @@ async function agents(client) {
   for (const d of defs) {
     console.log(`${d.ref}   contract ${d.outputContract}   mutating ${d.mutating}   timeout ${d.limits.timeout_seconds}s   attempts ${d.limits.attempts}`);
     console.log(`  capabilities  ${d.capabilities.filesystem}; ${(d.capabilities.services ?? []).join(", ") || "-"}`);
+    if (d.modelTier || d.model) {
+      // Declared intent (WM-135); the per-route resolved value rides on each
+      // event type line below, since resolution is per adapter.
+      const parts = [];
+      if (d.modelTier) parts.push(`tier ${d.modelTier}`);
+      if (d.model) parts.push(`override ${d.model}`);
+      console.log(`  model         ${parts.join("   ")}`);
+    }
     console.log(`  files         ${d.promptFile}, ${d.inputSchemaFile}, ${d.outputSchemaFile}`);
     for (const t of d.eventTypes) {
-      console.log(`  event type    ${t.type}   adapter ${t.adapter}   scope ${t.idempotencyScope.join("+")}   ttl ${t.proposalTtlSeconds ?? "-"}s`);
+      const model = t.resolvedModel != null ? `   model ${t.resolvedModel}` : "";
+      console.log(`  event type    ${t.type}   adapter ${t.adapter}   scope ${t.idempotencyScope.join("+")}   ttl ${t.proposalTtlSeconds ?? "-"}s${model}`);
     }
   }
 }

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -21,6 +21,7 @@ import { createWriteStream, mkdirSync, readFileSync, writeFileSync } from "node:
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { FACTORY_ROOT } from "../config.mjs";
+import { DEFAULT_MODEL } from "../registry.mjs";
 
 export const KILL_GRACE_MS = 30_000;
 
@@ -99,9 +100,15 @@ export function safeChildEnvironment(env = {}) {
  * runaway guard tick.mjs passes every ticket process (policy.yaml `budget`:
  * notional API-equivalent units on subscription auth, not money). The
  * dispatch design (§6) requires it before the first tier-2 mutating run.
+ * `model` is the planner-resolved value pinned in the RunSpec (WM-135):
+ * passed verbatim as `--model` unless it is the "default" sentinel or null,
+ * both of which mean "ride the CLI's own default" — today's behavior.
  */
-export function buildClaudeArgv({ prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig, settingsPath }) {
+export function buildClaudeArgv({ prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig, settingsPath, model }) {
   const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
+  if (typeof model === "string" && model !== "" && model !== DEFAULT_MODEL) {
+    args.push("--model", model);
+  }
   if (allowedTools && allowedTools.length > 0) {
     args.push("--allowedTools", allowedTools.join(","));
   }
@@ -238,7 +245,7 @@ export async function execute({
   const settings = buildClaudeSettings({ spec, def, workspaceDir });
   const settingsPath = settings ? path.join(workspaceDir, ".claude-policy.json") : null;
   if (settingsPath) writeFileSync(settingsPath, `${JSON.stringify(settings)}\n`, "utf8");
-  const argv = buildClaudeArgv({ prompt, def, mcpConfig, settingsPath });
+  const argv = buildClaudeArgv({ prompt, def, mcpConfig, settingsPath, model: spec?.model });
 
   return new Promise((resolve, reject) => {
     const child = spawn("claude", argv, {

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -215,6 +215,20 @@ describe("buildClaudeArgv (OPS-407, WM-62)", () => {
     expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: 0 } } })).not.toContain("--max-budget-usd");
     expect(buildClaudeArgv({ prompt: "p", def: { mutating: false, limits: { budget_usd: "15" } } })).not.toContain("--max-budget-usd");
   });
+
+  test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {
+    const withModel = buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "sonnet" });
+    const i = withModel.indexOf("--model");
+    expect(i).toBeGreaterThan(-1);
+    expect(withModel[i + 1]).toBe("sonnet");
+
+    // The "default" sentinel means "ride the CLI default" — no flag at all,
+    // byte-identical argv to a spec that pinned nothing.
+    const unpinned = buildClaudeArgv({ prompt: "p", def: { mutating: false } });
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "default" })).toEqual(unpinned);
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: null })).toEqual(unpinned);
+    expect(buildClaudeArgv({ prompt: "p", def: { mutating: false }, model: "" })).toEqual(unpinned);
+  });
 });
 
 describe("execute conformance (OPS-427, docs/event-runtime.md §6)", () => {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -20,6 +20,7 @@ import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { planEvent, requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
+import { resolveModel } from "./registry.mjs";
 import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
@@ -345,6 +346,10 @@ function agentsView(registry) {
       // Per-agent repo scope (WM-64), the repo analogue of hosts. Null means
       // unrestricted.
       repos: def.repos ?? null,
+      // Model-tier routing (WM-135): declared intent (tier), the exact-id
+      // override, and — per routed adapter below — what the planner would pin.
+      modelTier: def.model_tier ?? null,
+      model: def.model ?? null,
       eventTypes: Object.entries(registry.eventTypes)
         .filter(([, mapping]) => mapping.agent === def.ref)
         .map(([type, mapping]) => ({
@@ -352,6 +357,9 @@ function agentsView(registry) {
           adapter: mapping.adapter,
           idempotencyScope: mapping.idempotencyScope,
           proposalTtlSeconds: mapping.proposalTtlSeconds ?? null,
+          // Resolved at load, so this can no longer throw here. Null when the
+          // adapter takes no model or the definition declares nothing.
+          resolvedModel: resolveModel(def, mapping.adapter, registry.modelTiers),
         })),
     })),
     // Recommendation edges (OPS-223) — the capability map's defining relation:

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -704,9 +704,9 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(def.mutating).toBe(false);
       // Model-tier routing (WM-135): declared intent plus the per-route
       // resolved value, straight off the committed registry + policy map.
-      expect(def.modelTier).toBeNull();
+      expect(def.modelTier).toBe("standard");
       expect(def.model).toBeNull();
-      expect(def.eventTypes[0].resolvedModel).toBeNull();
+      expect(def.eventTypes[0].resolvedModel).toBe("sonnet");
       const commandDef = defs.find((d) => d.ref === "reconcile@1");
       expect(commandDef.modelTier).toBeNull();
       expect(commandDef.eventTypes[0].resolvedModel).toBeNull();

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -702,6 +702,14 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(Object.keys(def.pins)).toHaveLength(3);
       expect(def.eventTypes[0].type).toBe("factory.status-report.requested");
       expect(def.mutating).toBe(false);
+      // Model-tier routing (WM-135): declared intent plus the per-route
+      // resolved value, straight off the committed registry + policy map.
+      expect(def.modelTier).toBeNull();
+      expect(def.model).toBeNull();
+      expect(def.eventTypes[0].resolvedModel).toBeNull();
+      const commandDef = defs.find((d) => d.ref === "reconcile@1");
+      expect(commandDef.modelTier).toBeNull();
+      expect(commandDef.eventTypes[0].resolvedModel).toBeNull();
       expect(contracts["factory.agent-result/v1"].properties.terminalState.enum).toContain("refused");
     } finally {
       server.close();

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -22,7 +22,7 @@ import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS, FACTORY
 import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun, resolveIdempotency } from "./lifecycle.mjs";
-import { getAgent, getEventType } from "./registry.mjs";
+import { getAgent, getEventType, resolveModel } from "./registry.mjs";
 import { getRepo, loadRepos, reposRoot } from "./repos.mjs";
 import { pinRepo } from "./repository.mjs";
 import { validate } from "./schema.mjs";
@@ -100,6 +100,18 @@ export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion
     // Declared repo scope (WM-64) rides in the spec so the proposal the
     // operator approves names it, same as capabilities.
     ...(def.repos ? { repos: def.repos } : {}),
+    // Model-tier routing (WM-135), the house repoPin pattern: the tier is
+    // resolved HERE, at plan time, and the concrete value is pinned so the
+    // proposal, receipt, and inspect output all name the exact model. Fields
+    // appear only when the definition declares intent — an undeclared
+    // definition's spec is byte-identical to before (regression contract).
+    // Resolution keys off the REGISTERED adapter (mapping.adapter), not the
+    // override: `--adapter-override fake` substitutes execution, and the fake
+    // ignores the model; the spec still records what was routed. A null model
+    // means the routed adapter takes none (not applicable).
+    ...(def.model_tier !== undefined || def.model !== undefined
+      ? { modelTier: def.model_tier ?? null, model: resolveModel(def, mapping.adapter, registry.modelTiers) }
+      : {}),
     timeoutSeconds: def.limits.timeout_seconds,
     maxAttempts: def.limits.attempts,
     idempotencyKey,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -390,6 +390,126 @@ describe("planEvent repo scoping (WM-64)", () => {
   });
 });
 
+describe("planEvent model pinning (WM-135)", () => {
+  // Synthetic agents again: the resolution semantics belong to the planner,
+  // not to any one shipped definition.
+  function tieredRegistry({ modelTier, model, adapter = "claude", modelTiers } = {}) {
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+      modelTiers: modelTiers ?? { claude: { strong: "default", standard: "sonnet", light: "haiku" } },
+    };
+    synthetic.eventTypes["test.tiered.requested"] = {
+      agent: "test-tiered@1",
+      adapter,
+      idempotencyScope: ["inputHash"],
+    };
+    synthetic.agents.set("test-tiered@1", {
+      id: "test-tiered",
+      version: 1,
+      ref: "test-tiered@1",
+      output_contract: "factory.test/v1",
+      workspace: { type: "ephemeral" },
+      capabilities: { services: [] },
+      limits: { timeout_seconds: 60, attempts: 1 },
+      mutating: false,
+      ...(modelTier !== undefined ? { model_tier: modelTier } : {}),
+      ...(model !== undefined ? { model } : {}),
+      inputSchema: { type: "object" },
+    });
+    return synthetic;
+  }
+
+  const tieredEnvelope = (payload = { subject: "x" }) => ({
+    type: "test.tiered.requested",
+    eventId: `tier-${JSON.stringify(payload)}`,
+    correlationId: null,
+    payload,
+  });
+
+  test("declared tier resolves through the policy map and is pinned into the spec the operator approves", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(db, tieredRegistry({ modelTier: "standard" }), ref, { now: NOW, policyVersion: "git:test" });
+    expect(outcome.decision).toBe("run");
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.model).toBe("sonnet");
+    expect(spec.modelTier).toBe("standard");
+  });
+
+  test("tier resolving to the default sentinel pins \"default\" explicitly — visible, not implicit", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(db, tieredRegistry({ modelTier: "strong" }), ref, { now: NOW, policyVersion: "git:test" });
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.model).toBe("default");
+    expect(spec.modelTier).toBe("strong");
+  });
+
+  test("per-definition model override wins over the tier map", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(
+      db,
+      tieredRegistry({ modelTier: "standard", model: "claude-opus-4-1" }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.model).toBe("claude-opus-4-1");
+    expect(spec.modelTier).toBe("standard");
+  });
+
+  test("a definition declaring nothing produces a spec without model fields — today's behavior (regression)", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(db, tieredRegistry(), ref, { now: NOW, policyVersion: "git:test" });
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect("model" in spec).toBe(false);
+    expect("modelTier" in spec).toBe(false);
+  });
+
+  test("a tier routed via a non-model adapter is recorded as not applicable (model null), never an error", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(
+      db,
+      tieredRegistry({ modelTier: "light", adapter: "fake", modelTiers: {} }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
+    expect(outcome.decision).toBe("run");
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.model).toBeNull();
+    expect(spec.modelTier).toBe("light");
+  });
+
+  test("adapterOverride does not change resolution: the registered claude route still pins the model", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(db, tieredRegistry({ modelTier: "light" }), ref, {
+      now: NOW,
+      policyVersion: "git:test",
+      adapterOverride: "fake",
+    });
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.adapter).toBe("fake");
+    expect(spec.model).toBe("haiku");
+  });
+
+  test("declared tier with no policy mapping fails the plan closed — never a silent adapter default", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    // Bypassing loadRegistry's own load-time check (synthetic registry): the
+    // planner is the second line of the same fail-closed rule.
+    expect(() =>
+      planEvent(db, tieredRegistry({ modelTier: "light", modelTiers: {} }), ref, { now: NOW, policyVersion: "git:test" }),
+    ).toThrow(/no mapping for adapter "claude"/);
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+  });
+});
+
 describe("buildRunSpec", () => {
   test("is pure and honors adapterOverride", () => {
     const mapping = registry.eventTypes["factory.status-report.requested"];

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -92,6 +92,10 @@ describe("planEvent", () => {
       policyVersion: "git:test",
       outputContract: "factory.status-report/v1",
       capabilities: ["linear:read"],
+      // Model-tier routing (WM-135): the committed definition declares
+      // standard, policy maps it to sonnet, the planner pins the resolution.
+      modelTier: "standard",
+      model: "sonnet",
       timeoutSeconds: 600,
       maxAttempts: 1,
       idempotencyKey: `factory-status-report@1:factory.status-report/v1:workflow-01:${hashJson(payload)}`,

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -13,6 +13,7 @@ import path from "node:path";
 import { hashBytes } from "./canonical.mjs";
 import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
+import { reposRoot } from "./repos.mjs";
 
 export class RegistryError extends Error {
   constructor(message) {
@@ -22,6 +23,89 @@ export class RegistryError extends Error {
 }
 
 const PINNED_FIELDS = ["prompt", "input_schema", "output_schema"];
+
+// ---------------------------------------------------------------------------
+// Model-tier routing (WM-135). Definitions declare INTENT — a tier from a
+// closed vocabulary — never a concrete model id (the per-definition `model`
+// override is the one escape hatch, and it wins over the tier). The tier →
+// model mapping is operator policy, per adapter, in config/policy.yaml's
+// `models:` block, so retiering the fleet is a one-line policy PR, not an
+// edit fanned across every definition.
+
+export const MODEL_TIERS = ["strong", "standard", "light"];
+
+/**
+ * The sentinel meaning "pass no model flag — use the CLI's own default".
+ * Pinned verbatim into the RunSpec so the proposal an operator approves says
+ * explicitly that the run rides the adapter default.
+ */
+export const DEFAULT_MODEL = "default";
+
+/** Adapters that accept a model at all. command/actions/fake take none: a
+ * declared tier there resolves to null (not applicable), never an error. */
+export const MODEL_ADAPTERS = new Set(["claude"]);
+
+/**
+ * Read the `models:` tier map from config/policy.yaml (same root rule as
+ * repos.yaml: the running factory checkout, FACTORY_REPOS_ROOT to override).
+ * Shape is validated fail-closed — an unknown tier key or a non-string value
+ * is a config error at load, not a surprise at dispatch. A missing file or
+ * absent block is an empty map: fine until some definition declares a tier,
+ * at which point resolution fails closed below.
+ */
+export function loadModelTierMap({ root = reposRoot() } = {}) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return {};
+  let parsed;
+  try {
+    parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    throw new RegistryError(`${file}: unparseable policy.yaml — ${err.message}`);
+  }
+  const models = parsed?.models;
+  if (models === undefined || models === null) return {};
+  if (typeof models !== "object" || Array.isArray(models)) {
+    throw new RegistryError(`${file}: "models" must map adapter names to tier maps (WM-135)`);
+  }
+  for (const [adapter, tiers] of Object.entries(models)) {
+    if (typeof tiers !== "object" || tiers === null || Array.isArray(tiers)) {
+      throw new RegistryError(`${file}: models.${adapter} must map tiers to model values (WM-135)`);
+    }
+    for (const [tier, value] of Object.entries(tiers)) {
+      if (!MODEL_TIERS.includes(tier)) {
+        throw new RegistryError(`${file}: models.${adapter}.${tier} is not a tier (${MODEL_TIERS.join(", ")})`);
+      }
+      if (typeof value !== "string" || value.trim() === "") {
+        throw new RegistryError(
+          `${file}: models.${adapter}.${tier} must be a non-empty model value ("${DEFAULT_MODEL}" for the adapter default)`,
+        );
+      }
+    }
+  }
+  return models;
+}
+
+/**
+ * Resolve what model a definition runs on for a given adapter.
+ * Order: per-definition `model` override > policy tier map > adapter default.
+ * Returns null when the adapter takes no model (command/actions/fake — a
+ * declared tier is recorded as not applicable, never an error) or when the
+ * definition declares nothing (adapter default; today's behavior). A declared
+ * tier with no mapping for a model-consuming adapter throws — fail closed,
+ * never a silent fallback.
+ */
+export function resolveModel(def, adapter, modelTiers) {
+  if (!MODEL_ADAPTERS.has(adapter)) return null;
+  if (def?.model !== undefined) return def.model;
+  if (def?.model_tier === undefined) return null;
+  const value = modelTiers?.[adapter]?.[def.model_tier];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new RegistryError(
+      `${def.ref ?? def.id}: model_tier "${def.model_tier}" has no mapping for adapter "${adapter}" — add models.${adapter}.${def.model_tier} to config/policy.yaml (WM-135, fail closed)`,
+    );
+  }
+  return value;
+}
 
 function loadAgentDef(root, file) {
   const def = JSON.parse(readFileSync(file, "utf8"));
@@ -76,6 +160,19 @@ function loadAgentDef(root, file) {
       );
     }
   }
+  // Model-tier routing (WM-135): `model_tier` is a closed enum of intent;
+  // `model` is the exact-id escape hatch. Both may coexist — the override
+  // wins — but each must be well-formed, and whether a declared tier actually
+  // maps to a model for the routed adapter is checked in loadRegistry, where
+  // the adapter is known.
+  if (def.model_tier !== undefined && !MODEL_TIERS.includes(def.model_tier)) {
+    throw new RegistryError(
+      `${file}: "model_tier" must be one of ${MODEL_TIERS.join(", ")} (got ${JSON.stringify(def.model_tier)}) — definitions declare intent, not model ids (WM-135)`,
+    );
+  }
+  if (def.model !== undefined && (typeof def.model !== "string" || def.model.trim() === "")) {
+    throw new RegistryError(`${file}: "model" must be a non-empty string model id — omit the field for tier/default routing (WM-135)`);
+  }
   const pins = def.pins ?? {};
   for (const field of PINNED_FIELDS) {
     const rel = def[field];
@@ -100,7 +197,7 @@ function loadAgentDef(root, file) {
 /**
  * @returns {{ root: string, agents: Map<string, object>, eventTypes: object, schemas: object }}
  */
-export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
+export function loadRegistry({ root = RUNTIME_ROOT, modelTiers = loadModelTierMap() } = {}) {
   const agents = new Map();
   const agentsDir = path.join(root, "agents");
   for (const name of readdirSync(agentsDir).filter((n) => n.endsWith(".json")).sort()) {
@@ -125,6 +222,14 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
     }
     if (!Array.isArray(mapping.idempotencyScope) || mapping.idempotencyScope.length === 0) {
       throw new RegistryError(`event type ${type} declares no idempotency scope (§5.4)`);
+    }
+    // Model-tier routing (WM-135): every routed (agent, adapter) pair must
+    // resolve NOW — a declared tier without a policy mapping is a load error,
+    // never a silent fall-through to the adapter default at dispatch time.
+    try {
+      resolveModel(agents.get(mapping.agent), mapping.adapter, modelTiers);
+    } catch (err) {
+      throw new RegistryError(`event type ${type}: ${err.message}`);
     }
   }
 
@@ -213,7 +318,7 @@ export function loadRegistry({ root = RUNTIME_ROOT } = {}) {
     }
   }
 
-  return { root, agents, eventTypes, schemas, edges, schedules };
+  return { root, agents, eventTypes, schemas, edges, schedules, modelTiers };
 }
 
 export function getAgent(registry, ref) {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -3,8 +3,11 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { cpSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { RUNTIME_ROOT } from "./config.mjs";
-import { RegistryError, getAgent, getEventType, loadRegistry, updatePins } from "./registry.mjs";
+import {
+  DEFAULT_MODEL, RegistryError, getAgent, getEventType, loadModelTierMap, loadRegistry, resolveModel, updatePins,
+} from "./registry.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
 function tempRegistry() {
@@ -94,6 +97,97 @@ describe("registry", () => {
     withRepos(["bj29", "not-in-repos-yaml"]);
     const registry = loadRegistry({ root });
     expect(getAgent(registry, "factory-status-report@1").repos).toEqual(["bj29", "not-in-repos-yaml"]);
+  });
+
+  test("model_tier: valid tiers load and are readable; absent field stays absent (WM-135)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "factory-status-report.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "standard" }));
+    const registry = loadRegistry({ root, modelTiers: { claude: { standard: "sonnet" } } });
+    expect(getAgent(registry, "factory-status-report@1").model_tier).toBe("standard");
+    // A definition that declares nothing is untouched — adapter default.
+    expect(getAgent(registry, "ci-doctor@2").model_tier).toBeUndefined();
+    expect(getAgent(registry, "ci-doctor@2").model).toBeUndefined();
+  });
+
+  test("model_tier outside the closed enum fails at load (WM-135)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "factory-status-report.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    for (const bad of ["medium", "opus-4", 3, null]) {
+      writeFileSync(defFile, JSON.stringify({ ...def, model_tier: bad }));
+      expect(() => loadRegistry({ root, modelTiers: { claude: { standard: "sonnet" } } })).toThrow(/"model_tier"/);
+    }
+  });
+
+  test("declared tier with no mapping for the routed adapter fails closed at load (WM-135)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "factory-status-report.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "light" }));
+    // No claude tier map at all, and a map missing this one tier: both refuse.
+    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/no mapping for adapter "claude"/);
+    expect(() => loadRegistry({ root, modelTiers: { claude: { strong: "default" } } })).toThrow(
+      /model_tier "light" has no mapping/,
+    );
+  });
+
+  test("a tier on a command/actions-routed agent is not applicable, never an error (WM-135)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "reconcile.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "light" }));
+    // reconcile routes via the command adapter — no tier map needed.
+    const registry = loadRegistry({ root, modelTiers: {} });
+    expect(resolveModel(getAgent(registry, "reconcile@1"), "command", registry.modelTiers)).toBeNull();
+  });
+
+  test("model override: malformed rejected, well-formed wins over the tier (WM-135)", () => {
+    const root = tempRegistry();
+    const defFile = path.join(root, "agents", "factory-status-report.json");
+    const def = JSON.parse(readFileSync(defFile, "utf8"));
+    writeFileSync(defFile, JSON.stringify({ ...def, model: "" }));
+    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/"model"/);
+    writeFileSync(defFile, JSON.stringify({ ...def, model: 42 }));
+    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/"model"/);
+
+    // Both fields allowed; the override wins, and it also satisfies load even
+    // though "light" has no mapping — the tier is never consulted.
+    writeFileSync(defFile, JSON.stringify({ ...def, model: "claude-opus-4-1", model_tier: "light" }));
+    const registry = loadRegistry({ root, modelTiers: {} });
+    const loaded = getAgent(registry, "factory-status-report@1");
+    expect(resolveModel(loaded, "claude", registry.modelTiers)).toBe("claude-opus-4-1");
+  });
+
+  test("resolveModel: override > tier map > adapter default; sentinel passes through (WM-135)", () => {
+    const tiers = { claude: { strong: "default", standard: "sonnet", light: "haiku" } };
+    expect(resolveModel({ ref: "x@1", model_tier: "standard" }, "claude", tiers)).toBe("sonnet");
+    expect(resolveModel({ ref: "x@1", model_tier: "strong" }, "claude", tiers)).toBe(DEFAULT_MODEL);
+    expect(resolveModel({ ref: "x@1", model: "haiku", model_tier: "strong" }, "claude", tiers)).toBe("haiku");
+    expect(resolveModel({ ref: "x@1" }, "claude", tiers)).toBeNull(); // nothing declared → adapter default
+    expect(resolveModel({ ref: "x@1", model_tier: "light" }, "command", tiers)).toBeNull(); // not applicable
+    expect(() => resolveModel({ ref: "x@1", model_tier: "light" }, "claude", {})).toThrow(RegistryError);
+  });
+
+  test("loadModelTierMap: reads policy.yaml, validates shape fail-closed, tolerates absence (WM-135)", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "event-policy-"));
+    expect(loadModelTierMap({ root })).toEqual({}); // no policy.yaml at all
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const write = (yaml) => writeFileSync(path.join(root, "config", "policy.yaml"), yaml);
+
+    write("concurrency:\n  max_in_flight_per_repo: 3\n"); // no models block
+    expect(loadModelTierMap({ root })).toEqual({});
+
+    write("models:\n  claude:\n    strong: default\n    standard: sonnet\n    light: haiku\n");
+    expect(loadModelTierMap({ root })).toEqual({ claude: { strong: "default", standard: "sonnet", light: "haiku" } });
+
+    write("models:\n  claude:\n    strnog: sonnet\n"); // typo'd tier key
+    expect(() => loadModelTierMap({ root })).toThrow(/not a tier/);
+    write("models:\n  claude:\n    standard: 7\n"); // non-string value
+    expect(() => loadModelTierMap({ root })).toThrow(/non-empty model value/);
+    write("models:\n  claude: sonnet\n"); // adapter entry not a map
+    expect(() => loadModelTierMap({ root })).toThrow(/must map tiers/);
   });
 
   test("event type mapped to an unregistered agent fails closed", () => {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -104,11 +104,11 @@ describe("registry", () => {
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "standard" }));
-    const registry = loadRegistry({ root, modelTiers: { claude: { standard: "sonnet" } } });
+    const registry = loadRegistry({ root, modelTiers: { claude: { strong: "default", standard: "sonnet" } } });
     expect(getAgent(registry, "factory-status-report@1").model_tier).toBe("standard");
     // A definition that declares nothing is untouched — adapter default.
-    expect(getAgent(registry, "ci-doctor@2").model_tier).toBeUndefined();
-    expect(getAgent(registry, "ci-doctor@2").model).toBeUndefined();
+    expect(getAgent(registry, "reconcile@1").model_tier).toBeUndefined();
+    expect(getAgent(registry, "reconcile@1").model).toBeUndefined();
   });
 
   test("model_tier outside the closed enum fails at load (WM-135)", () => {
@@ -117,7 +117,9 @@ describe("registry", () => {
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     for (const bad of ["medium", "opus-4", 3, null]) {
       writeFileSync(defFile, JSON.stringify({ ...def, model_tier: bad }));
-      expect(() => loadRegistry({ root, modelTiers: { claude: { standard: "sonnet" } } })).toThrow(/"model_tier"/);
+      expect(() => loadRegistry({ root, modelTiers: { claude: { strong: "default", standard: "sonnet" } } })).toThrow(
+        /"model_tier"/,
+      );
     }
   });
 
@@ -138,8 +140,9 @@ describe("registry", () => {
     const defFile = path.join(root, "agents", "reconcile.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "light" }));
-    // reconcile routes via the command adapter — no tier map needed.
-    const registry = loadRegistry({ root, modelTiers: {} });
+    // reconcile routes via the command adapter — "light" needs no mapping
+    // there, even though the map below deliberately lacks it.
+    const registry = loadRegistry({ root, modelTiers: { claude: { strong: "default", standard: "sonnet" } } });
     expect(resolveModel(getAgent(registry, "reconcile@1"), "command", registry.modelTiers)).toBeNull();
   });
 
@@ -147,15 +150,16 @@ describe("registry", () => {
     const root = tempRegistry();
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
+    const tiers = { claude: { strong: "default", standard: "sonnet" } };
     writeFileSync(defFile, JSON.stringify({ ...def, model: "" }));
-    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/"model"/);
+    expect(() => loadRegistry({ root, modelTiers: tiers })).toThrow(/"model"/);
     writeFileSync(defFile, JSON.stringify({ ...def, model: 42 }));
-    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/"model"/);
+    expect(() => loadRegistry({ root, modelTiers: tiers })).toThrow(/"model"/);
 
     // Both fields allowed; the override wins, and it also satisfies load even
     // though "light" has no mapping — the tier is never consulted.
     writeFileSync(defFile, JSON.stringify({ ...def, model: "claude-opus-4-1", model_tier: "light" }));
-    const registry = loadRegistry({ root, modelTiers: {} });
+    const registry = loadRegistry({ root, modelTiers: tiers });
     const loaded = getAgent(registry, "factory-status-report@1");
     expect(resolveModel(loaded, "claude", registry.modelTiers)).toBe("claude-opus-4-1");
   });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planEvent } from "./planner.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { openDb } from "./db.mjs";
@@ -105,6 +107,52 @@ describe("worker", () => {
     expect(repositoryStatus(repo)).toBe(baseline);
     writeFileSync(path.join(repo, "generated", "agent-write.log"), "new\n");
     expect(repositoryStatus(repo)).not.toBe(baseline);
+  });
+
+  test("e2e (WM-135): tiered claude route plans a spec with the model pinned; the fake adapter executes it, ignoring the model", async () => {
+    const db = openDb(":memory:");
+    // The real status-report definition with a declared tier, on a registry
+    // whose policy map says standard → sonnet.
+    const synthetic = { ...registry, agents: new Map(registry.agents), modelTiers: { claude: { standard: "sonnet" } } };
+    synthetic.agents.set("factory-status-report@1", { ...getAgent(registry, "factory-status-report@1"), model_tier: "standard" });
+
+    const envelope = {
+      schemaVersion: "factory.event/v1",
+      eventId: "wm135-e2e-1",
+      type: "factory.status-report.requested",
+      source: "operator-webhook",
+      subject: "factory",
+      occurredAt: new Date(T0).toISOString(),
+      correlationId: "wm135-corr",
+      causationId: null,
+      payload: { repos: ["ok"] },
+    };
+    const admitted = admitEvent(db, synthetic, envelope, { now: T0 });
+    expect(admitted.admitted).toBe(true);
+
+    const outcome = planEvent(
+      db,
+      synthetic,
+      { source: admitted.event.source, eventId: admitted.event.event_id },
+      { now: T0, policyVersion: "git:test", adapterOverride: "fake" },
+    );
+    expect(outcome.decision).toBe("run");
+    // The pinned resolution is what the operator would approve: the
+    // registered claude route's model, even though execution is the fake.
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec.model).toBe("sonnet");
+    expect(spec.modelTier).toBe("standard");
+    expect(spec.adapter).toBe("fake");
+
+    transition(db, { runId: outcome.runId, to: "APPROVED", actor: "test", now: T0 });
+    transition(db, { runId: outcome.runId, to: "QUEUED", actor: "test", now: T0 });
+    const summary = await runOnce(db, synthetic, adapters, opts());
+    expect(summary.runId).toBe(outcome.runId);
+    expect(summary.terminalState).toBe("COMPLETED");
+    // The run's stored spec — what inspect/receipts read — carries the pin.
+    const stored = JSON.parse(db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(outcome.runId).spec_json);
+    expect(stored.model).toBe("sonnet");
+    expect(stored.modelTier).toBe("standard");
   });
 
   test("happy path: COMPLETED, results row, receipt, one completion outbox event, workspace destroyed", async () => {


### PR DESCRIPTION
Fixes WM-135

Implements the ratified model-tier design in three staged commits:

1. **`model_tier` field + policy tier map** — optional `strong|standard|light` in agent definitions (closed enum), `models:` block in config/policy.yaml (`claude: {strong: default, standard: sonnet, light: haiku}`); `default` sentinel = pass no `--model`. Fail closed at registry load for every routed (agent, adapter) pair; malformed map = load error.
2. **Plan-time resolution pinned into the RunSpec** — resolution order: per-definition `model` override > tier map > adapter default; re-validated at `buildRunSpec` (missing mapping → plan_failures → dead-letter, never a silent default). Pinned in `spec_json` so proposals, receipts, and `inspect` all name the actual model; `GET /agents` + `cli.mjs agents` render tier/override/resolved-model. Claude adapter passes `--model` only for non-default. Non-model adapters (command/actions/fake) record `model: null`, never error. Undeclared definitions produce byte-identical specs (regression `toEqual`).
3. **Initial assignments** — `strong`: dispatch, merge-scan; `standard`: the scan/diagnose fleet (work/triage/sweep/unblock/ship scans, ci-doctor, status-report, disk-diagnose, run-postmortem); docs §6.

This is also the substrate OPS-296 (pi adapter MVP) plugs into: `models.pi` with sol/terra/luna as strong/standard/light.

Verification: `bun test event-runtime/` → 935 pass, 0 fail; full `bun test` → 1249 pass, 0 fail (108 files).