### PR TITLE
docs(webui): §5.2 addendum, §5.3 component conventions, §5.4 typography scale

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -384,11 +384,250 @@ no shared set. Every rule below is checkable in review.
   active-attention banner). Pulse means "happening now"; a static state never
   pulses.
 
+#### Icon placement grammar (WM-187)
+
+Where an icon or glyph may sit, relative to the text it belongs to. Anything
+not in this table is not a placement.
+
+| Context                    | Position                        | Rule                                                                                                           |
+| -------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| State badge / status label | leading, `gap-1.5`              | Icon then word. Never trailing, never alone.                                                                   |
+| Button                     | leading only                    | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                     |
+| Table cell                 | leading, baseline-aligned       | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it. |
+| Section / group header     | between chevron and label       | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                          |
+| Nav rail                   | none                            | Text-only until the rail outgrows its labels; a leading icon column is the _only_ shape it may take then.      |
+| Keyboard hint              | trailing, in `<kbd>` or `.mono` | Right-aligned in its row (`FilterInput` `/`, palette rows). Never inline in prose.                             |
+
+Icons and glyphs sit **on the text baseline** and take the text color of
+their label (`currentColor`); an icon lighter or brighter than its own label
+is a bug.
+
+#### Sizing scale
+
+Icon size follows the type size next to it — it is never set independently:
+
+| Text size        | Icon | Where                                            |
+| ---------------- | ---- | ------------------------------------------------ |
+| 11px (badges)    | 12px | `StateBadge`, table cells, chips                 |
+| 12–13px (body)   | 14px | Default. Buttons, list rows, KV values           |
+| 14–15px (titles) | 16px | `DetailPane` title, `Dialog` title, empty states |
+
+Chevrons and sort arrows are the exception: 9px, because they are affordance
+punctuation, not content.
+
+#### Interactive states for icons and glyphs
+
+Two "reveal on hover" idioms exist today; from here there is one per case:
+
+- **Affordance that is always present** (chip `×`, palette hints): rendered
+  at `--text-faint`, rises to `--text` on the parent's hover/focus via
+  `group-hover:` — never hidden.
+- **Affordance that is contextual** (sort arrow on an unsorted column, JSON
+  copy button): `opacity-0` → `group-hover:opacity-50` → `opacity-100` when
+  active. Reserved for controls that would add noise if always shown.
+- **Disabled**: the whole control takes `opacity-40` + `cursor-not-allowed`
+  (as `Button` does); the icon is not dimmed separately.
+- **Focus**: the ring belongs to the control (`:focus-visible` outline in
+  `theme.css`), never to the icon.
+
+#### Text on hue washes
+
+Text on a hue wash is **always the hue itself** (`color: hue` on a 12% wash
+of the same hue), never `--text` or `--text-dim`. The derived hues share the
+accent's lightness/chroma, so this reads on all three themes in dark and
+light; in `contrast` the wash goes very faint and the hue text carries the
+whole signal — that is fine, but it means **check every new hue usage in all
+three themes** (the §5.1 appearance axis), not just the default.
+
+#### Empty, loading, and error states
+
+Text only. `ListEmpty` is the standard: one line of copy, an optional
+follow-up hint, an optional single action. No illustration, no icon, no
+emoji, no "sad state" art. Loading copy is `Loading <noun>…`; error copy
+names the dependency that is down. A spinner is not used anywhere — the 2 s
+poll (§6) makes staleness the honest signal, not motion.
+
+#### Accessibility for icons and glyphs
+
+- Decorative (has an adjacent visible label): `aria-hidden="true"`. This is
+  the normal case and should be nearly the only case.
+- Meaningful (no visible label — avoid, but if it exists): `role="img"` +
+  `aria-label`, and the parent control also gets `title` for sighted hover.
+- Never convey a state by icon or hue alone: the word is always present
+  (`StateBadge` renders `{state}`; the group header renders `label`).
+- Motion: `animate-pulse` is the only animation and it must be wrapped so
+  `prefers-reduced-motion: reduce` disables it (Tailwind
+  `motion-safe:animate-pulse`). Existing bare `animate-pulse` uses are debt.
+
+#### Adding an icon or glyph — checklist
+
+Before a PR introduces one, in this order:
+
+1. Would a word do? Then use the word.
+2. Is it in the approved glyph table? Use exactly that glyph for exactly that
+   meaning. If not, and it is a state, it is an OPS-498 SVG icon. If neither,
+   this section changes first (own PR), then the code.
+3. Does it appear in at least two places, or is it a one-off decoration? A
+   one-off is not added.
+4. Placement matches the grammar table; size matches the scale table.
+5. `aria-hidden` and a text label are present.
+6. Rendered and checked in all three themes.
+
+Reviewer version (grep-able): no emoji, no `text-[color:var(`, no
+`color-mix` percentage outside the wash table, no `Record<string, "var(--hue`
+outside `ui.tsx`, no `animate-pulse` without `motion-safe:`, no icon-only
+control without `aria-label`.
+
+#### Worked examples
+
+From the codebase, so the rules are concrete:
+
+- **Identity borrowing a state hue** — `views/Projects.tsx` `TEAM_HUES` maps
+  `CLNT` → `--hue-ok`. In Runs, that green means COMPLETED. Fix: teams get a
+  neutral `Pill` (or an accent-derived identity treatment that is none of the
+  six state hues). WM-134.
+- **Two spellings of one color** — `text-[color:var(--hue-warn)]` in
+  Workers/Overview versus `text-(--hue-warn)` elsewhere. Fix: the
+  parenthesized form. WM-134.
+- **A wash that invented its own strength** — `color-mix(... 14% ...)` on the
+  Projects "report only" pill. Fix: 12%, the badge row of the wash table.
+- **A glyph reused for a second meaning** — `×` means "remove this chip". It
+  must not appear as a "failed" marker in a table cell; that is
+  `--hue-err` + the word (and, after OPS-498, the disc+× icon).
+
+### 5.3 Component conventions (WM-187)
+
+`components/ui.tsx` is the component vocabulary; a view composes it and does
+not re-invent it. These are the conventions the primitives encode, written
+down so a new view can be checked against them.
+
+#### The view skeleton
+
+Every list view is `ListPane` (pinned chrome: title, `Tabs`, `FilterInput`,
+`DisplayOptions`; scrolling table below) plus an optional `DetailPane` on the
+right (§5.1). The chrome padding is `px-5 pt-5 pb-3`, the table area `px-5
+pb-5`; the detail pane is `border-l bg-(--surface-1)` with a pinned title
+row, its actions on their **own** wrapping row beneath, and one `close` slot
+top-right (WM-97). A view that needs a different frame is a spec change
+(§10.11 and §10.13 are the two that exist).
+
+#### Tables
+
+- Structure: `<table className="w-full border-separate border-spacing-0">`,
+  header via `Th` (sticky `top-0`, `h-7`, hairline as an inset shadow so the
+  group headers can pin at exactly `top-7`), optional `GroupHeaderRow` bands
+  under it.
+- Cells: `px-3 py-1.5 border-b border-(--border)` — one row height across
+  the app. (`Schedules` uses `py-2` today; that is debt, not a variant.)
+  Numeric columns are `tabular-nums` and right-aligned via `Th align="right"`.
+- Ids and machine values are `.mono`; prose columns are body text; secondary
+  columns are `--text-dim`, tertiary `--text-faint`. Long values `truncate`
+  inside a `max-w-*` with the full value in `title`; ids render through
+  `shortId()` and keep the full id in `title` and on copy verbs.
+- Row states: `.row-selected` (accent 16% + inset accent bar) wins over
+  status washes; hover is `hover:bg-(--surface-2)`; status washes are
+  `.row-wash-err`/`.row-wash-warn` at 6% and nothing else.
+- Empty/loading/error rows are `ListEmpty` with `colSpan` = the column count.
+- In-cell navigation is `JumpLink` (stops propagation, so it does not select
+  the row). Bulk selection surfaces `BulkActionBar`, never inline buttons per
+  row.
+
+#### Filters and inputs
+
+- The list filter is `FilterInput`: `w-56`, `/` to focus, Esc clears then
+  blurs, facet autocomplete with hue dots for state values, active tokens as
+  dismissible chips (the whole chip is the remove target). One filter box per
+  view, in the chrome row, right of the tabs.
+- Free text with suggestions is `SuggestInput`; string arrays are
+  `ChipInput`. Both are `.mono` because they hold ids, repos, and paths.
+- Inputs are `rounded-md border-(--border) bg-(--surface-1)` (or `-0` inside
+  a `-1` panel), `text-[12px]`, `focus:border-(--accent)`, placeholder in
+  `--text-faint`. No filled/underlined variants; no floating labels — a
+  `<label>` above, `text-[11px] text-(--text-faint)`.
+
+#### Tabs
+
+`Tabs` is the segmented strip: `role="tablist"`, `text-[11px]`, active =
+`bg-(--surface-3) text-(--text)`, disabled tabs stay clickable and explain
+themselves via `title` (WM-76). Tabs switch _sub-views of one list_; they do
+not navigate — navigation is the rail and `g` chords. `ContextTabs`
+(operator-pinned runs, §10.12) is a different thing and lives above the
+content, not in the chrome row.
+
+#### Buttons and verbs
+
+`Button` has exactly three variants: `default`, `primary`, `danger`.
+`primary` is the one accent-filled action per surface (at most one visible at
+a time); `danger` is text-in-`--hue-err` on a neutral fill — never a red
+fill. Verb labels are verbs ("Approve", "Cancel run"), sentence case; a verb
+that opens a dialog ends in `…`. Verb failure renders inline via `VerbError`
+under the buttons (404/409 are normal, §6), never as a toast alone.
+
+#### Dialogs (modals) and side panels
+
+- Modal = `Dialog`: centered at `pt-[10vh]`, `w-[480px]` / `wide` 720 /
+  `extraWide` 920, focus-trapped, Esc closes, backdrop click closes, title in
+  `.display`. Used for **verbs that need input or confirmation** (inject,
+  cancel-with-reason, shortcuts). Anything the operator reads while doing
+  something else is not a modal.
+- Side panel = `DetailPane`: reading surface for the selected row. There is
+  no third "slide-over" pattern; if content does not fit the pane, it becomes
+  the full-page run view (§10.11), not an overlay.
+- Confirmations for destructive verbs use `Dialog` with the `danger` button
+  and restate the target (`Cancel run run_ec9c87f9?`); no browser `confirm()`.
+
+#### Chips, pills, badges
+
+- `StateBadge` — lifecycle/status only, hue from the `ui.tsx` maps.
+- `Pill` — read-only neutral value (`.mono`, `--surface-2`, `--text-dim`);
+  identity and constants go here.
+- Filter tokens / chip-input chips — dismissible, `×` trailing.
+- Nav badge — count with hue wash; hidden from the accessible name and
+  re-attached via `aria-describedby`.
+
+Four things, four looks. A "badge" that is not one of these is a `Pill`.
+
+#### Feedback
+
+- Toasts (`notify`) are for **outcomes of verbs**: `ok`/`err`/`info`, 3 s,
+  max 5, dismiss on click. `err` goes to the assertive live region. Never
+  used for validation (that is `VerbError`) or for state changes the operator
+  did not cause (that is the list updating).
+- Banners (`Overview` attention block, `Workers` stale-heartbeat block,
+  `RunFailureBanner`): hue border + 8% wash + pulsing dot, at the top of the
+  content, for **conditions needing attention now**. One per view at most.
+- Collapsible secondary payloads are `Disclosure` (`<details>`), label in
+  `--text-faint`. Key/value facts are `KV` (copyable when a string).
+
+### 5.4 Typography scale (WM-187)
+
+§5.1 names the faces; this fixes the sizes. Today views use 10, 10.5, 11,
+12, 13 and 15px ad hoc; from here the scale is:
+
+| Size   | Role                                           | Face                   |
+| ------ | ---------------------------------------------- | ---------------------- |
+| 15px   | Dialog title                                   | `.display` semibold    |
+| 14px   | View title, `DetailPane` title, brand          | `.display` semibold    |
+| 13px   | Body: nav items, table body text, KV values    | Inter (`body` default) |
+| 12px   | Dense body: buttons, inputs, toasts, list rows | Inter                  |
+| 11.5px | Monospace values (`.mono`)                     | ui-monospace           |
+| 11px   | Labels, badges, `Th`, hints, section headings  | Inter (`--text-faint`) |
+| 10px   | `<kbd>` and keyboard hints only                | Inter                  |
+
+Rules: `.display` only at 14–15px and stat-tile numerals (`text-xl`); nothing
+below 10px; `10.5px` and other in-between values are debt. Table body cells
+inherit 13px from `body` unless the column is `.mono` (11.5) or a
+label-class column (11px `--text-dim`). Section headings are 11px uppercase
+`tracking-wide --text-faint` (`Section`) — the only uppercase in the app
+besides the env chip. Weights: `font-medium` for active/emphasis,
+`font-semibold` for titles, nothing bolder.
+
 #### Known debt (filed, not fixed here)
 
 State-icon implementation is OPS-498. Syntax normalization, wash
-normalization, and the Projects team-hue fix are follow-up tickets — this
-section is the standard they normalize _to_.
+normalization, and the Projects team-hue fix are WM-134. Table row-height
+(`Schedules` `py-2`), sub-11px sizes, and bare `animate-pulse` are additional
+WM-134 scope — this section is the standard they normalize _to_.
 
 ## 6. Liveness and concurrency honesty
 


### PR DESCRIPTION
Extends the design guide from WM-133 to be comprehensive:

- §5.2 additions: icon placement grammar, size scale, interactive-state idioms, text-on-wash contrast, empty/loading/error rules, icon a11y (role=img, reduced motion), add/review checklist, worked examples from the codebase.
- §5.3 Component conventions: view skeleton, tables (one row height, cell classes, row states), filters/inputs, tabs, buttons/verbs, dialogs vs detail pane (no slide-over pattern), chips/pills/badges, toasts/banners.
- §5.4 Typography scale: fixes the ad-hoc 10/10.5/11/12/13/15px into a named scale.

Docs only. Verification: `npx prettier --check docs/event-runtime-webui.md` — pass.

Fixes WM-187