### PR TITLE
fix(web): gate bulk proposal approve and require reject reasons (WM-141)

### DIFF
--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -5,7 +5,10 @@ import { Proposals } from "./Proposals";
 import { api } from "../api";
 import {
   changeInput,
+  createEventFixture,
   createProposalFixture,
+  createRunListItemFixture,
+  createRunSpecFixture,
   createStatusFixture,
   renderWithClient,
   restoreApi,
@@ -193,10 +196,12 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     const selectAll = r.getByLabelText("Select all proposals");
     fireEvent.click(selectAll);
 
-    // Click Approve selected (3)
-    const approveBtn = r.getByText("Approve selected (3)");
+    // Click Approve selected — confirm must appear before any POST
+    const approveBtn = r.getByText("Approve selected (2)");
+    fireEvent.click(approveBtn);
+    expect(approvedIds).toEqual([]);
     await act(async () => {
-      fireEvent.click(approveBtn);
+      fireEvent.click(r.getByRole("button", { name: "Approve and queue" }));
     });
 
     // Should have approved prop_1 and prop_2, skipping prop_3
@@ -571,5 +576,203 @@ describe("Proposals component harness: cross-tab reveal", () => {
         });
       },
     );
+  });
+});
+
+describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
+  let origProposals: typeof api.proposals;
+  let origProposalHistory: typeof api.proposalHistory;
+  let origStatus: typeof api.status;
+  let origRuns: typeof api.runs;
+  let origEvents: typeof api.events;
+  let origAgents: typeof api.agents;
+  let origApprove: typeof api.approve;
+  let origReject: typeof api.reject;
+
+  beforeEach(() => {
+    origProposals = api.proposals;
+    origProposalHistory = api.proposalHistory;
+    origStatus = api.status;
+    origRuns = api.runs;
+    origEvents = api.events;
+    origAgents = api.agents;
+    origApprove = api.approve;
+    origReject = api.reject;
+
+    api.status = async () => stubStatus();
+    api.runs = async () => ({ runs: [] });
+    api.events = async () => ({ events: [] });
+    api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
+    api.proposalHistory = async () => ({ proposals: [] });
+  });
+
+  afterEach(() => {
+    api.proposals = origProposals;
+    api.proposalHistory = origProposalHistory;
+    api.status = origStatus;
+    api.runs = origRuns;
+    api.events = origEvents;
+    api.agents = origAgents;
+    api.approve = origApprove;
+    api.reject = origReject;
+  });
+
+  test("bulk approve does not call api.approve until confirm", async () => {
+    const p1 = stubProposal("prop_1", "open", {
+      agent: "triage-scan",
+      spec: createRunSpecFixture("run_prop_1", { agent: "triage-scan", capabilities: ["read"], timeoutSeconds: 600 }),
+    });
+    const p2 = stubProposal("prop_2", "open", {
+      agent: "security-scan",
+      spec: createRunSpecFixture("run_prop_2", { agent: "security-scan", capabilities: ["net"], timeoutSeconds: 120 }),
+    });
+    const stale = stubProposal("prop_stale", "open", {
+      decision: "run",
+      runId: "run_stale",
+      agent: "stale-agent",
+    });
+    api.proposals = async () => ({ proposals: [p1, p2, stale] });
+    api.runs = async () => ({
+      runs: [createRunListItemFixture({ runId: "run_stale", state: "CANCELLED", agent: "stale-agent" })],
+    });
+
+    const approvedIds: string[] = [];
+    api.approve = async (id: string) => {
+      approvedIds.push(id);
+      return { approved: true, runId: `run_${id}`, proposal: undefined, replanned: false };
+    };
+
+    const r = renderProposals();
+    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+
+    fireEvent.click(r.getByLabelText("Select all proposals"));
+    fireEvent.click(r.getByText("Approve selected (2)"));
+
+    expect(approvedIds).toEqual([]);
+    const dialog = r.getByRole("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog.textContent).toMatch(/triage-scan/);
+    expect(dialog.textContent).toMatch(/security-scan/);
+    expect(dialog.textContent).toMatch(/read/);
+    expect(dialog.textContent).toMatch(/net/);
+    expect(dialog.textContent).toMatch(/600s/);
+    expect(dialog.textContent).toMatch(/120s/);
+    expect(dialog.textContent).toContain("timeoutSeconds");
+    expect(dialog.textContent).not.toMatch(/stale-agent/);
+
+    await act(async () => {
+      fireEvent.click(r.getByRole("button", { name: "Approve and queue" }));
+    });
+
+    expect(approvedIds).toEqual(["prop_1", "prop_2"]);
+  });
+
+  test("dismiss/reject never fires without a trimmed reason", async () => {
+    const p1 = stubProposal("prop_1", "open", { agent: "triage-scan" });
+    api.proposals = async () => ({ proposals: [p1] });
+
+    const rejectedCalls: { id: string; why?: string }[] = [];
+    api.reject = async (id: string, why?: string) => {
+      rejectedCalls.push({ id, why });
+      return { rejected: true };
+    };
+
+    const r = renderProposals({ focusProposalId: "prop_1" });
+    await waitFor(() => expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy());
+
+    const dismiss = r.queryByRole("button", { name: /^Dismiss$/ });
+    if (dismiss) fireEvent.click(dismiss);
+    expect(rejectedCalls).toEqual([]);
+
+    fireEvent.click(r.getByRole("button", { name: /^Reject/ }));
+    const confirm = await waitFor(() => r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement);
+    expect(confirm.disabled).toBe(true);
+
+    const reasonInput = r.getByPlaceholderText(/Reason \(required/i) as HTMLInputElement;
+    await act(async () => {
+      changeInput(reasonInput, "   ");
+    });
+    expect((r.getByRole("button", { name: "Confirm" }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.keyDown(reasonInput, { key: "Enter" });
+    expect(rejectedCalls).toEqual([]);
+
+    await act(async () => {
+      changeInput(reasonInput, " Scope too wide ");
+    });
+    await act(async () => {
+      fireEvent.click(r.getByRole("button", { name: "Confirm" }));
+    });
+    expect(rejectedCalls).toEqual([{ id: "prop_1", why: "Scope too wide" }]);
+  });
+
+  test("one stubbed replan response does not silently continue bulk approve", async () => {
+    const p1 = stubProposal("prop_1", "open", {
+      agent: "triage-scan",
+      spec: createRunSpecFixture("run_prop_1", { timeoutSeconds: 600 }),
+    });
+    const p2 = stubProposal("prop_2", "open", { agent: "security-scan" });
+    const replacement = stubProposal("prop_1b", "open", {
+      agent: "triage-scan",
+      spec: createRunSpecFixture("run_prop_1b", { timeoutSeconds: 900, agent: "triage-scan" }),
+    });
+    api.proposals = async () => ({ proposals: [p1, p2] });
+
+    const approveCalls: string[] = [];
+    api.approve = async (id: string) => {
+      approveCalls.push(id);
+      if (id === "prop_1") {
+        return { approved: false, runId: undefined, replanned: true, proposal: replacement };
+      }
+      return { approved: true, runId: `run_${id}`, proposal: undefined, replanned: false };
+    };
+
+    const r = renderProposals();
+    await waitFor(() => expect(r.getByLabelText("Select proposal prop_1")).toBeTruthy());
+    fireEvent.click(r.getByLabelText("Select all proposals"));
+    fireEvent.click(r.getByText("Approve selected (2)"));
+
+    const confirm = r.queryByRole("button", { name: "Approve and queue" });
+    if (confirm) {
+      await act(async () => {
+        fireEvent.click(confirm);
+      });
+    } else {
+      await act(async () => {});
+    }
+
+    await waitFor(() => expect(approveCalls.length).toBeGreaterThan(0));
+    expect(approveCalls).toEqual(["prop_1"]);
+    expect(r.getByText(/re-planned against current state/i)).toBeTruthy();
+    expect(r.getByText(/nothing runs until you approve the new proposal explicitly/i)).toBeTruthy();
+  });
+
+  test("repo context shows a persistent caption that the list is scoped to that repo", async () => {
+    const p1 = stubProposal("prop_1", "open", { repos: ["repo-test"], agent: "triage-scan" });
+    api.proposals = async () => ({ proposals: [p1] });
+
+    const r = renderProposals({ context: { kind: "repo", name: "repo-test" } });
+    await waitFor(() => expect(r.getByText("triage-scan")).toBeTruthy());
+    expect(r.getByText("Showing proposals that name repo-test.")).toBeTruthy();
+  });
+
+  test("origin column title is the full eventId; reason column title is p.reason", async () => {
+    const eventId = "evt_abc123_full_event_id";
+    const reason = "Needs a very long planner reason for the truncated cell";
+    const p1 = stubProposal("prop_1", "open", {
+      eventId,
+      eventSource: "github",
+      reason,
+      agent: "triage-scan",
+    });
+    api.proposals = async () => ({ proposals: [p1] });
+    api.events = async () => ({
+      events: [createEventFixture({ eventId, source: "github", type: "pull_request.opened" })],
+    });
+
+    const r = renderProposals();
+    const origin = await waitFor(() => r.getByText(eventId));
+    expect(origin.closest("td")?.getAttribute("title")).toBe(eventId);
+    const reasonCell = r.getByText(reason);
+    expect(reasonCell.closest("td")?.getAttribute("title")).toBe(reason);
   });
 });

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -211,6 +211,7 @@ export function Proposals({
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkApproving, setBulkApproving] = useState(false);
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [bulkRejectOpen, setBulkRejectOpen] = useState(false);
   const [bulkRejecting, setBulkRejecting] = useState(false);
   const [bulkReason, setBulkReason] = useState("");
@@ -282,29 +283,44 @@ export function Proposals({
   );
 
   const handleBulkApprove = async () => {
-    if (!approvableSelected.length) return;
+    if (!connected || !approvableSelected.length) return;
+    setBulkConfirmOpen(false);
     setBulkApproving(true);
     let ok = 0;
-    let replanned = 0;
     let err = 0;
+    const processed = new Set<string>();
+    let haltedOnReplan: { before: Proposal; after: Proposal } | null = null;
     for (const p of approvableSelected) {
       try {
         const o = await api.approve(p.id);
+        processed.add(p.id);
         if (o.approved && o.runId) {
           ok++;
           onRunQueued(o.runId);
         } else if (o.replanned && o.proposal) {
-          replanned++;
+          haltedOnReplan = { before: p, after: o.proposal };
+          break;
         }
       } catch {
         err++;
+        processed.add(p.id);
       }
     }
     invalidate();
-    setSelectedIds(new Set());
     setBulkApproving(false);
+    if (haltedOnReplan) {
+      setReplan(haltedOnReplan);
+      onSelectProposal(haltedOnReplan.after.id);
+      notify(`Proposal expired — re-planned new spec`, "info");
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of processed) next.delete(id);
+        return next;
+      });
+    } else {
+      setSelectedIds(new Set());
+    }
     if (ok) notify(`Approved ${ok} proposal${ok === 1 ? "" : "s"}`, "ok");
-    if (replanned) notify(`${replanned} proposal${replanned === 1 ? "" : "s"} expired and re-planned`, "info");
     if (err) notify(`Failed to approve ${err} proposal${err === 1 ? "" : "s"}`, "err");
   };
 
@@ -466,7 +482,11 @@ export function Proposals({
   });
 
   const reject = useMutation({
-    mutationFn: ({ id, why }: { id: string; why?: string }) => api.reject(id, why),
+    mutationFn: ({ id, why }: { id: string; why: string }) => {
+      const trimmed = why.trim();
+      if (!trimmed) return Promise.reject(new Error("Rejection reason required"));
+      return api.reject(id, trimmed);
+    },
     onSuccess: (_, { id }) => {
       invalidate();
       notify(`Rejected proposal ${id}`, "info");
@@ -545,6 +565,11 @@ export function Proposals({
           <>
         <h1 className="display mb-4 text-lg font-semibold">Proposals</h1>
         {context.kind === "inflight" && <ScopeCaption context={context} surface="fleet" />}
+        {context.kind === "repo" && (
+          <p className="mb-3 text-[11px] text-(--text-faint)">
+            {`Showing proposals that name ${context.name}.`}
+          </p>
+        )}
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <div className="flex gap-1" role="tablist" aria-label="Proposal status">
@@ -700,11 +725,11 @@ export function Proposals({
                     </td>
                   )}
                   {show.has("origin") && (
-                    <td className={`mono max-w-40 truncate ${tdCls} text-(--text-faint)`} title={originType(p) ?? undefined}>
+                    <td className={`mono max-w-40 truncate ${tdCls} text-(--text-faint)`} title={p.eventId ?? undefined}>
                       {p.eventId && p.eventSource ? (
                         <JumpLink
                           onClick={() => onJumpEvent(p.eventSource!, p.eventId!)}
-                          title={originType(p) ?? "Open origin event"}
+                          title={p.eventId}
                         >
                           {p.eventId}
                         </JumpLink>
@@ -719,7 +744,9 @@ export function Proposals({
                     </td>
                   )}
                   {show.has("reason") && (
-                    <td className={`max-w-64 truncate ${tdCls} text-(--text-dim)`}>{p.reason ?? "-"}</td>
+                    <td className={`max-w-64 truncate ${tdCls} text-(--text-dim)`} title={p.reason ?? undefined}>
+                      {p.reason ?? "-"}
+                    </td>
                   )}
                 </tr>
               );
@@ -929,13 +956,6 @@ export function Proposals({
                   Approve… <span className="mono ml-1 opacity-70">a</span>
                 </Button>
               )}
-              <Button
-                variant="danger"
-                disabled={!connected || reject.isPending}
-                onClick={() => reject.mutate({ id: sel.id })}
-              >
-                Dismiss
-              </Button>
               <Button variant="danger" disabled={!connected || reject.isPending} onClick={openReject}>
                 Reject… <span className="mono ml-1 opacity-70">x</span>
               </Button>
@@ -1006,12 +1026,15 @@ export function Proposals({
             <KV k="attempts" v={String(sel.spec?.maxAttempts)} />
             <KV k="ttl" v={<Countdown createdAt={sel.created_at} ttlSeconds={sel.ttl_seconds} />} />
           </div>
-          {sel.spec && <JsonBlock value={sel.spec} />}
+          {sel.spec && (
+            <div className="mb-3 max-h-[50vh] overflow-auto">
+              <JsonBlock value={sel.spec} />
+            </div>
+          )}
           <div className="mt-3 flex justify-end gap-2">
             <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
             <Button
               variant="primary"
-              autoFocus
               disabled={!connected || approve.isPending}
               onClick={() => {
                 setConfirmApprove(false);
@@ -1032,7 +1055,7 @@ export function Proposals({
           </div>
           <SpecDiff before={replan.before.spec} after={replan.after.spec} />
           <div className="mt-3 flex justify-end gap-2">
-            <Button onClick={() => setReplan(null)}>Not now</Button>
+            <Button onClick={() => setReplan(null)}>Not yet</Button>
             <Button
               variant="primary"
               disabled={!connected || approve.isPending}
@@ -1053,9 +1076,9 @@ export function Proposals({
           <Button
             variant="primary"
             disabled={!connected || bulkApproving || approvableSelected.length === 0}
-            onClick={handleBulkApprove}
+            onClick={() => setBulkConfirmOpen(true)}
           >
-            {bulkApproving ? "Approving…" : `Approve selected (${selectedIds.size})`}
+            {bulkApproving ? "Approving…" : `Approve selected (${approvableSelected.length})`}
           </Button>
           <Button
             variant="danger"
@@ -1068,6 +1091,44 @@ export function Proposals({
             Reject selected ({selectedIds.size})
           </Button>
         </BulkActionBar>
+      )}
+
+      {bulkConfirmOpen && approvableSelected.length > 0 && (
+        <Dialog
+          title={`Approve and queue ${approvableSelected.length} run${approvableSelected.length === 1 ? "" : "s"}?`}
+          onClose={() => setBulkConfirmOpen(false)}
+          wide
+        >
+          <div className="mb-3 text-[12px] text-(--text-dim)">
+            You are approving {approvableSelected.length === 1 ? "this exact immutable spec" : "these exact immutable specs"}{" "}
+            — each agent below runs with these capabilities the moment you confirm. Stale and non-run
+            rows are skipped.
+          </div>
+          <div className="flex max-h-[60vh] flex-col gap-4 overflow-auto">
+            {approvableSelected.map((p) => (
+              <div key={p.id} className="rounded-md border border-(--border) bg-(--surface-0) p-2.5">
+                <div className="mb-2 font-medium text-[12px]">{p.agent ?? p.id}</div>
+                <KV k="agent" v={p.spec?.agent} />
+                <KV k="capabilities" v={p.spec?.capabilities.join(", ") || "none"} />
+                <KV k="timeout" v={`${p.spec?.timeoutSeconds}s`} />
+                {p.spec && <JsonBlock value={p.spec} />}
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex justify-end gap-2">
+            <Button onClick={() => setBulkConfirmOpen(false)}>Not yet</Button>
+            <Button
+              variant="primary"
+              autoFocus
+              disabled={!connected || bulkApproving}
+              onClick={() => {
+                void handleBulkApprove();
+              }}
+            >
+              Approve and queue
+            </Button>
+          </div>
+        </Dialog>
       )}
 
       {bulkRejectOpen && (


### PR DESCRIPTION
## Summary
- Bulk **Approve selected** opens a confirm that surfaces agent, capabilities, timeout, and spec JSON; `api.approve` is not called until confirm. Stale/non-run rows stay skipped; a `{ replanned: true }` response halts the loop and opens the same SpecDiff treatment as single approve.
- **Dismiss** is removed so every rejection from this UI requires a trimmed reason (same path as **Reject…** / bulk reject).
- Repo context shows a persistent scoped caption; Origin `title` is the full eventId and Reason `title` is `p.reason`.

## Test plan
- [x] `cd event-runtime/web && bun test` — 391 pass (after merge of origin/develop)
- [x] Negative tests failed on HEAD before the fix (bulk POST-before-confirm, Dismiss-without-reason, silent bulk replan continue)
- [x] UX critique against the worktree demo UI (`http://127.0.0.1:7715`) — FIX-FIRST round 1 (single-approve KV scrolled off-screen; bar vs dialog count), round 2 SHIP

Follow-ups: WM-177 (repo caption excluded-count), WM-178 (bulk confirm KV parity with single)

UX critique: required — FIX-FIRST resolved in 2 round(s)

Fixes WM-141