### PR TITLE
fix(event-runtime): stale-only fleet no longer says no live workers (WM-155)

### DIFF
--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Workers, defaultWorkerTab, isLive, partitionWorkers } from "./Workers";
+import { Workers, defaultWorkerTab, fleetBanner, isLive, partitionWorkers } from "./Workers";
 import { api } from "../api";
 import type { Worker, WorkerState } from "../types";
 
@@ -115,6 +115,56 @@ describe("Workers view default visibility (WM-98)", () => {
       });
       expect(getByText("w_stopped_2")).toBeTruthy();
       expect(getByRole("tab", { selected: true }).textContent).toContain("All");
+    });
+  });
+});
+
+describe("fleet banner vs Live tab (WM-155)", () => {
+  test("classifier: empty, all-stopped, and stale-only are distinct; idle/busy suppress the banner", () => {
+    expect(fleetBanner([])).toEqual({ kind: "empty" });
+    expect(fleetBanner([stubWorker("w_stopped", "stopped")])).toEqual({ kind: "all-stopped", count: 1 });
+    expect(fleetBanner([stubWorker("w_stale", "busy", true)])).toEqual({ kind: "stale", stale: 1, stopped: 0 });
+    expect(
+      fleetBanner([stubWorker("w_stale", "idle", true), stubWorker("w_stopped", "stopped")]),
+    ).toEqual({ kind: "stale", stale: 1, stopped: 1 });
+    expect(fleetBanner([stubWorker("w_idle", "idle")])).toBeNull();
+    expect(fleetBanner([stubWorker("w_idle", "idle"), stubWorker("w_stale", "busy", true)])).toBeNull();
+  });
+
+  test("stale-only fleet opens on Live with the stale row and does not say “No live workers detected”", async () => {
+    const workers = [stubWorker("w_stale_only", "busy", true)];
+    await withWorkers(workers, async () => {
+      const { getByText, queryByText, getByRole } = renderWorkers();
+      await waitFor(() => {
+        expect(getByText("w_stale_only")).toBeTruthy();
+      });
+      expect(getByRole("tab", { selected: true }).textContent).toContain("Live");
+      expect(queryByText("No live workers detected")).toBeNull();
+      expect(getByText("Workers are stale")).toBeTruthy();
+      expect(getByText(/missed the heartbeat window/i)).toBeTruthy();
+    });
+  });
+
+  test("empty registry banner says no workers registered, not “No live workers detected”", async () => {
+    await withWorkers([], async () => {
+      const { getByText, queryByText, findByText } = renderWorkers();
+      expect(await findByText("No workers registered")).toBeTruthy();
+      expect(queryByText("No live workers detected")).toBeNull();
+      expect(getByText(/No workers have registered with the runtime/i)).toBeTruthy();
+    });
+  });
+
+  test("all-stopped banner says workers are stopped, not stale-or-stopped", async () => {
+    const workers = [stubWorker("w_stopped_1", "stopped"), stubWorker("w_stopped_2", "stopped")];
+    await withWorkers(workers, async () => {
+      const { getByText, queryByText } = renderWorkers();
+      await waitFor(() => {
+        expect(getByText("w_stopped_1")).toBeTruthy();
+      });
+      expect(getByText("All workers are stopped")).toBeTruthy();
+      expect(queryByText("No live workers detected")).toBeNull();
+      expect(queryByText(/stopped or stale/)).toBeNull();
+      expect(getByText(/2 registered workers are stopped/)).toBeTruthy();
     });
   });
 });

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -54,6 +54,32 @@ export type WorkerTab = (typeof WORKER_TABS)[number];
  */
 export const isLive = (w: Worker) => health(w) !== "stopped";
 
