### PR TITLE
fix(web): scope Overview tiles to context and label factory-wide feeds (WM-147)

### DIFF
--- a/event-runtime/web/src/context.ts
+++ b/event-runtime/web/src/context.ts
@@ -39,6 +39,48 @@ export function matchesInFlight(state: string, ctx: OperatorContext): boolean {
   return state === "LEASED" || state === "RUNNING";
 }
 
+/**
+ * Count rows that would appear under the current operator context — the same
+ * `matchesRepo` / `matchesInFlight` filter Events, Proposals, and Runs apply.
+ * Pass `state` for run lists so In flight keeps only LEASED and RUNNING.
+ */
+export function scopedCount<T>(
+  items: readonly T[],
+  ctx: OperatorContext,
+  pick: {
+    repos: (item: T) => string[] | undefined;
+    state?: (item: T) => string;
+  },
+): number {
+  let n = 0;
+  for (const item of items) {
+    if (!matchesRepo(pick.repos(item), ctx)) continue;
+    if (pick.state && !matchesInFlight(pick.state(item), ctx)) continue;
+    n += 1;
+  }
+  return n;
+}
+
+/** Tally the same filtered rows by a key (event status, run state). */
+export function scopedTally<T>(
+  items: readonly T[],
+  ctx: OperatorContext,
+  pick: {
+    repos: (item: T) => string[] | undefined;
+    state?: (item: T) => string;
+    key: (item: T) => string;
+  },
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const item of items) {
+    if (!matchesRepo(pick.repos(item), ctx)) continue;
+    if (pick.state && !matchesInFlight(pick.state(item), ctx)) continue;
+    const k = pick.key(item);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
 /** In flight is a toggle: clicking it while active exits to All (WM-91). */
 export function toggleInflight(active: OperatorContext): OperatorContext {
   return active.kind === "inflight" ? { kind: "all" } : { kind: "inflight" };

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -4,7 +4,9 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Overview, groupJournalEntries } from "./Overview";
 import { api } from "../api";
-import type { JournalEntry, Proposal, StatusView } from "../types";
+import type { OperatorContext } from "../context";
+import { scopedCount, scopedTally } from "../context";
+import type { AdmittedEvent, JournalEntry, Proposal, RunListItem, StatusView } from "../types";
 
 afterEach(() => {
   cleanup();
@@ -40,6 +42,41 @@ function baseStatus(overrides: Partial<StatusView["anomalies"]> = {}): StatusVie
   };
 }
 
+function stubEvent(overrides: Partial<AdmittedEvent> & Pick<AdmittedEvent, "eventId" | "status" | "repos">): AdmittedEvent {
+  const now = new Date().toISOString();
+  return {
+    source: "github",
+    type: "pull_request.opened",
+    subject: null,
+    occurredAt: now,
+    receivedAt: now,
+    correlationId: null,
+    planFailures: 0,
+    lastPlanError: null,
+    admittedAt: now,
+    proposalId: null,
+    runId: null,
+    envelope: {},
+    ...overrides,
+  };
+}
+
+function stubRun(overrides: Partial<RunListItem> & Pick<RunListItem, "runId" | "state" | "repos">): RunListItem {
+  const now = new Date().toISOString();
+  return {
+    attempts: 1,
+    maxAttempts: 3,
+    agent: "triage-scan",
+    adapter: "fake",
+    reasonCode: null,
+    eventId: null,
+    eventSource: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
 const stubProposal: Proposal = {
   id: "prop_abc123def456",
   decision: "human_needed",
@@ -58,11 +95,11 @@ const stubProposal: Proposal = {
   repos: [],
 };
 
-function renderOverview() {
+function renderOverview(context: OperatorContext = { kind: "all" }) {
   return renderWithClient(
     <Overview
       connected={true}
-      context={{ kind: "all" }}
+      context={context}
       onJumpRun={noop}
       onJumpProposal={noop}
       onJumpEvents={noop}
@@ -262,6 +299,260 @@ describe("Overview anomaly deck (WM-95)", () => {
       api.proposals = origProposals;
       api.outbox = origOutbox;
       api.journal = origJournal;
+    }
+  });
+});
+
+describe("scopedCount / scopedTally (WM-147)", () => {
+  const repo = { kind: "repo" as const, name: "bj29" };
+  const rows = [
+    { repos: ["bj29"], state: "LEASED" },
+    { repos: ["ok"], state: "LEASED" },
+    { repos: ["bj29"], state: "QUEUED" },
+    { repos: [], state: "RUNNING" },
+  ];
+
+  test("repo tab counts named-repo rows only; unscoped rows stay out", () => {
+    expect(scopedCount(rows, repo, { repos: (r) => r.repos })).toBe(2);
+    expect(scopedCount(rows, { kind: "all" }, { repos: (r) => r.repos })).toBe(4);
+    expect(scopedTally(rows, repo, { repos: (r) => r.repos, key: (r) => r.state })).toEqual({
+      LEASED: 1,
+      QUEUED: 1,
+    });
+  });
+
+  test("in flight keeps LEASED/RUNNING and drops QUEUED even when repos match", () => {
+    expect(
+      scopedTally(rows, { kind: "inflight" }, {
+        repos: (r) => r.repos,
+        state: (r) => r.state,
+        key: (r) => r.state,
+      }),
+    ).toEqual({ LEASED: 2, RUNNING: 1 });
+    expect(
+      scopedCount(rows, { kind: "inflight" }, { repos: (r) => r.repos, state: (r) => r.state }),
+    ).toBe(3);
+  });
+});
+
+describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
+  function stubApis(opts: {
+    status: StatusView;
+    events?: AdmittedEvent[];
+    runs?: RunListItem[];
+    proposals?: Proposal[];
+  }) {
+    const restore = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+      events: api.events,
+      runs: api.runs,
+    };
+    api.status = async () => opts.status;
+    api.proposals = async () => ({ proposals: opts.proposals ?? [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    api.events = async () => ({ events: opts.events ?? [] });
+    api.runs = async () => ({ runs: opts.runs ?? [] });
+    return () => {
+      api.status = restore.status;
+      api.proposals = restore.proposals;
+      api.outbox = restore.outbox;
+      api.journal = restore.journal;
+      api.events = restore.events;
+      api.runs = restore.runs;
+    };
+  }
+
+  test("repo tab: event tiles show scoped counts, not factory-wide GET /status totals", async () => {
+    const restore = stubApis({
+      status: {
+        ...baseStatus(),
+        events: { human_needed: 4, dead_lettered: 2 },
+        proposals: { open: 5, expired: 2 },
+        workers: { live: 3, busy: 1, stale: 0 },
+      },
+      events: [
+        stubEvent({ eventId: "e1", status: "human_needed", repos: ["bj29"] }),
+        stubEvent({ eventId: "e2", status: "human_needed", repos: ["ok"] }),
+        stubEvent({ eventId: "e3", status: "human_needed", repos: [] }),
+        stubEvent({ eventId: "e4", status: "dead_lettered", repos: ["ok"] }),
+      ],
+      proposals: [
+        { ...stubProposal, id: "p1", repos: ["bj29"], expired: false },
+        { ...stubProposal, id: "p2", repos: ["ok"], expired: false },
+        { ...stubProposal, id: "p3", repos: ["bj29"], expired: true },
+      ],
+    });
+
+    try {
+      const { getByRole, queryByRole } = renderOverview({ kind: "repo", name: "bj29" });
+
+      await waitFor(() => getByRole("button", { name: "events · human_needed: 1" }));
+
+      // Negative: factory-wide totals must not appear as the clickable count.
+      expect(queryByRole("button", { name: "events · human_needed: 4" })).toBeNull();
+      expect(queryByRole("button", { name: "events · dead_lettered: 2" })).toBeNull();
+      expect(getByRole("button", { name: "events · dead_lettered: 0" })).toBeTruthy();
+      expect(getByRole("button", { name: "proposals · open: 2" })).toBeTruthy();
+      expect(queryByRole("button", { name: "proposals · open: 5" })).toBeNull();
+      expect(getByRole("button", { name: "proposals · expired: 1" })).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  test("repo tab: worker tiles keep factory-wide counts but are marked before click", async () => {
+    const restore = stubApis({
+      status: {
+        ...baseStatus(),
+        events: { admitted: 1 },
+        workers: { live: 3, busy: 1, stale: 2 },
+      },
+      events: [stubEvent({ eventId: "e1", status: "admitted", repos: ["bj29"] })],
+    });
+
+    try {
+      const { getByRole, queryByRole } = renderOverview({ kind: "repo", name: "bj29" });
+
+      await waitFor(() => getByRole("button", { name: /workers · live/ }));
+
+      expect(getByRole("button", { name: "workers · live · factory-wide: 3" })).toBeTruthy();
+      expect(getByRole("button", { name: "workers · busy · factory-wide: 1" })).toBeTruthy();
+      expect(getByRole("button", { name: "workers · stale · factory-wide: 2" })).toBeTruthy();
+      expect(queryByRole("button", { name: "workers · live: 3" })).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  test("repo tab: Activity and Outbox state they are factory-wide; All does not", async () => {
+    const restore = stubApis({
+      status: { ...baseStatus(), events: { admitted: 0 } },
+    });
+
+    try {
+      const repo = renderOverview({ kind: "repo", name: "bj29" });
+      await waitFor(() => repo.getByText(/Activity · latest/));
+      expect(repo.getByText(/Activity · latest/).textContent?.toLowerCase()).toMatch(/factory-wide/);
+      expect(repo.getByText(/Outbox/).textContent?.toLowerCase()).toMatch(/factory-wide/);
+      expect(repo.container.textContent).not.toMatch(/\/journal|\/outbox|GET \//);
+      repo.unmount();
+
+      const all = renderOverview({ kind: "all" });
+      await waitFor(() => all.getByText(/Activity · latest/));
+      expect(all.getByText(/Activity · latest/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+      expect(all.getByText(/Outbox/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+      expect(all.queryByRole("status")).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  test("in-flight: run-state tiles match Runs list filtering (LEASED/RUNNING only)", async () => {
+    const restore = stubApis({
+      status: {
+        ...baseStatus(),
+        runs: {
+          byState: {
+            QUEUED: 5,
+            LEASED: 2,
+            RUNNING: 3,
+            COMPLETED: 9,
+          },
+        },
+      },
+      runs: [
+        stubRun({ runId: "r1", state: "QUEUED", repos: ["bj29"] }),
+        stubRun({ runId: "r2", state: "LEASED", repos: ["ok"] }),
+        stubRun({ runId: "r3", state: "LEASED", repos: [] }),
+        stubRun({ runId: "r4", state: "RUNNING", repos: ["bj29"] }),
+        stubRun({ runId: "r5", state: "COMPLETED", repos: ["bj29"] }),
+      ],
+    });
+
+    try {
+      const { getByRole, queryByRole } = renderOverview({ kind: "inflight" });
+
+      await waitFor(() => getByRole("button", { name: "active · leased: 2" }));
+
+      // Negative: factory-wide queued/completed totals must not appear.
+      expect(queryByRole("button", { name: "active · queued: 5" })).toBeNull();
+      expect(getByRole("button", { name: "active · queued: 0" })).toBeTruthy();
+      expect(getByRole("button", { name: "active · leased: 2" })).toBeTruthy();
+      expect(getByRole("button", { name: "active · running: 1" })).toBeTruthy();
+      expect(queryByRole("button", { name: "runs · completed: 9" })).toBeNull();
+      expect(getByRole("button", { name: "runs · completed: 0" })).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  test("repo tab: anomaly deck heading is marked factory-wide; All is not", async () => {
+    const restore = stubApis({
+      status: baseStatus({ staleLeases: 1 }),
+    });
+
+    try {
+      const repo = renderOverview({ kind: "repo", name: "bj29" });
+      await waitFor(() => repo.getByText(/Doctor Anomaly Deck/));
+      expect(repo.getByText(/Doctor Anomaly Deck/).textContent?.toLowerCase()).toMatch(/factory-wide/);
+      repo.unmount();
+
+      const all = renderOverview({ kind: "all" });
+      await waitFor(() => all.getByText(/Doctor Anomaly Deck/));
+      expect(all.getByText(/Doctor Anomaly Deck/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+    } finally {
+      restore();
+    }
+  });
+
+  test("scope notice is glanceable when context ≠ All", async () => {
+    const restore = stubApis({
+      status: { ...baseStatus(), events: { admitted: 0 } },
+    });
+
+    try {
+      const repo = renderOverview({ kind: "repo", name: "bj29" });
+      await waitFor(() => repo.getByRole("status"));
+      const notice = repo.getByRole("status");
+      expect(notice.textContent).toMatch(/bj29/);
+      expect(notice.className).not.toMatch(/text-\[11px\]/);
+      repo.unmount();
+
+      const inflight = renderOverview({ kind: "inflight" });
+      await waitFor(() => inflight.getByRole("status"));
+      expect(inflight.getByRole("status").textContent).toMatch(/in flight/i);
+    } finally {
+      restore();
+    }
+  });
+
+  test("event and run grids are 2–4 columns below sm, not 5/8", async () => {
+    const restore = stubApis({
+      status: {
+        ...baseStatus(),
+        events: { admitted: 1 },
+        runs: { byState: { QUEUED: 1 } },
+      },
+    });
+
+    try {
+      const { getByText } = renderOverview();
+      await waitFor(() => getByText(/1\. Event Intake/));
+
+      const eventGrid = getByText(/1\. Event Intake/).nextElementSibling;
+      expect(eventGrid?.className).toMatch(/\bgrid-cols-2\b/);
+      expect(eventGrid?.className).not.toMatch(/^grid grid-cols-5 /);
+
+      const runGrid = getByText(/3\. Execution Fleet/).nextElementSibling;
+      expect(runGrid?.className).toMatch(/\bgrid-cols-2\b/);
+      expect(runGrid?.className).not.toMatch(/^grid grid-cols-4 /);
+      expect(runGrid?.className).toMatch(/xl:grid-cols-8/);
+    } finally {
+      restore();
     }
   });
 });

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
 import { hashPath } from "../hash";
 import { useNow, useRequeuePoll } from "../hooks";
 import type { JournalEntry, EventFocus, Proposal, RunState } from "../types";
 import type { OperatorContext } from "../context";
-import { ScopeCaption } from "../components/ContextTabs";
+import { scopedCount, scopedTally } from "../context";
 import {
   Ago,
   Button,
@@ -77,6 +77,45 @@ export function groupJournalEntries(entries: JournalEntry[]): ActivityGroup[] {
     }
   }
   return groups;
+}
+
+function OverviewTile({
+  label,
+  value,
+  hue,
+  onClick,
+  factoryWide = false,
+}: {
+  label: string;
+  value: ReactNode;
+  hue?: string;
+  onClick?: () => void;
+  factoryWide?: boolean;
+}) {
+  return (
+    <div className={factoryWide ? "opacity-70" : undefined}>
+      <StatTile
+        label={factoryWide ? `${label} · factory-wide` : label}
+        value={value}
+        hue={factoryWide ? undefined : hue}
+        onClick={onClick}
+      />
+    </div>
+  );
+}
+
+function OverviewScopeNotice({ context }: { context: OperatorContext }) {
+  if (context.kind === "all") return null;
+  return (
+    <div
+      role="status"
+      className="mb-4 rounded-md border border-(--border) bg-(--surface-2) px-3 py-2 text-[13px] text-(--text)"
+    >
+      {context.kind === "inflight"
+        ? "In flight filters Runs to leased and running. Other Overview counts are factory-wide."
+        : `Showing ${context.name} on Events, Proposals, and Runs. Workers, artifacts, and the feeds below are factory-wide.`}
+    </div>
+  );
 }
 
 /**
@@ -154,6 +193,21 @@ export function Overview({
     queryKey: ["proposals"],
     queryFn: api.proposals,
     refetchInterval: 2000,
+  });
+  // Same lists the destination views fetch when scoped, so tile counts match
+  // what a click would show (WM-147). Events/Proposals only filter on a repo
+  // tab; In flight only scopes Runs (LEASED / RUNNING).
+  const eventsQ = useQuery({
+    queryKey: ["events", "all"],
+    queryFn: () => api.events(),
+    refetchInterval: 2000,
+    enabled: context.kind === "repo",
+  });
+  const runsQ = useQuery({
+    queryKey: ["runs", "ALL"],
+    queryFn: () => api.runs(),
+    refetchInterval: 2000,
+    enabled: context.kind !== "all",
   });
   const feed = useJournalFeed();
 
@@ -262,6 +316,37 @@ export function Overview({
 
   const activeRunStates: RunState[] = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
   const terminalRunStates: RunState[] = ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"];
+  const factoryWide = context.kind !== "all";
+  const feedsUnscoped = context.kind === "repo";
+  const eventTally =
+    context.kind === "repo"
+      ? scopedTally(eventsQ.data?.events ?? [], context, {
+          repos: (e) => e.repos,
+          key: (e) => e.status,
+        })
+      : null;
+  const runTally = factoryWide
+    ? scopedTally(runsQ.data?.runs ?? [], context, {
+        repos: (r) => r.repos,
+        state: (r) => r.state,
+        key: (r) => r.state,
+      })
+    : null;
+  const openProposals = proposalsForDeck.data?.proposals ?? [];
+  const proposalOpen =
+    context.kind === "repo"
+      ? scopedCount(openProposals, context, { repos: (p) => p.repos })
+      : (s?.proposals.open ?? 0);
+  const proposalExpired =
+    context.kind === "repo"
+      ? scopedCount(
+          openProposals.filter((p) => p.expired),
+          context,
+          { repos: (p) => p.repos },
+        )
+      : (s?.proposals.expired ?? 0);
+  const eventValue = (k: string, factory: number) => (eventTally ? (eventTally[k] ?? 0) : factory);
+  const runValue = (k: RunState) => (runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0));
 
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
@@ -276,7 +361,7 @@ export function Overview({
           </button>
         </div>
       </div>
-      <ScopeCaption context={context} surface="overview" />
+      <OverviewScopeNotice context={context} />
 
       {/* Promoted Doctor Deck when anomalies exist */}
       {hasAnomalies && (
@@ -285,6 +370,7 @@ export function Overview({
             <div className="flex items-center gap-2 text-[12px] font-semibold text-[color:var(--hue-warn)] uppercase tracking-wide">
               <span className="size-2 rounded-full bg-[color:var(--hue-warn)] animate-pulse" />
               Doctor Anomaly Deck · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
+              {feedsUnscoped ? " · factory-wide" : ""}
             </div>
           </div>
           <div className="rounded-md border border-(--border) bg-(--surface-1)">
@@ -377,16 +463,19 @@ export function Overview({
               <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
                 1. Event Intake & Triage
               </div>
-              <div className="grid grid-cols-5 gap-2">
-                {Object.entries(s.events).map(([k, v]) => (
-                  <StatTile
-                    key={k}
-                    label={`events · ${k}`}
-                    value={v}
-                    hue={v > 0 ? EVENT_STATUS_HUES[k] : undefined}
-                    onClick={() => onJumpEvents({ status: k })}
-                  />
-                ))}
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+                {Object.entries(s.events).map(([k, v]) => {
+                  const value = eventValue(k, v);
+                  return (
+                    <OverviewTile
+                      key={k}
+                      label={`events · ${k}`}
+                      value={value}
+                      hue={value > 0 ? EVENT_STATUS_HUES[k] : undefined}
+                      onClick={() => onJumpEvents({ status: k })}
+                    />
+                  );
+                })}
               </div>
             </div>
 
@@ -395,16 +484,16 @@ export function Overview({
                 2. Watched Approval Gate
               </div>
               <div className="grid grid-cols-2 gap-2">
-                <StatTile
+                <OverviewTile
                   label="proposals · open"
-                  value={s.proposals.open}
-                  hue={s.proposals.open > 0 ? "var(--hue-info)" : undefined}
+                  value={proposalOpen}
+                  hue={proposalOpen > 0 ? "var(--hue-info)" : undefined}
                   onClick={() => onNavigate("proposals")}
                 />
-                <StatTile
+                <OverviewTile
                   label="proposals · expired"
-                  value={s.proposals.expired}
-                  hue={s.proposals.expired > 0 ? "var(--hue-warn)" : undefined}
+                  value={proposalExpired}
+                  hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
                   onClick={onJumpExpired}
                 />
               </div>
@@ -416,42 +505,51 @@ export function Overview({
             <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
               3. Execution Fleet & Capacity
             </div>
-            <div className="grid grid-cols-4 gap-2 xl:grid-cols-8">
-              {activeRunStates.map((k) => (
-                <StatTile
-                  key={k}
-                  label={`active · ${k.toLowerCase()}`}
-                  value={s.runs.byState[k] ?? 0}
-                  hue={(s.runs.byState[k] ?? 0) > 0 ? "var(--hue-warn)" : undefined}
-                  onClick={() => onJumpRuns(k)}
-                />
-              ))}
-              {terminalRunStates.map((k) => (
-                <StatTile
-                  key={k}
-                  label={`runs · ${k.toLowerCase()}`}
-                  value={s.runs.byState[k] ?? 0}
-                  hue={k === "FAILED" && (s.runs.byState[k] ?? 0) > 0 ? "var(--hue-err)" : undefined}
-                  onClick={() => onJumpRuns(k)}
-                />
-              ))}
-              <StatTile
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
+              {activeRunStates.map((k) => {
+                const value = runValue(k);
+                return (
+                  <OverviewTile
+                    key={k}
+                    label={`active · ${k.toLowerCase()}`}
+                    value={value}
+                    hue={value > 0 ? "var(--hue-warn)" : undefined}
+                    onClick={() => onJumpRuns(k)}
+                  />
+                );
+              })}
+              {terminalRunStates.map((k) => {
+                const value = runValue(k);
+                return (
+                  <OverviewTile
+                    key={k}
+                    label={`runs · ${k.toLowerCase()}`}
+                    value={value}
+                    hue={k === "FAILED" && value > 0 ? "var(--hue-err)" : undefined}
+                    onClick={() => onJumpRuns(k)}
+                  />
+                );
+              })}
+              <OverviewTile
                 label="workers · live"
                 value={s.workers.live}
                 hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
                 onClick={() => onNavigate("workers")}
+                factoryWide={factoryWide}
               />
-              <StatTile
+              <OverviewTile
                 label="workers · busy"
                 value={s.workers.busy}
                 hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
                 onClick={() => onNavigate("workers")}
+                factoryWide={factoryWide}
               />
-              <StatTile
+              <OverviewTile
                 label="workers · stale"
                 value={s.workers.stale}
                 hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
                 onClick={() => onNavigate("workers")}
+                factoryWide={factoryWide}
               />
             </div>
           </div>
@@ -462,12 +560,13 @@ export function Overview({
               4. Artifact Store
             </div>
             <div className="grid grid-cols-3 gap-2 lg:max-w-md">
-              <StatTile label="artifacts · files" value={s.artifacts.files} />
-              <StatTile label="artifacts · size" value={humanSize(s.artifacts.bytes)} />
-              <StatTile
+              <OverviewTile label="artifacts · files" value={s.artifacts.files} factoryWide={factoryWide} />
+              <OverviewTile label="artifacts · size" value={humanSize(s.artifacts.bytes)} factoryWide={factoryWide} />
+              <OverviewTile
                 label="artifacts · orphans"
                 value={s.artifacts.orphans}
                 hue={s.artifacts.orphanBytes > 0 ? "var(--hue-warn)" : undefined}
+                factoryWide={factoryWide}
               />
             </div>
           </div>
@@ -487,7 +586,14 @@ export function Overview({
       )}
 
       <div className="grid gap-x-5 xl:grid-cols-2">
-        <Section title={`Activity · latest ${Math.min(feed.entries.length, FEED_CAP)}`} card={false}>
+        <Section
+          title={
+            feedsUnscoped
+              ? `Activity · latest ${Math.min(feed.entries.length, FEED_CAP)} · factory-wide`
+              : `Activity · latest ${Math.min(feed.entries.length, FEED_CAP)}`
+          }
+          card={false}
+        >
           {feed.entries.length === 0 ? (
             <div className="text-(--text-faint)">
               {feed.isPending
@@ -529,7 +635,10 @@ export function Overview({
           )}
         </Section>
 
-        <Section title="Outbox — published results" card={false}>
+        <Section
+          title={feedsUnscoped ? "Outbox — published results · factory-wide" : "Outbox — published results"}
+          card={false}
+        >
           <div id="outbox">
           {(outbox.data?.outbox ?? []).length === 0 ? (
             <div className="text-(--text-faint)">


### PR DESCRIPTION
## Summary
- Under a repo tab, Overview event/proposal/run tiles count the same filtered lists the destination views use, instead of factory-wide status totals.
- Workers, artifacts, Activity, Outbox, and the anomaly deck are labeled factory-wide; a glanceable banner appears when context is not All.
- Responsive grids: 2–3 event columns and 2–4 run/worker columns below `sm` (8-col fleet only from `xl`).

## Test plan
- [x] `cd event-runtime/web && bun test` — 370 pass
- [x] Negative tests first (repo tab must not show factory-wide event counts; All must not warn on Activity/Outbox; In flight QUEUED must not show the unscoped total)
- [x] UX critique SHIP on seeded demo (`bin/worktree-up.sh WM-147` → http://127.0.0.1:7407). Polish F1 (anomaly deck heading) resolved in-branch. Follow-ups: WM-175 (sidebar at phone width), WM-176 (`worktree-up --here` vs 7391).

Fixes WM-147