### PR TITLE
fix(web): Projects unscoped caption and empty-dry Apply (WM-157)

### DIFF
--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -1,0 +1,209 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { Projects } from "./Projects";
+import {
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
+import type { JanitorResult, RepoItem } from "../types";
+import { CONTEXT_STORAGE_KEY } from "../context";
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+  window.location.hash = "";
+  sessionStorage.clear();
+});
+
+const noop = () => {};
+
+function repo(overrides: Partial<RepoItem> = {}): RepoItem {
+  return {
+    name: "factory",
+    path: "/tmp/factory",
+    github: "watt-mind/factory",
+    team: "WM",
+    project: "Factory",
+    base: "develop",
+    deployBranch: "master",
+    reportOnly: false,
+    maxInFlight: null,
+    worktreeRoot: "/tmp/worktrees/factory",
+    hasWorktreeUp: true,
+    hasWorktreeDown: true,
+    hasWorktreeWarm: true,
+    verify: "bun test",
+    ...overrides,
+  };
+}
+
+function janitor(overrides: Partial<JanitorResult> = {}): JanitorResult {
+  return {
+    repo: "factory",
+    apply: false,
+    actor: "janitor",
+    reclaimable: [],
+    kept: [],
+    named: [],
+    unknown: [],
+    removed: [],
+    refused: [],
+    held: [],
+    ...overrides,
+  };
+}
+
+function renderProjects(focusRepoName: string | null = null) {
+  return renderWithClient(
+    <Projects connected={true} focusRepoName={focusRepoName} onSelectRepo={noop} />,
+  );
+}
+
+async function openJanitor(focus = "factory") {
+  const r = renderProjects(focus);
+  await waitFor(() => {
+    expect(r.getByRole("button", { name: "Run Dry Janitor" })).toBeTruthy();
+  });
+  return r;
+}
+
+describe("Projects unscoped caption (WM-157)", () => {
+  test("All context shows no factory-wide caption", async () => {
+    window.location.hash = "#/projects";
+    // Stale sessionStorage must not invent a caption — hash is the live source (same as App).
+    sessionStorage.setItem(CONTEXT_STORAGE_KEY, JSON.stringify({ openRepos: ["factory"], active: "factory" }));
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects();
+      await waitFor(() => {
+        expect(r.getByText("factory")).toBeTruthy();
+      });
+      expect(r.queryByText(/not scoped to/)).toBeNull();
+      expect(r.queryByText(/In flight scopes/)).toBeNull();
+    });
+  });
+
+  test("repo context tab captions that the registry is factory-wide", async () => {
+    window.location.hash = "#/projects?project=factory";
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects();
+      await waitFor(() => {
+        expect(r.getByText("factory")).toBeTruthy();
+      });
+      expect(r.getByText("registry is not scoped to factory.")).toBeTruthy();
+    });
+  });
+
+  test("In flight context tab captions that the registry is factory-wide", async () => {
+    window.location.hash = "#/projects?project=inflight";
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects();
+      await waitFor(() => {
+        expect(r.getByText("factory")).toBeTruthy();
+      });
+      expect(r.getByText("In flight scopes Runs list.")).toBeTruthy();
+    });
+  });
+
+  test("repo caption appears after a same-view replaceState (context tab, no hashchange)", async () => {
+    window.location.hash = "#/projects";
+    await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
+      const r = renderProjects();
+      await waitFor(() => {
+        expect(r.getByText("factory")).toBeTruthy();
+      });
+      expect(r.queryByText(/not scoped to/)).toBeNull();
+
+      // App's context-tab writer uses replaceState (no hashchange). Swallow the
+      // event happy-dom fires on location.hash so this matches that path.
+      const swallow = (e: Event) => e.stopImmediatePropagation();
+      window.addEventListener("hashchange", swallow, true);
+      try {
+        window.location.hash = "#/projects?project=factory";
+        r.rerender(<Projects connected={true} focusRepoName={null} onSelectRepo={noop} />);
+      } finally {
+        window.removeEventListener("hashchange", swallow, true);
+      }
+
+      expect(r.getByText("registry is not scoped to factory.")).toBeTruthy();
+    });
+  });
+});
+
+describe("Projects Clean Reclaimable Apply (WM-157)", () => {
+  test("Apply stays disabled and confirm does not open when dry found nothing", async () => {
+    await withApi(
+      {
+        repos: async () => ({ repos: [repo()] }),
+        janitor: async (name: string) => janitor({ repo: name, reclaimable: [] }),
+      },
+      async () => {
+        const r = await openJanitor();
+        fireEvent.click(r.getByRole("button", { name: "Run Dry Janitor" }));
+        await waitFor(() => {
+          expect(r.getByText("0 reclaimable")).toBeTruthy();
+        });
+        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        expect((apply as HTMLButtonElement).disabled).toBe(true);
+        expect(r.getByText("Nothing to reclaim")).toBeTruthy();
+        fireEvent.click(apply);
+        expect(r.queryByRole("dialog")).toBeNull();
+        expect(r.queryByText(/Type/)).toBeNull();
+      },
+    );
+  });
+
+  test("Apply enables when dry found reclaimable worktrees and confirm can open", async () => {
+    await withApi(
+      {
+        repos: async () => ({ repos: [repo()] }),
+        janitor: async (name: string) =>
+          janitor({
+            repo: name,
+            reclaimable: [{ id: "WM-1", state: "Done" }],
+          }),
+      },
+      async () => {
+        const r = await openJanitor();
+        fireEvent.click(r.getByRole("button", { name: "Run Dry Janitor" }));
+        await waitFor(() => {
+          expect(r.getByText("1 reclaimable")).toBeTruthy();
+        });
+        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        expect((apply as HTMLButtonElement).disabled).toBe(false);
+        expect(r.queryByText("Nothing to reclaim")).toBeNull();
+        fireEvent.click(apply);
+        expect(r.getByRole("dialog")).toBeTruthy();
+        expect(r.getByText("Clean Worktrees for factory")).toBeTruthy();
+      },
+    );
+  });
+
+  test("report-only repo without worktree_down stays disabled even with reclaimable", async () => {
+    await withApi(
+      {
+        repos: async () => ({
+          repos: [repo({ reportOnly: true, hasWorktreeDown: false })],
+        }),
+        janitor: async (name: string) =>
+          janitor({
+            repo: name,
+            reclaimable: [{ id: "WM-1", state: "Done" }],
+          }),
+      },
+      async () => {
+        const r = await openJanitor();
+        fireEvent.click(r.getByRole("button", { name: "Run Dry Janitor" }));
+        await waitFor(() => {
+          expect(r.getByText("1 reclaimable")).toBeTruthy();
+        });
+        const apply = r.getByRole("button", { name: "Clean Reclaimable Worktrees…" });
+        expect((apply as HTMLButtonElement).disabled).toBe(true);
+        expect(r.getByText(/Apply is disabled: report-only repo/)).toBeTruthy();
+        fireEvent.click(apply);
+        expect(r.queryByRole("dialog")).toBeNull();
+      },
+    );
+  });
+});

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -1,9 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { api, ApiError } from "../api";
+import { contextFromProject, type OperatorContext } from "../context";
+import { hashProject } from "../hash";
 import { useListKeys } from "../hooks";
 import { setContextActions } from "../palette";
 import type { JanitorResult } from "../types";
