### PR TITLE
fix(event-runtime): validate persisted theme against THEMES (WM-151)

### DIFF
--- a/event-runtime/web/src/hooks.test.ts
+++ b/event-runtime/web/src/hooks.test.ts
@@ -2,13 +2,20 @@ import "./test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, render } from "@testing-library/react";
 import { createElement as h, useState } from "react";
-import { modal, useHashRoute, useListKeys } from "./hooks";
+import { modal, useHashRoute, useListKeys, useTheme } from "./hooks";
 
 afterEach(() => {
   cleanup();
   modal.depth = 0;
   window.location.hash = "";
+  localStorage.removeItem("evrt-theme");
+  delete document.documentElement.dataset.theme;
 });
+
+function ThemeProbe() {
+  const [theme] = useTheme();
+  return h("span", { "data-testid": "theme" }, theme);
+}
 
 /** Helper list component driving useListKeys */
 function InteractiveList(props: {
@@ -85,6 +92,16 @@ function HashSyncedList(props: { count: number; prefix: string }) {
     ),
   );
 }
+
+describe("useTheme", () => {
+  test("corrupt evrt-theme in localStorage resets to dark and rewrites storage", () => {
+    localStorage.setItem("evrt-theme", "foo");
+    const r = render(h(ThemeProbe));
+    expect(r.getByTestId("theme").textContent).toBe("dark");
+    expect(localStorage.getItem("evrt-theme")).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+});
 
 describe("useListKeys unit tests — rapid j/k keydown movement", () => {
   test("holding 'j' across rapid keydown events advances selection to count - 1", () => {

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -223,11 +223,16 @@ export function useDisplayOptions<T>(
 export const THEMES = ["dark", "light", "contrast"] as const;
 export type Theme = (typeof THEMES)[number];
 
+function isTheme(value: string | null): value is Theme {
+  return value !== null && (THEMES as readonly string[]).includes(value);
+}
+
 /** Theme state on <html data-theme>; dark is the default (spec §5.1). */
 export function useTheme(): [Theme, () => void] {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem("evrt-theme") as Theme) || "dark",
-  );
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem("evrt-theme");
+    return isTheme(stored) ? stored : "dark";
+  });
   useEffect(() => {
     if (theme === "dark") delete document.documentElement.dataset.theme;
     else document.documentElement.dataset.theme = theme;


### PR DESCRIPTION
## Summary

- Add `isTheme` guard in `useTheme` so only `dark`, `light`, and `contrast` are accepted from localStorage
- Corrupt or stale `evrt-theme` values reset to `dark` and rewrite storage via the existing effect
- Unit test covers corrupt localStorage on init

## Test plan

- [x] `cd event-runtime/web && bun test` — 362 pass, 0 fail

## UX critique

skipped — isolated persistence fix, no new user flow or interaction change

Fixes WM-151