### PR TITLE
feat(event-runtime): pi harness adapter (MVP) — pi -p --mode json alongside claude

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -62,6 +62,13 @@ models:
     strong: default        # CLI default — preserves today's dispatch behavior
     standard: sonnet
     light: haiku
+  # pi (OPS-296), Codex subscription window: sol/terra/luna are the
+  # provider's own strong/standard/light tier names, passed verbatim as
+  # `--model` (provider/id form; no separate --provider flag needed).
+  pi:
+    strong: openai-codex/gpt-5.6-sol
+    standard: openai-codex/gpt-5.6-terra
+    light: openai-codex/gpt-5.6-luna
 
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -402,11 +402,42 @@ names an entry in a small adapter registry, one per harness the runtime has
 actually tested. The emit pipeline targets several harnesses (Claude Code,
 Codex, Gemini, Cursor, Pi); the event runtime admits only adapters with a
 passing conformance test covering structured output, timeout and shutdown
-behavior, and workspace confinement. The registry has four entries: `claude`
-(the LLM harness), `command` (a closed argv template), `actions` (an approved
-action list resolved against a closed registry, remote-SSH or local-argv), and
-`fake` (tests and demo environments). It does not inherit the current runner's
-entire adapter surface.
+behavior, and workspace confinement. The registry has entries for `claude`
+(the primary LLM harness), `pi` (OPS-296, a second LLM harness on the Codex
+subscription window), `command` (a closed argv template), `actions` (an
+approved action list resolved against a closed registry, remote-SSH or
+local-argv), and `fake` (tests and demo environments). It does not inherit the
+current runner's entire adapter surface.
+
+**The `pi` adapter (`lib/adapters/pi.mjs`, OPS-296) mirrors `claude.mjs`,
+adapted to a different CLI shape.** `pi -p --mode json` (prompt piped to
+stdin, matching `runners/run-agent.sh`'s existing invocation) rather than
+`claude -p <prompt>`; `--model` takes the tier-resolved `provider/id` value
+directly (`openai-codex/gpt-5.6-terra`), no separate `--provider` flag. There
+is no `--max-budget-usd` equivalent and no per-tool settings/sandbox policy —
+those, and native capability enforcement derived from `spec.capabilities`, are
+deliberately stage 2. `mutating: false` passes `--tools read,grep,find,ls`:
+pi's own documented read-only pattern is omitting bash/edit/write from the
+tool allowlist entirely, never exposing them to the model, rather than
+intercepting a call to them at runtime the way claude's settings/sandbox
+policy does — see §14. (An earlier draft of this design read `-r` as pi's
+read-only flag; the installed CLI's own `--help` says otherwise — `-r` is
+`--resume`, a session selector, unrelated to tool access. Verify adapter flags
+against the actual CLI before relying on ticket text.) `mutating: true` pi
+agents are admissible under the same registry rule as any other LLM adapter
+(`docs/event-runtime-dispatch.md` §6, WM-108): only over a tier-2 `worktree`
+workspace — the registry's admission check at load time is adapter-agnostic
+already, so no adapter-specific carve-out was needed. A missing `pi` CLI (and
+no `npx` fallback) on PATH is a preflight refusal, not a spawn crash: the
+adapter throws before spawning anything, and the worker recognizes it as the
+typed `cli_not_found` reason code rather than the generic `adapter_error`.
+Trace mapping targets pi's real `--mode json` shape — `message_end` (role
+`assistant`) content blocks for `assistant_text`/`tool_use`,
+`tool_execution_end` for `tool_result`. pi has no single terminal summary
+message the way claude's `type: "result"` is one, so `usage` is accumulated
+across every assistant turn's own reported tokens/cost and emitted once at
+process close; fields pi never reported land as explicit `null`/`{}`, never a
+guessed value.
 
 **Live trace is an optional adapter capability (`factory.trace/v1`).** An
 adapter may stream what the agent is doing mid-run — via the `onTrace`
@@ -805,6 +836,19 @@ does not yet turn declarations such as `linear:read` into network authority:
 those still answer *what was authorized*, not *what was possible*. The
 declaration is validated at admission, recorded immutably in the `RunSpec`, and
 auditable after the fact.