+export type FleetBanner =
+  | { kind: "empty" }
+  | { kind: "all-stopped"; count: number }
+  | { kind: "stale"; stale: number; stopped: number };
+
+/**
+ * Banner that agrees with `isLive` / the Live tab. Stale workers are live
+ * (they may still hold a run), so a stale-only fleet is not “no live workers”.
+ * Returns null when at least one idle/busy worker can claim work.
+ */
+export function fleetBanner(rows: Worker[]): FleetBanner | null {
+  if (rows.length === 0) return { kind: "empty" };
+  let stale = 0;
+  let stopped = 0;
+  let claiming = 0;
+  for (const w of rows) {
+    const h = health(w);
+    if (h === "stale") stale += 1;
+    else if (h === "stopped") stopped += 1;
+    else claiming += 1;
+  }
+  if (claiming > 0) return null;
+  if (stale > 0) return { kind: "stale", stale, stopped };
+  return { kind: "all-stopped", count: stopped };
+}
+
 /** Split the registry into live and stopped, preserving order within each group. */
 export function partitionWorkers(rows: Worker[]): { live: Worker[]; stopped: Worker[] } {
   const live: Worker[] = [];
@@ -190,6 +216,50 @@ const openRun = (runId: string) => {
   window.location.hash = `#/runs/${runId}`;
 };
 
+function FleetStatusBanner({ banner }: { banner: FleetBanner }) {
+  const hue = banner.kind === "stale" ? "var(--hue-err)" : "var(--hue-warn)";
+  const title =
+    banner.kind === "empty"
+      ? "No workers registered"
+      : banner.kind === "all-stopped"
+        ? "All workers are stopped"
+        : "Workers are stale";
+  const lead =
+    banner.kind === "empty"
+      ? "No workers have registered with the runtime."
+      : banner.kind === "all-stopped"
+        ? `${banner.count} registered worker${banner.count === 1 ? " is" : "s are"} stopped.`
+        : `${banner.stale} worker${banner.stale === 1 ? "" : "s"} missed the heartbeat window${
+            banner.stopped > 0 ? ` (${banner.stopped} stopped)` : ""
+          } and may still hold a run.`;
+  return (
+    <div
+      className="mb-3 rounded-md border p-3 text-[12px]"
+      style={{
+        color: hue,
+        borderColor: `color-mix(in oklch, ${hue} 55%, var(--border))`,
+        background: `color-mix(in oklch, ${hue} 8%, var(--surface-1))`,
+      }}
+    >
+      <div className="flex items-center gap-2 font-semibold">
+        <span
+          className={`size-2 shrink-0 rounded-full ${banner.kind === "stale" ? "" : "animate-pulse"}`}
+          style={{ background: hue }}
+        />
+        <span>{title}</span>
+      </div>
+      <div className="mt-1 text-(--text-dim)">
+        {lead}{" "}
+        Queued runs will remain waiting until a worker is started with{" "}
+        <code className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[11px] text-(--text)">
+          bun event-runtime/cli.mjs work
+        </code>
+        .
+      </div>
+    </div>
+  );
+}
+
 /**
  * Workers — the registry the CLI `workers` command prints, made legible. The
  * question this view answers is who could claim the next run and who only
@@ -209,12 +279,8 @@ export function Workers({
   const query = useQuery({ queryKey: ["workers"], queryFn: api.workers, refetchInterval: 2000 });
   const rows = query.data?.workers ?? [];
 
-  const liveCount = useMemo(
-    () => rows.filter((w) => !w.stale && w.state !== "stopped").length,
-    [rows],
-  );
-
   const parts = useMemo(() => partitionWorkers(rows), [rows]);
+  const banner = useMemo(() => fleetBanner(rows), [rows]);
 
   // `null` = no explicit choice yet: follow the data (live when any worker is
   // live). The first click pins the tab and the default stops moving under it.
@@ -358,27 +424,7 @@ export function Workers({
                 label="Filter workers"
               />
             </div>
-            {query.isSuccess && liveCount === 0 && (
-              <div
-                className="mb-3 rounded-md border border-[color:var(--hue-warn)] bg-[color:color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3 text-[12px]"
-                style={{ color: "var(--hue-warn)" }}
-              >
-                <div className="flex items-center gap-2 font-semibold">
-                  <span className="size-2 shrink-0 rounded-full bg-[color:var(--hue-warn)] animate-pulse" />
-                  <span>No live workers detected</span>
-                </div>
-                <div className="mt-1 text-(--text-dim)">
-                  {rows.length === 0
-                    ? "No workers have registered with the runtime."
-                    : `${rows.length} registered worker${rows.length === 1 ? " is" : "s are"} stopped or stale.`}{" "}
-                  Queued runs will remain waiting until a worker is started with{" "}
-                  <code className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[11px] text-(--text)">
-                    bun event-runtime/cli.mjs work
-                  </code>
-                  .
-                </div>
-              </div>
-            )}
+            {query.isSuccess && banner && <FleetStatusBanner banner={banner} />}
           </>
         }
       >


### PR DESCRIPTION
## Summary
- Fleet banner now agrees with `isLive()` / the Live tab: stale workers are live because they may still hold a run.
- Banner copy distinguishes empty registry, all-stopped, and heartbeat-stale — never “No live workers detected” while stale rows are visible on Live.
- Regression tests in `Workers.test.tsx`; the stale-only case was observed failing before the copy change.

## Test plan
- [x] `cd event-runtime/web && bun test` — 365 pass
- [x] UX critique on a staged stale-only fleet — SHIP

UX critique: required — SHIP

Follow-ups (Triage): WM-159 (footer “no workers”), WM-162 (Stopped tab empty-state Esc hint), WM-163 (mobile tab overflow).

Fixes WM-155