### PR TITLE
fix(graph): keep inspect loop stable across live polls (WM-154)

### DIFF
--- a/event-runtime/web/src/graph/layout.test.ts
+++ b/event-runtime/web/src/graph/layout.test.ts
@@ -1,7 +1,37 @@
 import "../test-dom";
 import { describe, expect, test } from "bun:test";
-import { layoutGraph, LAYOUT_TIMEOUT_MS, NODE_HEIGHT, NODE_WIDTH } from "./layout";
-import type { CapabilityGraph } from "./model";
+import {
+  graphIdentity,
+  layoutGraph,
+  layoutGraphIfIdentityChanged,
+  LAYOUT_TIMEOUT_MS,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+} from "./layout";
+import type { CapabilityGraph, GraphNode } from "./model";
+
+function sampleGraph(): CapabilityGraph {
+  return {
+    nodes: [
+      { id: "event:gh.failed", kind: "eventType", label: "gh.failed", adapter: "claude", scope: [], ttl: null },
+      {
+        id: "agent:doctor@1",
+        kind: "agent",
+        label: "doctor@1",
+        adapter: "claude",
+        mutating: false,
+        execution: "model",
+        contract: "c/v1",
+        capabilities: [],
+        actions: [],
+        hosts: [],
+      },
+    ],
+    edges: [
+      { id: "routes:gh.failed", source: "event:gh.failed", target: "agent:doctor@1", kind: "routes" },
+    ],
+  };
+}
 
 describe("layoutGraph", () => {
   test("exports layout constants", () => {
@@ -43,6 +73,62 @@ describe("layoutGraph", () => {
     expect(typeof agentPos.y).toBe("number");
     // Left-to-right direction means target agent is positioned to the right of source event
     expect(agentPos.x).toBeGreaterThan(eventPos.x);
+  });
+
+  test("graphIdentity ignores overlay-only count and badge fields", () => {
+    const base = sampleGraph();
+    const overlay: CapabilityGraph = {
+      nodes: base.nodes.map((n) =>
+        n.kind === "eventType"
+          ? { ...n, admittedCount: 9, plannedCount: 4 }
+          : n.kind === "agent"
+            ? { ...n, activeRuns: [{ state: "RUNNING", count: 2 }] }
+            : n,
+      ),
+      edges: base.edges.map((e) => ({ ...e, label: "routes (3)", invocations: 3 })),
+    };
+    expect(graphIdentity(overlay)).toBe(graphIdentity(base));
+  });
+
+  test("graphIdentity changes when a node or edge is added or removed", () => {
+    const base = sampleGraph();
+    const extraNode: GraphNode = {
+      id: "terminal:doctor@1",
+      kind: "terminal",
+      label: "chain ends",
+      reason: "TICKET",
+    };
+    expect(
+      graphIdentity({ ...base, nodes: [...base.nodes, extraNode] }),
+    ).not.toBe(graphIdentity(base));
+    expect(
+      graphIdentity({
+        ...base,
+        edges: [...base.edges, { id: "rec:x", source: "agent:doctor@1", target: "event:gh.failed", kind: "recommends" }],
+      }),
+    ).not.toBe(graphIdentity(base));
+  });
+
+  test("overlay-only changes do not call layoutGraph", async () => {
+    const base = sampleGraph();
+    const overlay: CapabilityGraph = {
+      nodes: base.nodes.map((n) =>
+        n.kind === "eventType" ? { ...n, admittedCount: 12 } : n,
+      ),
+      edges: base.edges,
+    };
+    let calls = 0;
+    const layout = async () => {
+      calls += 1;
+      return new Map(base.nodes.map((n) => [n.id, { x: 0, y: 0 }] as const));
+    };
+    const first = await layoutGraphIfIdentityChanged(base, null, layout);
+    expect(calls).toBe(1);
+    expect(first.positions).not.toBeNull();
+    const second = await layoutGraphIfIdentityChanged(overlay, first.identity, layout);
+    expect(calls).toBe(1);
+    expect(second.positions).toBeNull();
+    expect(second.identity).toBe(first.identity);
   });
 
   test("rejects when layout calculation exceeds bounded timeout", async () => {

--- a/event-runtime/web/src/graph/layout.ts
+++ b/event-runtime/web/src/graph/layout.ts
@@ -20,6 +20,38 @@ const OPTIONS = {
   "elk.edgeRouting": "SPLINES",
 };
 
+/**
+ * Topology fingerprint: node ids and edge id/source/target. Overlay fields
+ * (counts, badges, invocation labels) are ignored so live polls do not
+ * re-run ELK.
+ */
+export function graphIdentity(graph: CapabilityGraph): string {
+  const nodes = graph.nodes.map((n) => n.id).sort();
+  const edges = graph.edges.map((e) => `${e.id}\t${e.source}\t${e.target}`).sort();
+  return `${nodes.join("\n")}\n--\n${edges.join("\n")}`;
+}
+
+export type LayoutFn = (
+  graph: CapabilityGraph,
+  timeoutMs?: number,
+) => Promise<Map<string, { x: number; y: number }>>;
+
+/**
+ * Run `layout` only when node/edge identity changed (or `prevIdentity` is
+ * null). Overlay-only updates return `positions: null`.
+ */
+export async function layoutGraphIfIdentityChanged(
+  graph: CapabilityGraph,
+  prevIdentity: string | null,
+  layout: LayoutFn = layoutGraph,
+): Promise<{ identity: string; positions: Map<string, { x: number; y: number }> | null }> {
+  const identity = graphIdentity(graph);
+  if (prevIdentity !== null && identity === prevIdentity) {
+    return { identity, positions: null };
+  }
+  return { identity, positions: await layout(graph) };
+}
+
 export async function layoutGraph(
   graph: CapabilityGraph,
   timeoutMs: number = LAYOUT_TIMEOUT_MS,

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -308,6 +308,8 @@ const stubAgent = (ref: string): AgentsView["agents"][number] =>
     command: null,
     actionRegistry: null,
     hosts: null,
+    modelTier: null,
+    model: null,
     eventTypes: [],
   }) as AgentsView["agents"][number];
 

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -1,12 +1,24 @@
 import "../test-dom";
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
-import { AgentNode, EventTypeNode, ProposalNode, TerminalNode } from "./nodes";
+import { AgentNode, EventTypeNode, ProposalNode, TerminalNode, nodeAccessibleName } from "./nodes";
 import type { GraphNode } from "./model";
+import { Graph } from "../views/Graph";
+import {
+  changeInput,
+  createAgentsFixture,
+  createProposalFixture,
+  createStatusFixture,
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
+import type { AgentsView } from "../types";
 
 afterEach(() => {
   cleanup();
+  restoreApi();
 });
 
 function renderNode(ui: React.ReactElement) {
@@ -150,6 +162,117 @@ describe("ProposalNode", () => {
   });
 });
 
+describe("node accessible names and selection", () => {
+  const eventNode: GraphNode = {
+    id: "event:gh.failed",
+    kind: "eventType",
+    label: "gh.failed",
+    adapter: "claude",
+    scope: ["repo"],
+    ttl: null,
+    admittedCount: 4,
+    plannedCount: 2,
+  };
+  const agentNode: GraphNode = {
+    id: "agent:doctor@1",
+    kind: "agent",
+    label: "doctor@1",
+    adapter: "claude",
+    mutating: false,
+    execution: "model",
+    contract: "c/v1",
+    capabilities: [],
+    actions: [],
+    hosts: [],
+    activeRuns: [{ state: "RUNNING", count: 1 }],
+  };
+  const terminalNode: GraphNode = {
+    id: "terminal:doctor@1",
+    kind: "terminal",
+    label: "chain ends",
+    reason: "TICKET, ENV",
+  };
+  const proposalNode: GraphNode = {
+    id: "proposal:prop_123",
+    kind: "proposal",
+    label: "pending: ci-rerun@1",
+    proposalId: "prop_123",
+    decision: "run",
+    agentRef: "ci-rerun@1",
+    eventType: "ci.rerun",
+    proposal: {
+      id: "prop_123",
+      decision: "run",
+      status: "open",
+      expired: false,
+      created_at: new Date().toISOString(),
+      ttl_seconds: 600,
+      decided_at: null,
+      decided_by: null,
+      reason: null,
+      runId: "run_456",
+      eventId: "ev_789",
+      eventSource: "gh",
+      agent: "ci-rerun@1",
+      spec: null,
+      repos: [],
+    },
+  };
+
+  test("names include kind, label, and material state for every node kind", () => {
+    expect(nodeAccessibleName(eventNode)).toContain("event type");
+    expect(nodeAccessibleName(eventNode)).toContain("gh.failed");
+    expect(nodeAccessibleName(eventNode)).toMatch(/4 admitted/);
+    expect(nodeAccessibleName(agentNode)).toContain("agent");
+    expect(nodeAccessibleName(agentNode)).toContain("doctor@1");
+    expect(nodeAccessibleName(agentNode)).toContain("RUNNING");
+    expect(nodeAccessibleName(terminalNode)).toContain("terminal");
+    expect(nodeAccessibleName(terminalNode)).toContain("chain ends");
+    expect(nodeAccessibleName(terminalNode)).toContain("TICKET, ENV");
+    expect(nodeAccessibleName(proposalNode)).toContain("proposal");
+    expect(nodeAccessibleName(proposalNode)).toContain("pending: ci-rerun@1");
+    expect(nodeAccessibleName(proposalNode)).toContain("run");
+  });
+
+  test("each kind exposes the accessible name and aria-selected on the node", () => {
+    const cases: Array<{ ui: React.ReactElement; name: RegExp }> = [
+      { ui: <EventTypeNode {...nodeProps(eventNode)} selected />, name: /event type/i },
+      { ui: <AgentNode {...nodeProps(agentNode)} selected />, name: /agent/i },
+      { ui: <TerminalNode {...nodeProps(terminalNode)} selected />, name: /terminal/i },
+      { ui: <ProposalNode {...nodeProps(proposalNode)} selected />, name: /proposal/i },
+    ];
+    for (const { ui, name } of cases) {
+      const { getByRole, unmount } = renderNode(ui);
+      const node = getByRole("button", { name });
+      expect(node.getAttribute("aria-selected")).toBe("true");
+      expect(node.getAttribute("aria-pressed")).toBe("true");
+      unmount();
+    }
+  });
+
+  test("unselected nodes set aria-selected false", () => {
+    const { getByRole } = renderNode(<EventTypeNode {...nodeProps(eventNode)} />);
+    expect(getByRole("button", { name: /event type/i }).getAttribute("aria-selected")).toBe("false");
+    expect(getByRole("button", { name: /event type/i }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("the current search match is visually distinct from other hits", () => {
+    const hit = renderNode(<EventTypeNode {...nodeProps(eventNode, { searchHit: true })} />);
+    const hitEl = hit.getByRole("button", { name: /event type/i });
+    expect(hitEl.getAttribute("data-search-hit")).toBe("true");
+    expect(hitEl.getAttribute("data-search-current")).toBeNull();
+    const hitStyle = (hitEl as HTMLElement).style.outlineStyle;
+    hit.unmount();
+
+    const current = renderNode(
+      <EventTypeNode {...nodeProps(eventNode, { searchHit: true, searchCurrent: true })} />,
+    );
+    const currentEl = current.getByRole("button", { name: /event type/i });
+    expect(currentEl.getAttribute("data-search-current")).toBe("true");
+    expect((currentEl as HTMLElement).style.outlineStyle).not.toBe(hitStyle);
+  });
+});
+
 describe("TerminalNode", () => {
   test("renders terminal node with reason", () => {
     const node: GraphNode = {
@@ -162,5 +285,147 @@ describe("TerminalNode", () => {
     const { getByText } = renderNode(<TerminalNode {...nodeProps(node)} />);
     expect(getByText("chain ends")).toBeTruthy();
     expect(getByText("TICKET, ENV")).toBeTruthy();
+  });
+});
+
+const stubAgent = (ref: string): AgentsView["agents"][number] =>
+  ({
+    ref,
+    id: ref.split("@")[0],
+    version: 1,
+    outputContract: "c/v1",
+    workspace: { type: "ephemeral" },
+    capabilities: { services: [] },
+    limits: { timeout_seconds: 60, attempts: 1 },
+    mutating: false,
+    promptFile: "p.md",
+    prompt: "",
+    inputSchemaFile: "i.json",
+    inputSchema: {},
+    outputSchemaFile: "o.json",
+    outputSchema: {},
+    pins: {},
+    command: null,
+    actionRegistry: null,
+    hosts: null,
+    eventTypes: [],
+  }) as AgentsView["agents"][number];
+
+const graphAgents = (): AgentsView =>
+  createAgentsFixture({
+    agents: [stubAgent("doctor@1"), stubAgent("rerun@1")],
+    eventTypes: [
+      {
+        type: "gh.failed",
+        agent: "doctor@1",
+        adapter: "claude",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+      {
+        type: "ci.rerun",
+        agent: "rerun@1",
+        adapter: "command",
+        idempotencyScope: [],
+        proposalTtlSeconds: null,
+      },
+    ],
+  });
+
+function renderGraph(props: Partial<Parameters<typeof Graph>[0]> = {}) {
+  return renderWithClient(
+    <Graph
+      context={{ kind: "all" }}
+      focusNodeId={null}
+      onSelectNode={() => {}}
+      onJumpAgent={() => {}}
+      onJumpEvents={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe("Graph view inspect loop", () => {
+  test("search input is mounted before layout so / does not leave Graph", async () => {
+    await withApi(
+      {
+        agents: async () => createAgentsFixture(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByLabelText } = renderGraph();
+        const input = await waitFor(() => getByLabelText("Search graph nodes"));
+        expect(input.hasAttribute("data-view-filter")).toBe(true);
+      },
+    );
+  });
+
+  test("search input carries data-view-filter so / can focus it", async () => {
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByLabelText } = renderGraph();
+        const input = await waitFor(() => getByLabelText("Search graph nodes"));
+        expect(input.hasAttribute("data-view-filter")).toBe(true);
+      },
+    );
+  });
+
+  test("Enter selects match 1 of N instead of skipping to match 2", async () => {
+    const onSelectNode = mock(() => {});
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByLabelText } = renderGraph({ onSelectNode });
+        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+        changeInput(input, "agent:");
+        fireEvent.keyDown(input, { key: "Enter" });
+        expect(onSelectNode).toHaveBeenCalledWith("agent:doctor@1");
+        expect(onSelectNode).not.toHaveBeenCalledWith("agent:rerun@1");
+      },
+    );
+  });
+
+  test("stale deep-link shows Node not found with a control that clears to #/graph", async () => {
+    const onSelectNode = mock(() => {});
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole, getByText } = renderGraph({
+          focusNodeId: "event:does-not-exist",
+          onSelectNode,
+        });
+        await waitFor(() => getByText("Node not found"));
+        fireEvent.click(getByRole("button", { name: "Show graph" }));
+        expect(onSelectNode).toHaveBeenCalledWith(null);
+      },
+    );
+  });
+
+  test("selected proposal node shows Open in Proposals jumping via hashPath", async () => {
+    const proposal = createProposalFixture({ id: "prop_abc", agent: "doctor@1" });
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        proposals: async () => ({ proposals: [proposal] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole } = renderGraph({ focusNodeId: "proposal:prop_abc" });
+        const btn = await waitFor(() => getByRole("button", { name: "Open in Proposals" }));
+        window.location.hash = "#/graph/proposal:prop_abc";
+        fireEvent.click(btn);
+        expect(window.location.hash).toBe("#/proposals/prop_abc");
+      },
+    );
   });
 });

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -10,6 +10,34 @@ import { DECISION_HUES, STATE_HUES, StateBadge } from "../components/ui";
 const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
 
 const searchHitOf = (data: NodeProps["data"]) => Boolean((data as { searchHit?: boolean }).searchHit);
+const searchCurrentOf = (data: NodeProps["data"]) =>
+  Boolean((data as { searchCurrent?: boolean }).searchCurrent);
+
+function materialState(node: GraphNode): string {
+  switch (node.kind) {
+    case "eventType": {
+      const admitted = node.admittedCount ?? 0;
+      const planned = node.plannedCount ?? 0;
+      if (admitted > 0 || planned > 0) return `${admitted} admitted, ${planned} planned`;
+      return "idle";
+    }
+    case "agent": {
+      const runs = node.activeRuns ?? [];
+      if (runs.length === 0) return "idle";
+      return runs.map(({ state, count }) => (count > 1 ? `${state} ${count}` : state)).join(", ");
+    }
+    case "proposal":
+      return node.proposal.expired ? `${node.decision}, expired` : node.decision;
+    case "terminal":
+      return node.reason;
+  }
+}
+
+/** Accessible name: kind + label + material state (counts, run badges, decision). */
+export function nodeAccessibleName(node: GraphNode): string {
+  const kind = node.kind === "eventType" ? "event type" : node.kind;
+  return `${kind} ${node.label}, ${materialState(node)}`;
+}
 
 function Shell({
   children,
@@ -17,17 +45,27 @@ function Shell({
   selected,
   dashed,
   searchHit,
+  searchCurrent,
+  accessibleName,
 }: {
   children: React.ReactNode;
   accent: string;
   selected?: boolean;
   dashed?: boolean;
   searchHit?: boolean;
+  searchCurrent?: boolean;
+  accessibleName: string;
 }) {
   return (
     <div
       className="rounded-md px-3 py-2 text-left"
       tabIndex={0}
+      role="button"
+      aria-label={accessibleName}
+      aria-selected={selected ? true : false}
+      aria-pressed={selected ? true : false}
+      data-search-hit={searchHit || searchCurrent ? "true" : undefined}
+      data-search-current={searchCurrent ? "true" : undefined}
       style={{
         width: 236,
         height: 92,
@@ -35,8 +73,10 @@ function Shell({
         border: `1px ${dashed ? "dashed" : "solid"} ${selected ? accent : "var(--border)"}`,
         boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
         borderLeft: `3px solid ${accent}`,
-        outline: searchHit ? "2px solid var(--accent)" : undefined,
-        outlineOffset: searchHit ? 2 : undefined,
+        outlineWidth: searchHit || searchCurrent ? "2px" : undefined,
+        outlineStyle: searchCurrent ? "solid" : searchHit ? "dashed" : undefined,
+        outlineColor: searchHit || searchCurrent ? "var(--accent)" : undefined,
+        outlineOffset: searchHit || searchCurrent ? 2 : undefined,
       }}
     >
       {children}
@@ -62,7 +102,13 @@ export function EventTypeNode({ data, selected }: NodeProps) {
   const hasCounts = admitted > 0 || planned > 0;
 
   return (
-    <Shell accent={NODE_STYLES.eventType.accent} selected={selected} searchHit={searchHitOf(data)}>
+    <Shell
+      accent={NODE_STYLES.eventType.accent}
+      selected={selected}
+      searchHit={searchHitOf(data)}
+      searchCurrent={searchCurrentOf(data)}
+      accessibleName={nodeAccessibleName(node)}
+    >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
         <span className="text-[10px] tracking-wide uppercase" style={{ color: NODE_STYLES.eventType.accent }}>
@@ -115,7 +161,13 @@ export function AgentNode({ data, selected }: NodeProps) {
   const activeRuns = node.activeRuns ?? [];
 
   return (
-    <Shell accent={accent} selected={selected} searchHit={searchHitOf(data)}>
+    <Shell
+      accent={accent}
+      selected={selected}
+      searchHit={searchHitOf(data)}
+      searchCurrent={searchCurrentOf(data)}
+      accessibleName={nodeAccessibleName(node)}
+    >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-2">
         <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
@@ -172,6 +224,8 @@ export function TerminalNode({ data, selected }: NodeProps) {
       selected={selected}
       dashed={NODE_STYLES.terminal.dashed}
       searchHit={searchHitOf(data)}
+      searchCurrent={searchCurrentOf(data)}
+      accessibleName={nodeAccessibleName(node)}
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="text-[10px] tracking-wide uppercase" style={{ color: "var(--text-faint)" }}>
@@ -193,6 +247,8 @@ export function ProposalNode({ data, selected }: NodeProps) {
       selected={selected}
       dashed={NODE_STYLES.proposal.dashed}
       searchHit={searchHitOf(data)}
+      searchCurrent={searchCurrentOf(data)}
+      accessibleName={nodeAccessibleName(node)}
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">

--- a/event-runtime/web/src/graph/search.test.ts
+++ b/event-runtime/web/src/graph/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { largestComponentIds, matchNodes } from "./search";
+import { largestComponentIds, matchNodes, missingFocusNode, searchEnter } from "./search";
 import type { CapabilityGraph, GraphNode } from "./model";
 
 const event = (type: string): GraphNode => ({
@@ -50,6 +50,38 @@ describe("matchNodes", () => {
 
   test("no match returns empty", () => {
     expect(matchNodes(nodes, "zzz")).toEqual([]);
+  });
+});
+
+describe("searchEnter", () => {
+  const matches = ["event:a", "agent:b", "agent:c"];
+
+  test("empty matches do not select anything", () => {
+    expect(searchEnter([], 0, null)).toBeNull();
+  });
+
+  test("first Enter selects match 1 of N, not match 2", () => {
+    expect(searchEnter(matches, 0, null)).toEqual({ selectId: "event:a", nextIdx: 0 });
+  });
+
+  test("Enter while the current match is already selected advances to the next", () => {
+    expect(searchEnter(matches, 0, "event:a")).toEqual({ selectId: "agent:b", nextIdx: 1 });
+  });
+});
+
+describe("missingFocusNode", () => {
+  test("does not report a missing node while the graph is still loading", () => {
+    expect(missingFocusNode(undefined, "event:gone", false)).toBe(false);
+    expect(missingFocusNode([{ id: "event:a" }], "event:gone", false)).toBe(false);
+  });
+
+  test("reports missing when a loaded graph has no node for the deep-link id", () => {
+    expect(missingFocusNode([{ id: "event:a" }], "event:gone", true)).toBe(true);
+  });
+
+  test("does not report missing when the deep-link node exists", () => {
+    expect(missingFocusNode([{ id: "event:a" }], "event:a", true)).toBe(false);
+    expect(missingFocusNode([{ id: "event:a" }], null, true)).toBe(false);
   });
 });
 

--- a/event-runtime/web/src/graph/search.ts
+++ b/event-runtime/web/src/graph/search.ts
@@ -17,6 +17,38 @@ export function matchNodes(nodes: GraphNode[], query: string): string[] {
 }
 
 /**
+ * Enter on a non-empty query selects the current match (match 1 of N first).
+ * A second Enter while that match is already selected advances to the next.
+ */
+export function searchEnter(
+  matches: string[],
+  matchIdx: number,
+  selectedId: string | null,
+): { selectId: string; nextIdx: number } | null {
+  if (matches.length === 0) return null;
+  const idx = ((matchIdx % matches.length) + matches.length) % matches.length;
+  const current = matches[idx]!;
+  if (selectedId === current && matches.length > 1) {
+    const nextIdx = (idx + 1) % matches.length;
+    return { selectId: matches[nextIdx]!, nextIdx };
+  }
+  return { selectId: current, nextIdx: idx };
+}
+
+/**
+ * Stale `#/graph/:nodeId`: the hash names a node that is not in the loaded
+ * graph. While loading, this is false so the banner does not flash.
+ */
+export function missingFocusNode(
+  nodes: Array<{ id: string }> | null | undefined,
+  focusNodeId: string | null,
+  loaded: boolean,
+): boolean {
+  if (!loaded || !focusNodeId || !nodes) return false;
+  return !nodes.some((n) => n.id === focusNodeId);
+}
+
+/**
  * Node ids of the largest connected component (undirected), edges winning
  * ties — the initial view centers here instead of fitting every stray island
  * on screen at once.

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -431,9 +431,11 @@ export function Graph({
             onNodeClick={(_, node) => onSelectNode(node.id)}
             onPaneClick={() => onSelectNode(null)}
             onNodesChange={(changes: NodeChange[]) => {
+              const kept = changes.filter((c) => c.type === "position" || c.type === "dimensions");
+              if (kept.length === 0) return;
               setPositioned((prev) => {
                 if (!prev) return prev;
-                return { ...prev, nodes: applyNodeChanges(changes, prev.nodes) };
+                return { ...prev, nodes: applyNodeChanges(kept, prev.nodes) };
               });
             }}
             onInit={(inst) => {
@@ -441,6 +443,7 @@ export function Graph({
               setFlowReady((n) => n + 1);
             }}
             nodesFocusable
+            deleteKeyCode={null}
             proOptions={{ hideAttribution: true }}
             minZoom={0.2}
           >

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -1,10 +1,12 @@
 import {
+  applyNodeChanges,
   Background,
   Controls,
   MiniMap,
   ReactFlow,
   type Edge,
   type Node,
+  type NodeChange,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useQuery } from "@tanstack/react-query";
@@ -13,8 +15,9 @@ import { api } from "../api";
 import { keyGuard, useNow } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
-import { largestComponentIds, matchNodes } from "../graph/search";
+import { largestComponentIds, matchNodes, missingFocusNode, searchEnter } from "../graph/search";
 import { EDGE_STYLES, legendEntries } from "../graph/style";
+import { hashPath, hashProject, withProject } from "../hash";
 import type { EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import {
@@ -37,6 +40,45 @@ import { ScopeCaption } from "../components/ContextTabs";
 // (WM-99). The initial fit centers on the largest component and never goes
 // below this floor — the minimap covers "where is everything else".
 const INITIAL_FIT_MIN_ZOOM = 0.65;
+
+function flowEdges(graph: { edges: Array<{ id: string; source: string; target: string; kind: keyof typeof EDGE_STYLES; label?: string }> }): Edge[] {
+  return graph.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    animated: false,
+    style: {
+      stroke: EDGE_STYLES[edge.kind].stroke,
+      strokeWidth: 1.5,
+      strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
+    },
+    labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
+    labelBgStyle: { fill: "var(--surface-0)" },
+  }));
+}
+
+function applyGraphOverlay(
+  prev: { nodes: Node[]; edges: Edge[] } | null,
+  graph: { nodes: GraphNode[]; edges: Parameters<typeof flowEdges>[0]["edges"] },
+): { nodes: Node[]; edges: Edge[] } | null {
+  if (!prev) return prev;
+  const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+  if (prev.nodes.length !== graph.nodes.length || prev.nodes.some((n) => !byId.has(n.id))) {
+    return prev;
+  }
+  return {
+    nodes: prev.nodes.map((n) => ({
+      ...n,
+      data: { ...(n.data as object), node: byId.get(n.id) },
+    })),
+    edges: flowEdges(graph),
+  };
+}
+
+function jumpHash(path: string) {
+  window.location.hash = `#/${withProject(path, hashProject(window.location.hash))}`;
+}
 
 /**
  * Graph (webui roadmap / OPS-224 phase 1, chrome OPS-230, phase 2 overlays OPS-227):
@@ -65,6 +107,9 @@ export function Graph({
 
   const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
   const [layoutError, setLayoutError] = useState<"chunk" | "layout" | "mapping" | null>(null);
+  const [layoutEpoch, setLayoutEpoch] = useState(0);
+  const lastIdentityRef = useRef<string | null>(null);
+  const epochLaidOutRef = useRef(0);
   const flowRef = useRef<{
     getZoom: () => number;
     fitView: (opts: {
@@ -101,13 +146,23 @@ export function Graph({
     setLayoutError(null);
     // elkjs is ~1.4 MB of pre-minified layout engine, so it rides in its own
     // async chunk (OPS-255) — fetched the first time there is a graph to lay
-    // out, never by the list views.
+    // out, never by the list views. Overlay polls reuse positions when
+    // node/edge identity is unchanged (WM-154).
     import("../graph/layout")
       .then(
-        ({ layoutGraph, NODE_HEIGHT, NODE_WIDTH }) =>
-          layoutGraph(graph)
-            .then((positions) => {
+        ({ layoutGraphIfIdentityChanged, NODE_HEIGHT, NODE_WIDTH }) => {
+          const prevIdentity =
+            layoutEpoch !== epochLaidOutRef.current ? null : lastIdentityRef.current;
+          return layoutGraphIfIdentityChanged(graph, prevIdentity)
+            .then((result) => {
               if (cancelled) return;
+              lastIdentityRef.current = result.identity;
+              epochLaidOutRef.current = layoutEpoch;
+              if (!result.positions) {
+                setPositioned((prev) => applyGraphOverlay(prev, graph));
+                return;
+              }
+              const positions = result.positions;
               try {
                 setPositioned({
                   nodes: graph.nodes.map((node) => ({
@@ -119,20 +174,7 @@ export function Graph({
                     width: NODE_WIDTH,
                     height: NODE_HEIGHT,
                   })),
-                  edges: graph.edges.map((edge) => ({
-                    id: edge.id,
-                    source: edge.source,
-                    target: edge.target,
-                    label: edge.label,
-                    animated: false,
-                    style: {
-                      stroke: EDGE_STYLES[edge.kind].stroke,
-                      strokeWidth: 1.5,
-                      strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
-                    },
-                    labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
-                    labelBgStyle: { fill: "var(--surface-0)" },
-                  })),
+                  edges: flowEdges(graph),
                 });
               } catch (err) {
                 if (cancelled) return;
@@ -144,7 +186,8 @@ export function Graph({
               if (cancelled) return;
               console.error("graph layout calculation failed", err);
               setLayoutError("layout");
-            }),
+            });
+        },
         (err: unknown) => {
           if (cancelled) return;
           console.error("graph layout chunk import failed", err);
@@ -154,7 +197,7 @@ export function Graph({
     return () => {
       cancelled = true;
     };
-  }, [graph]);
+  }, [graph, layoutEpoch]);
 
   // Node search (WM-99): case-insensitive substring on label/id, matches
   // highlighted on canvas, Enter cycles through them.
@@ -172,13 +215,15 @@ export function Graph({
         ? positioned.nodes.map((n) => ({
             ...n,
             selected: n.id === focusNodeId,
-            data: { ...n.data, searchHit: matchSet.has(n.id) },
+            data: { ...n.data, searchHit: matchSet.has(n.id), searchCurrent: n.id === currentMatch },
           }))
         : [],
-    [positioned, focusNodeId, matchSet],
+    [positioned, focusNodeId, matchSet, currentMatch],
   );
 
   const selected: GraphNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
+  const graphLoaded = Boolean(graph) && !registry.isPending;
+  const staleFocus = missingFocusNode(graph?.nodes, focusNodeId, graphLoaded);
   const agentDef =
     selected?.kind === "agent"
       ? registry.data?.agents.find((a) => a.ref === selected.label)
@@ -291,36 +336,56 @@ export function Graph({
             what this runtime can do — registered routes and recommendation edges
           </div>
           <ScopeCaption context={context} surface="graph" />
-        </div>
-        {positioned && graph && graph.nodes.length > 0 && (
-          <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
-            <div className="flex items-center gap-2">
-              {query.trim() && (
-                <span className="text-[11px] text-(--text-faint)">
-                  {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
-                </span>
-              )}
-              <input
-                type="text"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && matches.length) {
-                    e.preventDefault();
-                    setMatchIdx((i) => (i + 1) % matches.length);
-                  } else if (e.key === "Escape") {
-                    e.preventDefault();
-                    if (query) setQuery("");
-                    else e.currentTarget.blur();
-                  }
-                }}
-                placeholder="Search nodes…"
-                aria-label="Search graph nodes"
-                spellCheck={false}
-                className="w-52 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
-              />
+          {staleFocus && (
+            <div
+              className="mt-2 flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[12px]"
+              role="status"
+              style={{
+                color: "var(--hue-warn)",
+                background: "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
+              }}
+            >
+              <span>Node not found</span>
+              <Button onClick={() => onSelectNode(null)}>Show graph</Button>
             </div>
-            {legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
+          )}
+        </div>
+        <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+          <div className="flex items-center gap-2">
+            {query.trim() && (
+              <span className="text-[11px] text-(--text-faint)">
+                {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
+              </span>
+            )}
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  const result = searchEnter(matches, safeMatchIdx, focusNodeId);
+                  if (result) {
+                    e.preventDefault();
+                    setMatchIdx(result.nextIdx);
+                    onSelectNode(result.selectId);
+                  }
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  if (query) setQuery("");
+                  else e.currentTarget.blur();
+                }
+              }}
+              placeholder="Search nodes…"
+              aria-label="Search graph nodes"
+              data-view-filter
+              spellCheck={false}
+              className="w-52 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+            />
+            {positioned && graph && graph.nodes.length > 0 && (
+              <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
+            )}
+          </div>
+          {positioned && graph && graph.nodes.length > 0 && legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
               <div
                 className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
                 role="img"
@@ -358,7 +423,6 @@ export function Graph({
               </div>
             )}
           </div>
-        )}
         {positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow
             nodes={nodes}
@@ -366,6 +430,12 @@ export function Graph({
             nodeTypes={nodeTypes}
             onNodeClick={(_, node) => onSelectNode(node.id)}
             onPaneClick={() => onSelectNode(null)}
+            onNodesChange={(changes: NodeChange[]) => {
+              setPositioned((prev) => {
+                if (!prev) return prev;
+                return { ...prev, nodes: applyNodeChanges(changes, prev.nodes) };
+              });
+            }}
             onInit={(inst) => {
               flowRef.current = inst;
               setFlowReady((n) => n + 1);
@@ -490,6 +560,9 @@ export function Graph({
               {selected.agentRef && (
                 <Button onClick={() => onJumpAgent(selected.agentRef!)}>Open in Agents</Button>
               )}
+              <Button onClick={() => jumpHash(hashPath("proposals", selected.proposalId))}>
+                Open in Proposals
+              </Button>
             </>
           )}
 


### PR DESCRIPTION
## Summary
- ELK runs only when node/edge **identity** changes; overlay polls keep dragged positions until topology changes or **Reset layout**.
- Search Enter selects match 1 of N (opens the detail pane / `#/graph/:nodeId`); current match is visually distinct from other hits.
- Graph search always has `data-view-filter` so `/` focuses it without leaving Graph, including while layout is still running.
- Stale `#/graph/:nodeId` shows **Node not found** with a control back to `#/graph`.
- Custom nodes expose accessible names (kind + label + material state), `aria-selected`, and `aria-pressed`.
- Selected proposal ghosts show **Open in Proposals** via `hashPath("proposals", id)` (no App.tsx).

## Test plan
- [x] `cd event-runtime/web && bun test` — 379 pass
- [ ] On Graph: `/` focuses search; Enter selects match 1 of N; second Enter advances
- [ ] Invalid `#/graph/event:does-not-exist` shows the banner; Show graph clears it
- [ ] Proposal node → Open in Proposals lands on `#/proposals/:id`
- [ ] Drag a node, wait for a poll — position sticks; Reset layout restores ELK

UX critique: required — FIX-FIRST resolved in 1 round (search input mounted before layout so `/` cannot drop onto Events). Round 2 SHIP. Visual coverage not assessed (no browser MCP). Follow-ups: WM-165 (hash jump vs HashWriter), WM-166 (search counter jitter).

Fixes WM-154