### PR TITLE
fix(webui): shortcuts overlay documents theme cycle, context strip, copy link (WM-152)

### DIFF
--- a/event-runtime/web/src/components/ShortcutsDialog.test.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.test.tsx
@@ -1,0 +1,28 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { modal } from "../hooks";
+import { ShortcutsDialog } from "./ShortcutsDialog";
+
+beforeEach(() => {
+  modal.depth = 0;
+});
+
+afterEach(() => {
+  modal.depth = 0;
+  cleanup();
+});
+
+describe("ShortcutsDialog", () => {
+  test("documents theme cycle, copy link, and context-strip keys", () => {
+    const r = render(<ShortcutsDialog onClose={() => {}} />);
+
+    expect(r.getByText("cycle theme (dark → light → contrast)")).toBeDefined();
+    expect(r.getByText("copy link to this page")).toBeDefined();
+
+    const contextStrip = r.getByRole("region", { name: "Context strip" });
+    expect(contextStrip.textContent).toContain("Tab");
+    expect(contextStrip.textContent).toContain("Home / End");
+    expect(contextStrip.textContent).toContain("Delete / ⌫");
+  });
+});

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -3,6 +3,8 @@ import { NAV } from "../nav";
 
 const ACTIONS: { keys: string; does: string }[] = [
   { keys: "⌘K", does: "command palette" },
+  { keys: "⌘K", does: "copy link to this page" },
+  { keys: "⌘K · footer Theme", does: "cycle theme (dark → light → contrast)" },
   { keys: "i", does: "inject event" },
   { keys: "/", does: "focus filter (Events, if none on this view)" },
   { keys: "j k  ↑↓", does: "move list (or graph) selection" },
@@ -15,6 +17,14 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "x", does: "reject proposal / cancel run" },
   { keys: "q", does: "requeue dead-lettered / human_needed event" },
   { keys: "?", does: "this list" },
+];
+
+const CONTEXT_STRIP: { keys: string; does: string }[] = [
+  { keys: "Tab", does: "focus context strip (single stop, roving tabindex)" },
+  { keys: "← →", does: "move focus among All / repos / In flight tabs" },
+  { keys: "Home / End", does: "first / last context tab" },
+  { keys: "Enter / Space", does: "activate focused filter" },
+  { keys: "Delete / ⌫", does: "close focused repo tab (focus returns to active tab)" },
 ];
 
 /** Keyboard cheatsheet (Linear's `?`). Spec §5 is the contract; this is the reminder. */
@@ -46,7 +56,24 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
           <div>
             {ACTIONS.map((r) => (
               <div
-                key={r.keys}
+                key={`${r.keys}::${r.does}`}
+                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+              >
+                <span className="mono text-(--text)">{r.keys}</span>
+                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section aria-label="Context strip">
+          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+            Context strip
+          </div>
+          <div>
+            {CONTEXT_STRIP.map((r) => (
+              <div
+                key={`${r.keys}::${r.does}`}
                 className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
               >
                 <span className="mono text-(--text)">{r.keys}</span>


### PR DESCRIPTION
## Summary
- Extend the `?` keyboard overlay ACTIONS with ⌘K copy-link and theme-cycle rows (dark → light → contrast, via palette and footer Theme button).
- Add a Context strip section documenting toolbar keys per spec §5 (Tab, arrows, Home/End, Enter/Space, Delete/Backspace).
- Add `ShortcutsDialog.test.tsx` asserting the new rows render when the overlay mounts.

## Test plan
- [x] `cd event-runtime/web && bun test` — 362 pass, including new ShortcutsDialog test

Fixes WM-152