+
+**pi (OPS-296) enforces `mutating: false` more coarsely than claude, and says
+so rather than implying a parity it doesn't have.** claude intercepts a denied
+tool call at runtime and reports a recognizable refusal message (WM-127); pi's
+`--tools read,grep,find,ls` never offers bash/edit/write to the model as
+callable functions in the first place, so there is no equivalent runtime
+denial to observe or classify — `lib/adapters/pi.mjs`'s
+`HARNESS_DENIAL_PATTERNS` is deliberately empty until a real refusal shape is
+confirmed from the CLI, same discipline as claude's list. This is the same
+audited-not-enforced framing as the service-capability declarations above:
+what's authorized is recorded and reviewable; what's actually possible for the
+model to attempt (a `bash` invocation of `pi` itself if the workspace's own
+`PATH` were compromised, say) is a stage-2 concern, same as claude's.
 
 Two per-definition allowlists ARE enforced by construction today, in contrast
 to the audited-not-enforced service capabilities: the actions adapter's **host

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -1,0 +1,339 @@
+/**
+ * pi CLI adapter (docs/event-runtime.md §6, §14; OPS-296) — the second LLM
+ * harness alongside `lib/adapters/claude.mjs`, on the Codex subscription
+ * window (`--model openai-codex/<id>`, OAuth, no API key). MVP scope only:
+ * native capability enforcement derived from `spec.capabilities` and
+ * cooperative cancellation with partial output are deliberately deferred to
+ * stage 2 (see the follow-up ticket linked from OPS-296).
+ *
+ * Spawns a bounded `pi -p --mode json` process (prompt piped to stdin, the
+ * standard `./input.json` → `./result.json` PROMPT_SUFFIX contract, cwd =
+ * workspace), enforces the run spec's timeout with TERM→KILL(killGraceMs),
+ * strips OpenAI-family (and other provider) API keys so the CLI authenticates
+ * against the subscription window instead of billing per token, and captures
+ * full stdout as the `.transcript.json` artifact — same shape as the claude
+ * adapter.
+ *
+ * Correction from the ticket's design text, confirmed against the installed
+ * CLI (`pi --help`, `pi 0.84.1`): `-r` is `--resume`, not read-only — using it
+ * for `mutating: false` would have been actively wrong (it selects a session
+ * to resume, it does not restrict tools). pi's own documented read-only
+ * pattern is `--tools read,grep,find,ls`: the write/bash tools are never
+ * offered to the model, so there is no runtime "permission denied" message to
+ * intercept the way claude's settings/sandbox policy produces one — coarser
+ * than claude's per-tool deny list, audited-not-enforced per §14 until stage
+ * 2's native capability enforcement lands.
+ *
+ * Trace mapping targets pi's real `--mode json` shape (investigated live, not
+ * assumed): assistant text/tool calls arrive fully formed on `message_end`
+ * (role `assistant`) content blocks — `message_update` deltas are the same
+ * data streamed incrementally and are skipped to avoid double-emitting. Tool
+ * results come from `tool_execution_end`, not the redundant `toolResult`-role
+ * message pair. pi has no single terminal summary message the way claude's
+ * `type: "result"` is one; each assistant turn reports its own token/cost
+ * usage, so `execute()` accumulates `extractUsage()` across the run and emits
+ * one combined `usage` trace event at process close — present fields when pi
+ * reported them, explicit null/empty when it never got that far.
+ */
+import { spawn } from "node:child_process";
+import { createWriteStream, readFileSync } from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { PROMPT_SUFFIX } from "./claude.mjs";
+
+export { PROMPT_SUFFIX };
+
+export const KILL_GRACE_MS = 30_000;
+
+/** Trace events preview text; the recorder's byte bound is the real limit. */
+const TEXT_PREVIEW_CHARS = 4000;
+
+// pi's own documented read-only pattern (`pi --help`, "Read-only mode (no
+// file modifications possible)"): omit bash/edit/write from the tool
+// allowlist entirely, rather than intercept calls to them at runtime.
+export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"];
+
+export class CliNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CliNotFoundError";
+    this.code = "cli_not_found";
+  }
+}
+
+/**
+ * Resolve the pi binary: `pi` on PATH, else `npx pi` (runners/run-agent.sh
+ * precedent). `which` is injectable for tests; defaults to `Bun.which`
+ * scoped to the child's own PATH, not the worker process's.
+ */
+export function resolvePiCommand({ which = Bun.which } = {}) {
+  if (which("pi")) return { command: "pi", args: [] };
+  if (which("npx")) return { command: "npx", args: ["pi"] };
+  return null;
+}
+
+/**
+ * Build argv for spawning pi. The prompt itself travels on stdin, not argv
+ * (matches `runners/run-agent.sh`'s `printf "%s\n" "$BODY" | pi -p ...`).
+ * `model` is the planner-resolved value pinned in the RunSpec (WM-135):
+ * passed verbatim as `--model` unless it is the "default" sentinel or null/empty.
+ */
+export function buildPiArgv({ def, model }) {
+  const args = ["-p", "--mode", "json"];
+  if (typeof model === "string" && model !== "" && model !== "default") {
+    args.push("--model", model);
+  }
+  if (def?.mutating === false) {
+    args.push("--tools", READ_ONLY_TOOLS.join(","));
+  }
+  return args;
+}
+
+/** Keep untrusted model subprocesses from inheriting the worker's authority. */
+export function safeChildEnvironment(env = {}) {
+  const inherited = ["HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM", "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"];
+  const childEnv = Object.fromEntries(inherited.flatMap((key) => process.env[key] === undefined ? [] : [[key, process.env[key]]]));
+  Object.assign(childEnv, env);
+  // Subscription auth (Codex/ChatGPT OAuth) is the point of routing through
+  // pi at all — an inherited key would silently switch a run to per-token
+  // billing (same rationale as run-agent.sh's UNSET_KEYS, all providers pi
+  // itself recognizes, not just OpenAI's).
+  for (const key of [
+    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
+  ]) {
+    delete childEnv[key];
+  }
+  return childEnv;
+}
+
+/**
+ * Harness-authored refusal shapes only (WM-127 lesson, carried over from the
+ * claude adapter). pi enforces read-only by never exposing bash/edit/write to
+ * the model — there is no runtime "permission denied" interception the way
+ * claude's settings/sandbox policy produces one, so no pattern has been
+ * confirmed from the CLI yet. An arbitrary tool_execution_end error (a failed
+ * `bash` command, an OS-level EACCES) must not be misclassified as a policy
+ * denial; leaving this empty is the honest MVP state, not an oversight.
+ * Extend only with strings confirmed from the CLI.
+ */
+export const HARNESS_DENIAL_PATTERNS = [];
+
+export function isHarnessDenial(content) {
+  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+}
+
+function clip(text) {
+  const s = String(text ?? "");
+  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+}
+
+/** Flatten a tool result content value (pi's shape: an array of text blocks). */
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((block) => block?.type === "text")
+      .map((block) => block.text ?? "")
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Map one parsed `pi --mode json` line to factory.trace/v1 events. Pure, so
+ * it is unit-testable without spawning a model. Keyed off `message_end` (the
+ * complete message) and `tool_execution_end` (the canonical tool-result
+ * source) — `message_update` deltas and the redundant `toolResult`-role
+ * message pair carry the same information and are deliberately not mapped,
+ * to avoid double-emitting.
+ *
+ * @param {any} msg - one parsed NDJSON line from `pi -p --mode json`
+ * @returns {Array<{kind: string, payload: object}>}
+ */
+export function mapStreamEvent(msg) {
+  if (!msg || typeof msg !== "object") return [];
+
+  if (msg.type === "message_end" && msg.message?.role === "assistant") {
+    const blocks = msg.message?.content;
+    if (!Array.isArray(blocks)) return [];
+    const events = [];
+    for (const block of blocks) {
+      if (block?.type === "text" && block.text) {
+        events.push({ kind: "assistant_text", payload: { text: clip(block.text) } });
+      } else if (block?.type === "toolCall") {
+        events.push({ kind: "tool_use", payload: { id: block.id ?? null, name: block.name, input: block.arguments } });
+      }
+    }
+    return events;
+  }
+
+  if (msg.type === "tool_execution_end") {
+    const payload = { content: clip(contentText(msg.result?.content)), toolUseId: msg.toolCallId ?? null };
+    if (msg.isError === true) payload.isError = true;
+    return [{ kind: "tool_result", payload }];
+  }
+
+  return []; // session/agent_start/turn_start/message_update/turn_end/agent_end/agent_settled — not part of the trace contract
+}
+
+/**
+ * Extract one assistant turn's token/cost usage, or null when the message
+ * carries none. Pure — `execute()` accumulates across a run into the single
+ * `usage` trace event pi's protocol has no equivalent terminal message for.
+ */
+export function extractUsage(msg) {
+  if (!msg || msg.type !== "message_end" || msg.message?.role !== "assistant") return null;
+  const u = msg.message?.usage;
+  if (!u || typeof u !== "object") return null;
+  const usage = {};
+  for (const key of ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"]) {
+    if (typeof u[key] === "number") usage[key] = u[key];
+  }
+  const costUSD = typeof u.cost?.total === "number" ? u.cost.total : null;
+  return { usage, costUSD };
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
+ */
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  killGraceMs = KILL_GRACE_MS,
+  env = {},
+  onTrace,
+  abortSignal,
+  signal,
+}) {
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const childEnv = safeChildEnvironment(env);
+
+  const resolved = resolvePiCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  if (!resolved) {
+    // Preflight refusal (OPS-296 AC): missing CLI is a typed condition the
+    // worker recognizes as `cli_not_found`, not an opaque `adapter_error`
+    // crash — see the `CliNotFoundError` handling in lib/worker.mjs.
+    throw new CliNotFoundError(
+      "neither pi nor npx is on PATH — install the pi CLI, or ensure npx can fetch it (docs/event-runtime.md §6)",
+    );
+  }
+  const argv = [...resolved.args, ...buildPiArgv({ def, model: spec?.model })];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolved.command, argv, {
+      cwd: workspaceDir,
+      env: childEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    child.stdin.on("error", () => {}); // a child that exits before reading stdin must not crash the worker
+    child.stdin.write(prompt);
+    child.stdin.end();
+
+    // Capture the CLI's structured output as a runtime artifact, same
+    // contract as the claude adapter: NDJSON, one message per line.
+    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    transcript.on("error", () => {});
+    if (child.stdout) {
+      child.stdout.pipe(transcript);
+    }
+
+    // Live trace: same stdout, line by line. Observational only — a trace
+    // recorder must never race execution by terminating the child.
+    const policyDenials = [];
+    let lastTool = null;
+    const toolNames = new Map();
+    let turnCount = 0;
+    let costTotal = null;
+    const usageTotals = {};
+    if (child.stdout) {
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        let parsed;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          return; // not JSON — ignore
+        }
+        try {
+          for (const event of mapStreamEvent(parsed)) {
+            if (event.kind === "tool_use") {
+              lastTool = event.payload?.name ?? null;
+              if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
+            }
+            onTrace?.(event.kind, event.payload);
+            const content = typeof event.payload?.content === "string" ? event.payload.content : "";
+            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
+              const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+              policyDenials.push(denial);
+              onTrace?.("lifecycle", { note: "policy_denial", ...denial });
+            }
+          }
+          const turnUsage = extractUsage(parsed);
+          if (turnUsage) {
+            turnCount += 1;
+            if (turnUsage.costUSD !== null) costTotal = (costTotal ?? 0) + turnUsage.costUSD;
+            for (const [key, value] of Object.entries(turnUsage.usage)) {
+              usageTotals[key] = (usageTotals[key] ?? 0) + value;
+            }
+          }
+        } catch {
+          // a recorder failure must never fail the run
+        }
+      });
+    }
+
+    let timedOut = false;
+    let killTimer = null;
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+      killTimer.unref?.();
+    }, timeoutMs);
+
+    const onAbort = () => {
+      child.kill("SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+        killTimer.unref?.();
+      }
+    };
+    const abortSig = abortSignal ?? signal;
+    if (abortSig) {
+      if (abortSig.aborted) {
+        onAbort();
+      } else {
+        abortSig.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    child.on("error", (err) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      transcript.destroy();
+      reject(err);
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      // pi has no single terminal summary message; report what was actually
+      // observed — explicit null/empty when the run never produced a turn,
+      // never a fabricated zero.
+      onTrace?.("usage", {
+        durationMs: null,
+        numTurns: turnCount > 0 ? turnCount : null,
+        costUSD: costTotal,
+        usage: usageTotals,
+      });
+      // Same WM-127 rule as claude: a denial observed mid-run is evidence,
+      // not a verdict — only surfaced to the worker when the run also failed.
+      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
+    });
+  });
+}

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -1,0 +1,512 @@
+import { describe, expect, test, afterAll } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PROMPT_SUFFIX } from "./claude.mjs";
+import {
+  buildPiArgv,
+  CliNotFoundError,
+  execute,
+  extractUsage,
+  isHarnessDenial,
+  KILL_GRACE_MS,
+  mapStreamEvent,
+  READ_ONLY_TOOLS,
+  resolvePiCommand,
+  safeChildEnvironment,
+} from "./pi.mjs";
+
+describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
+  test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {
+    // These look exactly like the strings that WOULD match claude's patterns,
+    // and like plausible OS/tool errors. None are a confirmed pi-authored
+    // refusal shape, so all must stay unclassified.
+    expect(isHarnessDenial("Permission to use bash has been denied.")).toBe(false);
+    expect(isHarnessDenial("pi requested permission to use write, but you haven't granted it yet.")).toBe(false);
+    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
+    expect(isHarnessDenial("bash: /etc/hosts: Permission denied")).toBe(false);
+    expect(isHarnessDenial(null)).toBe(false);
+    expect(isHarnessDenial(undefined)).toBe(false);
+  });
+});
+
+describe("mapStreamEvent (real `pi --mode json` shapes, investigated live)", () => {
+  test("assistant message_end text block → assistant_text", () => {
+    const events = mapStreamEvent({
+      type: "message_end",
+      message: { role: "assistant", content: [{ type: "text", text: "Files: `a.txt`." }] },
+    });
+    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "Files: `a.txt`." } }]);
+  });
+
+  test("assistant message_end toolCall block → tool_use; mixed blocks map in order", () => {
+    const events = mapStreamEvent({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "planning" },
+          { type: "toolCall", id: "call_1|fc_1", name: "read", arguments: { path: "a.txt" } },
+        ],
+      },
+    });
+    expect(events).toEqual([
+      { kind: "tool_use", payload: { id: "call_1|fc_1", name: "read", input: { path: "a.txt" } } },
+    ]);
+  });
+
+  test("tool_execution_end → tool_result, text content flattened, isError", () => {
+    const ok = mapStreamEvent({
+      type: "tool_execution_end",
+      toolCallId: "call_1|fc_1",
+      toolName: "read",
+      result: { content: [{ type: "text", text: "hello world\n" }] },
+      isError: false,
+    });
+    expect(ok).toEqual([{ kind: "tool_result", payload: { content: "hello world\n", toolUseId: "call_1|fc_1" } }]);
+
+    const err = mapStreamEvent({
+      type: "tool_execution_end",
+      toolCallId: "call_2",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "line 1" }, { type: "text", text: "line 2" }] },
+      isError: true,
+    });
+    expect(err).toEqual([{ kind: "tool_result", payload: { content: "line 1\nline 2", toolUseId: "call_2", isError: true } }]);
+  });
+
+  test("unrecognized message types are ignored silently", () => {
+    expect(mapStreamEvent({ type: "session", version: 3 })).toEqual([]);
+    expect(mapStreamEvent({ type: "agent_start" })).toEqual([]);
+    expect(mapStreamEvent({ type: "turn_start" })).toEqual([]);
+    expect(mapStreamEvent({ type: "message_end", message: { role: "user", content: [{ type: "text", text: "hi" }] } })).toEqual([]);
+    expect(mapStreamEvent({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "x" } })).toEqual([]);
+    expect(mapStreamEvent({ type: "turn_end", message: {} })).toEqual([]);
+    expect(mapStreamEvent({ type: "agent_end", messages: [] })).toEqual([]);
+    expect(mapStreamEvent({ type: "agent_settled" })).toEqual([]);
+    expect(mapStreamEvent({ type: "message_end" })).toEqual([]); // no message body
+    expect(mapStreamEvent(null)).toEqual([]);
+    expect(mapStreamEvent("not an object")).toEqual([]);
+  });
+
+  test("very long assistant text is clipped, not passed through whole", () => {
+    const [event] = mapStreamEvent({
+      type: "message_end",
+      message: { role: "assistant", content: [{ type: "text", text: "y".repeat(10_000) }] },
+    });
+    expect(event.kind).toBe("assistant_text");
+    expect(event.payload.text.length).toBeLessThan(5_000);
+    expect(event.payload.text.endsWith("…[truncated]")).toBe(true);
+  });
+});
+
+describe("extractUsage", () => {
+  test("assistant message_end with usage → token fields + cost", () => {
+    const usage = extractUsage({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [],
+        usage: { input: 983, output: 16, cacheRead: 2560, cacheWrite: 0, reasoning: 0, totalTokens: 3559, cost: { total: 0.000267 } },
+      },
+    });
+    expect(usage).toEqual({
+      usage: { input: 983, output: 16, cacheRead: 2560, cacheWrite: 0, reasoning: 0, totalTokens: 3559 },
+      costUSD: 0.000267,
+    });
+  });
+
+  test("non-assistant, missing usage, or non-message_end → null", () => {
+    expect(extractUsage({ type: "message_end", message: { role: "user", usage: { input: 1 } } })).toBeNull();
+    expect(extractUsage({ type: "message_end", message: { role: "assistant" } })).toBeNull();
+    expect(extractUsage({ type: "message_update" })).toBeNull();
+    expect(extractUsage(null)).toBeNull();
+  });
+});
+
+describe("buildPiArgv", () => {
+  test("prompt travels on stdin, not argv — base argv is -p --mode json", () => {
+    expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual(["-p", "--mode", "json"]);
+  });
+
+  test("mutating: false → --tools read,grep,find,ls (pi's own read-only pattern, not -r)", () => {
+    const argv = buildPiArgv({ def: { mutating: false }, model: null });
+    expect(argv).toContain("--tools");
+    expect(argv[argv.indexOf("--tools") + 1]).toBe(READ_ONLY_TOOLS.join(","));
+    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls"]);
+  });
+
+  test("mutating: true → no --tools restriction", () => {
+    expect(buildPiArgv({ def: { mutating: true }, model: null })).not.toContain("--tools");
+  });
+
+  test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {
+    const withModel = buildPiArgv({ def: { mutating: false }, model: "openai-codex/gpt-5.6-terra" });
+    const i = withModel.indexOf("--model");
+    expect(i).toBeGreaterThan(-1);
+    expect(withModel[i + 1]).toBe("openai-codex/gpt-5.6-terra");
+
+    const unpinned = buildPiArgv({ def: { mutating: false }, model: undefined });
+    expect(buildPiArgv({ def: { mutating: false }, model: "default" })).toEqual(unpinned);
+    expect(buildPiArgv({ def: { mutating: false }, model: null })).toEqual(unpinned);
+    expect(buildPiArgv({ def: { mutating: false }, model: "" })).toEqual(unpinned);
+  });
+});
+
+describe("resolvePiCommand", () => {
+  test("pi on PATH → run it directly", () => {
+    const which = (name) => (name === "pi" ? "/usr/local/bin/pi" : null);
+    expect(resolvePiCommand({ which })).toEqual({ command: "pi", args: [] });
+  });
+
+  test("pi missing, npx present → npx pi fallback", () => {
+    const which = (name) => (name === "npx" ? "/usr/local/bin/npx" : null);
+    expect(resolvePiCommand({ which })).toEqual({ command: "npx", args: ["pi"] });
+  });
+
+  test("neither on PATH → null", () => {
+    expect(resolvePiCommand({ which: () => null })).toBeNull();
+  });
+});
+
+describe("safeChildEnvironment", () => {
+  test("strips every provider API key pi recognizes, keeps declared env", () => {
+    const env = safeChildEnvironment({
+      ANTHROPIC_API_KEY: "a",
+      OPENAI_API_KEY: "b",
+      GEMINI_API_KEY: "c",
+      GOOGLE_API_KEY: "d",
+      GOOGLE_GENAI_API_KEY: "e",
+      MISTRAL_API_KEY: "f",
+      DEEPSEEK_API_KEY: "g",
+      GROQ_API_KEY: "h",
+      CUSTOM_VAR: "kept",
+    });
+    for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY"]) {
+      expect(env[key]).toBeUndefined();
+    }
+    expect(env.CUSTOM_VAR).toBe("kept");
+  });
+});
+
+describe("execute conformance (OPS-296, docs/event-runtime.md §6)", () => {
+  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-pi-test-")));
+  const stubBinDir = path.join(tmpBase, "bin");
+  mkdirSync(stubBinDir, { recursive: true });
+  const emptyBinDir = path.join(tmpBase, "empty-bin");
+  mkdirSync(emptyBinDir, { recursive: true });
+
+  const stubPiPath = path.join(stubBinDir, "pi");
+  const stubScript = `#!/usr/bin/env bun
+import { writeFileSync } from "node:fs";
+
+let stdin = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { stdin += chunk; });
+process.stdin.on("end", () => {
+  if (process.env.FACTORY_TEST_RECORD_FILE) {
+    writeFileSync(
+      process.env.FACTORY_TEST_RECORD_FILE,
+      JSON.stringify({ cwd: process.cwd(), env: process.env, argv: process.argv, stdin }),
+      "utf8",
+    );
+  }
+
+  const behavior = process.env.FACTORY_TEST_BEHAVIOR || "normal";
+
+  if (behavior === "normal") {
+    process.stdout.write(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Working..." }],
+        usage: { input: 15, output: 25, cost: { total: 0.001 } },
+      },
+    }) + "\\n");
+    process.exit(0);
+  }
+
+  if (behavior === "exit_code") {
+    const code = parseInt(process.env.FACTORY_TEST_EXIT_CODE || "1", 10);
+    process.exit(code);
+  }
+
+  if (behavior === "sleep_sigterm") {
+    setInterval(() => {}, 10_000);
+  }
+
+  if (behavior === "ignore_sigterm") {
+    process.on("SIGTERM", () => {});
+    setInterval(() => {}, 10_000);
+  }
+
+  if (behavior === "emit_tool_then_success") {
+    process.stdout.write(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.txt" } }],
+        usage: { input: 100, output: 10, cost: { total: 0.0005 } },
+      },
+    }) + "\\n");
+    process.stdout.write(JSON.stringify({
+      type: "tool_execution_end",
+      toolCallId: "call_1",
+      toolName: "read",
+      result: { content: [{ type: "text", text: "hello world" }] },
+      isError: false,
+    }) + "\\n");
+    process.stdout.write(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done." }],
+        usage: { input: 50, output: 5, cost: { total: 0.0002 } },
+      },
+    }) + "\\n");
+    process.exit(0);
+  }
+
+  if (behavior === "emit_error_tool_result") {
+    // Looks exactly like a permission-denied message, but is not a confirmed
+    // pi-authored refusal shape (WM-127 lesson) — must never become policy_denied.
+    process.stdout.write(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "touch /etc/nope" } }],
+      },
+    }) + "\\n");
+    process.stdout.write(JSON.stringify({
+      type: "tool_execution_end",
+      toolCallId: "call_1",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "Permission to use bash has been denied." }] },
+      isError: true,
+    }) + "\\n");
+    process.exit(1);
+  }
+});
+`;
+  writeFileSync(stubPiPath, stubScript, { mode: 0o755 });
+
+  const promptFile = path.join(tmpBase, "prompt.md");
+  writeFileSync(promptFile, "You are a test agent.", "utf8");
+
+  afterAll(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const defaultDef = {
+    ref: "test-pi-agent@1",
+    promptPath: promptFile,
+    mutating: false,
+  };
+  const defaultSpec = {
+    agent: "test-pi-agent@1",
+    input: { repos: ["bj29"] },
+  };
+
+  test("executes stub binary in workspaceDir, strips API keys, pipes prompt on stdin, captures transcript + trace", async () => {
+    const workspaceDir = ws();
+    const recordFile = path.join(workspaceDir, "record.json");
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec: { ...defaultSpec, model: "openai-codex/gpt-5.6-terra" },
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        OPENAI_API_KEY: "sk-secret-key-must-be-stripped",
+        CUSTOM_VAR: "custom_value",
+        FACTORY_TEST_BEHAVIOR: "normal",
+        FACTORY_TEST_RECORD_FILE: recordFile,
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+
+    // 1. Workspace confinement: cwd is workspaceDir
+    expect(existsSync(recordFile)).toBe(true);
+    const record = JSON.parse(readFileSync(recordFile, "utf8"));
+    expect(record.cwd).toBe(workspaceDir);
+
+    // 2. Env security
+    expect(record.env.OPENAI_API_KEY).toBeUndefined();
+    expect(record.env.CUSTOM_VAR).toBe("custom_value");
+
+    // 3. Prompt on stdin, not argv; argv shape
+    expect(record.stdin).toBe(`You are a test agent.${PROMPT_SUFFIX}`);
+    expect(record.argv).not.toContain(`You are a test agent.${PROMPT_SUFFIX}`);
+    expect(record.argv).toContain("-p");
+    expect(record.argv).toContain("--mode");
+    expect(record.argv).toContain("json");
+    expect(record.argv).toContain("--model");
+    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("openai-codex/gpt-5.6-terra");
+    expect(record.argv).toContain("--tools");
+    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls");
+
+    // 4. .transcript.json artifact capture
+    const transcriptPath = path.join(workspaceDir, ".transcript.json");
+    expect(existsSync(transcriptPath)).toBe(true);
+    expect(readFileSync(transcriptPath, "utf8")).toContain('"type":"message_end"');
+
+    // 5. Live trace mapping: assistant text, then one combined usage event
+    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working...")).toBe(true);
+    const usageEvent = traceEvents.find((e) => e.kind === "usage");
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent.payload.numTurns).toBe(1);
+    expect(usageEvent.payload.costUSD).toBeCloseTo(0.001, 6);
+    expect(usageEvent.payload.usage.input).toBe(15);
+  });
+
+  test("nonzero exit code propagates and timedOut is false", async () => {
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "exit_code",
+        FACTORY_TEST_EXIT_CODE: "42",
+      },
+    });
+    expect(outcome.exitCode).toBe(42);
+    expect(outcome.timedOut).toBe(false);
+  });
+
+  test("timeout sends SIGTERM and returns timedOut: true", async () => {
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 150,
+      killGraceMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+      },
+    });
+    expect(outcome.timedOut).toBe(true);
+  });
+
+  test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 100,
+      killGraceMs: 100,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "ignore_sigterm",
+      },
+    });
+    expect(outcome.timedOut).toBe(true);
+  });
+
+  test("abortSignal terminates child process promptly with timedOut: false", async () => {
+    const ac = new AbortController();
+    const runPromise = execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 10_000,
+      killGraceMs: 500,
+      abortSignal: ac.signal,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+      },
+    });
+    setTimeout(() => ac.abort(), 100);
+    const outcome = await runPromise;
+    expect(outcome.timedOut).toBe(false);
+  });
+
+  test("multiple assistant turns accumulate into one combined usage trace event", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_tool_then_success",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "read")).toBe(true);
+    expect(traceEvents.some((e) => e.kind === "tool_result" && e.payload.content === "hello world")).toBe(true);
+
+    const usageEvent = traceEvents.find((e) => e.kind === "usage");
+    expect(usageEvent.payload.numTurns).toBe(2);
+    expect(usageEvent.payload.costUSD).toBeCloseTo(0.0007, 6);
+    expect(usageEvent.payload.usage.input).toBe(150);
+  });
+
+  test("a tool_execution_end error that reads exactly like a permission denial is never classified as policy_denied (WM-127)", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_error_tool_result",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.policyDenials).toEqual([]);
+    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+  });
+
+  test("run with no output at all reports usage as explicit n/a, not a fabricated zero", async () => {
+    const traceEvents = [];
+    await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "exit_code",
+        FACTORY_TEST_EXIT_CODE: "0",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    const usageEvent = traceEvents.find((e) => e.kind === "usage");
+    expect(usageEvent.payload).toEqual({ durationMs: null, numTurns: null, costUSD: null, usage: {} });
+  });
+
+  test("missing pi and npx on PATH is a typed CliNotFoundError, not a spawn crash (OPS-296 AC)", async () => {
+    await expect(
+      execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+        env: { PATH: emptyBinDir },
+      }),
+    ).rejects.toThrow(CliNotFoundError);
+
+    await expect(
+      execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+        env: { PATH: emptyBinDir },
+      }),
+    ).rejects.toMatchObject({ code: "cli_not_found" });
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -43,7 +43,7 @@ export const DEFAULT_MODEL = "default";
 
 /** Adapters that accept a model at all. command/actions/fake take none: a
  * declared tier there resolves to null (not applicable), never an error. */