+import { ScopeCaption } from "../components/ContextTabs";
 import {
   Button,
   DetailPane,
@@ -18,6 +21,11 @@ import {
   copyText,
   notify,
 } from "../components/ui";
+
+/** Live operator context from the hash — same source App uses. Read on every render: context-tab switches replaceState and do not fire hashchange. Do not read sessionStorage: stale `active` must not caption All. */
+function operatorContext(): OperatorContext {
+  return contextFromProject(hashProject(typeof window === "undefined" ? "" : window.location.hash));
+}
 
 const TEAM_HUES: Record<string, string> = {
   CLNT: "var(--hue-ok)",
@@ -38,6 +46,7 @@ export function Projects({
   onSelectRepo: (name: string | null) => void;
 }) {
   const queryClient = useQueryClient();
+  const context = operatorContext();
   const [filter, setFilter] = useState("");
   const [filterMode, setFilterMode] = useState<"ALL" | "DISPATCHABLE" | "REPORT_ONLY">("ALL");
 
@@ -233,6 +242,7 @@ export function Projects({
         chrome={
           <>
             <h1 className="display mb-4 text-lg font-semibold">Projects</h1>
+            <ScopeCaption context={context} surface="registry" />
             <div className="mb-3">
               <FilterInput
                 value={filter}
@@ -550,15 +560,20 @@ export function Projects({
                       dryMutation.isPending ||
                       applyMutation.isPending ||
                       !dryResult ||
+                      dryResult.reclaimable.length === 0 ||
                       (sel.reportOnly && !sel.hasWorktreeDown)
                     }
                     onClick={() => {
+                      if (!dryResult?.reclaimable.length) return;
                       setConfirmInput("");
                       setConfirmOpen(true);
                     }}
                   >
                     Clean Reclaimable Worktrees…
                   </Button>
+                  {dryResult && dryResult.reclaimable.length === 0 && (
+                    <span className="text-[11px] text-(--text-faint)">Nothing to reclaim</span>
+                  )}
 
                   <Button
                     disabled={!connected || quickDispatchMutation.isPending}
@@ -769,7 +784,7 @@ export function Projects({
         </DetailPane>
       )}
 
-      {confirmOpen && sel && (
+      {confirmOpen && sel && (dryResult?.reclaimable.length ?? 0) > 0 && (
         <Dialog
           title={`Clean Worktrees for ${sel.name}`}
           onClose={() => {


### PR DESCRIPTION
## Summary

- Projects reads operator context from the hash (`hashProject` / `contextFromProject`) and shows the same factory-wide `ScopeCaption` as Agents when a repo or In flight tab is active. All stays silent. Hash is read on every render so context-tab `replaceState` (no `hashchange`) updates the caption.
- “Clean Reclaimable Worktrees…” is disabled when `dryResult.reclaimable.length === 0`, with inline “Nothing to reclaim”. Confirm cannot open with zero reclaimable. Dry with reclaimable > 0 still enables Apply; report-only + no `worktree_down` guard unchanged.

## Test plan

- [x] `cd event-runtime/web && bun test` — 368 pass
- [x] Negative tests first: All hash has no caption; empty dry leaves Apply disabled
- [x] UX critique: required — FIX-FIRST (repo-tab caption missed `replaceState`) resolved in 1 round, then SHIP

Follow-up: WM-169 (mobile viewport clip, Triage).

Fixes WM-157