### PR TITLE
fix(web): inject dialog UX polish (WM-78–WM-86)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -1,7 +1,7 @@
 import "./test-dom";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, waitFor, within } from "@testing-library/react";
 import { App } from "./App";
 import { NAV } from "./nav";
 import type { StatusView } from "./types";
@@ -60,6 +60,17 @@ beforeEach(() => {
     const url = String(input);
     if (url.includes("/api/health")) return jsonResponse(HEALTH);
     if (url.includes("/api/status")) return jsonResponse(STATUS);
+    if (url.includes("/api/agents")) {
+      return jsonResponse({
+        agents: [],
+        eventTypes: [],
+        edges: {},
+        contracts: {},
+        schemaHash: "test",
+        publishedAt: new Date().toISOString(),
+      });
+    }
+    if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
     // Views poll their own endpoints; an empty list keeps them quiet.
     return jsonResponse([]);
   }) as typeof fetch;
@@ -134,11 +145,23 @@ describe("bottom status bar", () => {
       expect(statusBar.textContent).toContain("test");
       expect(statusBar.textContent).toContain("1 worker");
       expect(statusBar.textContent).toContain("⌘K commands");
+      expect(statusBar.textContent).toContain("i inject");
       expect(statusBar.textContent).toContain("g go");
       expect(statusBar.textContent).toContain("? keys");
     });
 
     const themeButton = within(statusBar).getByRole("button", { name: /Theme:/i });
     expect(themeButton).toBeTruthy();
+  });
+});
+
+describe("inject hotkey (WM-80)", () => {
+  test("`i` opens the inject dialog with template search focused", async () => {
+    const { findByPlaceholderText } = renderApp();
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "i", bubbles: true }));
+    });
+    const search = await findByPlaceholderText(/search event types/i);
+    expect(document.activeElement === search).toBe(true);
   });
 });

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -599,8 +599,8 @@ export function App() {
 
         <div className="flex items-center gap-3">
           <div className="text-(--text-faint)">
-            <span className="mono">⌘K</span> commands · <span className="mono">g</span> go ·{" "}
-            <span className="mono">?</span> keys
+            <span className="mono">⌘K</span> commands · <span className="mono">i</span> inject ·{" "}
+            <span className="mono">g</span> go · <span className="mono">?</span> keys
           </div>
           <button
             type="button"

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -559,7 +559,7 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
     }));
 
   test("picking this envelope resets Form state from the given payload", () =>
-    withSchemaApi(async (r) => {
+    withSchemaApi(async () => {
       cleanup();
       const given = {
         schemaVersion: "factory.event/v1",

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -613,6 +613,29 @@ describe("InjectDialog humanized errors and hidden planner fields (WM-86)", () =
     }));
 });
 
+describe("InjectDialog keyboard search (WM-80)", () => {
+  test("template search is the autofocus target when the dialog opens", () =>
+    withSchemaApi(async (r) => {
+      const search = r.getByPlaceholderText(/search event types/i);
+      expect(search.getAttribute("autofocus")).not.toBeNull();
+      expect(document.activeElement).toBe(search);
+    }));
+
+  test("ArrowDown from search focuses the first template result", () =>
+    withSchemaApi(async (r) => {
+      const search = r.getByPlaceholderText(/search event types/i) as HTMLInputElement;
+      act(() => {
+        search.focus();
+      });
+      act(() => {
+        fireEvent.keyDown(search, { key: "ArrowDown" });
+      });
+      const radios = r.getAllByRole("radio");
+      expect(radios.length).toBeGreaterThan(0);
+      expect(document.activeElement).toBe(radios[0]);
+    }));
+});
+
 describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {
   test("schema-invalid confirm is labeled Inject anyway, not Confirm inject", () =>
     withSchemaApi(async (r) => {

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -192,6 +192,8 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       expect([...host.querySelectorAll("option")].map((o) => o.value)).toContain("web");
       const usedPct = r.getByLabelText("usedPct") as HTMLInputElement;
       expect(usedPct.getAttribute("type")).toBe("number");
+      expect(usedPct.getAttribute("min")).toBe("0");
+      expect(usedPct.getAttribute("max")).toBe("100");
       expect(r.getByLabelText("mount")).toBeTruthy();
       expect(r.getByLabelText("alertId")).toBeTruthy();
       // Envelope preview disclosure is present in Form mode.

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -663,3 +663,38 @@ describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {
       expect(r.queryAllByRole("button", { name: /inject anyway/i })).toHaveLength(0);
     }));
 });
+
+describe("InjectDialog last-used template (WM-81)", () => {
+  test("preselects the last injected template on the next open; blank remains one click", () =>
+    withSchemaApi(async (r) => {
+      const origReplay = api.replay;
+      api.replay = async () => ({ admitted: true, duplicate: false, eventId: "e-last" });
+      try {
+        await selectTemplate(r, /disk\.diagnose/i);
+        act(() => {
+          changeInput(r.getByLabelText("mount"), "/var");
+        });
+        act(() => {
+          fireEvent.click(r.getByRole("button", { name: /inject/i }));
+        });
+        await act(async () => {
+          fireEvent.click(r.getByRole("button", { name: /^confirm inject$/i }));
+        });
+        r.unmount();
+        const r2 = renderWithClient(<InjectDialog onClose={() => {}} />);
+        const chip = await r2.findByRole("radio", {
+          name: (n) => n.includes("disk.diagnose") && n.includes("disk@1"),
+        });
+        expect(chip.getAttribute("aria-checked")).toBe("true");
+        expect(r2.getByRole("tab", { name: /form/i }).getAttribute("aria-selected")).toBe("true");
+        expect(r2.getByLabelText("usedPct")).toBeTruthy();
+        act(() => {
+          fireEvent.click(r2.getByRole("radio", { name: /blank envelope/i }));
+        });
+        expect(r2.getByRole("radio", { name: /blank envelope/i }).getAttribute("aria-checked")).toBe("true");
+        expect(r2.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+      } finally {
+        api.replay = origReplay;
+      }
+    }));
+});

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -213,16 +213,16 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
     withSchemaApi(async (r) => {
       await selectTemplate(r, /triage\.scan\.requested/i);
       const optionsOf = (input: HTMLInputElement) => {
-        const listId = input.getAttribute("list");
-        expect(listId).toBeTruthy();
-        const list = document.getElementById(listId!);
-        expect(list).toBeTruthy();
-        return [...list!.querySelectorAll("option")].map((o) => o.getAttribute("value"));
+        act(() => {
+          fireEvent.focus(input);
+        });
+        return r.getAllByRole("option").map((o) => o.textContent);
       };
       const repo = r.getByLabelText("repo") as HTMLInputElement;
       let options = optionsOf(repo);
       expect(options).toContain("bj29");
       expect(options).toContain("factory");
+      expect(repo.getAttribute("list")).toBeNull();
 
       await selectTemplate(r, /ci\.run\.failed/i);
       options = optionsOf(r.getByLabelText("repo") as HTMLInputElement);

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -574,3 +574,39 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
       expect(view.queryAllByLabelText("mount")).toHaveLength(0);
     }));
 });
