### PR TITLE
fix(event-runtime): wrap lifecycle reasons and include them in the hover title (WM-145)

### DIFF
--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -145,3 +145,33 @@ describe("Lifecycle timeline (WM-136)", () => {
     expect(r.getByText("LEASED→")).toBeTruthy();
   });
 });
+
+describe("Lifecycle reason readability (WM-145)", () => {
+  const LONG_REASON =
+    "planner refused: the worker exceeded the attempt budget after waiting on a hung adapter handshake that never completed";
+
+  test("exposes a long lifecycle reason via title, not actor-only, and does not truncate it", () => {
+    const now = new Date().toISOString();
+    const lifecycle = [
+      createLifecycleEventFixture(1, "run_x", null, "QUEUED", null, now),
+      createLifecycleEventFixture(2, "run_x", "QUEUED", "FAILED", LONG_REASON, now),
+    ];
+    const d = createRunDetailFixture({ run: { state: "FAILED" } as RunDetail["run"], lifecycle });
+    const r = renderBlocks(d);
+
+    const failedRow = Array.from(r.container.querySelectorAll("li")).find((li) =>
+      li.textContent?.includes(LONG_REASON),
+    );
+    expect(failedRow).toBeTruthy();
+
+    const titled = Array.from(failedRow!.querySelectorAll("[title]")).filter((el) =>
+      (el.getAttribute("title") ?? "").includes(LONG_REASON),
+    );
+    expect(titled.length).toBeGreaterThan(0);
+
+    const truncated = Array.from(failedRow!.querySelectorAll(".truncate")).filter((el) =>
+      el.textContent?.includes(LONG_REASON),
+    );
+    expect(truncated.length).toBe(0);
+  });
+});

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -492,7 +492,7 @@ export function RunDetailBlocks({
                   )}
                   <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
                 </span>
-                <span className="flex min-w-0 flex-1 items-center gap-x-2">
+                <span className="flex min-w-0 flex-1 items-start gap-x-2">
                   {/* Fixed-width badge column, badge's own dot dropped in favor
                       of the rail's: with it, every actor started at whatever x
                       its state name happened to end at, and each row carried
@@ -505,7 +505,11 @@ export function RunDetailBlocks({
                     )}
                     <StateBadge state={e.to_state} dot={false} />
                   </span>
-                  <span className="min-w-0 truncate text-[11.5px] text-(--text-faint)" title={e.actor}>
+                  {/* WM-145: wrap the reason; title includes it, not actor alone. */}
+                  <span
+                    className="min-w-0 flex-1 break-words whitespace-pre-wrap text-[11.5px] leading-relaxed text-(--text-faint)"
+                    title={e.reason ? `${e.actor} · ${e.reason}` : e.actor}
+                  >
                     <ActorRef actor={e.actor} className="text-[11.5px]" />
                     {e.reason ? ` · ${e.reason}` : ""}
                   </span>


### PR DESCRIPTION
## Summary
- Lifecycle rows no longer CSS-truncate the reason; long planner/worker strings wrap (`break-words` / `whitespace-pre-wrap`).
- Hover `title` includes the full reason when present (actor · reason), not the actor alone.
- Attempt `reason_code` rows are unchanged.

## Test plan
- [x] Negative test first: long-reason title assertion failed on actor-only `title`.
- [x] `cd event-runtime/web && bun test` — 362 pass, 0 fail.

UX critique: skipped — isolated copy/readability (wrap + title); no new interaction, state transition, or layout of a user-completable flow.

Fixes WM-145