-export const MODEL_ADAPTERS = new Set(["claude"]);
+export const MODEL_ADAPTERS = new Set(["claude", "pi"]);
 
 /**
  * Read the `models:` tier map from config/policy.yaml (same root rule as

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -572,11 +572,19 @@ export async function executeClaimed(db, registry, adapters, claim, {
       }
       return { cancelled: false, error: err.message };
     }
-    const reasonCode = "adapter_error";
-    const journalReason = `adapter_error: ${err?.message ?? String(err)}`;
+    // A missing CLI (OPS-296: `pi`/`npx` absent from PATH) is a typed,
+    // recognizable adapter precondition, not an opaque crash — an adapter
+    // signals it by throwing an error with `code: "cli_not_found"` (see
+    // lib/adapters/pi.mjs's CliNotFoundError) before ever spawning a child.
+    // No `requeue`: retrying on the same worker just fails the same way.
+    const isCliNotFound = err?.code === "cli_not_found";
+    const reasonCode = isCliNotFound ? "cli_not_found" : "adapter_error";
+    const journalReason = isCliNotFound
+      ? `cli_not_found: ${err.message}`
+      : `adapter_error: ${err?.message ?? String(err)}`;
     let res;
     try {
-      res = failTerminal("FAILED", journalReason, reasonCode, { requeue: true });
+      res = failTerminal("FAILED", journalReason, reasonCode, { requeue: !isCliNotFound });
     } catch {
       // if failTerminal could not transition, continue
     }


### PR DESCRIPTION
## Summary
- New `lib/adapters/pi.mjs`, mirroring `claude.mjs`: `pi -p --mode json` with the prompt piped to stdin, `--model <tier-resolved provider/id>`, `--tools read,grep,find,ls` for `mutating: false` (pi's own documented read-only pattern — write/bash are never exposed to the model as callable tools).
- **Correction from the ticket's design text, verified against the installed CLI (`pi --help`, v0.84.1):** `-r` is `--resume` (a session selector), not read-only — using it would have been actively wrong. Implemented the verified `--tools` mechanism instead.
- Trace mapping targets pi's real `--mode json` shape (investigated live): `message_end` (role assistant) → `assistant_text`/`tool_use`, `tool_execution_end` → `tool_result`. pi has no single terminal summary message the way claude's `type: "result"` is one, so usage is accumulated per-turn and emitted once as a combined `usage` trace event at process close; unreported fields are explicit `null`/`{}`, never fabricated.
- No confirmed pi-authored refusal shape exists yet (pi enforces read-only by not exposing tools, not by runtime interception) — `HARNESS_DENIAL_PATTERNS` is deliberately empty, tested to confirm denial-shaped stderr never misclassifies as `policy_denied` (WM-127 discipline).
- Missing `pi`/`npx` on PATH → typed `CliNotFoundError` before spawning; `worker.mjs` recognizes `err.code === "cli_not_found"` as a typed FAILED reason (no requeue) instead of the generic `adapter_error` crash path.
- `registry.mjs`: `"pi"` added to `MODEL_ADAPTERS` so `model_tier` resolves for pi-adapter definitions.
- `config/policy.yaml`: `models.pi: {strong: openai-codex/gpt-5.6-sol, standard: openai-codex/gpt-5.6-terra, light: openai-codex/gpt-5.6-luna}` — all three ids confirmed reachable live via `pi --list-models`.
- `docs/event-runtime.md` §6/§14 updated with the pi adapter's design and its coarser (audited-not-enforced) read-only enforcement relative to claude.

**Out of scope (filed as OPS-517):** wiring `pi` into `cli.mjs`'s adapter map and registering an actual pi-backed agent definition/event-type, so the adapter is dispatchable end-to-end — those files are outside OPS-296's Owned Paths.

Fixes OPS-296

## Test plan
- [x] `bun test event-runtime/` — 960 pass, 0 fail (includes 25 new `pi.mjs` adapter tests: pure mapping/argv/env unit tests + stub-binary execute() conformance tests mirroring `claude.test.mjs`'s pattern)
- [x] Real read-only smoke run against the installed `pi` CLI (`openai-codex/gpt-5.6-luna`): exit 0, only read-only tools invoked, transcript + trace captured, usage summed across 6 turns
- [x] `bun -e '...loadRegistry()...'` — registry loads cleanly with the new `models.pi` tier map, 28 agent definitions unaffected