### PR TITLE
fix(web): show VerbError in RunFull cancel dialog (WM-144)

### DIFF
--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -1,0 +1,67 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { ApiError } from "../api";
+import { RunFull } from "./RunFull";
+import {
+  createRunDetailFixture,
+  createRunListItemFixture,
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
+import type { RunDetail } from "../types";
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+});
+
+const noop = () => {};
+const CANCEL_409 = "illegal transition CANCELLED → CANCELLED";
+
+function renderRunFull(runId: string) {
+  return renderWithClient(
+    <RunFull
+      runId={runId}
+      connected={true}
+      onBack={noop}
+      onJumpAgent={noop}
+      onJumpEvent={noop}
+    />,
+  );
+}
+
+describe("RunFull cancel dialog (WM-144)", () => {
+  test("a simulated 409 on cancel shows a persistent inline message in the dialog", async () => {
+    const runId = "run_cancel_race";
+    const detail = createRunDetailFixture({ run: { runId, state: "RUNNING" } as RunDetail["run"] });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({ runs: [createRunListItemFixture({ runId, state: "RUNNING" })] }),
+        cancel: async () => {
+          throw new ApiError(CANCEL_409, 409);
+        },
+      },
+      async () => {
+        const { getByRole, getByText } = renderRunFull(runId);
+
+        await waitFor(() => getByText("Cancel"));
+        fireEvent.click(getByText("Cancel"));
+
+        const dialog = getByRole("dialog");
+        expect(dialog.textContent).toContain(`Cancel ${runId}?`);
+        expect(within(dialog).queryByText(CANCEL_409)).toBeNull();
+
+        fireEvent.click(within(dialog).getByRole("button", { name: "Cancel run" }));
+
+        await waitFor(() => {
+          expect(within(dialog).getByText(CANCEL_409)).toBeTruthy();
+        });
+        // Dialog stays open so the race is explained inline, not only as a toast.
+        expect(getByRole("dialog")).toBeTruthy();
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -228,6 +228,7 @@ export function RunFull({
               ? "The running attempt is stopped with TERM, then KILL, and terminates as cancelled."
               : "The run is cancelled before execution; the operator is recorded as actor."}
           </div>
+          <VerbError error={cancel.error} />
           <input
             value={cancelReason}
             onChange={(e) => setCancelReason(e.target.value)}


### PR DESCRIPTION
## Summary
- RunFull's cancel dialog now renders `VerbError` for `cancel.error`, matching the Runs panel, so a 409/404 race stays as a persistent inline explanation in the dialog.
- Negative test first: a simulated 409 on cancel from RunFull asserts the message appears inside the dialog (not only a toast). Observed failing before the one-line fix, then passing.

## Test plan
- [x] `cd event-runtime/web && bun test` — 362 pass, 0 fail
- [x] Negative test observed failing against the unfixed dialog, then passing

UX critique: required — NOT-ASSESSED (factory-ux-critic had no browser MCP in this Cursor session; unit test covers the 409 inline path). New evidence on OPS-391; --here port collision filed as OPS-519.

Fixes WM-144