### PR TITLE
fix(web): context tabs keyboard + view-name captions (WM-148)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -405,8 +405,16 @@ describe("ScopeCaption", () => {
     expect(fleet.container.textContent?.toLowerCase()).not.toContain("fleet");
     cleanup();
 
+    // Empty hash is not Agents/Schedules — keep the factory-wide registry copy (WM-157 Projects).
     const registry = render(<ScopeCaption context={repoCtx} surface="registry" />);
-    expect(registry.container.textContent).toContain("Agents are not scoped to factory");
-    expect(registry.container.textContent?.toLowerCase()).not.toContain("registry");
+    expect(registry.container.textContent).toContain("registry is not scoped to factory");
+    expect(registry.container.textContent).not.toContain("Agents");
+  });
+
+  test("Projects hash keeps factory-wide registry copy, not Agents", () => {
+    window.location.hash = "#/projects";
+    const r = render(<ScopeCaption context={repoCtx} surface="registry" />);
+    expect(r.container.textContent).toContain("registry is not scoped to factory");
+    expect(r.container.textContent).not.toContain("Agents");
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -1,9 +1,9 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, createEvent, fireEvent, render } from "@testing-library/react";
 import type { OperatorContext } from "../context";
 import type { RepoItem } from "../types";
-import { ContextTabs } from "./ContextTabs";
+import { ContextTabs, ScopeCaption } from "./ContextTabs";
 
 function repo(name: string): RepoItem {
   return {
@@ -53,6 +53,27 @@ describe("ContextTabs", () => {
 
     const closeBtn = r.getByRole("button", { name: "Close factory" });
     expect(closeBtn.getAttribute("tabindex")).toBe("-1");
+  });
+
+  test("active context tab is the sequential tab stop; the toolbar is not", () => {
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const toolbar = r.getByRole("toolbar", { name: "Context" });
+    expect(toolbar.hasAttribute("tabindex")).toBe(false);
+
+    const all = r.getByRole("button", { name: "All" });
+    expect(all.getAttribute("tabindex")).toBe("0");
+    expect(all.className).toContain("focus-visible:ring-2");
   });
 
   test("focuses the remaining active context button after closing a tab when activeElement is body (Chromium recovery)", () => {
@@ -131,5 +152,261 @@ describe("ContextTabs", () => {
 
     fireEvent.click(inflightBtn);
     expect(selected).toEqual([{ kind: "all" }]);
+  });
+
+  test("ArrowRight moves focus without activating the destination tab", () => {
+    const selected: OperatorContext[] = [];
+    const opened: string[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={["factory", "client"]}
+        active={{ kind: "all" }}
+        onSelect={(ctx) => selected.push(ctx)}
+        onOpen={(name) => opened.push(name)}
+        onClose={() => {}}
+      />,
+    );
+
+    const allBtn = r.getByRole("button", { name: "All" });
+    allBtn.focus();
+    act(() => {
+      fireEvent.keyDown(allBtn, { key: "ArrowRight" });
+    });
+
+    expect(document.activeElement).toBe(r.getByRole("button", { name: "factory" }));
+    expect(selected).toEqual([]);
+    expect(opened).toEqual([]);
+  });
+
+  test("Enter on a focused context tab activates it", () => {
+    const selected: OperatorContext[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "all" }}
+        onSelect={(ctx) => selected.push(ctx)}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const factoryBtn = r.getByRole("button", { name: "factory" });
+    factoryBtn.focus();
+    act(() => {
+      fireEvent.keyDown(factoryBtn, { key: "Enter" });
+    });
+    expect(selected).toEqual([{ kind: "repo", name: "factory" }]);
+  });
+
+  test("Space on a focused context tab activates it and preventDefault so the page does not scroll", () => {
+    const selected: OperatorContext[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "repo", name: "factory" }}
+        onSelect={(ctx) => selected.push(ctx)}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const inflightBtn = r.getByRole("button", { name: "In flight" });
+    inflightBtn.focus();
+    const space = createEvent.keyDown(inflightBtn, { key: " " });
+    act(() => {
+      fireEvent(inflightBtn, space);
+    });
+    expect(space.defaultPrevented).toBe(true);
+    expect(selected).toEqual([{ kind: "inflight" }]);
+  });
+
+  test("Enter on All and Space on a pinned run activate those tabs", () => {
+    const selected: OperatorContext[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "repo", name: "factory" }}
+        onSelect={(ctx) => selected.push(ctx)}
+        onOpen={() => {}}
+        onClose={() => {}}
+        pinnedRuns={["run_abc"]}
+      />,
+    );
+
+    const allBtn = r.getByRole("button", { name: "All" });
+    allBtn.focus();
+    act(() => {
+      fireEvent.keyDown(allBtn, { key: "Enter" });
+    });
+    expect(selected).toEqual([{ kind: "all" }]);
+
+    window.location.hash = "";
+    const runBtn = r.getByRole("button", { name: "run_abc" });
+    runBtn.focus();
+    act(() => {
+      fireEvent.keyDown(runBtn, { key: " " });
+    });
+    expect(window.location.hash).toBe("#/runs/run_abc");
+  });
+
+  test("closed repo picker ignores ArrowDown and Enter (does not open a repo)", () => {
+    const opened: string[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={(name) => opened.push(name)}
+        onClose={() => {}}
+      />,
+    );
+
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+    plus.focus();
+    fireEvent.keyDown(plus, { key: "ArrowDown" });
+    fireEvent.keyDown(plus, { key: "Enter" });
+    expect(opened).toEqual([]);
+    expect(r.queryByRole("listbox")).toBeNull();
+  });
+
+  test("empty picker copy does not use registry or fleet jargon", () => {
+    const r = render(
+      <ContextTabs
+        repos={[]}
+        reposError={false}
+        openRepos={[]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(r.getByRole("button", { name: "Open a repo tab" }));
+    });
+    const text = r.getByRole("listbox").textContent ?? "";
+    expect(text).toContain("No repos available.");
+    expect(text.toLowerCase()).not.toContain("registry");
+    expect(text.toLowerCase()).not.toContain("fleet");
+  });
+
+  test("opening + moves focus into the listbox; arrows move highlight; Enter selects", () => {
+    const opened: string[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("alpha"), repo("bravo"), repo("charlie")]}
+        reposError={false}
+        openRepos={[]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={(name) => opened.push(name)}
+        onClose={() => {}}
+      />,
+    );
+
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+    act(() => {
+      fireEvent.click(plus);
+    });
+
+    const listbox = r.getByRole("listbox", { name: "Factory repos" });
+    expect(document.activeElement?.getAttribute("role")).toBe("listbox");
+
+    const options = r.getAllByRole("option");
+    expect(options.map((el) => el.textContent)).toEqual(["alpha", "bravo", "charlie"]);
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    expect(options[1].getAttribute("aria-selected")).toBe("false");
+
+    act(() => {
+      fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    });
+    expect(options[0].getAttribute("aria-selected")).toBe("false");
+    expect(options[1].getAttribute("aria-selected")).toBe("true");
+
+    act(() => {
+      fireEvent.keyDown(listbox, { key: "Enter" });
+    });
+    expect(opened).toEqual(["bravo"]);
+    expect(r.queryByRole("listbox")).toBeNull();
+  });
+
+  test("Escape closes the repo picker and returns focus to +", () => {
+    const opened: string[] = [];
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={[]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={(name) => opened.push(name)}
+        onClose={() => {}}
+      />,
+    );
+
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+    act(() => {
+      fireEvent.click(plus);
+    });
+    expect(r.getByRole("listbox")).toBeDefined();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(r.queryByRole("listbox")).toBeNull();
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Open a repo tab");
+    expect(opened).toEqual([]);
+  });
+});
+
+describe("ScopeCaption", () => {
+  const repoCtx: OperatorContext = { kind: "repo", name: "factory" };
+
+  test("kind=all renders nothing (no caption to leak jargon)", () => {
+    const r = render(<ScopeCaption context={{ kind: "all" }} surface="fleet" />);
+    expect(r.container.textContent).toBe("");
+  });
+
+  test("Workers/Agents/Schedules/Overview/Graph use view names, not fleet or registry", () => {
+    const cases: Array<{ hash: string; surface: "fleet" | "registry" | "graph" | "overview"; expect: string }> = [
+      { hash: "#/workers", surface: "fleet", expect: "Workers are not scoped to factory" },
+      { hash: "#/agents", surface: "registry", expect: "Agents are not scoped to factory" },
+      { hash: "#/schedules", surface: "registry", expect: "Schedules are not scoped to factory" },
+      { hash: "#/overview", surface: "overview", expect: "Overview counts are not scoped to factory" },
+      { hash: "#/graph", surface: "graph", expect: "Graph is not scoped to factory" },
+    ];
+
+    for (const c of cases) {
+      window.location.hash = c.hash;
+      const r = render(<ScopeCaption context={repoCtx} surface={c.surface} />);
+      const text = r.container.textContent ?? "";
+      expect(text).toContain(c.expect);
+      expect(text.toLowerCase()).not.toContain("fleet");
+      expect(text.toLowerCase()).not.toContain("registry");
+      cleanup();
+    }
+  });
+
+  test("surface fallback still avoids jargon when hash is empty", () => {
+    window.location.hash = "";
+    const fleet = render(<ScopeCaption context={repoCtx} surface="fleet" />);
+    expect(fleet.container.textContent).toContain("Workers are not scoped to factory");
+    expect(fleet.container.textContent?.toLowerCase()).not.toContain("fleet");
+    cleanup();
+
+    const registry = render(<ScopeCaption context={repoCtx} surface="registry" />);
+    expect(registry.container.textContent).toContain("Agents are not scoped to factory");
+    expect(registry.container.textContent?.toLowerCase()).not.toContain("registry");
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { OperatorContext } from "../context";
 import { INFLIGHT, toggleInflight } from "../context";
+import { hashView } from "../hash";
 import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
 
@@ -28,22 +29,51 @@ const getHashRunId = () => {
   return m ? decodeURIComponent(m[1]) : null;
 };
 
+type CaptionSurface = "fleet" | "registry" | "graph" | "overview";
+
+const SURFACE_SUBJECT: Record<CaptionSurface, { subject: string; plural: boolean }> = {
+  fleet: { subject: "Workers", plural: true },
+  registry: { subject: "Agents", plural: true },
+  graph: { subject: "Graph", plural: false },
+  overview: { subject: "Overview counts", plural: true },
+};
+
+/** Agents and Schedules both pass surface="registry"; hash is the only discriminator without editing views. */
+const REGISTRY_VIEW_SUBJECT: Record<string, { subject: string; plural: boolean }> = {
+  agents: { subject: "Agents", plural: true },
+  schedules: { subject: "Schedules", plural: true },
+};
+
+function captionSubject(surface: CaptionSurface) {
+  if (surface === "registry" && typeof window !== "undefined") {
+    const fromHash = REGISTRY_VIEW_SUBJECT[hashView(window.location.hash)];
+    if (fromHash) return fromHash;
+  }
+  return SURFACE_SUBJECT[surface];
+}
+
 export function ScopeCaption({
   context,
   surface,
 }: {
   context: OperatorContext;
-  surface: "fleet" | "registry" | "graph" | "overview";
+  surface: CaptionSurface;
 }) {
   if (context.kind === "all") return null;
   const n = context.kind === "inflight" ? "In flight" : context.name;
+  if (context.kind === "inflight") {
+    return (
+      <p className="mb-3 text-[11px] text-(--text-faint)">
+        {surface === "overview"
+          ? "In flight scopes Runs list — counts are factory-wide."
+          : "In flight scopes Runs list."}
+      </p>
+    );
+  }
+  const { subject, plural } = captionSubject(surface);
   return (
     <p className="mb-3 text-[11px] text-(--text-faint)">
-      {context.kind === "inflight"
-        ? surface === "overview"
-          ? "In flight scopes Runs list — counts are factory-wide."
-          : "In flight scopes Runs list."
-        : `${surface === "overview" ? "Overview counts are" : `${surface} is`} not scoped to ${n}.`}
+      {`${subject} ${plural ? "are" : "is"} not scoped to ${n}.`}
     </p>
   );
 }
@@ -74,7 +104,10 @@ export function ContextTabs({
   onUnpinRun?: (runId: string) => void;
 }) {
   const [picker, setPicker] = useState(false);
+  const [pickerHighlight, setPickerHighlight] = useState(0);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const plusRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
   const stripRef = useRef<HTMLDivElement>(null);
   const [internalPinned, setInternalPinned] = useState<string[]>(readPinnedRuns);
 
@@ -156,6 +189,12 @@ export function ContextTabs({
 
   useEffect(() => {
     if (!picker) return;
+    setPickerHighlight(0);
+    listboxRef.current?.focus();
+  }, [picker]);
+
+  useEffect(() => {
+    if (!picker) return;
     function onDoc(e: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPicker(false);
     }
@@ -164,6 +203,7 @@ export function ContextTabs({
       e.preventDefault();
       e.stopPropagation();
       setPicker(false);
+      plusRef.current?.focus();
     }
     document.addEventListener("mousedown", onDoc);
     window.addEventListener("keydown", onKey, true);
@@ -191,6 +231,12 @@ export function ContextTabs({
             : tabIds[(currentIndex + delta + tabIds.length) % tabIds.length];
       setTabStopId(nextId);
       stripRef.current?.querySelector<HTMLButtonElement>(`[data-context-tab="${nextId}"]`)?.focus();
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      stripRef.current
+        ?.querySelector<HTMLButtonElement>(`[data-context-tab="${currentId}"]`)
+        ?.click();
     } else if (e.key === "Delete" || e.key === "Backspace") {
       e.preventDefault();
       e.stopPropagation();
@@ -200,10 +246,44 @@ export function ContextTabs({
     }
   };
 
+  const closePicker = (restorePlus = false) => {
+    setPicker(false);
+    if (restorePlus) plusRef.current?.focus();
+  };
+
+  const selectPickerRepo = (name: string) => {
+    onOpen(name);
+    closePicker(true);
+  };
+
+  const handlePickerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (available.length === 0) return;
+      setPickerHighlight((i) => (i + 1) % available.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (available.length === 0) return;
+      setPickerHighlight((i) => (i - 1 + available.length) % available.length);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setPickerHighlight(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      if (available.length === 0) return;
+      setPickerHighlight(available.length - 1);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      const choice = available[pickerHighlight];
+      if (choice) selectPickerRepo(choice.name);
+    }
+  };
+
   // Active state uses the accent tokens (not --surface-3) so it stays visible
   // against --surface-1 in light theme, where the two grays sit too close (WM-91).
   const tabClass = (id: string) =>
-    `flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+    `flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1 text-[12px] font-medium outline-none focus-visible:ring-2 focus-visible:ring-(--accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--surface-1) ${
       activeId === id
         ? "bg-(--accent-dim) text-(--text) ring-1 ring-inset ring-(--accent)"
         : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
@@ -213,7 +293,7 @@ export function ContextTabs({
     <div className="flex h-9 shrink-0 items-stretch gap-0.5 border-b border-(--border) bg-(--surface-1) px-2">
       <div
         ref={stripRef}
-        className="flex min-w-0 flex-1 items-stretch gap-0.5"
+        className="flex min-w-0 flex-1 items-stretch gap-0.5 outline-none"
         role="toolbar"
         aria-label="Context"
         onKeyDown={handleKeyDown}
@@ -329,6 +409,7 @@ export function ContextTabs({
       </div>
       <div className="relative flex shrink-0 items-center" ref={pickerRef}>
         <button
+          ref={plusRef}
           type="button"
           aria-expanded={picker}
           aria-haspopup="listbox"
@@ -342,28 +423,39 @@ export function ContextTabs({
         </button>
         {picker && (
           <div
+            ref={listboxRef}
             id="repo-picker-listbox"
             role="listbox"
+            tabIndex={0}
             aria-label="Factory repos"
-            className="absolute top-full right-0 z-30 mt-1 max-h-72 min-w-48 overflow-auto rounded-md border border-(--border) bg-(--surface-1) py-1 shadow-lg"
+            aria-activedescendant={
+              available[pickerHighlight] ? `repo-picker-opt-${pickerHighlight}` : undefined
+            }
+            className="absolute top-full right-0 z-30 mt-1 max-h-72 min-w-48 overflow-auto rounded-md border border-(--border) bg-(--surface-1) py-1 shadow-lg outline-none"
+            onKeyDown={handlePickerKeyDown}
           >
             {reposError ? (
               <div className="px-3 py-2 text-[12px] text-(--text-faint)">Cannot reach /repos.</div>
             ) : available.length === 0 ? (
               <div className="px-3 py-2 text-[12px] text-(--text-faint)">
-                {repos.length === 0 ? "No repos in the registry." : "All repos are open."}
+                {repos.length === 0 ? "No repos available." : "All repos are open."}
               </div>
             ) : (
-              available.map((r) => (
+              available.map((r, i) => (
                 <button
                   key={r.name}
+                  id={`repo-picker-opt-${i}`}
                   type="button"
                   role="option"
-                  className="block w-full px-3 py-1.5 text-left text-[12px] text-(--text) hover:bg-(--surface-2)"
-                  onClick={() => {
-                    onOpen(r.name);
-                    setPicker(false);
-                  }}
+                  tabIndex={-1}
+                  aria-selected={i === pickerHighlight}
+                  className={`block w-full px-3 py-1.5 text-left text-[12px] text-(--text) ${
+                    i === pickerHighlight
+                      ? "bg-(--surface-2) ring-1 ring-inset ring-(--accent)"
+                      : "hover:bg-(--surface-2)"
+                  }`}
+                  onMouseEnter={() => setPickerHighlight(i)}
+                  onClick={() => selectPickerRepo(r.name)}
                 >
                   {r.name}
                   {r.team ? <span className="ml-2 text-(--text-faint)">{r.team}</span> : null}

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -33,7 +33,8 @@ type CaptionSurface = "fleet" | "registry" | "graph" | "overview";
 
 const SURFACE_SUBJECT: Record<CaptionSurface, { subject: string; plural: boolean }> = {
   fleet: { subject: "Workers", plural: true },
-  registry: { subject: "Agents", plural: true },
+  // Projects also passes surface="registry"; only agents/schedules hashes map to view names below.
+  registry: { subject: "registry", plural: false },
   graph: { subject: "Graph", plural: false },
   overview: { subject: "Overview counts", plural: true },
 };


### PR DESCRIPTION
## Summary
- Re-lands #279 after it was reverted from `develop` (CI red: Projects `ScopeCaption` said “Agents”).
- Enter/Space activate context tabs; repo picker is keyboard-operable; captions use Workers/Agents/Schedules/Overview/Graph.
- `surface="registry"` remaps to Agents/Schedules **only** on those hashes. Projects (and empty hash) keep “registry is not scoped to factory.” so WM-157 stays honest.

## Test plan
- [x] `cd event-runtime/web && bun test` — 439 pass
- [ ] CI Verify on this PR
- [ ] Confirm Projects page still shows factory-wide registry caption under a repo context tab

Fixes WM-148