### PR TITLE
fix(web): command palette modal guard, focus trap, search ring (WM-150)

### DIFF
--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -57,7 +57,7 @@ function appendExtra(dialog: HTMLElement): HTMLButtonElement {
 
 beforeEach(() => {
   modal.depth = 0;
-  globalThis.fetch = (async () =>
+  globalThis.fetch = (async (_input: RequestInfo | URL) =>
     jsonResponse({
       runs: [],
       proposals: [],

--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -1,0 +1,163 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { modal } from "../hooks";
+import { CommandPalette, type PaletteAction } from "./CommandPalette";
+
+const ACTIONS: PaletteAction[] = [
+  { label: "Overview", hint: "g g", group: "Go", run: () => {} },
+  { label: "Copy id", hint: "c", run: () => {} },
+];
+
+const NOOP = () => {};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const realFetch = globalThis.fetch;
+
+function renderPalette(actions: PaletteAction[] = ACTIONS) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <button type="button" data-testid="outside">
+        nav
+      </button>
+      <CommandPalette
+        actions={actions}
+        onJumpRun={NOOP}
+        onJumpProposal={NOOP}
+        onJumpEvent={NOOP}
+        onJumpAgent={NOOP}
+        onJumpWorker={NOOP}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function chordK() {
+  fireEvent.keyDown(window, { key: "k", metaKey: true });
+}
+
+function appendExtra(dialog: HTMLElement): HTMLButtonElement {
+  const extra = document.createElement("button");
+  extra.type = "button";
+  extra.dataset.testid = "extra";
+  extra.textContent = "extra";
+  dialog.appendChild(extra);
+  return extra;
+}
+
+beforeEach(() => {
+  modal.depth = 0;
+  globalThis.fetch = (async () =>
+    jsonResponse({
+      runs: [],
+      proposals: [],
+      events: [],
+      agents: [],
+      workers: [],
+      repos: [],
+    })) as typeof fetch;
+});
+
+afterEach(() => {
+  modal.depth = 0;
+  globalThis.fetch = realFetch;
+  cleanup();
+});
+
+describe("CommandPalette", () => {
+  test("⌘K does not open while another modal owns the stack", () => {
+    const r = renderPalette();
+    modal.depth = 1;
+    chordK();
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+  });
+
+  test("⌘K still closes the palette when it is already open", () => {
+    const r = renderPalette();
+    chordK();
+    expect(r.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
+    expect(modal.depth).toBe(1);
+    chordK();
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(modal.depth).toBe(0);
+  });
+
+  test("opening focuses the search input", () => {
+    const r = renderPalette();
+    chordK();
+    expect(document.activeElement).toBe(r.getByPlaceholderText("Type a command…"));
+  });
+
+  test("Tab from the last control wraps to the first inside the panel", () => {
+    const r = renderPalette();
+    chordK();
+    const dialog = r.getByRole("dialog", { name: "Command palette" });
+    const input = r.getByPlaceholderText("Type a command…");
+    const extra = appendExtra(dialog);
+    extra.focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(input);
+  });
+
+  test("Shift+Tab from the first control wraps to the last inside the panel", () => {
+    const r = renderPalette();
+    chordK();
+    const dialog = r.getByRole("dialog", { name: "Command palette" });
+    const input = r.getByPlaceholderText("Type a command…");
+    const extra = appendExtra(dialog);
+    input.focus();
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(extra);
+  });
+
+  test("closing via Escape restores focus to the previously focused element", () => {
+    const r = renderPalette();
+    const outside = r.getByTestId("outside");
+    outside.focus();
+    chordK();
+    expect(r.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  test("closing via backdrop restores focus to the previously focused element", () => {
+    const r = renderPalette();
+    const outside = r.getByTestId("outside");
+    outside.focus();
+    chordK();
+    fireEvent.mouseDown(r.getByTestId("palette-overlay"));
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  test("selecting an item restores focus to the previously focused element", () => {
+    let ran = false;
+    const r = renderPalette([{ label: "Overview", group: "Go", run: () => { ran = true; } }]);
+    const outside = r.getByTestId("outside");
+    outside.focus();
+    chordK();
+    fireEvent.click(r.getByText("Overview"));
+    expect(ran).toBe(true);
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  test("search input uses an accent focus border and no outline", () => {
+    const r = renderPalette();
+    chordK();
+    const classes = r.getByPlaceholderText("Type a command…").className.split(/\s+/);
+    expect(classes).toContain("outline-none");
+    expect(classes).toContain("focus:border-(--accent)");
+  });
+});

--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -30,6 +30,7 @@ function renderPalette(actions: PaletteAction[] = ACTIONS) {
       <button type="button" data-testid="outside">
         nav
       </button>
+      <input data-testid="view-filter" data-view-filter />
       <CommandPalette
         actions={actions}
         onJumpRun={NOOP}
@@ -151,6 +152,22 @@ describe("CommandPalette", () => {
     expect(ran).toBe(true);
     expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
     expect(document.activeElement).toBe(outside);
+  });
+
+  test("selecting an item that focuses another element keeps that focus", () => {
+    const r = renderPalette([
+      {
+        label: "Focus filter",
+        run: () => {
+          document.querySelector<HTMLElement>("[data-view-filter]")?.focus();
+        },
+      },
+    ]);
+    r.getByTestId("outside").focus();
+    chordK();
+    fireEvent.click(r.getByText("Focus filter"));
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(document.activeElement).toBe(r.getByTestId("view-filter"));
   });
 
   test("search input uses an accent focus border and no outline", () => {

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -114,6 +114,10 @@ export function CommandPalette({
     return () => {
       modal.depth -= 1;
       window.removeEventListener("keydown", onKey);
+      const active = document.activeElement;
+      const claimed =
+        active instanceof HTMLElement && active !== document.body && active.isConnected;
+      if (claimed) return;
       const previous = previousFocusRef.current;
       if (previous && (previous.isConnected ?? document.contains(previous))) {
         try {

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -1,11 +1,37 @@
 import { useQuery } from "@tanstack/react-query";
 import { Command } from "cmdk";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { GO_CHORD_MS, goPrefix, goSequence } from "../goSequence";
 import { keyGuard, modal } from "../hooks";
 import { useContextActions } from "../palette";
 import { health } from "../workerHealth";
+
+const FOCUSABLE =
+  "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+function tabCycle(root: HTMLElement, e: KeyboardEvent) {
+  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
+    (el) => el.offsetParent !== null || el === document.activeElement,
+  );
+  if (nodes.length === 0) {
+    e.preventDefault();
+    root.focus();
+    return;
+  }
+  const first = nodes[0];
+  const last = nodes[nodes.length - 1];
+  const active = document.activeElement;
+  if (e.shiftKey) {
+    if (active === first || !root.contains(active)) {
+      e.preventDefault();
+      last.focus();
+    }
+  } else if (active === last || !root.contains(active)) {
+    e.preventDefault();
+    first.focus();
+  }
+}
 
 export interface PaletteAction {
   label: string;
@@ -33,7 +59,19 @@ export function CommandPalette({
   onJumpProject?: (name: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
   const contextActions = useContextActions();
+
+  // Capture the trigger before autoFocus moves into the search box. CommandPalette
+  // stays mounted while closed, so Dialog's mount/unmount useFocusReturn would
+  // restore on the wrong lifetime.
+  if (open && !wasOpenRef.current) {
+    const active = document.activeElement;
+    previousFocusRef.current = active instanceof HTMLElement ? active : null;
+  }
+  wasOpenRef.current = open;
 
   // Jump targets load only while the palette is open; cache keys shared with
   // the views, so this is usually a cache hit, not a request.
@@ -50,10 +88,13 @@ export function CommandPalette({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen((o) => !o);
-      }
+      if (e.key !== "k" || !(e.metaKey || e.ctrlKey)) return;
+      e.preventDefault();
+      setOpen((o) => {
+        if (o) return false;
+        if (modal.depth > 0) return false;
+        return true;
+      });
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -64,17 +105,30 @@ export function CommandPalette({
     modal.depth += 1;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
+      else if (e.key === "Tab" && panelRef.current) tabCycle(panelRef.current, e);
     };
     window.addEventListener("keydown", onKey);
+    const root = panelRef.current;
+    const input = root?.querySelector<HTMLElement>("input");
+    (input ?? root)?.focus();
     return () => {
       modal.depth -= 1;
       window.removeEventListener("keydown", onKey);
+      const previous = previousFocusRef.current;
+      if (previous && (previous.isConnected ?? document.contains(previous))) {
+        try {
+          previous.focus();
+        } catch {
+          // detached or unfocusable
+        }
+      }
     };
   }, [open]);
 
   if (!open) return null;
   return (
     <div
+      data-testid="palette-overlay"
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[16vh]"
       onMouseDown={(e) => e.target === e.currentTarget && setOpen(false)}
     >
@@ -83,11 +137,17 @@ export function CommandPalette({
         loop
         label="Command palette"
       >
-        <div role="dialog" aria-modal="true" aria-label="Command palette">
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Command palette"
+          tabIndex={-1}
+        >
         <Command.Input
           autoFocus
           placeholder="Type a command…"
-          className="w-full border-b border-(--border) bg-transparent px-4 py-3 text-[14px] text-(--text) outline-none placeholder:text-(--text-faint)"
+          className="w-full border-b border-(--border) bg-transparent px-4 py-3 text-[14px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
         />
         <Command.List className="max-h-72 overflow-auto p-1.5">
           <Command.Empty className="px-3 py-6 text-center text-(--text-faint)">


### PR DESCRIPTION
## Summary
- ⌘K no longer opens the command palette while another modal owns `modal.depth`; toggle-close still works when the palette is already open.
- Focus trap and focus return live in `CommandPalette` (it stays mounted while closed, so Dialog's mount/unmount hook is the wrong lifetime). Tab/Shift+Tab stay in the panel; Escape, backdrop, and item select restore the previous control.
- Search input keeps `outline-none` and adds `focus:border-(--accent)` to match list filters.

## Test plan
- [x] `cd event-runtime/web && bun test` — 370 pass
- [x] Negative tests first: modal guard, Tab wrap, focus return (observed failing, then green)

UX critique: required — NOT-ASSESSED (no browser MCP)

Fixes WM-150