### PR TITLE
fix(web): SpecDiff overflow affordance and sticky header (WM-146)

### DIFF
--- a/event-runtime/web/src/components/SpecDiff.test.tsx
+++ b/event-runtime/web/src/components/SpecDiff.test.tsx
@@ -52,7 +52,7 @@ describe("SpecDiff component", () => {
 
     expect(r.getByText("No spec changes.")).toBeDefined();
     expect(r.queryByText("Copy diff")).toBeNull();
-    expect(r.container.querySelector("pre")).toBeNull();
+    expect(r.queryByTestId("spec-diff-scroll")).toBeNull();
   });
 
   test("renders diff header and changed lines when specs differ", () => {
@@ -64,10 +64,10 @@ describe("SpecDiff component", () => {
     expect(r.getByText("2 changed lines")).toBeDefined();
     expect(r.getByRole("button", { name: "Copy diff" })).toBeDefined();
 
-    const pre = r.container.querySelector("pre");
-    expect(pre).not.toBeNull();
-    expect(pre?.textContent).toContain("-   \"maxAttempts\": 3");
-    expect(pre?.textContent).toContain("+   \"maxAttempts\": 5");
+    const scroller = r.getByTestId("spec-diff-scroll");
+    expect(scroller).not.toBeNull();
+    expect(scroller.textContent).toContain("-   \"maxAttempts\": 3");
+    expect(scroller.textContent).toContain("+   \"maxAttempts\": 5");
   });
 
   test("singular changed line count when exactly 1 line changes", () => {
@@ -75,6 +75,56 @@ describe("SpecDiff component", () => {
     // An addition of a single line to a multi-line array:
     const r = render(<SpecDiff before={["a"]} after={["a", "b"]} />);
     expect(r.container.textContent).toContain("changed line");
+  });
+
+  function mockScrollerDimensions(
+    scroller: HTMLElement,
+    { clientHeight, scrollHeight, scrollTop = 0 }: { clientHeight: number; scrollHeight: number; scrollTop?: number },
+  ) {
+    Object.defineProperty(scroller, "clientHeight", { configurable: true, value: clientHeight });
+    Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: scrollHeight });
+    Object.defineProperty(scroller, "scrollTop", { configurable: true, value: scrollTop, writable: true });
+  }
+
+  test("does not show overflow affordance when diff fits within max height", () => {
+    const before = { maxAttempts: 3 };
+    const after = { maxAttempts: 5 };
+    const r = render(<SpecDiff before={before} after={after} />);
+
+    const scroller = r.getByTestId("spec-diff-scroll");
+    mockScrollerDimensions(scroller, { clientHeight: 500, scrollHeight: 120 });
+
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+
+    expect(r.queryByText(/more lines below/)).toBeNull();
+  });
+
+  test("shows overflow affordance when diff exceeds max height", () => {
+    const lines = Array.from({ length: 40 }, (_, i) => `line-${i}`);
+    const before = { input: lines };
+    const after = { input: [...lines, "added-line"] };
+    const r = render(<SpecDiff before={before} after={after} />);
+
+    const scroller = r.getByTestId("spec-diff-scroll");
+    mockScrollerDimensions(scroller, { clientHeight: 120, scrollHeight: 800 });
+
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+
+    expect(r.getByText(/\d+ more lines below/)).toBeDefined();
+  });
+
+  test("keeps changed-line header sticky while scrolling diff body", () => {
+    const before = { maxAttempts: 3 };
+    const after = { maxAttempts: 5 };
+    const r = render(<SpecDiff before={before} after={after} />);
+
+    const header = r.getByTestId("spec-diff-header");
+    expect(header.className).toContain("sticky");
+    expect(header.className).toContain("top-0");
   });
 
   test("clicking Copy diff writes to clipboard and produces toast feedback", () => {

--- a/event-runtime/web/src/components/SpecDiff.test.tsx
+++ b/event-runtime/web/src/components/SpecDiff.test.tsx
@@ -117,6 +117,17 @@ describe("SpecDiff component", () => {
     expect(r.getByText(/\d+ more lines below/)).toBeDefined();
   });
 
+  test("preserves JSON indent after dropping pre (whitespace-pre-wrap on body)", () => {
+    const before = { maxAttempts: 3 };
+    const after = { maxAttempts: 5 };
+    const r = render(<SpecDiff before={before} after={after} />);
+
+    const body = r.getByTestId("spec-diff-body");
+    expect(body.className).toContain("whitespace-pre-wrap");
+    const indented = [...body.querySelectorAll("[data-diff-line]")].map((el) => el.textContent ?? "");
+    expect(indented.some((t) => t.startsWith("-   \"maxAttempts\"") || t.startsWith("+   \"maxAttempts\""))).toBe(true);
+  });
+
   test("keeps changed-line header sticky while scrolling diff body", () => {
     const before = { maxAttempts: 3 };
     const after = { maxAttempts: 5 };

--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -120,7 +120,7 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
           Copy diff
         </Button>
       </div>
-      <div className="p-3 leading-relaxed">
+      <div data-testid="spec-diff-body" className="whitespace-pre-wrap p-3 leading-relaxed">
         {lines.map((l, idx) => (
           <div
             key={idx}

--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -1,6 +1,7 @@
 // Line diff for two RunSpecs — the §12 replan path must show the operator
 // exactly what changed before they approve the re-planned spec.
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button, copyText } from "./ui";
 
 export type DiffLine = { type: "same" | "del" | "add"; text: string };
@@ -40,12 +41,61 @@ export function formatDiff(lines: DiffLine[]): string {
     .join("\n");
 }
 
+function countLinesBelowViewport(scroller: HTMLElement): number {
+  const scrollBottom = scroller.scrollTop + scroller.clientHeight;
+  const lineEls = scroller.querySelectorAll("[data-diff-line]");
+  let below = 0;
+  for (const line of lineEls) {
+    const el = line as HTMLElement;
+    if (el.offsetTop + el.offsetHeight > scrollBottom + 1) below++;
+  }
+  return below;
+}
+
 export function SpecDiff({ before, after }: { before: unknown; after: unknown }) {
   const lines = diffLines(
     JSON.stringify(before, null, 2).split("\n"),
     JSON.stringify(after, null, 2).split("\n"),
   );
   const changed = lines.filter((l) => l.type !== "same").length;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [linesBelow, setLinesBelow] = useState(0);
+
+  const updateOverflow = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const hasOverflow = el.scrollHeight > el.clientHeight + 1;
+    if (!hasOverflow) {
+      setLinesBelow(0);
+      return;
+    }
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 4;
+    if (atBottom) {
+      setLinesBelow(0);
+      return;
+    }
+    let below = countLinesBelowViewport(el);
+    if (below === 0) {
+      const scrollable = el.scrollHeight - el.clientHeight;
+      const remaining = scrollable - el.scrollTop;
+      const totalLines = el.querySelectorAll("[data-diff-line]").length;
+      below = Math.max(1, Math.ceil((remaining / scrollable) * totalLines));
+    }
+    setLinesBelow(below);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateOverflow();
+    const ro = new ResizeObserver(updateOverflow);
+    ro.observe(el);
+    el.addEventListener("scroll", updateOverflow, { passive: true });
+    return () => {
+      ro.disconnect();
+      el.removeEventListener("scroll", updateOverflow);
+    };
+  }, [lines, updateOverflow]);
 
   if (changed === 0) {
     return (
@@ -56,17 +106,25 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
   }
 
   return (
-    <div>
-      <div className="mb-1.5 flex items-center justify-between text-[11px] text-(--text-faint)">
+    <div
+      ref={scrollRef}
+      data-testid="spec-diff-scroll"
+      className="mono relative max-h-80 overflow-auto rounded-md border border-(--border) bg-(--surface-0)"
+    >
+      <div
+        data-testid="spec-diff-header"
+        className="sticky top-0 z-10 flex items-center justify-between border-b border-(--border) bg-(--surface-0) px-3 py-1.5 text-[11px] text-(--text-faint)"
+      >
         <span>{`${changed} changed line${changed === 1 ? "" : "s"}`}</span>
         <Button onClick={() => copyText(formatDiff(lines), "diff")}>
           Copy diff
         </Button>
       </div>
-      <pre className="mono max-h-80 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-3 leading-relaxed">
+      <div className="p-3 leading-relaxed">
         {lines.map((l, idx) => (
           <div
             key={idx}
+            data-diff-line
             style={
               l.type === "del"
                 ? { color: "var(--hue-err)", background: "color-mix(in oklch, var(--hue-err) 8%, transparent)" }
@@ -79,7 +137,18 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
             {l.text}
           </div>
         ))}
-      </pre>
+      </div>
+      {linesBelow > 0 && (
+        <>
+          <div
+            className="pointer-events-none sticky bottom-0 -mt-8 h-8 bg-linear-to-t from-(--surface-0) to-transparent"
+            aria-hidden
+          />
+          <div className="sticky bottom-0 bg-(--surface-0) px-3 pb-2 pt-0.5 text-center text-[10px] text-(--text-faint)">
+            {`${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add overflow detection to `SpecDiff` with a bottom fade and "N more lines below" hint when the diff exceeds `max-h-80`.
- Move the changed-line summary and Copy diff button into a sticky header inside the scroll container so it stays visible while scrolling.
- Add regression tests covering short diffs (no affordance), overflowing diffs (affordance shown), and sticky header classes.

## Test plan

- [x] `cd event-runtime/web && bun test` — 364 pass
- [x] Negative test: short diff hides affordance; tall diff shows "N more lines below"
- [x] UX critique: **SHIP** — sticky header + overflow affordance verified in live replan dialog (:7543). Follow-ups: WM-171 (line wrap), WM-172 (fade contrast), WM-173 (mobile proposals layout)

Fixes WM-146