+
+describe("InjectDialog humanized errors and hidden planner fields (WM-86)", () => {
+  test("pattern field errors do not leak the raw regex", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const mount = r.getByLabelText("mount") as HTMLInputElement;
+      act(() => {
+        changeInput(mount, "not-a-path");
+        fireEvent.blur(mount);
+      });
+      expect(r.queryAllByText(/\^\/\[A-Za-z0-9/).length).toBe(0);
+      expect(r.getAllByText(/expected format/i).length).toBeGreaterThan(0);
+    }));
+
+  test("hidden planner-field errors name the JSON tab", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /triage\.scan\.requested/i);
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /json/i }));
+      });
+      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const parsed = JSON.parse(textarea.value);
+      parsed.payload.repo = "factory";
+      parsed.payload.repoPin = { repo: "factory", sha: "not-a-sha" };
+      act(() => {
+        changeInput(textarea, JSON.stringify(parsed, null, 2));
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /form/i }));
+      });
+      const banner = r.container.textContent ?? "";
+      expect(banner).toMatch(/repoPin/i);
+      expect(banner).toMatch(/JSON tab/i);
+      expect(banner).not.toMatch(/\^\[0-9a-f\]\{40\}/);
+    }));
+});

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -9,6 +9,10 @@ import { changeInput } from "../test-render";
 
 afterEach(() => {
   cleanup();
+  try {
+    sessionStorage.clear();
+    localStorage.clear();
+  } catch {}
 });
 
 function renderWithClient(ui: React.ReactElement) {
@@ -463,4 +467,70 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
       api.agents = origAgents;
     }
   });
+});
+
+describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => {
+  test("submitForm reports missing required envelope fields instead of confirming", () =>
+    withSchemaApi(async (r) => {
+      const origReplay = api.replay;
+      const sent: unknown[] = [];
+      api.replay = async (envelope: unknown) => {
+        sent.push(envelope);
+        return { admitted: true, duplicate: false, eventId: "e1" };
+      };
+      try {
+        await selectTemplate(r, /disk\.diagnose/i);
+        act(() => {
+          fireEvent.click(r.getByRole("tab", { name: /json/i }));
+        });
+        const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+        const parsed = JSON.parse(textarea.value);
+        delete parsed.eventId;
+        act(() => {
+          changeInput(textarea, JSON.stringify(parsed, null, 2));
+        });
+        act(() => {
+          fireEvent.click(r.getByRole("tab", { name: /form/i }));
+        });
+        act(() => {
+          fireEvent.click(r.getByRole("button", { name: /inject/i }));
+        });
+        expect(sent.length).toBe(0);
+        expect(r.getByText(/missing required string field/i)).toBeTruthy();
+        expect(r.getByText(/eventId/i)).toBeTruthy();
+        expect(r.queryByRole("button", { name: /confirm inject/i })).toBeNull();
+      } finally {
+        api.replay = origReplay;
+      }
+    }));
+
+  test("picking blank envelope resets stale Form state", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      expect(r.getByLabelText("usedPct")).toBeTruthy();
+      await selectTemplate(r, /blank envelope/i);
+      expect(r.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+      expect(r.queryByLabelText("usedPct")).toBeNull();
+      expect(r.queryByLabelText("mount")).toBeNull();
+    }));
+
+  test("picking this envelope resets Form state from the given payload", () =>
+    withSchemaApi(async (r) => {
+      cleanup();
+      const given = {
+        schemaVersion: "factory.event/v1",
+        eventId: "given-1",
+        type: "triage.scan.requested",
+        source: "web-trigger",
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        payload: { repo: "factory" },
+      };
+      const view = renderWithClient(<InjectDialog onClose={() => {}} initialEnvelope={given} />);
+      await selectTemplate(view, /disk\.diagnose/i);
+      expect(view.getByLabelText("usedPct")).toBeTruthy();
+      await selectTemplate(view, /this envelope/i);
+      expect(view.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
+      expect(view.queryByLabelText("usedPct")).toBeNull();
+      expect(view.queryByLabelText("mount")).toBeNull();
+    }));
 });

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -246,12 +246,13 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       expect((r.getByLabelText("scheduledAt") as HTMLInputElement).value).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     }));
 
