### PR TITLE
fix(event-runtime): display options label and focus management (WM-149)

### DIFF
--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -89,11 +89,13 @@ describe("DisplayOptions panel", () => {
     // Relative to whatever depth other test files leaked: only the delta is ours.
     const base = modal.depth;
     const r = render(<Harness />);
-    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    const trigger = r.getByRole("button", { name: /display/i });
+    fireEvent.click(trigger);
     expect(modal.depth).toBe(base + 1);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(r.queryByRole("dialog", { name: "Display options" })).toBeNull();
     expect(modal.depth).toBe(base);
+    expect(document.activeElement).toBe(trigger);
   });
 
   test("reset appears only once customized and restores defaults", () => {
@@ -104,6 +106,32 @@ describe("DisplayOptions panel", () => {
     fireEvent.change(r.getByLabelText("Group by"), { target: { value: "state" } });
     fireEvent.click(r.getByRole("button", { name: /reset/i }));
     expect(latest?.groupBy).toBe("none");
+  });
+
+  test("default sort option uses operator-facing label", () => {
+    const r = render(<Harness />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    const orderSelect = r.getByLabelText("Order by") as HTMLSelectElement;
+    const defaultOption = [...orderSelect.options].find((o) => o.value === "default");
+    expect(defaultOption?.textContent).toBe("Default order");
+    expect(defaultOption?.textContent).not.toBe("API order");
+  });
+
+  test("opening moves focus to the first interactive control", () => {
+    const r = render(<Harness />);
+    const trigger = r.getByRole("button", { name: /display/i });
+    fireEvent.click(trigger);
+    expect(document.activeElement).toBe(r.getByLabelText("Group by"));
+  });
+
+  test("outside-click dismiss restores focus to the Display trigger", () => {
+    const r = render(<Harness />);
+    const trigger = r.getByRole("button", { name: /display/i });
+    fireEvent.click(trigger);
+    expect(r.getByRole("dialog", { name: "Display options" })).toBeTruthy();
+    fireEvent.pointerDown(window, { target: document.body });
+    expect(r.queryByRole("dialog", { name: "Display options" })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 });
 

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -5,7 +5,7 @@
  * via `useDisplayOptions` and passes it down, so the panel never touches
  * storage and the table never re-derives what the panel showed.
  */
-import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode, type RefObject } from "react";
 import { modal } from "../hooks";
 import {
   DEFAULT_ORDER,
@@ -29,6 +29,7 @@ function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: stri
 
 function Select({
   id,
+  ref,
   value,
   onChange,
   options,
@@ -36,6 +37,7 @@ function Select({
   label,
 }: {
   id?: string;
+  ref?: RefObject<HTMLSelectElement | null>;
   value: string;
   onChange: (value: string) => void;
   options: { value: string; label: string }[];
@@ -44,6 +46,7 @@ function Select({
 }) {
   return (
     <select
+      ref={ref}
       id={id}
       value={value}
       disabled={disabled}
@@ -145,6 +148,7 @@ export function DisplayOptions<T>({
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const firstFocusRef = useRef<HTMLSelectElement>(null);
   const groupId = useId();
   const subId = useId();
   const orderId = useId();
@@ -161,7 +165,10 @@ export function DisplayOptions<T>({
       triggerRef.current?.focus();
     };
     const onPointer = (e: PointerEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     window.addEventListener("keydown", onKey, true);
     window.addEventListener("pointerdown", onPointer);
@@ -170,6 +177,10 @@ export function DisplayOptions<T>({
       window.removeEventListener("keydown", onKey, true);
       window.removeEventListener("pointerdown", onPointer);
     };
+  }, [open]);
+
+  useEffect(() => {
+    if (open) firstFocusRef.current?.focus();
   }, [open]);
 
   const customized = !isDefaultDisplayState(config, state);
@@ -209,6 +220,7 @@ export function DisplayOptions<T>({
           <OptionRow label="Grouping" htmlFor={groupId}>
             <Select
               id={groupId}
+              ref={firstFocusRef}
               label="Group by"
               value={state.groupBy}
               onChange={(groupBy) =>
@@ -257,7 +269,7 @@ export function DisplayOptions<T>({
                   }))
                 }
                 options={[
-                  { value: DEFAULT_ORDER, label: "API order" },
+                  { value: DEFAULT_ORDER, label: "Default order" },
                   ...config.sorts.map((f) => ({ value: f.key, label: f.label })),
                 ]}
               />


### PR DESCRIPTION
## Summary

- Rename default sort option from "API order" to operator-facing "Default order"
- Move focus to the Group by select when the Display panel opens
- Restore focus to the Display trigger on outside-click dismiss (matching Escape behavior)

## Test plan

- [x] `cd event-runtime/web && bun test` — 364 pass
- [x] New tests: label, focus-on-open, outside-click focus restore, Escape focus restore

UX critique: required — NOT-ASSESSED (browser MCP unavailable); in-scope F-1 (Escape focus assertion) resolved in tests. Manual keyboard check recommended on Runs/Events Display popover.

Fixes WM-149