### PR TITLE
fix(event-runtime): RunTrace a11y chrome, tablist keys, search x (WM-143)

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -133,4 +133,33 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(onCancelShortcut).toHaveBeenCalledTimes(1);
     expect(search.value).toBe("too");
   });
+
+  test("x on search of a COMPLETED run types the letter — cancel does not apply", async () => {
+    const r = renderTrace({ state: "COMPLETED" });
+    await waitForChrome(r);
+
+    const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+    search.focus();
+    fireEvent.keyDown(search, { key: "x" });
+    expect(document.activeElement).toBe(search);
+  });
+
+  test("x on search of a RUNNING run with no callback redispatches on a non-input target", async () => {
+    const seen: EventTarget[] = [];
+    const onWin = (e: KeyboardEvent) => {
+      if (e.key === "x") seen.push(e.target as EventTarget);
+    };
+    window.addEventListener("keydown", onWin);
+    try {
+      const r = renderTrace();
+      await waitForChrome(r);
+      const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+      search.focus();
+      fireEvent.keyDown(search, { key: "x" });
+      expect(document.activeElement).not.toBe(search);
+      expect(seen.some((t) => t instanceof HTMLElement && !t.closest("input"))).toBe(true);
+    } finally {
+      window.removeEventListener("keydown", onWin);
+    }
+  });
 });