-  test("validation flags a bad payload with a field-level error", () =>
+  test("validation flags a bad payload with a field-level error after blur", () =>
     withSchemaApi(async (r) => {
       await selectTemplate(r, /disk\.diagnose/i);
       const usedPct = r.getByLabelText("usedPct") as HTMLInputElement;
       act(() => {
         changeInput(usedPct, "150");
+        fireEvent.blur(usedPct);
       });
       expect(r.getByText(/above maximum 100/i)).toBeTruthy();
     }));
@@ -342,13 +343,17 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
       expect(logArtifact.getAttribute("placeholder") ?? "").not.toContain("^");
     }));
 
-  test("string arrays with minItems seed zero chips; the minItems warning covers the ask (critique r1)", () =>
+  test("string arrays with minItems seed zero chips; the minItems warning waits until submit (WM-78)", () =>
     withSchemaApi(async (r) => {
       await selectTemplate(r, /factory\.status\.requested/i);
       // No bare unlabeled "×" chip from a seeded empty string.
       expect(r.queryAllByRole("button", { name: /^remove/i }).length).toBe(0);
-      // The requirement is still surfaced, as a validation warning.
-      expect(r.getByText(/fewer than minItems 1/i)).toBeTruthy();
+      // Fresh form must not look broken (WM-78).
+      expect(r.queryAllByText(/fewer than minItems 1/i)).toHaveLength(0);
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      expect(r.getAllByText(/fewer than minItems 1/i).length).toBeGreaterThan(0);
     }));
 
   test("array-of-objects field renders a JSON sub-editor with parse indicator", () =>
@@ -469,6 +474,41 @@ describe("InjectDialog template selection sync (OPS-344)", () => {
   });
 });
 
+describe("InjectDialog field errors wait until blur or submit (WM-78)", () => {
+  test("required empty strings do not show minLength errors on template select", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /triage\.scan\.requested/i);
+      expect(r.getByLabelText("repo")).toBeTruthy();
+      expect(r.queryAllByText(/shorter than minLength/i)).toHaveLength(0);
+      expect(r.queryAllByText(/missing required/i)).toHaveLength(0);
+    }));
+
+  test("blurring an invalid field reveals its error", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /triage\.scan\.requested/i);
+      const repo = r.getByLabelText("repo") as HTMLInputElement;
+      expect(r.queryAllByText(/shorter than minLength/i)).toHaveLength(0);
+      act(() => {
+        fireEvent.blur(repo);
+      });
+      expect(r.getByText(/shorter than minLength/i)).toBeTruthy();
+    }));
+
+  test("a submit attempt reveals field errors without changing the ack flow", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const mount = r.getByLabelText("mount") as HTMLInputElement;
+      expect(mount.value).toBe("");
+      expect(r.queryAllByText(/does not match pattern/i)).toHaveLength(0);
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      expect(r.getAllByText(/does not match pattern/i).length).toBeGreaterThan(0);
+      expect(r.getByText(/does not validate/i)).toBeTruthy();
+      expect(r.getByRole("button", { name: /confirm inject/i })).toBeTruthy();
+    }));
+});
+
 describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => {
   test("submitForm reports missing required envelope fields instead of confirming", () =>
     withSchemaApi(async (r) => {
@@ -510,8 +550,8 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
       expect(r.getByLabelText("usedPct")).toBeTruthy();
       await selectTemplate(r, /blank envelope/i);
       expect(r.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
-      expect(r.queryByLabelText("usedPct")).toBeNull();
-      expect(r.queryByLabelText("mount")).toBeNull();
+      expect(r.queryAllByLabelText("usedPct")).toHaveLength(0);
+      expect(r.queryAllByLabelText("mount")).toHaveLength(0);
     }));
 
   test("picking this envelope resets Form state from the given payload", () =>
@@ -530,7 +570,7 @@ describe("InjectDialog Form-tab envelope guard and picker reset (WM-84)", () => 
       expect(view.getByLabelText("usedPct")).toBeTruthy();
       await selectTemplate(view, /this envelope/i);
       expect(view.getByRole("tab", { name: /json/i }).getAttribute("aria-selected")).toBe("true");
-      expect(view.queryByLabelText("usedPct")).toBeNull();
-      expect(view.queryByLabelText("mount")).toBeNull();
+      expect(view.queryAllByLabelText("usedPct")).toHaveLength(0);
+      expect(view.queryAllByLabelText("mount")).toHaveLength(0);
     }));
 });

