### PR TITLE
fix(event-runtime): pi read-only tool list keeps write — result contract requires ./result.json (OPS-518)

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -18,10 +18,12 @@
  * CLI (`pi --help`, `pi 0.84.1`): `-r` is `--resume`, not read-only — using it
  * for `mutating: false` would have been actively wrong (it selects a session
  * to resume, it does not restrict tools). pi's own documented read-only
- * pattern is `--tools read,grep,find,ls`: the write/bash tools are never
- * offered to the model, so there is no runtime "permission denied" message to
- * intercept the way claude's settings/sandbox policy produces one — coarser
- * than claude's per-tool deny list, audited-not-enforced per §14 until stage
+ * pattern is `--tools read,grep,find,ls,write`: bash/edit are never offered
+ * to the model, so there is no runtime "permission denied" message to
+ * intercept the way claude's settings/sandbox policy produces one. `write`
+ * stays even for mutating: false — the result contract requires writing
+ * ./result.json (OPS-518) — so read-only containment here is bash/edit
+ * omission plus the workspace cwd, audited-not-enforced per §14 until stage
  * 2's native capability enforcement lands.
  *
  * Trace mapping targets pi's real `--mode json` shape (investigated live, not
@@ -48,10 +50,15 @@ export const KILL_GRACE_MS = 30_000;
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
 
-// pi's own documented read-only pattern (`pi --help`, "Read-only mode (no
-// file modifications possible)"): omit bash/edit/write from the tool
-// allowlist entirely, rather than intercept calls to them at runtime.
-export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"];
+// pi's documented read-only pattern omits bash/edit from the tool allowlist
+// rather than intercepting calls at runtime — but `write` must stay: every
+// agent-result contract requires the model to write ./result.json, and a run
+// that cannot write it fails contract_violation:missing_result before doing
+// anything (OPS-518; same reasoning as claude.mjs's READ_ONLY_TOOLS keeping
+// Write/Edit). Containment for mutating: false is therefore bash/edit omission
+// plus the workspace-cwd boundary — audited, not enforced, per §14 until
+// stage 2's native capability enforcement (OPS-515).
+export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write"];
 
 export class CliNotFoundError extends Error {
   constructor(message) {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -129,11 +129,11 @@ describe("buildPiArgv", () => {
     expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual(["-p", "--mode", "json"]);
   });
 
-  test("mutating: false → --tools read,grep,find,ls (pi's own read-only pattern, not -r)", () => {
+  test("mutating: false → --tools read,grep,find,ls,write (pi's own read-only pattern, not -r)", () => {
     const argv = buildPiArgv({ def: { mutating: false }, model: null });
     expect(argv).toContain("--tools");
     expect(argv[argv.indexOf("--tools") + 1]).toBe(READ_ONLY_TOOLS.join(","));
-    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls"]);
+    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls,write"]);
   });
 
   test("mutating: true → no --tools restriction", () => {
@@ -348,7 +348,7 @@ process.stdin.on("end", () => {
     expect(record.argv).toContain("--model");
     expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("openai-codex/gpt-5.6-terra");
     expect(record.argv).toContain("--tools");
-    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls");
+    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write");
 
     // 4. .transcript.json artifact capture
     const transcriptPath = path.join(workspaceDir, ".transcript.json");


### PR DESCRIPTION
Fixes OPS-518

Every `mutating: false` pi-routed run failed `contract_violation: missing_result`: the registry forces non-worktree LLM agents to read-only, and pi's `READ_ONLY_TOOLS` omitted `write`, so the model structurally could not produce the required `./result.json` (confirmed live against pi 0.84.1 by the OPS-517 dispatch run). Fix mirrors claude.mjs's explicit design: keep `write` in the read-only allowlist (bash/edit stay omitted), because the result contract depends on it; containment for read-only runs is bash/edit omission + the workspace cwd, audited-not-enforced per §14 until OPS-515's native capability enforcement. Docstring updated so "coarser" no longer hides "cannot complete a run".

Verification: `bun test event-runtime/` → all pass (pi adapter suite 25 tests / 89 assertions green).