### PR TITLE
fix(web): gate schedule Run now on connected and set aria-selected (WM-156)

### DIFF
--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -1,9 +1,11 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Schedules, scheduleFilterTokens, type ScheduleItem } from "./Schedules";
 import { api } from "../api";
+import { useContextActions } from "../palette";
 
 afterEach(() => {
   cleanup();
@@ -71,18 +73,55 @@ afterEach(() => {
   api.events = origEvents;
 });
 
-function renderSchedules() {
-  return renderWithClient(
-    <Schedules
-      context={{ kind: "all" }}
-      focusScheduleLoop={null}
-      onSelectSchedule={noop}
-      onJumpProposal={noop}
-      onJumpRun={noop}
-      onJumpEvent={noop}
-      onJumpAgent={noop}
-    />,
-  );
+function scheduleViewProps(
+  overrides: Partial<{
+    connected: boolean;
+    focusScheduleLoop: string | null;
+    onSelectSchedule: (loop: string | null) => void;
+  }> = {},
+) {
+  return {
+    context: { kind: "all" as const },
+    focusScheduleLoop: null as string | null,
+    onSelectSchedule: noop,
+    onJumpProposal: noop,
+    onJumpRun: noop,
+    onJumpEvent: noop,
+    onJumpAgent: noop,
+    ...overrides,
+  };
+}
+
+function renderSchedules(
+  overrides: Partial<{
+    connected: boolean;
+    focusScheduleLoop: string | null;
+    onSelectSchedule: (loop: string | null) => void;
+  }> = {},
+) {
+  return renderWithClient(<Schedules {...scheduleViewProps(overrides)} />);
+}
+
+function StatefulSchedules({
+  connected,
+  initialLoop = null,
+}: {
+  connected?: boolean;
+  initialLoop?: string | null;
+}) {
+  const [loop, setLoop] = useState<string | null>(initialLoop);
+  return <Schedules {...scheduleViewProps({ connected, focusScheduleLoop: loop, onSelectSchedule: setLoop })} />;
+}
+
+function PaletteProbe() {
+  const actions = useContextActions();
+  return <div data-testid="palette-probe">{actions.map((a) => a.label).join(" | ")}</div>;
+}
+
+function pressKey(key: string) {
+  act(() => {
+    document.body.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
 }
 
 describe("Schedules enabled/state wording (WM-101)", () => {
@@ -164,5 +203,109 @@ describe("Schedules enabled/state wording (WM-101)", () => {
     }
     // error wins the state token
     expect(scheduleFilterTokens(schedule({ loop: "l", error: "bad cadence" }))).toContain("error");
+  });
+});
+
+describe("Schedules connected gating (WM-156)", () => {
+  test("list and detail Run now buttons are disabled when connected={false}", async () => {
+    const { getAllByRole } = renderSchedules({
+      connected: false,
+      focusScheduleLoop: "loop-enabled-running",
+    });
+
+    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(1));
+
+    for (const btn of getAllByRole("button", { name: "Run now…" })) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+
+  test("keyboard r does not open confirm when disconnected", async () => {
+    const { getAllByRole, queryByRole, queryByText } = renderWithClient(
+      <StatefulSchedules connected={false} initialLoop="loop-enabled-running" />,
+    );
+
+    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    pressKey("r");
+
+    expect(queryByRole("button", { name: "Trigger Run" }) === null).toBe(true);
+    expect(queryByText(/Run schedule/) === null).toBe(true);
+  });
+
+  test("palette omits Run now when disconnected", async () => {
+    const { getAllByRole, getByTestId } = renderWithClient(
+      <>
+        <StatefulSchedules connected={false} initialLoop="loop-enabled-running" />
+        <PaletteProbe />
+      </>,
+    );
+
+    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    await waitFor(() => expect(getByTestId("palette-probe").textContent).toContain("Copy loop-enabled-running"));
+
+    const labels = getByTestId("palette-probe").textContent ?? "";
+    expect(labels).not.toMatch(/Run .* now/);
+  });
+
+  test("confirm primary stays disabled after connection drops", async () => {
+    function ConfirmThenDisconnect() {
+      const [connected, setConnected] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setConnected(false)}>
+            simulate-disconnect
+          </button>
+          <StatefulSchedules connected={connected} initialLoop="loop-enabled-running" />
+        </>
+      );
+    }
+
+    const { getByText, getByRole, getAllByRole } = renderWithClient(<ConfirmThenDisconnect />);
+
+    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    fireEvent.click(getAllByRole("button", { name: "Run now…" })[0]!);
+    await waitFor(() => getByRole("button", { name: "Trigger Run" }));
+
+    expect((getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(getByText("simulate-disconnect"));
+
+    expect((getByRole("button", { name: "Trigger Run" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("Run now buttons are enabled when connected={true}", async () => {
+    const { getAllByRole } = renderSchedules({
+      connected: true,
+      focusScheduleLoop: "loop-enabled-running",
+    });
+
+    await waitFor(() => expect(getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(1));
+
+    for (const btn of getAllByRole("button", { name: "Run now…" })) {
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+    }
+  });
+});
+
+describe("Schedules aria-selected (WM-156)", () => {
+  test("selected row has aria-selected=true; others false; updates on click and j/k", async () => {
+    const { getByText, container } = renderWithClient(<StatefulSchedules connected={true} />);
+
+    await waitFor(() => getByText("loop-enabled-running"));
+
+    const dataRows = () => [...container.querySelectorAll("tbody tr")];
+    expect(dataRows().every((row) => row.getAttribute("aria-selected") === "false")).toBe(true);
+
+    fireEvent.click(getByText("loop-enabled-running"));
+    expect(dataRows()[0]!.getAttribute("aria-selected")).toBe("true");
+    expect(dataRows().slice(1).every((row) => row.getAttribute("aria-selected") === "false")).toBe(true);
+
+    pressKey("j");
+    expect(dataRows()[0]!.getAttribute("aria-selected")).toBe("false");
+    expect(dataRows()[1]!.getAttribute("aria-selected")).toBe("true");
+
+    pressKey("k");
+    expect(dataRows()[0]!.getAttribute("aria-selected")).toBe("true");
+    expect(dataRows()[1]!.getAttribute("aria-selected")).toBe("false");
   });
 });

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -49,6 +49,7 @@ export function scheduleFilterTokens(s: ScheduleItem): string[] {
  * next due countdown, and stopped clocks, with an ad-hoc trigger modal.
  */
 export function Schedules({
+  connected,
   context,
   focusScheduleLoop,
   onSelectSchedule,
@@ -161,7 +162,7 @@ export function Schedules({
     },
     keys: {
       c: () => sel && copyText(sel.loop, "schedule loop"),
-      r: () => sel && setConfirmLoop(sel),
+      r: () => sel && connected !== false && setConfirmLoop(sel),
     },
   });
 
@@ -169,14 +170,18 @@ export function Schedules({
     if (!sel) {
       setContextActions([]);
     } else {
-      setContextActions([
-        { label: `Run ${sel.loop} now…`, hint: "r", run: () => setConfirmLoop(sel) },
+      const copy = [
         { label: `Copy ${sel.loop}`, hint: "c", run: () => copyText(sel.loop, "schedule loop") },
         { label: "Copy link to this schedule", run: copyLink },
-      ]);
+      ];
+      setContextActions(
+        connected === false
+          ? copy
+          : [{ label: `Run ${sel.loop} now…`, hint: "r", run: () => setConfirmLoop(sel) }, ...copy],
+      );
     }
     return () => setContextActions([]);
-  }, [sel]);
+  }, [sel, connected]);
 
   return (
     <div className="flex h-full min-w-0">
@@ -228,6 +233,7 @@ export function Schedules({
                 <tr
                   key={s.loop}
                   onClick={() => onSelectSchedule(s.loop)}
+                  aria-selected={isSel}
                   className={`cursor-pointer border-b border-(--border) text-[13px] hover:bg-(--surface-2) ${
                     isSel ? "row-selected bg-(--surface-3)" : ""
                   }`}
@@ -331,6 +337,7 @@ export function Schedules({
                   </td>
                   <td className="border-b border-(--border) px-3 py-2 text-right">
                     <Button
+                      disabled={connected === false}
                       onClick={() => setConfirmLoop(s)}
                     >
                       Run now…
@@ -381,7 +388,11 @@ export function Schedules({
           }
           actions={
             <>
-              <Button variant="primary" onClick={() => setConfirmLoop(sel)}>
+              <Button
+                variant="primary"
+                disabled={connected === false}
+                onClick={() => setConfirmLoop(sel)}
+              >
                 Run now…
               </Button>
               <Button onClick={() => copyText(sel.loop, "schedule loop")}>Copy loop</Button>
@@ -676,7 +687,7 @@ export function Schedules({
               </Button>
               <Button
                 variant="primary"
-                disabled={triggerMut.isPending}
+                disabled={triggerMut.isPending || connected === false}
                 onClick={() => triggerMut.mutate(confirmLoop.loop)}
               >
                 {triggerMut.isPending ? "Triggering…" : "Trigger Run"}


### PR DESCRIPTION
## Summary
- Disable list/detail **Run now…**, keyboard `r`, and the palette “Run … now” verb when `connected === false`; keep the confirm primary disabled if the dialog is already open.
- Set `aria-selected` on schedule rows so selection is exposed the same way as Workers/Agents/Projects, including click and `j`/`k`.

## Test plan
- [x] `cd event-runtime/web && bun test` — 367 pass, 0 fail
- [x] Negative tests observed failing before the view change (disconnected buttons, `r`, palette, confirm primary, missing `aria-selected`)

UX critique: required — NOT-ASSESSED (factory-ux-critic had no browser MCP in this session; `cursor-ide-browser` absent). Same shape as OPS-391.

Fixes WM-156