--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -1,0 +1,136 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { TraceEntry } from "../types";
+import { changeInput, renderWithClient, restoreApi } from "../test-render";
+import { RunTrace } from "./RunTrace";
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+});
+
+const NOW = new Date().toISOString();
+
+function entry(seq: number, kind: string, payload: TraceEntry["payload"]): TraceEntry {
+  return { seq, attempt: 1, ts: NOW, kind, payload };
+}
+
+const TRACE: TraceEntry[] = [
+  entry(1, "tool_use", { name: "Read", input: { path: "AGENTS.md" } }),
+  entry(2, "tool_result", { content: "denied", isError: true }),
+  entry(3, "assistant_text", { text: "checking the file" }),
+  entry(4, "usage", {
+    usage: { input_tokens: 12, output_tokens: 34 },
+    costUSD: 0.0123,
+  }),
+];
+
+function renderTrace(overrides?: { onCancelShortcut?: () => void; state?: "RUNNING" | "COMPLETED" }) {
+  return renderWithClient(
+    <RunTrace
+      runId="run_trace_a11y"
+      state={overrides?.state ?? "RUNNING"}
+      variant="full"
+      onCancelShortcut={overrides?.onCancelShortcut}
+    />,
+    {
+      apiMocks: {
+        trace: async () => ({ head: TRACE[TRACE.length - 1].seq, entries: TRACE }),
+      },
+    },
+  );
+}
+
+async function waitForChrome(r: ReturnType<typeof renderTrace>) {
+  await waitFor(() => {
+    expect(r.getByRole("tablist", { name: "Trace kind" })).toBeTruthy();
+  });
+  return r.getByRole("tablist", { name: "Trace kind" });
+}
+
+describe("RunTrace a11y (WM-143)", () => {
+  test("renders no emoji in trace chrome (tools, tokens, errors, jump, clear)", async () => {
+    const r = renderTrace();
+    const tablist = await waitForChrome(r);
+
+    expect(r.getByText("tool · Read")).toBeTruthy();
+    expect(r.getByText(/12 in · 34 out/)).toBeTruthy();
+    const errorJump = r.getByRole("button", { name: /1 error/ });
+    expect(errorJump).toBeTruthy();
+
+    const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+    act(() => {
+      changeInput(search, "Read");
+    });
+    const clear = r.getByRole("button", { name: "Clear search" });
+    expect(clear).toBeTruthy();
+
+    const scroller = r.container.querySelector("[data-trace-idx]")?.parentElement as HTMLElement;
+    Object.defineProperty(scroller, "scrollHeight", { value: 400, configurable: true });
+    Object.defineProperty(scroller, "clientHeight", { value: 100, configurable: true });
+    Object.defineProperty(scroller, "scrollTop", { value: 0, configurable: true });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    const jump = await waitFor(() => r.getByRole("button", { name: /Jump to latest/ }));
+
+    const chrome = [tablist, errorJump, clear, jump, r.getByText(/12 in · 34 out/).parentElement!];
+    for (const el of chrome) {
+      expect(el.textContent ?? "").not.toMatch(/🔧|🔥|⚠️|⬇|✕/);
+      expect(el.textContent ?? "").not.toMatch(/\p{Extended_Pictographic}/u);
+    }
+    expect(r.container.textContent ?? "").not.toMatch(/🔧|🔥|⚠️|⬇|✕/);
+  });
+
+  test("filter chips are a tablist; Left/Right/Home/End move the selected kind", async () => {
+    const r = renderTrace();
+    const tablist = await waitForChrome(r);
+    const tabs = r.getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent?.replace(/\d+$/, "").trim())).toEqual([
+      "All",
+      "Tools",
+      "Reasoning",
+      "Errors",
+      "Usage",
+    ]);
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+
+    tabs[0].focus();
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(r.getByRole("tab", { name: /^Tools/ }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(r.getByRole("tab", { name: /^Reasoning/ }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(tablist, { key: "End" });
+    expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(tablist, { key: "Home" });
+    expect(r.getByRole("tab", { name: /^All/ }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+    expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
+  });
+
+  test("x on the trace search input calls onCancelShortcut; j/k/slash stay typing", async () => {
+    const onCancelShortcut = mock(() => {});
+    const r = renderTrace({ onCancelShortcut });
+    await waitForChrome(r);
+
+    const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+    search.focus();
+    act(() => {
+      changeInput(search, "too");
+    });
+
+    fireEvent.keyDown(search, { key: "j" });
+    fireEvent.keyDown(search, { key: "k" });
+    fireEvent.keyDown(search, { key: "/" });
+    expect(onCancelShortcut).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(search, { key: "x" });
+    expect(onCancelShortcut).toHaveBeenCalledTimes(1);
+    expect(search.value).toBe("too");
+  });
+});

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Fragment, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import type { RunState, TraceEntry, TracePayload } from "../types";
+import { isCancellable } from "./RunDetailBlocks";
 import { humanSize, JsonBlock, Section, notify } from "./ui";
 
 function copyText(text: string, label: string = "text") {
@@ -649,6 +650,7 @@ export function RunTrace({
 
   const onSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "x" || e.metaKey || e.ctrlKey || e.altKey) return;
+    if (!isCancellable(state)) return;
     e.preventDefault();
     e.stopPropagation();
     if (onCancelShortcut) {

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Fragment, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import type { RunState, TraceEntry, TracePayload } from "../types";
 import { humanSize, JsonBlock, Section, notify } from "./ui";
@@ -407,7 +407,7 @@ function TraceBody({
     return (
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
-          <span className="mono">🔧 {p.name ?? "unknown tool"}</span>
+          <span className="mono">tool · {p.name ?? "unknown tool"}</span>
           {durationMs != null && maxMs != null && <TimingWaterfall durationMs={durationMs} maxMs={maxMs} />}
         </div>
         {p.input !== undefined && (
@@ -477,6 +477,12 @@ const isErrorKind = (e: TraceEntry) =>
   (e.kind === "lifecycle" && e.payload?.note === "trace_truncated");
 const isUsageKind = (k: string) => k === "usage";
 
+const FILTER_ORDER: TraceFilterKind[] = ["all", "tools", "reasoning", "errors", "usage"];
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
+}
+
 /**
  * Trace (webui doc §10.10, §10.11, controls OPS-358) — the factory.trace/v1 stream:
  * what the model is saying and which tools it is calling, live while the run
@@ -493,11 +499,14 @@ export function RunTrace({
   state,
   variant = "panel",
   onExpand,
+  onCancelShortcut,
 }: {
   runId: string;
   state: RunState;
   variant?: "panel" | "full";
   onExpand?: () => void;
+  /** Opens the parent's cancel confirm. Search `x` calls this instead of typing. */
+  onCancelShortcut?: () => void;
 }) {
   const full = variant === "full";
   const live = LIVE_STATES.includes(state);
@@ -612,6 +621,43 @@ export function RunTrace({
   }, [shown, search]);
 
   const scroller = useRef<HTMLDivElement>(null);
+  const regionRef = useRef<HTMLDivElement>(null);
+
+  const onTraceRegionKeyDown = (e: ReactKeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTypingTarget(e.target)) return;
+    const i = FILTER_ORDER.indexOf(filter);
+    if (i < 0) return;
+    let next: TraceFilterKind | null = null;
+    if (e.key === "ArrowRight") next = FILTER_ORDER[(i + 1) % FILTER_ORDER.length];
+    else if (e.key === "ArrowLeft") next = FILTER_ORDER[(i - 1 + FILTER_ORDER.length) % FILTER_ORDER.length];
+    else if (e.key === "Home") next = FILTER_ORDER[0];
+    else if (e.key === "End") next = FILTER_ORDER[FILTER_ORDER.length - 1];
+    if (!next || next === filter) {
+      if (next === filter) e.preventDefault();
+      return;
+    }
+    e.preventDefault();
+    setFilter(next);
+    if ((e.target as HTMLElement).closest('[role="tab"]')) {
+      const key = next;
+      queueMicrotask(() => {
+        regionRef.current?.querySelector<HTMLElement>(`[role="tab"][data-filter="${key}"]`)?.focus();
+      });
+    }
+  };
+
+  const onSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "x" || e.metaKey || e.ctrlKey || e.altKey) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (onCancelShortcut) {
+      onCancelShortcut();
+      return;
+    }
+    e.currentTarget.blur();
+    document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "x", bubbles: true }));
+  };
 
   // Jump to active search match:
   useEffect(() => {
@@ -700,7 +746,7 @@ export function RunTrace({
   ];
 
   const body = (
-    <>
+    <div ref={regionRef} onKeyDown={onTraceRegionKeyDown}>
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         {live ? (
           <div className="flex items-center gap-2">
@@ -737,7 +783,7 @@ export function RunTrace({
 
         {tokenStats.hasTokens && (
           <div className="flex items-center gap-1.5 rounded bg-(--surface-1) border border-(--border) px-2 py-0.5 text-[10.5px] mono text-(--text-dim)">
-            <span title="Cumulative token burn across trace">🔥 {tokenStats.promptTokens.toLocaleString()} in · {tokenStats.completionTokens.toLocaleString()} out</span>
+            <span title="Cumulative token burn across trace">{tokenStats.promptTokens.toLocaleString()} in · {tokenStats.completionTokens.toLocaleString()} out</span>
             {tokenStats.totalCost > 0 && <span className="text-(--text-faint)">(${tokenStats.totalCost.toFixed(4)})</span>}
           </div>
         )}
@@ -745,11 +791,15 @@ export function RunTrace({
 
       {entries.length > 0 && (
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-          <div className="flex flex-wrap gap-1">
+          <div className="flex flex-wrap gap-1" role="tablist" aria-label="Trace kind">
             {filterTabs.map((t) => (
               <button
                 key={t.key}
                 type="button"
+                role="tab"
+                data-filter={t.key}
+                aria-selected={filter === t.key}
+                tabIndex={filter === t.key ? 0 : -1}
                 onClick={() => setFilter(t.key)}
                 className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
                   filter === t.key
@@ -777,7 +827,6 @@ export function RunTrace({
                 }}
                 title="Jump to next error entry"
               >
-                <span>⚠️</span>
                 <span>{counts.errors === 1 ? "1 error" : `${counts.errors} errors`}</span>
                 {activeErrorIdx !== null && (
                   <span className="mono text-[10px] opacity-75">
@@ -794,7 +843,9 @@ export function RunTrace({
                   setSearch(e.target.value);
                   setActiveMatch(0);
                 }}
+                onKeyDown={onSearchKeyDown}
                 placeholder="Search trace…"
+                aria-label="Search trace"
                 className="w-24 bg-transparent outline-none text-(--text) placeholder:text-(--text-faint) sm:w-32"
               />
               {search && (
@@ -809,16 +860,18 @@ export function RunTrace({
                         onClick={() => setActiveMatch((m) => (m - 1 + searchMatches.length) % searchMatches.length)}
                         className="text-(--text-faint) hover:text-(--text)"
                         title="Previous match"
+                        aria-label="Previous match"
                       >
-                        ↑
+                        <span aria-hidden="true">↑</span>
                       </button>
                       <button
                         type="button"
                         onClick={() => setActiveMatch((m) => (m + 1) % searchMatches.length)}
                         className="text-(--text-faint) hover:text-(--text)"
                         title="Next match"
+                        aria-label="Next match"
                       >
-                        ↓
+                        <span aria-hidden="true">↓</span>
                       </button>
                     </>
                   )}
@@ -826,8 +879,10 @@ export function RunTrace({
                     type="button"
                     onClick={() => setSearch("")}
                     className="text-(--text-faint) hover:text-(--text)"
+                    title="Clear search"
+                    aria-label="Clear search"
                   >
-                    ✕
+                    <span aria-hidden="true">×</span>
                   </button>
                 </>
               )}
@@ -916,7 +971,6 @@ export function RunTrace({
                 onClick={jumpToLatest}
                 className="flex items-center gap-1.5 rounded-full bg-(--accent) px-3 py-1 text-[11px] font-medium text-white shadow-lg transition-transform hover:scale-105 active:scale-95"
               >
-                <span>⬇</span>
                 <span>
                   {unreadCount > 0
                     ? `New activity (${unreadCount}) — Jump to latest`
@@ -941,7 +995,7 @@ export function RunTrace({
           )}
         </div>
       )}
-    </>
+    </div>
   );
 
   if (full) {


### PR DESCRIPTION
## Summary
- Replace banned RunTrace emoji with words and approved glyphs (`tool · name`, token counts, error-jump, jump-to-latest, `×` clear-search).
- Kind filter chips are a `tablist` with Left/Right/Home/End while focus is in the trace region (search field stays typing).
- Search `x` calls optional `onCancelShortcut`, or blurs and re-dispatches `x` so RunFull/Runs cancel still opens without editing `hooks.ts`.

## Test plan
- [x] Negative tests observed failing, then `cd event-runtime/web && bun test` — 364 pass, 0 fail
- [ ] Keyboard: tab to kind chips, Left/Right/Home/End cycle filters
- [ ] Focus Search trace, type `j`/`k`/`/`, then `x` on a RUNNING run — cancel confirm opens
- [ ] Confirm no 🔧 🔥 ⚠️ ⬇ ✕ in trace chrome

UX critique: required — NOT-ASSESSED (browser MCP unavailable to the critic subagent; web UI was up at the worktree ports)

Fixes WM-143