### PR TITLE
fix(web): Events inbox repo caption and short event ids (WM-142)

### DIFF
--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -10,6 +10,7 @@ import {
   restoreApi,
   withApi,
 } from "../test-render";
+import { shortId } from "../components/ui";
 import type { AdmittedEvent, EventFocus } from "../types";
 
 afterEach(() => {
@@ -65,9 +66,13 @@ describe("Events component harness: selection & detail view", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { getByText } = renderEvents({ onSelectEvent });
+        const { getByText, container } = renderEvents({ onSelectEvent });
 
-        const cell = await waitFor(() => getByText("evt_click_test"));
+        const cell = await waitFor(() => {
+          const el = container.querySelector('td[title="evt_click_test"]');
+          if (!el) throw new Error("event row not rendered");
+          return el;
+        });
         const row = cell.closest("tr");
         expect(row).toBeTruthy();
         fireEvent.click(row!);
@@ -146,7 +151,7 @@ describe("Events component harness: filter retention", () => {
         const { getByLabelText, container } = renderEvents({ focusEvent });
 
         await waitFor(() => container.querySelector("tr.row-selected"));
-        expect(container.querySelector("tbody")?.textContent).toContain("evt_pr_closed");
+        expect(container.querySelector('td[title="evt_pr_closed"]')).toBeTruthy();
 
         const filterInput = getByLabelText("Filter events") as HTMLInputElement;
         act(() => {
@@ -154,14 +159,14 @@ describe("Events component harness: filter retention", () => {
         });
 
         await waitFor(() => {
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_pr_opened");
-          expect(container.querySelector("tbody")?.textContent).not.toContain("evt_pr_closed");
+          expect(container.querySelector('td[title="evt_pr_opened"]')).toBeTruthy();
+          expect(container.querySelector('td[title="evt_pr_closed"]')).toBeNull();
         });
 
         // Selected event remains highlighted
         const selectedRow = container.querySelector("tr.row-selected");
         expect(selectedRow).toBeTruthy();
-        expect(selectedRow?.textContent).toContain("evt_pr_opened");
+        expect(selectedRow?.querySelector('td[title="evt_pr_opened"]')).toBeTruthy();
       },
     );
   });
@@ -214,7 +219,7 @@ describe("Events component harness: cross-tab reveal", () => {
         await waitFor(() => {
           const allTab = getByRole("tab", { name: /^All/i });
           expect(allTab.getAttribute("aria-selected")).toBe("true");
-          expect(container.querySelector("tbody")?.textContent).toContain("evt_dead_lettered_1");
+          expect(container.querySelector('td[title="evt_dead_lettered_1"]')).toBeTruthy();
         });
       },
     );
@@ -586,6 +591,60 @@ describe("Events component harness: facet chips synchronization with FilterInput
           expect(prButton?.getAttribute("aria-pressed")).toBe("false");
           expect(filterInput.value).toBe("");
         });
+      },
+    );
+  });
+});
+
+describe("Events repo scope caption (WM-142)", () => {
+  test("repo context renders scope caption while rows are filtered", async () => {
+    const matching = stubEvent("evt_repo_match", "admitted", { repos: ["factory"] });
+    const other = stubEvent("evt_other_repo", "admitted", { repos: ["other-repo"] });
+
+    await withApi(
+      {
+        events: async () => ({ events: [matching, other] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByText, container } = renderEvents({
+          context: { kind: "repo", name: "factory" },
+        });
+
+        await waitFor(() => {
+          expect(getByText(/Scoped to/i)).toBeTruthy();
+          expect(getByText(/factory/i)).toBeTruthy();
+          expect(getByText(/only rows naming this repo/i)).toBeTruthy();
+        });
+
+        expect(container.querySelector('td[title="evt_repo_match"]')).toBeTruthy();
+        expect(container.querySelector('td[title="evt_other_repo"]')).toBeNull();
+      },
+    );
+  });
+});
+
+describe("Events table short event ids (WM-142)", () => {
+  test("event id cell displays the short form and carries the full id as title", async () => {
+    const eventId = "evt_ec9c87f9-4c1d-4f4a-9d7e-2c2f3a1b0c9d";
+    const e1 = stubEvent(eventId, "admitted");
+
+    await withApi(
+      {
+        events: async () => ({ events: [e1] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { container } = renderEvents({
+          focusEvent: { source: "github", eventId },
+        });
+
+        const cell = await waitFor(() => {
+          const el = container.querySelector(`td[title="${eventId}"]`);
+          if (!el) throw new Error("event id cell with full-id title is missing");
+          return el;
+        });
+        expect(cell.textContent).toBe(shortId(eventId));
       },
     );
   });

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -66,7 +66,7 @@ describe("Events component harness: selection & detail view", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { getByText, container } = renderEvents({ onSelectEvent });
+        const { container } = renderEvents({ onSelectEvent });
 
         const cell = await waitFor(() => {
           const el = container.querySelector('td[title="evt_click_test"]');

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -42,6 +42,7 @@ import {
   VerbError,
   copyText,
   copyLink,
+  shortId,
 } from "../components/ui";
 
 function toggleFacetInQuery(filter: string, key: "type" | "source", value: string): string {
@@ -505,6 +506,11 @@ export function Events({
           <>
         <h1 className="display mb-4 text-lg font-semibold">Events</h1>
         {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
+        {context.kind === "repo" && (
+          <p className="mb-3 text-[11px] text-(--text-faint)">
+            Scoped to <span className="mono">{context.name}</span> — only rows naming this repo.
+          </p>
+        )}
 
         <div className="mb-3 flex flex-wrap gap-1" role="tablist" aria-label="Event status">
           {STATUS_TABS.map((t) => {
@@ -644,7 +650,9 @@ export function Events({
                     aria-selected={isSelected}
                     className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${isSelected ? "row-selected" : ""}`}
                   >
-                    <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5">{e.eventId}</td>
+                    <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5" title={e.eventId}>
+                      {shortId(e.eventId)}
+                    </td>
                     {show.has("source") && (
                       <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
                         {e.source}


### PR DESCRIPTION
## Summary
- Show a persistent repo-scope caption on Events when a repo context tab is active (`Scoped to {name} — only rows naming this repo.`), so filtered triage no longer looks global.
- Abbreviate event ids in the table via `shortId()` with the full id in `title` (hover), matching Runs WM-96; copy-id (`c`) and the detail panel still use the full id.

## Test plan
- [x] `cd event-runtime/web && bun test` — 363 pass
- [x] WM-142 negative tests: repo caption with non-empty filtered list; event id cell short form + full id title
- [x] UX critique — SHIP (repo caption, shortId+title, detail panel full id verified on live bundle)

Fixes WM-142