### PR TITLE
ui-ux(event-runtime-web): anchor the run sidebar and restyle the detail blocks (WM-136)

### DIFF
--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -62,9 +62,11 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
     expect(internals).toBeTruthy();
     expect(internals!.open).toBe(false);
     // The demoted rows live inside that disclosure, not on the glance tier.
+    // Scoped to the disclosure: labels like `workspace` also appear on the
+    // attempt cards, so a document-wide query would match more than one.
     for (const key of ["idempotencyKey", "specHash", "inputHash", "workspace", "promptVersion", "policyVersion"]) {
-      const row = r.getByText(key);
-      expect(internals!.contains(row)).toBe(true);
+      const labels = Array.from(internals!.querySelectorAll("span")).filter((s) => s.textContent === key);
+      expect(labels.length).toBe(1);
     }
     // The RunSpec ground truth stays, collapsed.
     const spec = details.find((el) => el.textContent?.includes("immutable RunSpec"));

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { RunDetailBlocks } from "./RunDetailBlocks";
-import { createRunDetailFixture } from "../test-render";
+import { createLifecycleEventFixture, createRunDetailFixture } from "../test-render";
 import type { RunDetail, RunState } from "../types";
 
 afterEach(() => {
@@ -103,5 +103,45 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
     // VERIFYING has already exited its agent — not cancellable, same rule as the panel.
     const verifying = renderBlocks(createRunDetailFixture({ run: { state: "VERIFYING" } as RunDetail["run"] }));
     expect(verifying.queryByText("Cancel")).toBeNull();
+  });
+});
+
+describe("Lifecycle timeline (WM-136)", () => {
+  test("renders exactly one dot per transition and aligns actors at a constant column", () => {
+    const now = new Date().toISOString();
+    const lifecycle = [
+      createLifecycleEventFixture(1, "run_x", null, "PROPOSED", null, now),
+      createLifecycleEventFixture(2, "run_x", "PROPOSED", "APPROVED", null, now),
+      createLifecycleEventFixture(3, "run_x", "APPROVED", "RUNNING", null, now),
+    ];
+    const d = createRunDetailFixture({ run: { state: "RUNNING" } as RunDetail["run"], lifecycle });
+    const r = renderBlocks(d);
+
+    // The rail contributes one dot per row; StateBadge's own dot is
+    // suppressed there so a transition never shows two.
+    const rows = r.container.querySelectorAll("li");
+    expect(rows.length).toBe(3);
+    for (const row of Array.from(rows)) {
+      expect(row.querySelectorAll(".rounded-full").length).toBe(1);
+    }
+
+    // Every badge column is the same fixed width, so the actor after it
+    // starts at one x regardless of how long the state name is.
+    const badgeColumns = Array.from(r.container.querySelectorAll("li .w-\\[100px\\]"));
+    expect(badgeColumns.length).toBe(3);
+  });
+
+  test("shows the from-state only where the chain actually breaks", () => {
+    const now = new Date().toISOString();
+    const lifecycle = [
+      createLifecycleEventFixture(1, "run_x", null, "QUEUED", null, now),
+      createLifecycleEventFixture(2, "run_x", "QUEUED", "RUNNING", null, now),
+      // A gap: this event's `from` disagrees with the previous row's `to`.
+      createLifecycleEventFixture(3, "run_x", "LEASED", "TIMED_OUT", null, now),
+    ];
+    const d = createRunDetailFixture({ run: { state: "TIMED_OUT" } as RunDetail["run"], lifecycle });
+    const r = renderBlocks(d);
+    expect(r.queryByText("QUEUED→")).toBeNull();
+    expect(r.getByText("LEASED→")).toBeTruthy();
   });
 });

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -12,6 +12,7 @@ import {
   JumpLink,
   KV,
   Section,
+  STATE_HUES,
   StateBadge,
   VerbError,
   copyText,
@@ -411,7 +412,7 @@ export function RunDetailBlocks({
           answer to a budget about to be spent on a hung agent. */}
       {current && clocks && (
         <Section title="Deadlines">
-          <div className="rounded-md border border-(--border) px-3 py-2 tabular-nums" aria-live="off">
+          <div className="py-1 tabular-nums" aria-live="off">
             <div className="flex items-baseline justify-between gap-4">
               <span className="text-(--text-faint)">
                 attempt #{current.attempt}{" "}
@@ -465,62 +466,108 @@ export function RunDetailBlocks({
       <VerbError error={verbError} />
 
       <Section title="Lifecycle">
-        <div className="rounded-md border border-(--border) px-3 py-1">
-          {d.lifecycle.map((e) => (
-            <div key={e.seq} className="flex items-baseline gap-2 border-b border-(--border) py-1.5 last:border-0">
-              <span className="mono w-[64px] shrink-0 text-(--text-faint)" title={e.at}>
-                {new Date(e.at).toLocaleTimeString([], { hour12: false })}
-              </span>
-              <span className="shrink-0">
-                {e.from_state ?? "·"} → <StateBadge state={e.to_state} />
-              </span>
-              <span className="truncate text-(--text-faint)">
-                <ActorRef actor={e.actor} className="text-[13px]" />
-                {e.reason ? ` · ${e.reason}` : ""}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ol className="m-0 list-none p-0">
+          {d.lifecycle.map((e, i) => {
+            const prev = i > 0 ? d.lifecycle[i - 1] : null;
+            // The lifecycle is a chain, so `from` is the previous row's `to` and
+            // printing it on every line was pure redundancy — and, since state
+            // names differ in length, it pushed each badge to a different x and
+            // made the column look ragged. Only an actual break in the chain is
+            // worth spelling out (WM-136).
+            const jumped = prev != null && e.from_state !== prev.to_state;
+            const hue = STATE_HUES[e.to_state] ?? "var(--hue-idle)";
+            const time = new Date(e.at).toLocaleTimeString([], { hour12: false });
+            return (
+              <li key={e.seq} className="flex gap-2.5 py-1">
+                <span className="mono w-[52px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)" title={e.at}>
+                  {/* A burst of transitions shares one second; repeating it reads as noise. */}
+                  {prev && time === new Date(prev.at).toLocaleTimeString([], { hour12: false }) ? "" : time}
+                </span>
+                {/* Rail: a dot per transition, joined to the next one. */}
+                <span className="relative flex w-2 shrink-0 justify-center" aria-hidden="true">
+                  {i < d.lifecycle.length - 1 && (
+                    <span className="absolute top-2.5 bottom-[-4px] w-px bg-(--border)" />
+                  )}
+                  <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
+                </span>
+                <span className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+                  {jumped && (
+                    <span className="text-[11px] text-(--text-faint)">{e.from_state ?? "·"} →</span>
+                  )}
+                  <StateBadge state={e.to_state} />
+                  <span className="min-w-0 truncate text-[11.5px] text-(--text-faint)" title={e.actor}>
+                    <ActorRef actor={e.actor} className="text-[11.5px]" />
+                    {e.reason ? ` · ${e.reason}` : ""}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
       </Section>
 
       {afterLifecycle}
 
       {d.attempts.length > 0 && (
-        <Section title="Attempts">
+        <Section title="Attempts" card={false}>
           {d.attempts.map((a) => (
-            <div key={a.attempt} className="mb-1 rounded-md border border-(--border) px-3 py-1.5">
-              <div className="flex justify-between">
-                <span>#{a.attempt}</span>
-                <span className="text-(--text-dim)">{a.terminal_state ?? "in flight"}</span>
+            <div key={a.attempt} className="mb-1.5 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 last:mb-0">
+              <div className="flex items-center justify-between gap-2">
+                <span className="mono text-[12px] font-medium text-(--text)">#{a.attempt}</span>
+                {a.terminal_state ? (
+                  <StateBadge state={a.terminal_state} />
+                ) : (
+                  <span className="text-[11px] text-(--text-faint)">in flight</span>
+                )}
               </div>
-              <div className="mono truncate text-[11px] text-(--text-faint)">
-                {a.reason_code ?? ""} {a.workspace_path ?? ""}
-              </div>
-              <div className="flex items-baseline gap-1.5 truncate text-[11px] text-(--text-faint)">
-                <span>owner</span>
-                {a.lease_owner ? <ActorRef actor={a.lease_owner} /> : <span className="mono">unclaimed</span>}
-              </div>
-              {(a.started_at || a.finished_at) && (
-                <div className="mt-1 flex gap-3 text-[11px] text-(--text-faint)">
-                  {a.started_at && (
-                    <span>
-                      started <Ago iso={a.started_at} now={now} />
-                    </span>
-                  )}
-                  {a.finished_at && (
-                    <span>
-                      finished <Ago iso={a.finished_at} now={now} />
-                    </span>
-                  )}
+              {a.reason_code && (
+                <div className="mono mt-1 truncate text-[11px] text-(--hue-err)" title={a.reason_code}>
+                  {a.reason_code}
                 </div>
               )}
+              {/* Label/value pairs at the panel's rhythm — the fields used to run
+                  together on one faint line where the workspace path pushed the
+                  owner off the edge (WM-136). */}
+              <div className="mt-1.5 grid grid-cols-[minmax(0,4.5rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-0.5 text-[11px] text-(--text-faint)">
+                <span>owner</span>
+                <span className="min-w-0 truncate" title={a.lease_owner ?? "unclaimed"}>
+                  {a.lease_owner ? <ActorRef actor={a.lease_owner} /> : <span className="mono">unclaimed</span>}
+                </span>
+                {a.workspace_path && (
+                  <>
+                    <span>workspace</span>
+                    <span className="mono min-w-0 truncate" title={a.workspace_path}>
+                      {a.workspace_path}
+                    </span>
+                  </>
+                )}
+                {a.started_at && (
+                  <>
+                    <span>started</span>
+                    <span className="min-w-0 truncate">
+                      <Ago iso={a.started_at} now={now} />
+                    </span>
+                  </>
+                )}
+                {a.finished_at && (
+                  <>
+                    <span>finished</span>
+                    <span className="min-w-0 truncate">
+                      <Ago iso={a.finished_at} now={now} />
+                    </span>
+                  </>
+                )}
+              </div>
             </div>
           ))}
         </Section>
       )}
 
       {d.result && (
-        <Section title={`Result · ${d.result.terminalState}${d.result.reasonCode ? ` · ${d.result.reasonCode}` : ""}`}>
+        <Section
+          id="run-result"
+          title={`Result · ${d.result.terminalState}${d.result.reasonCode ? ` · ${d.result.reasonCode}` : ""}`}
+        >
           {d.result.artifact !== undefined ? (
             <Disclosure label="artifact" defaultOpen>
               <JsonBlock value={d.result.artifact} />
@@ -543,7 +590,7 @@ export function RunDetailBlocks({
           {(d.result.artifacts ?? []).length === 0 ? (
             <div className="text-(--text-faint)">No stored artifacts.</div>
           ) : (
-            <div className="rounded-md border border-(--border) px-3 py-1">
+            <div>
               {(d.result.artifacts ?? []).map((a) => (
                 <ArtifactRow key={a.sha256} a={a} />
               ))}

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -372,7 +372,9 @@ export function RunDetailBlocks({
           }
         />
         <KV k="adapter" v={d.run.spec.adapter} />
-        <KV k="attempts" v={`${d.run.attempts}/${d.run.spec.maxAttempts}`} />
+        {/* A count, not an identifier — mono bought it nothing but a mismatched
+            font next to "any worker" and "26m ago" on the rows around it. */}
+        <KV k="attempts" v={`${d.run.attempts}/${d.run.spec.maxAttempts}`} mono={false} />
         <InputRows input={d.run.spec.input} />
         {origin?.eventId && (
           <KV
@@ -490,11 +492,19 @@ export function RunDetailBlocks({
                   )}
                   <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
                 </span>
-                <span className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
-                  {jumped && (
-                    <span className="text-[11px] text-(--text-faint)">{e.from_state ?? "·"} →</span>
-                  )}
-                  <StateBadge state={e.to_state} />
+                <span className="flex min-w-0 flex-1 items-center gap-x-2">
+                  {/* Fixed-width badge column, badge's own dot dropped in favor
+                      of the rail's: with it, every actor started at whatever x
+                      its state name happened to end at, and each row carried
+                      two dots for one state (WM-136). */}
+                  <span className="flex w-[100px] shrink-0 items-center gap-1">
+                    {jumped && (
+                      <span className="shrink-0 text-[10px] text-(--text-faint)" title={`from ${e.from_state ?? "·"}`}>
+                        {e.from_state ?? "·"}→
+                      </span>
+                    )}
+                    <StateBadge state={e.to_state} dot={false} />
+                  </span>
                   <span className="min-w-0 truncate text-[11.5px] text-(--text-faint)" title={e.actor}>
                     <ActorRef actor={e.actor} className="text-[11.5px]" />
                     {e.reason ? ` · ${e.reason}` : ""}

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, ToastContainer } from "./ui";
+import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
@@ -396,5 +396,16 @@ describe("Section cards and collapse persistence (WM-136)", () => {
     // Same section, different terminal state in the title — still collapsed.
     const again = render(<Section id="run-result" title="Result · FAILED · agent_exit_1"><KV k="a" v="b" /></Section>);
     expect(again.queryByText("a")).toBeNull();
+  });
+});
+
+describe("StateBadge dot suppression (WM-136)", () => {
+  test("renders its own dot by default and omits it when dot={false}", () => {
+    const withDot = render(<StateBadge state="RUNNING" />);
+    expect(withDot.container.querySelector(".rounded-full")).toBeTruthy();
+    cleanup();
+    const bare = render(<StateBadge state="RUNNING" dot={false} />);
+    expect(bare.container.querySelector(".rounded-full")).toBeNull();
+    expect(bare.getByText("RUNNING")).toBeTruthy();
   });
 });

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, notify, shortId, ToastContainer } from "./ui";
+import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
@@ -316,3 +316,85 @@ describe("FilterInput autocomplete (OPS-506)", () => {
   });
 });
 
+
+describe("KV mono discipline (WM-136)", () => {
+  test("renders identifier-ish values in mono and prose values in the UI font", () => {
+    const r = render(
+      <>
+        <KV k="agent" v="dispatch@1" />
+        <KV k="workspace" v="/Users/x/.factory/event-runtime" />
+        <KV k="placement" v="any worker" />
+      </>,
+    );
+    expect(classes(r.getByTitle("dispatch@1"))).toContain("mono");
+    expect(classes(r.getByTitle("/Users/x/.factory/event-runtime"))).toContain("mono");
+    // "any worker" is language, not an identifier — character alignment buys nothing.
+    expect(classes(r.getByTitle("any worker"))).not.toContain("mono");
+  });
+
+  test("honours an explicit mono override in both directions", () => {
+    const r = render(
+      <>
+        <KV k="forced" v="two words" mono />
+        <KV k="unforced" v="single-token" mono={false} />
+      </>,
+    );
+    expect(classes(r.getByTitle("two words"))).toContain("mono");
+    expect(classes(r.getByTitle("single-token"))).not.toContain("mono");
+  });
+
+  test("keeps copy-on-click and the full-value tooltip on truncated values", () => {
+    const r = render(<KV k="specHash" v="sha256:abcdef" />);
+    const value = r.getByTitle("sha256:abcdef");
+    expect(value.tagName).toBe("BUTTON");
+    expect(classes(value)).toContain("truncate");
+  });
+});
+
+describe("Section cards and collapse persistence (WM-136)", () => {
+  beforeEach(() => localStorage.clear());
+
+  test("wraps rows in a card by default and skips it when card is false", () => {
+    const carded = render(<Section title="Run"><KV k="agent" v="a@1" /></Section>);
+    expect(carded.container.querySelector(".rounded-md")).toBeTruthy();
+    cleanup();
+    const bare = render(<Section title="Heartbeat" card={false}><KV k="agent" v="a@1" /></Section>);
+    expect(bare.container.querySelector(".rounded-md")).toBeNull();
+  });
+
+  test("collapses on click, hides its rows, and persists the choice", () => {
+    const r = render(<Section title="Lifecycle"><KV k="agent" v="a@1" /></Section>);
+    expect(r.queryByText("agent")).toBeTruthy();
+    fireEvent.click(r.getByRole("button", { expanded: true }));
+    expect(r.queryByText("agent")).toBeNull();
+    expect(JSON.parse(localStorage.getItem("evrt-sections-collapsed")!)).toContain("Lifecycle");
+    // A remount reads the persisted choice back.
+    cleanup();
+    const again = render(<Section title="Lifecycle"><KV k="agent" v="a@1" /></Section>);
+    expect(again.queryByText("agent")).toBeNull();
+  });
+
+  test("a toggle does not stomp a sibling section's persisted collapse", () => {
+    localStorage.setItem("evrt-sections-collapsed", JSON.stringify(["Receipt"]));
+    const r = render(
+      <>
+        <Section title="Run"><KV k="agent" v="a@1" /></Section>
+        <Section title="Receipt"><KV k="hash" v="abc" /></Section>
+      </>,
+    );
+    fireEvent.click(r.getByRole("button", { expanded: true, name: /Run/ }));
+    const stored = JSON.parse(localStorage.getItem("evrt-sections-collapsed")!);
+    expect(stored).toContain("Run");
+    expect(stored).toContain("Receipt");
+  });
+
+  test("keys persistence on id so a title carrying live data stays stable", () => {
+    const r = render(<Section id="run-result" title="Result · COMPLETED · ok"><KV k="a" v="b" /></Section>);
+    fireEvent.click(r.getByRole("button", { expanded: true }));
+    expect(JSON.parse(localStorage.getItem("evrt-sections-collapsed")!)).toEqual(["run-result"]);
+    cleanup();
+    // Same section, different terminal state in the title — still collapsed.
+    const again = render(<Section id="run-result" title="Result · FAILED · agent_exit_1"><KV k="a" v="b" /></Section>);
+    expect(again.queryByText("a")).toBeNull();
+  });
+});

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -590,9 +590,14 @@ export function GroupHeaderRow({
 export function StateBadge({
   state,
   hues = STATE_HUES,
+  dot = true,
 }: {
   state: string;
   hues?: Record<string, string>;
+  /** Off wherever the caller already draws its own dot for this state (the
+   *  Lifecycle timeline's rail beads) — two dots for one state read as a
+   *  mistake, not emphasis (WM-136). */
+  dot?: boolean;
 }) {
   const hue = hues[state] ?? "var(--hue-idle)";
   return (
@@ -600,7 +605,7 @@ export function StateBadge({
       className="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px] font-medium"
       style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
     >
-      <span className="size-1.5 rounded-full" style={{ background: hue }} />
+      {dot && <span className="size-1.5 rounded-full" style={{ background: hue }} />}
       {state}
     </span>
   );

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -907,23 +907,121 @@ export function Disclosure({
   );
 }
 
-export function Section({ title, children }: { title: string; children: ReactNode }) {
+const SECTIONS_KEY = "evrt-sections-collapsed";
+
+/** Collapsed section ids, shared by every Section on the page (WM-136). */
+function loadCollapsedSections(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(SECTIONS_KEY) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === "string") : [];
+  } catch {
+    // Private mode / stale value: sections simply start expanded.
+    return [];
+  }
+}
+
+/**
+ * Read-modify-write against storage rather than against a cached copy — every
+ * Section on the page shares this one key, so a toggle must not stomp the
+ * collapse state of its siblings mounted at the same time.
+ */
+function saveCollapsedSection(id: string, collapsed: boolean): void {
+  try {
+    const next = new Set(loadCollapsedSections());
+    if (collapsed) next.add(id);
+    else next.delete(id);
+    localStorage.setItem(SECTIONS_KEY, JSON.stringify([...next]));
+  } catch {
+    // Quota / private mode: collapse still works, it just does not persist.
+  }
+}
+
+/**
+ * A titled group of detail rows, rendered as one card (WM-136). The card
+ * boundary is what separates concerns, so rows inside it carry no dividers of
+ * their own — a hairline under every row read as a ledger dump rather than a
+ * panel. Collapsing persists across reloads, keyed by `id` (pass one whenever
+ * the title interpolates live data, or the key changes with the run).
+ *
+ * `card={false}` is for sections whose children already draw their own
+ * bordered containers — nesting a card inside a card doubles the border.
+ */
+export function Section({
+  title,
+  id,
+  children,
+  card = true,
+  collapsible = true,
+}: {
+  title: string;
+  id?: string;
+  children: ReactNode;
+  card?: boolean;
+  collapsible?: boolean;
+}) {
+  const key = id ?? title;
+  const [collapsed, setCollapsed] = useState(() => collapsible && loadCollapsedSections().includes(key));
+  const toggle = () =>
+    setCollapsed((prev) => {
+      const next = !prev;
+      saveCollapsedSection(key, next);
+      return next;
+    });
+
+  const heading = (
+    <span className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{title}</span>
+  );
+
   return (
     <div className="mb-5">
-      <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-        {title}
-      </div>
-      {children}
+      {collapsible ? (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          className="mb-1.5 flex w-full cursor-pointer items-center gap-1.5 text-left hover:text-(--text-dim)"
+        >
+          <span
+            aria-hidden="true"
+            className={`text-[9px] text-(--text-faint) transition-transform ${collapsed ? "" : "rotate-90"}`}
+          >
+            ▶
+          </span>
+          {heading}
+        </button>
+      ) : (
+        <div className="mb-1.5">{heading}</div>
+      )}
+      {!collapsed &&
+        (card ? (
+          <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-1.5">{children}</div>
+        ) : (
+          children
+        ))}
     </div>
   );
 }
 
-export function KV({ k, v }: { k: string; v: ReactNode }) {
+/**
+ * Monospace is for identifiers, not for prose. A string value with whitespace
+ * in it reads as language ("any worker", "not started"); everything else is an
+ * id, hash, ref, or path where character alignment actually helps. ReactNode
+ * values opt themselves in — `JumpLink` carries mono, `Ago` does not.
+ */
+const looksLikeIdentifier = (text: string) => !/\s/.test(text);
+
+export function KV({ k, v, mono }: { k: string; v: ReactNode; mono?: boolean }) {
   const text = typeof v === "string" ? v : null;
   const copyable = !!text && text !== "-";
+  const isMono = mono ?? (text !== null && looksLikeIdentifier(text));
+  // Fixed label column with the value left-aligned beside it: right-aligning
+  // values left a ragged edge (`1/1` next to `multi-dispatch-WM-127`) that the
+  // eye had to re-find on every row (WM-136).
   return (
-    <div className="flex justify-between gap-4 border-b border-(--border) py-1 last:border-0">
-      <span className="text-(--text-faint)">{k}</span>
+    <div className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
+      <span className="truncate text-(--text-faint)" title={k}>
+        {k}
+      </span>
       {copyable ? (
         <button
           type="button"
@@ -931,12 +1029,15 @@ export function KV({ k, v }: { k: string; v: ReactNode }) {
           // full string is readable without copying (WM-129 critique).
           title={text}
           onClick={() => copyText(text, k)}
-          className="mono max-w-[70%] truncate text-right text-(--text-dim) hover:text-(--accent)"
+          className={`truncate text-left text-(--text-dim) hover:text-(--accent) ${isMono ? "mono" : ""}`}
         >
           {text}
         </button>
       ) : (
-        <span className="mono truncate text-(--text-dim)" title={text ?? undefined}>
+        <span
+          className={`truncate text-left text-(--text-dim) ${isMono ? "mono" : ""}`}
+          title={text ?? undefined}
+        >
           {v ?? "-"}
         </span>
       )}

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -217,7 +217,7 @@ export function Agents({
           </Section>
 
           {sel.command && (
-            <Section title="Command argv">
+            <Section title="Command argv" card={false}>
               <div className="mb-1.5 flex justify-end">
                 <Button onClick={() => copyText(sel.command!.join(" "), "command")}>Copy command</Button>
               </div>
@@ -228,12 +228,13 @@ export function Agents({
           {sel.actionRegistry && (
             <Section
               title={`Action registry${sel.hosts && sel.hosts.length > 0 ? ` · hosts ${sel.hosts.join(", ")}` : ""}`}
+              card={false}
             >
               <JsonBlock value={sel.actionRegistry} />
             </Section>
           )}
 
-          <Section title={`Prompt · ${sel.promptFile}`}>
+          <Section title={`Prompt · ${sel.promptFile}`} card={false}>
             <div className="mb-1.5 flex justify-end">
               <Button onClick={() => copyText(sel.prompt, "prompt")}>Copy prompt</Button>
             </div>
@@ -262,7 +263,7 @@ export function Agents({
             ))}
           </Section>
 
-          <Section title="Event routing">
+          <Section title="Event routing" card={false}>
             {sel.eventTypes.length === 0 ? (
               <div className="text-(--text-faint)">No event types route to this agent.</div>
             ) : (

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -483,7 +483,7 @@ export function Graph({
                 )}
               </Section>
               {selected.proposal.spec && (
-                <Section title="Run spec">
+                <Section title="Run spec" card={false}>
                   <JsonBlock value={selected.proposal.spec} />
                 </Section>
               )}
@@ -531,16 +531,16 @@ export function Graph({
                 )}
               </Section>
               {agentDef.command && (
-                <Section title="Closed command template">
+                <Section title="Closed command template" card={false}>
                   <JsonBlock value={agentDef.command} />
                 </Section>
               )}
               {agentDef.actionRegistry && (
-                <Section title={`Closed action registry · hosts ${agentDef.hosts?.join(", ")}`}>
+                <Section title={`Closed action registry · hosts ${agentDef.hosts?.join(", ")}`} card={false}>
                   <JsonBlock value={agentDef.actionRegistry} />
                 </Section>
               )}
-              <Section title="Prompt">
+              <Section title="Prompt" card={false}>
                 <pre className="mono max-h-64 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-3 whitespace-pre-wrap">
                   {agentDef.prompt}
                 </pre>

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -487,7 +487,7 @@ export function Overview({
       )}
 
       <div className="grid gap-x-5 xl:grid-cols-2">
-        <Section title={`Activity · latest ${Math.min(feed.entries.length, FEED_CAP)}`}>
+        <Section title={`Activity · latest ${Math.min(feed.entries.length, FEED_CAP)}`} card={false}>
           {feed.entries.length === 0 ? (
             <div className="text-(--text-faint)">
               {feed.isPending
@@ -529,7 +529,7 @@ export function Overview({
           )}
         </Section>
 
-        <Section title="Outbox — published results">
+        <Section title="Outbox — published results" card={false}>
           <div id="outbox">
           {(outbox.data?.outbox ?? []).length === 0 ? (
             <div className="text-(--text-faint)">

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -528,7 +528,7 @@ export function Projects({
               </div>
             </Section>
 
-            <Section title="Worktree Janitor & Maintenance (OPS-362)">
+            <Section title="Worktree Janitor & Maintenance (OPS-362)" card={false}>
               <div className="rounded-md border border-(--border) bg-(--surface-0) p-3">
                 <div className="text-[12px] text-(--text-dim)">
                   Janitor inspects worktrees in <code className="mono">{sel.worktreeRoot ?? "repo worktrees"}</code>,

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -862,7 +862,7 @@ export function Proposals({
             const prev = (runsQuery.data?.runs ?? []).find((r) => r.agent === sel.agent && r.state === "COMPLETED");
 
             return (
-              <Section title="Summary Safety Card & Blast Radius Radar">
+              <Section title="Summary Safety Card & Blast Radius Radar" card={false}>
                 <div className="mb-3 rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px]">
                   <div className="mb-2 flex items-center justify-between border-b border-(--border) pb-2">
                     <div className="flex gap-2">

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -177,55 +177,49 @@ export function RunFull({
         </span>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        {unknownRun ? (
-          <div className="p-6 text-(--text-faint)">
-            Unknown run <span className="mono">{runId}</span> — it may not exist on this runtime.
-          </div>
-        ) : !d ? (
-          <div className="p-6 text-(--text-faint)">
-            {detail.isError ? "Could not load run detail." : "Loading run…"}
-          </div>
-        ) : (
-          <>
-          {/* The failure first, full width under the header (WM-93) — renders nothing for other states. */}
-          <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} className="mx-6 mt-6 mb-0" />
-          {/* items-start: a stretched flex child is full-height, which silently defeats the sidebar's sticky. */}
-          <div className="flex flex-col gap-8 p-6 xl:flex-row xl:items-start xl:pr-4">
-            {/* Main column: the trace, at a readable measure — the point of the page. */}
-            <main className="min-w-0 flex-1 xl:max-w-[900px]">
+      {unknownRun ? (
+        <div className="min-h-0 flex-1 overflow-auto p-6 text-(--text-faint)">
+          Unknown run <span className="mono">{runId}</span> — it may not exist on this runtime.
+        </div>
+      ) : !d ? (
+        <div className="min-h-0 flex-1 overflow-auto p-6 text-(--text-faint)">
+          {detail.isError ? "Could not load run detail." : "Loading run…"}
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
+          {/* Main column: the trace, at a readable measure — the point of the
+              page — scrolling on its own so the sidebar never moves with it. */}
+          <main className="min-w-0 flex-1 overflow-y-auto">
+            <div className="p-6 xl:max-w-[900px]">
+              {/* The failure first (WM-93) — renders nothing for other states. */}
+              <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} className="mb-6" />
               <RunTrace key={runId} runId={runId} state={d.run.state} variant="full" />
-            </main>
+            </div>
+          </main>
 
-            {/* Anchored to the right edge at the side panel's width, so
-                toggling panel ↔ full page reads as the left region swapping
-                rather than the whole layout reflowing; `ml-auto` parks the
-                slack left of the sidebar, since the trace column caps at its
-                readable measure and would otherwise leave it floating. Its
-                own scroll keeps the Deadlines clock and run vitals on screen
-                through a long trace, matching the panel. The height leaves
-                enough slack that the page itself never scrolls at xl, so no
-                outer scrollbar gutter pushes the sidebar off the edge and it
-                lands on the panel's exact right margin (WM-136). */}
-            <aside className="w-full shrink-0 xl:sticky xl:top-0 xl:ml-auto xl:max-h-[calc(100dvh-11rem)] xl:w-[428px] xl:overflow-y-auto">
-              <RunDetailBlocks
-                d={d}
-                now={now}
-                connected={connected}
-                origin={listRow}
-                onJumpAgent={onJumpAgent}
-                onJumpEvent={onJumpEvent}
-                onCancel={() => setConfirm("cancel")}
-                onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
-                onForceRetry={() => setConfirm("force-retry")}
-                retryPending={retry.isPending}
-                verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
-              />
-            </aside>
-          </div>
-          </>
-        )}
-      </div>
+          {/* Same shape as the side panel's DetailPane — border-l, fixed
+              width, own bg and scroll — so the two are pixel-identical and
+              toggling panel ↔ full page reads as the left region swapping
+              rather than the whole layout reflowing (WM-136). Stacks full
+              width below the trace under xl, where there is no room for two
+              columns. */}
+          <aside className="w-full shrink-0 overflow-y-auto border-(--border) bg-(--surface-1) p-4 xl:w-[460px] xl:border-l">
+            <RunDetailBlocks
+              d={d}
+              now={now}
+              connected={connected}
+              origin={listRow}
+              onJumpAgent={onJumpAgent}
+              onJumpEvent={onJumpEvent}
+              onCancel={() => setConfirm("cancel")}
+              onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
+              onForceRetry={() => setConfirm("force-retry")}
+              retryPending={retry.isPending}
+              verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
+            />
+          </aside>
+        </div>
+      )}
 
       {confirm === "cancel" && d && (
         <Dialog title={`Cancel ${d.run.runId}?`} onClose={() => setConfirm(null)}>

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -190,13 +190,24 @@ export function RunFull({
           <>
           {/* The failure first, full width under the header (WM-93) — renders nothing for other states. */}
           <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} className="mx-6 mt-6 mb-0" />
-          <div className="flex flex-col gap-8 p-6 xl:flex-row">
+          {/* items-start: a stretched flex child is full-height, which silently defeats the sidebar's sticky. */}
+          <div className="flex flex-col gap-8 p-6 xl:flex-row xl:items-start xl:pr-4">
             {/* Main column: the trace, at a readable measure — the point of the page. */}
             <main className="min-w-0 flex-1 xl:max-w-[900px]">
               <RunTrace key={runId} runId={runId} state={d.run.state} variant="full" />
             </main>
 
-            <aside className="w-full shrink-0 xl:w-[400px]">
+            {/* Anchored to the right edge at the side panel's width, so
+                toggling panel ↔ full page reads as the left region swapping
+                rather than the whole layout reflowing; `ml-auto` parks the
+                slack left of the sidebar, since the trace column caps at its
+                readable measure and would otherwise leave it floating. Its
+                own scroll keeps the Deadlines clock and run vitals on screen
+                through a long trace, matching the panel. The height leaves
+                enough slack that the page itself never scrolls at xl, so no
+                outer scrollbar gutter pushes the sidebar off the edge and it
+                lands on the panel's exact right margin (WM-136). */}
+            <aside className="w-full shrink-0 xl:sticky xl:top-0 xl:ml-auto xl:max-h-[calc(100dvh-11rem)] xl:w-[428px] xl:overflow-y-auto">
               <RunDetailBlocks
                 d={d}
                 now={now}

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -545,7 +545,7 @@ export function Workers({
             </div>
           )}
 
-          <Section title="Heartbeat">
+          <Section title="Heartbeat" card={false}>
             <div className="rounded-md border border-(--border) px-3 py-2 tabular-nums">
               <div className="flex items-baseline justify-between gap-4">
                 <span className="text-(--text-faint)">
@@ -592,7 +592,7 @@ export function Workers({
             {sel.stoppedAt && <KV k="stoppedAt" v={<Ago iso={sel.stoppedAt} now={now} />} />}
           </Section>
 
-          <Section title="Adapters">
+          <Section title="Adapters" card={false}>
             {sel.adapters.length === 0 ? (
               <div className="text-(--text-faint)">No adapters declared — this worker claims nothing.</div>
             ) : (
@@ -606,7 +606,7 @@ export function Workers({
             )}
           </Section>
 
-          <Section title="Labels">
+          <Section title="Labels" card={false}>
             <div className="mb-1.5 text-[11px] text-(--text-faint)">
               Placement labels the worker declared at registration — what a run&apos;s placement
               constraints are matched against.


### PR DESCRIPTION
Fixes WM-136

## What

**Anchoring** — the full page (`#/run/:id`) built the sidebar from a capped trace column plus a fixed-width aside, so once the trace hit its 900px cap the leftover flex space landed after the sidebar and it stopped being flush right; toggling panel ↔ full page shifted it. Rebuilt the full page to use the exact shape the side panel's `DetailPane` already uses — `border-l`, fixed 460px, own background, own `overflow-y-auto` — so main and aside scroll independently by construction and the two views are pixel-identical (confirmed via `getBoundingClientRect`).

**Restyle**, against Linear's issue sidebar as the reference:
- `Section` renders one bordered card per concern instead of every `KV` row drawing its own hairline (`card={false}` opts out where children already draw their own bordered container — applied everywhere that was true across the app, not just run detail).
- Section headers collapse with a chevron, persisted in `localStorage`, keyed by `id` where a title carries live data.
- `KV` values sit in a fixed, left-aligned second column instead of ragged right-alignment.
- Monospace reserved for identifiers; prose values ("any worker", "26m ago") render in the UI font. `StateBadge` gains a `dot={false}` escape hatch.
- Lifecycle is a dot-and-rail timeline: one dot per transition (was two — the rail's dot plus the badge's own), destination badges in a fixed-width column so the actor after them starts at one x down the whole list, repeated timestamps and the redundant from-state dropped except where the chain actually breaks.
- Attempt cards use the same label/value rhythm so the workspace path no longer pushes the owner off the edge.

## Verification

```
cd event-runtime/web && bunx tsc --noEmit && bun test src
351 pass, 0 fail (10 new tests: KV mono discipline, Section cards/collapse persistence, StateBadge dot, Lifecycle timeline dedup)
```

Visual: verified on the seeded demo env — panel/full-page sidebar geometry matches to the pixel (`x`, `width`, `right` identical via JS measurement); independent scroll confirmed via native `scrollIntoView` on both trace and sidebar; regression-checked Workers, Agents, Overview, Projects, Graph, Proposals detail panels for doubled borders after the shared-primitive change — none found.

UX critique round (factory-ux-critic): first pass returned FIX-FIRST on two findings — sidebar width/edge mismatch (real, fixed by the layout rebuild above) and sidebar not responding to mouse-wheel scroll (did not reproduce under native `scrollIntoView`; confirmed a Browser-pane wheel-targeting artifact, not a defect — `scrollTop` moves correctly and the two columns scroll independently).