--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -318,7 +318,9 @@ describe("InjectDialog schema-driven Form view (WM-76)", () => {
         // Not submitted yet: warned and waiting on explicit acknowledgement.
         expect(sent.length).toBe(0);
         expect(r.getByText(/does not validate/i)).toBeTruthy();
-        const confirm = r.getByRole("button", { name: /confirm inject/i });
+        expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
+        expect(r.queryByRole("button", { name: /^confirm inject$/i })).toBeNull();
+        const confirm = r.getByRole("button", { name: /inject anyway/i });
         await act(async () => {
           fireEvent.click(confirm);
         });
@@ -505,7 +507,7 @@ describe("InjectDialog field errors wait until blur or submit (WM-78)", () => {
       });
       expect(r.getAllByText(/does not match pattern/i).length).toBeGreaterThan(0);
       expect(r.getByText(/does not validate/i)).toBeTruthy();
-      expect(r.getByRole("button", { name: /confirm inject/i })).toBeTruthy();
+      expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
     }));
 });
 
@@ -608,5 +610,33 @@ describe("InjectDialog humanized errors and hidden planner fields (WM-86)", () =
       expect(banner).toMatch(/repoPin/i);
       expect(banner).toMatch(/JSON tab/i);
       expect(banner).not.toMatch(/\^\[0-9a-f\]\{40\}/);
+    }));
+});
+
+describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {
+  test("schema-invalid confirm is labeled Inject anyway, not Confirm inject", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      act(() => {
+        changeInput(r.getByLabelText("usedPct"), "150");
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
+      expect(r.queryAllByRole("button", { name: /^confirm inject$/i })).toHaveLength(0);
+    }));
+
+  test("valid payload still confirms with Confirm inject", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      act(() => {
+        changeInput(r.getByLabelText("mount"), "/var");
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      expect(r.getByRole("button", { name: /^confirm inject$/i })).toBeTruthy();
+      expect(r.queryAllByRole("button", { name: /inject anyway/i })).toHaveLength(0);
     }));
 });

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -274,6 +274,7 @@ export function InjectDialog({
   const [schemaAck, setSchemaAck] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   // WM-76 Form view state. The base is the envelope minus payload (generated
   // exactly as templates do); the form edits payload only. Nested object /
@@ -727,9 +728,7 @@ export function InjectDialog({
   tabRef.current = tab;
 
   useLayoutEffect(() => {
-    listRef.current
-      ?.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]')
-      ?.setAttribute("autofocus", "");
+    searchRef.current?.setAttribute("autofocus", "");
   }, []);
 
   useEffect(() => {
@@ -968,10 +967,19 @@ export function InjectDialog({
         <div className="md:col-span-5 flex flex-col min-h-0 border-b md:border-b-0 md:border-r border-(--border) pb-3 md:pb-0 md:pr-3">
           <div className="mb-2">
             <input
+              ref={searchRef}
               type="text"
               placeholder="Search event types / agents…"
               value={search}
+              aria-label="Search event types"
               onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key !== "ArrowDown") return;
+                const first = listRef.current?.querySelector<HTMLElement>('[role="radio"]');
+                if (!first) return;
+                e.preventDefault();
+                first.focus();
+              }}
               className="w-full rounded-md border border-(--border) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none focus:border-(--border-strong)"
             />
           </div>

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -543,7 +543,7 @@ export function InjectDialog({
   const optionalFields = formFields.filter((f) => !f.required);
 
   const formEnvelope = useMemo(
-    () => ({ ...formBase, payload: formPayload }),
+    (): Record<string, unknown> => ({ ...formBase, payload: formPayload }),
     [formBase, formPayload],
   );
 

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -647,7 +647,7 @@ export function InjectDialog({
     if (errs.length === 0 || schemaAck) return false;
     const summary = errs.slice(0, 3).join("; ") + (errs.length > 3 ? ` (+${errs.length - 3} more)` : "");
     setClientError(
-      `payload does not validate against the "${type}" input schema: ${summary}. Intake will admit it, but planning will park it human_needed. Confirm inject to proceed.`,
+      `payload does not validate against the "${type}" input schema: ${summary}. Intake will admit it, but planning will park it human_needed. Inject anyway to proceed.`,
     );
     setSchemaAck(true);
     setConfirming(true);
@@ -1236,8 +1236,13 @@ export function InjectDialog({
             {confirming ? (
               <>
                 <Button onClick={() => setConfirming(false)}>Back</Button>
-                <Button variant="primary" onClick={submit} disabled={inject.isPending} autoFocus>
-                  Confirm inject
+                <Button
+                  variant={schemaAck ? "danger" : "primary"}
+                  onClick={submit}
+                  disabled={inject.isPending}
+                  autoFocus
+                >
+                  {schemaAck ? "Inject anyway" : "Confirm inject"}
                 </Button>
               </>
             ) : (

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -418,8 +418,10 @@ export function InjectDialog({
   function applySelection(next: string | null) {
     if (next === checkedId) return;
     if (next === null) {
+      const env = blankEnvelope(openedAt);
       setSelected(null);
-      setText(pretty(blankEnvelope(openedAt)));
+      setText(pretty(env));
+      initFormFromEnvelope(env, null);
       setTab("json");
       setTabNotice(null);
       resetAcks();
@@ -427,8 +429,10 @@ export function InjectDialog({
       return;
     }
     if (next === "__given__" && initialEnvelope) {
+      const type = typeof initialEnvelope.type === "string" ? initialEnvelope.type : "";
       setSelected("__given__");
       setText(pretty(initialEnvelope));
+      initFormFromEnvelope(initialEnvelope, schemaFields(schemaFor(type)));
       setTab("json");
       setTabNotice(null);
       resetAcks();
@@ -640,6 +644,12 @@ export function InjectDialog({
     setClientError(null);
     if (invalidSubs.length > 0) {
       setClientError(`field ${invalidSubs.join(", ")}: not valid JSON`);
+      setConfirming(false);
+      return;
+    }
+    const missing = REQUIRED.filter((k) => typeof formEnvelope[k] !== "string" || !formEnvelope[k]);
+    if (missing.length) {
+      setClientError(`missing required string field${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}`);
       setConfirming(false);
       return;
     }

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -40,6 +40,7 @@ const REQUIRED = ["schemaVersion", "eventId", "type", "source", "occurredAt"];
 
 export const INJECT_DRAFT_KEY = "factory.injectDraft";
 export const INJECT_RECENT_STORAGE_KEY = "factory.injectRecent";
+export const INJECT_LAST_TEMPLATE_KEY = "factory.injectLastTemplate";
 export const MAX_RECENT_EVENTS = 5;
 
 export interface InjectDraft {
@@ -166,6 +167,31 @@ export function clearRecentEvents() {
   } catch {}
 }
 
+export function loadLastTemplate(): string | null {
+  try {
+    const storage = getLocalStorage();
+    if (!storage) return null;
+    const raw = storage.getItem(INJECT_LAST_TEMPLATE_KEY);
+    if (raw === null) return null;
+    if (raw === "") return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastTemplate(eventType: string | null) {
+  try {
+    const storage = getLocalStorage();
+    if (!storage) return;
+    if (eventType === null || eventType === "" || eventType.startsWith("__")) {
+      storage.setItem(INJECT_LAST_TEMPLATE_KEY, "");
+      return;
+    }
+    storage.setItem(INJECT_LAST_TEMPLATE_KEY, eventType);
+  } catch {}
+}
+
 function summarizePayload(env: Record<string, unknown> | undefined): string {
   if (!env || !isPlainObject(env.payload)) return "no payload";
   const payload = env.payload as Record<string, unknown>;
@@ -259,10 +285,11 @@ export function InjectDialog({
   );
 
   const [search, setSearch] = useState("");
+  const lastTemplateRef = useRef(false);
   const [selected, setSelected] = useState<string | null>(() => {
     if (initialEnvelope) return "__given__";
     if (initialDraft?.selected !== undefined) return initialDraft.selected;
-    return null;
+    return loadLastTemplate();
   });
   const [text, setText] = useState<string>(() => {
     if (initialEnvelope) return pretty(initialEnvelope);
@@ -393,6 +420,7 @@ export function InjectDialog({
 
   function choose(template: TriggerTemplate) {
     setSelected(template.eventType);
+    saveLastTemplate(template.eventType);
     setText(pretty(template.envelope));
     const fields = schemaFields(schemaFor(template.eventType));
     initFormFromEnvelope(template.envelope, fields);
@@ -427,6 +455,7 @@ export function InjectDialog({
     if (next === null) {
       const env = blankEnvelope(openedAt);
       setSelected(null);
+      saveLastTemplate(null);
       setText(pretty(env));
       initFormFromEnvelope(env, null);
       setTab("json");
@@ -457,6 +486,16 @@ export function InjectDialog({
     const t = templates.find((x) => x.eventType === next);
     if (t) choose(t);
   }
+
+  useLayoutEffect(() => {
+    if (initialEnvelope || initialDraft) return;
+    if (lastTemplateRef.current) return;
+    if (!selected) return;
+    const t = templates.find((x) => x.eventType === selected);
+    if (!t) return;
+    lastTemplateRef.current = true;
+    choose(t);
+  }, [templates, selected, initialEnvelope, initialDraft]);
 
   function templateIds(): Array<string | null> {
     return [

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -12,6 +12,7 @@ import { api } from "../api";
 import { buildTemplates, triggerId, type TriggerTemplate } from "../templates";
 import { validate } from "../lib/schema";
 import {
+  PLANNER_FIELDS,
   errorsByField,
   fieldErrorVisible,
   isAtField,
@@ -510,13 +511,21 @@ export function InjectDialog({
     () => (formSchema ? validate(formSchema, formPayload) : { valid: true, errors: [] as string[] }),
     [formSchema, formPayload],
   );
-  const fieldErrors = useMemo(() => errorsByField(formValidation.errors), [formValidation]);
+  const fieldErrors = useMemo(
+    () => errorsByField(formValidation.errors, formFields),
+    [formValidation, formFields],
+  );
   const knownNames = useMemo(() => new Set(formFields.map((f) => f.name)), [formFields]);
   const formLevelErrors = useMemo(() => {
     const out: string[] = [];
     for (const [k, msgs] of fieldErrors) {
       if (k === "") out.push(...msgs);
-      else if (!knownNames.has(k)) out.push(...msgs.map((m) => `${k}: ${m}`));
+      else if (!knownNames.has(k)) {
+        const where = PLANNER_FIELDS.has(k)
+          ? ` — ${k} is a planner field; edit it in the JSON tab`
+          : " — edit in the JSON tab";
+        out.push(...msgs.map((m) => `${k}: ${m}${where}`));
+      }
     }
     return out;
   }, [fieldErrors, knownNames]);

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -13,6 +13,7 @@ import { buildTemplates, triggerId, type TriggerTemplate } from "../templates";
 import { validate } from "../lib/schema";
 import {
   errorsByField,
+  fieldErrorVisible,
   isAtField,
   isIdField,
   placeholderFor,
@@ -295,6 +296,8 @@ export function InjectDialog({
     return {};
   });
   const [tabNotice, setTabNotice] = useState<string | null>(null);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
   const fieldIdBase = useId();
 
   // Autosave draft to sessionStorage (OPS-507)
@@ -375,6 +378,8 @@ export function InjectDialog({
       if (f.kind === "json") sub[f.name] = f.name in pay ? JSON.stringify(pay[f.name], null, 2) : "";
     }
     setSubJson(sub);
+    setTouched({});
+    setSubmitAttempted(false);
   }
 
   function resetAcks() {
@@ -642,6 +647,7 @@ export function InjectDialog({
 
   function submitForm() {
     setClientError(null);
+    setSubmitAttempted(true);
     if (invalidSubs.length > 0) {
       setClientError(`field ${invalidSubs.join(", ")}: not valid JSON`);
       setConfirming(false);
@@ -758,7 +764,8 @@ export function InjectDialog({
   function renderField(f: FieldSpec) {
     const fid = `${fieldIdBase}-${f.name}`;
     const value = formPayload[f.name];
-    const errs = fieldErrors.get(f.name) ?? [];
+    const errs =
+      fieldErrorVisible(f.name, touched, submitAttempted) ? (fieldErrors.get(f.name) ?? []) : [];
     const suggestions = repoSuggestions(f.name, f.schema, f.kind, repoItems);
 
     let control: React.ReactNode;
@@ -887,7 +894,11 @@ export function InjectDialog({
     }
 
     return (
-      <div key={f.name} className="mb-2.5 last:mb-0">
+      <div
+        key={f.name}
+        className="mb-2.5 last:mb-0"
+        onBlur={() => setTouched((t) => (t[f.name] ? t : { ...t, [f.name]: true }))}
+      >
         <div className="mb-0.5 flex items-center gap-2">
           <label
             htmlFor={f.kind === "const" ? undefined : fid}

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -860,6 +860,10 @@ export function InjectDialog({
             id={fid}
             type="number"
             step="any"
+            min={typeof f.schema.minimum === "number" ? f.schema.minimum : undefined}
+            max={typeof f.schema.maximum === "number" ? f.schema.maximum : undefined}
+            aria-valuemin={typeof f.schema.minimum === "number" ? f.schema.minimum : undefined}
+            aria-valuemax={typeof f.schema.maximum === "number" ? f.schema.maximum : undefined}
             value={typeof value === "number" || typeof value === "string" ? String(value) : ""}
             onChange={(e) => {
               const raw = e.target.value;

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, ToastContainer } from "./ui";
+import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { changeInput, typeText } from "../test-render";
 
@@ -568,6 +568,66 @@ describe("changeInput & typeText test helpers (WM-114)", () => {
     });
     expect(input.value).toBe("xyc");
     expect(input.selectionStart).toBe(2);
+  });
+});
+
+describe("SuggestInput popover (WM-79)", () => {
+  function Harness({ initial = "" }: { initial?: string }) {
+    const [value, setValue] = useState(initial);
+    return (
+      <SuggestInput
+        value={value}
+        onChange={setValue}
+        suggestions={["bj29", "factory", "watt-mind/bj29"]}
+        ariaLabel="repo"
+      />
+    );
+  }
+
+  test("does not use a native datalist", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "repo" });
+    expect(input.getAttribute("list")).toBeNull();
+    expect(r.container.querySelector("datalist")).toBeNull();
+  });
+
+  test("opens a styled listbox of suggestions on focus", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "repo" });
+    fireEvent.focus(input);
+    const listbox = r.getByRole("listbox");
+    expect(listbox).toBeTruthy();
+    expect(r.getByRole("option", { name: "bj29" })).toBeTruthy();
+    expect(r.getByRole("option", { name: "factory" })).toBeTruthy();
+  });
+
+  test("keeps free-text write-in when the value is not in the list", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "repo" }) as HTMLInputElement;
+    act(() => {
+      changeInput(input, "custom-repo");
+    });
+    expect(input.value).toBe("custom-repo");
+  });
+
+  test("ArrowDown / ArrowUp / Enter select a suggestion; Escape dismisses", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "repo" }) as HTMLInputElement;
+    fireEvent.focus(input);
+    const options = r.getAllByRole("option");
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(options[1].getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(input.value).toBe("factory");
+    expect(r.queryByRole("listbox")).toBeNull();
+
+    fireEvent.focus(input);
+    expect(r.getByRole("listbox")).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(r.queryByRole("listbox")).toBeNull();
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1214,7 +1214,7 @@ export function Pill({ children, title }: { children: ReactNode; title?: string 
   );
 }
 
-/** Text input with datalist suggestions and free write-in (WM-76 repo picker). */
+/** Text input with a token-styled suggestion popover and free write-in (WM-79). */
 export function SuggestInput({
   id,
   value,
@@ -1231,27 +1231,112 @@ export function SuggestInput({
   ariaLabel?: string;
 }) {
   const listId = useId();
+  const listRef = useRef<HTMLUListElement>(null);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+
+  const items = useMemo(() => {
+    if (!suggestions || suggestions.length === 0) return [];
+    const q = value.trim().toLowerCase();
+    if (!q) return suggestions;
+    const filtered = suggestions.filter((s) => s.toLowerCase().includes(q));
+    return filtered.length > 0 ? filtered : suggestions;
+  }, [suggestions, value]);
+
+  const show = open && items.length > 0;
+
+  useEffect(() => {
+    setHighlight(0);
+  }, [items]);
+
+  useEffect(() => {
+    if (!show || !listRef.current) return;
+    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [highlight, show]);
+
+  const pick = (s: string) => {
+    onChange(s);
+    setOpen(false);
+  };
+
   return (
-    <>
+    <span className="relative block">
       <input
         id={id}
         type="text"
+        role="combobox"
+        aria-expanded={show}
+        aria-autocomplete="list"
+        aria-controls={show ? listId : undefined}
+        aria-activedescendant={show && items[highlight] ? `${listId}-opt-${highlight}` : undefined}
         value={value}
-        list={suggestions && suggestions.length > 0 ? listId : undefined}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            if (items.length === 0) return;
+            e.preventDefault();
+            setOpen(true);
+            if (show) setHighlight((i) => (i + 1) % items.length);
+            return;
+          }
+          if (e.key === "ArrowUp") {
+            if (!show || items.length === 0) return;
+            e.preventDefault();
+            setHighlight((i) => (i - 1 + items.length) % items.length);
+            return;
+          }
+          if (e.key === "Enter" && show && items[highlight]) {
+            e.preventDefault();
+            e.stopPropagation();
+            pick(items[highlight]);
+            return;
+          }
+          if (e.key === "Escape" && show) {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpen(false);
+          }
+        }}
         placeholder={placeholder}
         aria-label={ariaLabel}
         spellCheck={false}
         className="mono w-full rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--border-strong)"
       />
-      {suggestions && suggestions.length > 0 && (
-        <datalist id={listId}>
-          {suggestions.map((s) => (
-            <option key={s} value={s} />
+      {show && (
+        <ul
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label="Suggestions"
+          className="absolute top-full left-0 z-30 mt-1 max-h-60 w-full overflow-auto rounded-md border border-(--border-strong) bg-(--surface-1) p-1 text-[12px] shadow-xl outline-none"
+        >
+          {items.map((s, idx) => (
+            <li
+              key={s}
+              id={`${listId}-opt-${idx}`}
+              role="option"
+              aria-selected={idx === highlight}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(s);
+              }}
+              className={`mono cursor-pointer truncate rounded px-2 py-1 select-none ${
+                idx === highlight
+                  ? "bg-(--surface-3) text-(--text)"
+                  : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+              }`}
+            >
+              {s}
+            </li>
           ))}
-        </datalist>
+        </ul>
       )}
-    </>
+    </span>
   );
 }
 

--- a/event-runtime/web/src/lib/injectForm.test.ts
+++ b/event-runtime/web/src/lib/injectForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { fieldErrorVisible } from "./injectForm";
+import { errorsByField, fieldErrorVisible, schemaFields } from "./injectForm";
 
 describe("fieldErrorVisible (WM-78)", () => {
   test("hides errors until the field is touched or submit is attempted", () => {
@@ -7,5 +7,39 @@ describe("fieldErrorVisible (WM-78)", () => {
     expect(fieldErrorVisible("repo", { repo: true }, false)).toBe(true);
     expect(fieldErrorVisible("repo", {}, true)).toBe(true);
     expect(fieldErrorVisible("repo", { other: true }, false)).toBe(false);
+  });
+});
+
+const MOUNT_SCHEMA = {
+  type: "object",
+  required: ["mount"],
+  properties: {
+    mount: { type: "string", pattern: "^/[A-Za-z0-9/._-]*$" },
+    repoPin: {
+      type: "object",
+      properties: { sha: { type: "string", pattern: "^[0-9a-f]{40}$" } },
+    },
+  },
+};
+
+describe("errorsByField pattern humanization (WM-86)", () => {
+  test("replaces raw regex with a placeholder-based format hint", () => {
+    const fields = schemaFields(MOUNT_SCHEMA) ?? [];
+    const mapped = errorsByField(
+      ["$.mount: does not match pattern ^/[A-Za-z0-9/._-]*$"],
+      fields,
+    );
+    const msg = (mapped.get("mount") ?? []).join(" ");
+    expect(msg).not.toContain("^/");
+    expect(msg).not.toMatch(/A-Za-z0-9/);
+    expect(msg).toMatch(/expected format/i);
+    expect(msg).toContain("/absolute/path");
+  });
+
+  test("does not leak regex when no placeholder is available", () => {
+    const mapped = errorsByField(["$.logArtifact: does not match pattern ^[0-9a-f]{64}$"]);
+    const msg = (mapped.get("logArtifact") ?? []).join(" ");
+    expect(msg).not.toContain("^");
+    expect(msg).toMatch(/expected format/i);
   });
 });

--- a/event-runtime/web/src/lib/injectForm.test.ts
+++ b/event-runtime/web/src/lib/injectForm.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { fieldErrorVisible } from "./injectForm";
+
+describe("fieldErrorVisible (WM-78)", () => {
+  test("hides errors until the field is touched or submit is attempted", () => {
+    expect(fieldErrorVisible("repo", {}, false)).toBe(false);
+    expect(fieldErrorVisible("repo", { repo: true }, false)).toBe(true);
+    expect(fieldErrorVisible("repo", {}, true)).toBe(true);
+    expect(fieldErrorVisible("repo", { other: true }, false)).toBe(false);
+  });
+});

--- a/event-runtime/web/src/lib/injectForm.ts
+++ b/event-runtime/web/src/lib/injectForm.ts
@@ -131,13 +131,23 @@ export function placeholderFor(name: string, schema: Record<string, unknown>): s
 /**
  * Route validator errors ("$.host: …", `$: missing required property "x"`)
  * to field names; unrouteable errors land under "" (form-level).
+ * Pattern mismatches never include the raw regex — they reuse placeholderFor
+ * when the field schema is known (WM-86).
  */
-export function errorsByField(errors: string[]): Map<string, string[]> {
+export function errorsByField(errors: string[], fields?: FieldSpec[]): Map<string, string[]> {
+  const byName = new Map((fields ?? []).map((f) => [f.name, f]));
   const out = new Map<string, string[]>();
   const push = (key: string, msg: string) => {
     const list = out.get(key) ?? [];
     list.push(msg);
     out.set(key, list);
+  };
+  const humanize = (name: string, msg: string): string => {
+    if (!/does not match pattern/.test(msg)) return msg;
+    const spec = byName.get(name);
+    const example = spec ? placeholderFor(name, spec.schema) : null;
+    const hint = example ? ` (e.g. ${example})` : "";
+    return msg.replace(/does not match pattern[\s\S]*$/, `does not match expected format${hint}`);
   };
   for (const err of errors) {
     const missing = err.match(/^\$: missing required property "([^"]+)"$/);
@@ -147,10 +157,12 @@ export function errorsByField(errors: string[]): Map<string, string[]> {
     }
     const fielded = err.match(/^\$\.([A-Za-z0-9_$-]+)((?:[.[])[^:]*)?: (.*)$/);
     if (fielded) {
-      push(fielded[1], `${fielded[2] ?? ""}${fielded[2] ? ": " : ""}${fielded[3]}`.trim());
+      const name = fielded[1];
+      const rest = `${fielded[2] ?? ""}${fielded[2] ? ": " : ""}${fielded[3]}`.trim();
+      push(name, humanize(name, rest));
       continue;
     }
-    push("", err.replace(/^\$: /, ""));
+    push("", humanize("", err.replace(/^\$: /, "")));
   }
   return out;
 }

--- a/event-runtime/web/src/lib/injectForm.ts
+++ b/event-runtime/web/src/lib/injectForm.ts
@@ -155,6 +155,15 @@ export function errorsByField(errors: string[]): Map<string, string[]> {
   return out;
 }
 
+/** Field-level errors stay hidden until the control is touched or submit is attempted. */
+export function fieldErrorVisible(
+  name: string,
+  touched: Record<string, boolean>,
+  submitAttempted: boolean,
+): boolean {
+  return submitAttempted || !!touched[name];
+}
+
 /** Payload keys the schema does not declare — kept, surfaced, never dropped. */
 export function unknownKeys(schema: unknown, payload: Record<string, unknown>): string[] {
   if (!isPlainObject(schema)) return [];


### PR DESCRIPTION
## Summary

Bundle of eight Inject-dialog UX tickets in one PR (human-requested).

- **WM-84** — Form-tab submit runs the same required-envelope guard as JSON; blank / `__given__` picks re-init form state.
- **WM-78** — Field errors stay hidden until blur or a submit attempt; form-level ack flow unchanged.
- **WM-86** — Pattern errors use `placeholderFor` (no raw regex); hidden planner-field errors name the JSON tab.
- **WM-85** — Schema-invalid confirm is labeled **Inject anyway** and uses the danger variant.
- **WM-80** — `i` focuses template search; ArrowDown from search focuses the first result; footer advertises `i inject`.
- **WM-81** — Last-used template persisted in localStorage and preselected on open; blank envelope remains one click.
- **WM-82** — Numeric inputs expose schema `minimum`/`maximum` via `min`/`max` and `aria-valuemin`/`aria-valuemax`.
- **WM-79** — `SuggestInput` uses a token-styled listbox popover (OKLCH surfaces); write-in and ArrowUp/Down/Enter/Escape kept.

Fixes WM-78
Fixes WM-79
Fixes WM-80
Fixes WM-81
Fixes WM-82
Fixes WM-84
Fixes WM-85
Fixes WM-86

## Verification

- `cd event-runtime/web && bun test` — pass (382 tests, 0 fail) after every ticket commit and again on the full bundle.

## UX critique

required — SHIP (visual NOT-ASSESSED: critic session had no browser MCP against http://127.0.0.1:7777; code review of all eight ACs found no in-scope FIX-FIRST). Out-of-scope follow-ups: WM-158 (agents payload crash), WM-160 (ChipInput datalist), WM-161 (ArrowUp from first template back to search).

## Test plan

- [ ] Press `i` — search is focused; type then ArrowDown into templates without Tab
- [ ] Inject a template, close, reopen — last template is preselected; blank envelope still one click
- [ ] Select a required-string template — no minLength error until blur or Inject
- [ ] Bad `mount` path — error is a format hint, not a regex
- [ ] Invalid `usedPct` — confirm button reads Inject anyway (danger), not Confirm inject
- [ ] `usedPct` a11y tree reports min 0 / max 100
- [ ] Repo field — custom popover, write-in, keyboard