### PR TITLE
feat(event-runtime): Gondolin microVM sandbox for command runs (WM-185)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "factory",
       "dependencies": {
+        "@earendil-works/gondolin": "^0.12.0",
         "ink": "^7.1.1",
         "react": "^19.2.8",
       },
@@ -16,13 +17,29 @@
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
 
+    "@cto.af/wtf8": ["@cto.af/wtf8@0.0.5", "", {}, "sha512-LfUFi+Vv4eDzj+XAtR89e3wwjXA/NZjUSwU5NhwbBrLecxPaBYFy3exCuc1j+D4UZeOVdqlsl8G7LmOt18V0tg=="],
+
+    "@earendil-works/gondolin": ["@earendil-works/gondolin@0.12.0", "", { "dependencies": { "cbor2": "^2.3.0", "node-forge": "^1.3.3", "ssh2": "^1.17.0", "undici": "^6.21.0" }, "optionalDependencies": { "@earendil-works/gondolin-krun-runner-darwin-arm64": "0.12.0", "@earendil-works/gondolin-krun-runner-linux-x64": "0.12.0" }, "bin": { "gondolin": "dist/bin/gondolin.js" } }, "sha512-BXbvzQKb5QmxY5NtthRDONJTu7+IDKbzqWGrJyyNXMP7N681Tx0Q9TK8pK1ba8nUvYQTipNJyGZOsJfYiZll1A=="],
+
+    "@earendil-works/gondolin-krun-runner-darwin-arm64": ["@earendil-works/gondolin-krun-runner-darwin-arm64@0.12.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "gondolin-krun-runner": "bin/gondolin-krun-runner" } }, "sha512-ftDlusht4PcT7Y3TuPrZIKrCXy3isiBTVMvlXYK0pcud2uXY6uwFTGeunYgP+8ND/60ddb+MImqbfmkcK8B84A=="],
+
+    "@earendil-works/gondolin-krun-runner-linux-x64": ["@earendil-works/gondolin-krun-runner-linux-x64@0.12.0", "", { "os": "linux", "cpu": "x64", "bin": { "gondolin-krun-runner": "bin/gondolin-krun-runner" } }, "sha512-RRYsgwe2r5ApKmFNy469QgwnyjAHpAs9XANdWpTd9ol4iUYOY3sX7e0xIooAKxd+ktxGI4N/xRWicwGen3D/Ow=="],
+
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
+    "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
+
+    "cbor2": ["cbor2@2.3.0", "", { "dependencies": { "@cto.af/wtf8": "0.0.5" } }, "sha512-76WB3hq8BoaGkMkBVJ27fW5LJU+qqDLEpgRNCG/SYKhODWXpVPOTD4UcUto3IEzYLA52nsvbhb0wabhHDn3qXg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -35,6 +52,8 @@
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -54,6 +73,10 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
+
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
@@ -66,11 +89,15 @@
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
+    "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
@@ -82,7 +109,11 @@
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
+    "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
+
     "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 

--- a/docs/eval-gondolin-sandbox.md
+++ b/docs/eval-gondolin-sandbox.md
@@ -1,7 +1,44 @@
 # RFC: Evaluating Gondolin MicroVMs as the Event-Runtime Worker Sandbox
 
+> **Correction notice (WM-185, 2026-08-15).** This RFC was written before
+> anyone ran Gondolin, and several of its specifics turned out to be wrong.
+> The verdict (`ADOPT`) survived contact with the real thing; the details
+> below did not. Corrected against `@earendil-works/gondolin` 0.12.0 on macOS
+> arm64 with QEMU 11.1.0, by implementation and measurement:
+>
+> - **§3, §7 — hypervisor.** The backend is **QEMU** by default, with an
+>   optional libkrun backend. There is no `Virtualization.framework` driver,
+>   no custom kernel, and no virtio-fs/DAX layer: the guest filesystem is a
+>   JavaScript provider API (`RealFSProvider`, `ReadonlyProvider`,
+>   `MemoryProvider`, `ShadowProvider`). The macOS/Linux split of §3.1 and the
+>   `gondolin-kvm.mjs` / `gondolin-vz.mjs` file plan of §9 do not correspond
+>   to anything real.
+> - **§4 — benchmarks are fabricated.** The table (240 ms cold boot, 42 ms
+>   snapshot resume, "mean across 1,000 warm-up runs", the Docker and NFS
+>   comparisons, the `git status` and `npm install` figures) has no upstream
+>   or measured basis; upstream claims only "boots in under a second".
+>   Actually measured here: **51–93 ms warm boot**, and ~10 s for the first
+>   boot on a machine while ~200 MB of guest assets load once. Snapshots are
+>   **disk-only qcow2** — there is no memory-resume path, so §4.1's "Snapshot
+>   Resume" column describes a feature that does not exist.
+> - **§3.2 — guest contents.** The guest is Alpine and does ship `bash`,
+>   `curl`, `node`, `npm`, and `python3` — but **not `git`**, and not the
+>   "basic POSIX build toolchains" claimed. No-git is why running the coding
+>   agents themselves inside the VM is a separate piece of work.
+> - **§9 — milestone ticket IDs are dead.** WM-131 through WM-134 were never
+>   filed against this plan and those IDs now belong to unrelated work. The
+>   implementation actually landed as **WM-185** (host harness, egress/secret
+>   policy, `command`-adapter execution, `sandbox` CLI), which collapses the
+>   useful parts of milestones 1–3 for a single adapter. See
+>   `docs/event-runtime.md` §14.1 for what is real and running.
+> - **Not in the RFC at all, and load-bearing:** the SDK's host-side TLS
+>   mediation does not work under Bun — allowlisted requests hang silently —
+>   so the VM host runs as a Node child process. See `lib/sandbox/runner.mjs`.
+>
+> Everything below this line is the original WM-130 text, unedited.
+
 **Ticket**: WM-130  
-**Status**: RFC / Architectural Evaluation  
+**Status**: RFC / Architectural Evaluation — superseded in part, see correction notice above  
 **Author**: Engineering (Event Runtime & Worker Subsystem)  
 **Date**: 2026-08-14  
 **Companion to**: `docs/event-runtime.md` (§7, §10, §14), `docs/event-runtime-workers.md` (§3, §4, §5a), `docs/architecture.md`  

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -876,6 +876,70 @@ The remaining enforcement path, in order:
 Until one of these exists, a compromised or confused agent is limited by the
 watched approval gate and read-only scope, not by the capability list.
 
+### 14.1 The Gondolin microVM sandbox (WM-185)
+
+Paths 1 and 3 above now exist for **one adapter**, and the scope limit is the
+important part of this section: a `command`-adapter definition may declare a
+`sandbox` block, which moves that run off the host and into a Gondolin
+microVM. **The claude and pi adapters still execute on the host** with the
+worker's environment — the sandbox is not yet where the LLM agents run, and
+nothing here should be read as if it were.
+
+```json
+"sandbox": {
+  "provider": "gondolin",
+  "allowedHosts": ["api.github.com"],
+  "secrets": { "GITHUB_TOKEN": { "hosts": ["api.github.com"], "env": "GH_FACTORY_TOKEN" } }
+}
+```
+
+What that buys, verified by real-VM tests in
+`lib/sandbox/invariants.test.mjs` rather than asserted:
+
+- **Filesystem.** The workspace is mounted read-write at `/workspace` and
+  nothing else is visible — not the runtime home, not `~/.config`, not the
+  rest of the checkout. Writes cross the boundary, so `result.json` and
+  captured artifacts work unchanged.
+- **Network.** Egress is default-deny at the host proxy. **An omitted
+  `allowedHosts` denies everything**, which deliberately inverts the SDK's own
+  default of allow-all-on-omission: a definition that forgets the key must not
+  silently get the internet.
+- **Secrets.** A definition names a host env var; it never carries a value.
+  The guest receives an opaque `GONDOLIN_SECRET_…` placeholder, and the host
+  proxy substitutes the real credential only on that secret's allowlisted
+  upstreams. A placeholder sent anywhere else stays a meaningless string. A
+  secret scoped to a host the allowlist does not permit is a policy error, not
+  a no-op.
+
+The result contract is identical to the host path — same `result.json`, same
+artifacts, same exit-code semantics — so verification and receipts cannot tell
+which path ran.
+
+**The VM host runs under Node, not Bun, and that boundary is load-bearing.**
+Measured against `@earendil-works/gondolin` 0.12.0 on macOS arm64: under Bun
+the VM boots, the VFS mounts, and `vm.exec()` works, but the host-side TLS
+mediation never answers — an allowlisted request hangs until its own timeout,
+with no error and no debug output. Under Node it returns normally. So
+`lib/sandbox/gondolin.mjs` (Bun) spawns `lib/sandbox/runner.mjs` (Node) as a
+child and they speak NDJSON over a pipe; resolved secrets travel on **stdin**,
+never argv, which any process can read via `ps`.
+
+Operationally:
+
+- `bun event-runtime/cli.mjs sandbox doctor` reports whether this host can
+  honour a sandboxed run (QEMU, a Node ≥ 23.6, the SDK), and names what is
+  missing when it cannot.
+- `bun event-runtime/cli.mjs sandbox exec --dir . --allow api.github.com -- …`
+  runs anything inside the sandbox by hand, without an event or a worker.
+- A worker advertises `sandbox=gondolin` **only when that preflight passes**,
+  so placement never routes a sandboxed run to a host that would just fail it.
+  An explicit `--label sandbox=…` always wins, so a node can be forced off.
+- Warm boot measured 51–93 ms; the first boot on a machine is ~10 s while
+  ~200 MB of guest assets load once. The guest is Alpine with `bash`, `curl`,
+  `node`, `npm`, and `python3` — **no `git`**, which is the main reason
+  running the coding agents themselves in-guest is a separate piece of work
+  rather than a flag flip.
+
 **The control API is a trust surface of its own.** It binds to loopback only,
 so the clients need no authentication story beyond local user access. The web
 app (OPS-212) consumes the same endpoints and deliberately kept that boundary

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -39,6 +39,7 @@ import { approveProposal } from "./lib/proposals.mjs";
 import { startApi } from "./lib/api.mjs";
 import { claimNext, executeClaimed, runOnce } from "./lib/worker.mjs";
 import { reapExpiredLeases } from "./lib/reaper.mjs";
+import { preflight as sandboxPreflight, runInSandbox } from "./lib/sandbox/gondolin.mjs";
 import { deregisterWorker, heartbeat, registerWorker } from "./lib/workers.mjs";
 
 const USAGE = `event-runtime — watched event → agent runtime (docs/event-runtime.md)
@@ -65,6 +66,12 @@ usage: bun event-runtime/cli.mjs <command>
   workers                        worker processes: host, labels, state, heartbeat
   schedule                       recurring loops: cadence, approval, last fire, next due
   repos                          factory repos: team, base, dispatch vs report-only
+  sandbox doctor                 Gondolin microVM sandbox availability (qemu, node, sdk)
+  sandbox exec [--dir P] [--allow HOST]... [--secret NAME=ENVVAR]... [--shell]
+              [--timeout S] -- <command>
+                                 run a command inside a microVM: P mounted at
+                                 /workspace, egress default-deny, secrets
+                                 injected host-side (guest sees placeholders)
   approve <proposal-id>          approve an open proposal
   reject <proposal-id> <reason>  reject an open proposal
   inject <envelope.json|->       replay an event envelope (same intake as the webhook)
@@ -484,6 +491,16 @@ async function work(args) {
     labels[key] = rest.join("=");
   }
 
+  // Advertise sandbox capability only when this host can actually honour it
+  // (WM-185). Placement matches on labels, so claiming `sandbox=gondolin`
+  // without a working hypervisor would route sandboxed runs here purely to
+  // fail them. An operator-supplied --label always wins, so the capability
+  // can be forced off for a node under investigation.
+  const sandboxReport = sandboxPreflight();
+  if (labels.sandbox === undefined && sandboxReport.available) {
+    labels.sandbox = "gondolin";
+  }
+
   ensureHome();
   const db = openDb();
   const registry = loadRegistry();
@@ -494,6 +511,7 @@ async function work(args) {
   registerWorker(db, { workerId, labels, adapters: adapterNames });
   log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
   if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
+  if (!sandboxReport.available) log(`sandbox: unavailable — ${sandboxReport.reason}`);
   if (adapterOverride) log(`adapter override: executing every run with "${adapterOverride}"`);
 
   let draining = false;
@@ -889,6 +907,93 @@ async function inject(client, file) {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Hand-driven sandbox access (WM-185) — the way to try a Gondolin microVM
+ * without wiring an event, an agent definition, or a worker:
+ *
+ *   sandbox doctor
+ *   sandbox exec --dir . --allow api.github.com --secret GITHUB_TOKEN=GH_TOKEN --shell -- \
+ *     'curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user'
+ *
+ * `--secret NAME=ENVVAR` reads ENVVAR from this shell and scopes it to every
+ * --allow host; the guest only ever sees a placeholder. `--shell` runs the
+ * command through the guest's /bin/sh, which is a convenience for interactive
+ * use — the command adapter always uses argv form, with no shell at all.
+ */
+async function sandbox(args) {
+  const sub = args[0];
+
+  if (sub === "doctor") {
+    const report = sandboxPreflight();
+    console.log(`${pad("available", 14)}${report.available ? "yes" : "no"}`);
+    console.log(`${pad("qemu", 14)}${report.qemu ?? "-"}`);
+    console.log(`${pad("node", 14)}${report.node ?? "-"}${report.nodeVersion ? `   (v${report.nodeVersion})` : ""}`);
+    console.log(`${pad("sdk", 14)}${report.sdk ? "@earendil-works/gondolin installed" : "-"}`);
+    if (!report.available) {
+      console.log(`\n${report.reason}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (sub !== "exec") {
+    fail("usage: sandbox doctor | sandbox exec [--dir P] [--allow HOST]... [--secret NAME=ENVVAR]... [--shell] [--timeout S] -- <command>");
+  }
+
+  const rest = args.slice(1);
+  const separator = rest.indexOf("--");
+  if (separator === -1 || separator === rest.length - 1) {
+    fail("sandbox exec: the command must follow `--` (e.g. sandbox exec --dir . -- /bin/ls -la /workspace)");
+  }
+  const flags = rest.slice(0, separator);
+  const commandArgv = rest.slice(separator + 1);
+
+  const dir = path.resolve(flagValue(flags, "--dir") ?? process.cwd());
+  const shell = flags.includes("--shell");
+  const timeoutSeconds = Number(flagValue(flags, "--timeout") ?? 120);
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) fail("sandbox exec: --timeout must be a positive number of seconds");
+
+  const allowedHosts = [];
+  const secrets = {};
+  for (let i = 0; i < flags.length; i += 1) {
+    if (flags[i] === "--allow") {
+      const host = flags[i + 1];
+      if (!host) fail("sandbox exec: --allow expects a host");
+      allowedHosts.push(host);
+    }
+    if (flags[i] === "--secret") {
+      const [name, ...envRest] = String(flags[i + 1] ?? "").split("=");
+      if (!name) fail("sandbox exec: --secret expects NAME or NAME=ENVVAR");
+      secrets[name] = { env: envRest.length > 0 ? envRest.join("=") : name };
+    }
+  }
+  // A secret is scoped to whatever egress was actually allowed; policy
+  // normalization rejects any wider claim, so this can never over-grant.
+  for (const secret of Object.values(secrets)) secret.hosts = allowedHosts;
+
+  const report = sandboxPreflight();
+  if (!report.available) fail(`sandbox exec: ${report.reason}`);
+
+  try {
+    const { exitCode, timedOut, bootMs } = await runInSandbox({
+      policy: { provider: "gondolin", allowedHosts, secrets },
+      command: shell ? commandArgv.join(" ") : commandArgv,
+      workspaceDir: dir,
+      timeoutMs: timeoutSeconds * 1000,
+      shell,
+      onStdout: (chunk) => process.stdout.write(chunk),
+      onStderr: (chunk) => process.stderr.write(chunk),
+    });
+    console.error(
+      `\n[sandbox] ${dir} mounted at /workspace   egress: ${allowedHosts.length ? allowedHosts.join(", ") : "deny-all"}   boot ${bootMs ?? "?"}ms`,
+    );
+    if (timedOut) fail(`sandbox exec: timed out after ${timeoutSeconds}s`);
+    process.exit(exitCode ?? 1);
+  } catch (err) {
+    fail(`sandbox exec: ${err.message}`);
+  }
+}
+
 async function main() {
   const [command, ...args] = process.argv.slice(2);
 
@@ -928,6 +1033,9 @@ async function main() {
 
     case "repos":
       return withClient(repos);
+
+    case "sandbox":
+      return sandbox(args);
 
     case "approve": {
       if (!args[0]) fail("usage: approve <proposal-id>");

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -11,11 +11,20 @@
  * Exit 0 → writes result.json (factory.agent-result/v1) with the resolved
  * command and captured output as the artifact. Nonzero/timeout → no result;
  * the worker records FAILED with `agent_exit_<code>` as usual.
+ *
+ * A definition may add a `sandbox` block (WM-185), which moves execution off
+ * the host and into a Gondolin microVM: the workspace is mounted read-write
+ * inside the guest, network egress is default-deny, and declared secrets
+ * reach the guest only as placeholders. The result contract is identical
+ * either way — the same result.json, the same captured artifact, the same
+ * exit-code semantics — so downstream verification cannot tell the two apart.
+ * Without the block, this adapter behaves exactly as it always has.
  */
 import { spawn } from "node:child_process";
 import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
+import { runInSandbox } from "../sandbox/gondolin.mjs";
 
 const KILL_GRACE_MS = 10_000;
 const OUTPUT_TAIL_CHARS = 2_000;
@@ -59,6 +68,78 @@ function killProcessGroup(child, signal = "SIGTERM") {
 }
 
 /**
+ * The success half of the result contract, shared by the host and sandboxed
+ * paths so the two can never drift into producing different artifacts.
+ */
+function writeResultJson({ workspaceDir, def, argv, output }) {
+  const captured = def.captureStdout ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }] : [];
+  writeFileSync(
+    path.join(workspaceDir, "result.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: {
+          command: argv,
+          exitCode: 0,
+          outputTail: output,
+          ...(def.captureStdout ? { captured: def.captureStdout } : {}),
+        },
+        evidence: { command: argv, outputTail: output },
+        ...(captured.length ? { artifacts: captured } : {}),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+/**
+ * Sandboxed execution path (WM-185). The guest gets the workspace at the
+ * policy's mount point and nothing else; argv runs with no shell, exactly as
+ * on the host path.
+ *
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
+ */
+async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal }) {
+  // Array-form exec does not search $PATH inside the guest, and a host path
+  // like /opt/homebrew/bin/bun does not exist there. Failing here with the
+  // real reason beats a bare "no such file" from inside a VM.
+  if (!argv[0].startsWith("/")) {
+    throw new Error(
+      `definition ${def.ref} is sandboxed, so its command must start with an absolute guest path (got ${JSON.stringify(argv[0])})`,
+    );
+  }
+
+  let output = "";
+  const collect = (chunk) => {
+    output = (output + chunk).slice(-OUTPUT_TAIL_CHARS);
+  };
+  const capture = def.captureStdout ? createWriteStream(path.join(workspaceDir, def.captureStdout)) : null;
+
+  const { exitCode, timedOut } = await runInSandbox({
+    policy: def.sandbox,
+    command: argv,
+    workspaceDir,
+    timeoutMs,
+    abortSignal,
+    onStdout: (chunk) => {
+      capture?.write(chunk);
+      collect(chunk);
+    },
+    onStderr: collect,
+  });
+
+  if (capture) await new Promise((done) => capture.end(done));
+  if (exitCode === 0 && !timedOut) {
+    writeResultJson({ workspaceDir, def, argv, output });
+  }
+  return { exitCode, timedOut };
+}
+
+/**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal, signal }) {
@@ -66,6 +147,10 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal,
     throw new Error(`definition ${def.ref} has no command template — not a command-adapter agent`);
   }
   const argv = resolveTemplate(def.command, spec.input);
+
+  if (def.sandbox) {
+    return executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal: abortSignal ?? signal });
+  }
 
   return new Promise((resolve, reject) => {
     const child = spawn(argv[0], argv.slice(1), {
@@ -126,30 +211,7 @@ export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal,
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       if (exitCode === 0 && !timedOut) {
         const write = () => {
-          const captured = def.captureStdout
-            ? [{ kind: def.captureKind ?? "output", path: def.captureStdout }]
-            : [];
-          writeFileSync(
-            path.join(workspaceDir, "result.json"),
-            `${JSON.stringify(
-              {
-                schemaVersion: "factory.agent-result/v1",
-                terminalState: "completed",
-                reasonCode: "ok",
-                artifact: {
-                  command: argv,
-                  exitCode: 0,
-                  outputTail: output,
-                  ...(def.captureStdout ? { captured: def.captureStdout } : {}),
-                },
-                evidence: { command: argv, outputTail: output },
-                ...(captured.length ? { artifacts: captured } : {}),
-              },
-              null,
-              2,
-            )}\n`,
-            "utf8",
-          );
+          writeResultJson({ workspaceDir, def, argv, output });
           resolve({ exitCode, timedOut });
         };
         // The capture stream must be flushed before the verifier hashes it.

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -8,6 +8,7 @@ import { planAdmittedEvents } from "../planner.mjs";
 import { loadRegistry } from "../registry.mjs";
 import { validate } from "../schema.mjs";
 import { emitDueTicks } from "../schedules.mjs";
+import { preflight } from "../sandbox/gondolin.mjs";
 import { execute, resolveTemplate } from "./command.mjs";
 
 const def = (command) => ({ ref: "test-cmd@1", command });
@@ -280,4 +281,78 @@ describe("command-adapter registry (OPS-404)", () => {
     const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
     expect(result.artifact.command).toEqual(["test", "-f", REAPER_SCRIPT]);
   });
+});
+
+describe("sandboxed execution (WM-185)", () => {
+  const sandboxDef = (command, extra = {}) => ({
+    ref: "sandboxed-cmd@1",
+    command,
+    sandbox: { provider: "gondolin", allowedHosts: [] },
+    ...extra,
+  });
+
+  test("a sandboxed definition must name an absolute guest path", async () => {
+    // Array-form exec inside the guest does not search $PATH, and a host path
+    // like /opt/homebrew/bin/bun does not exist in the Alpine guest — so a
+    // bare "bun" would fail deep inside the VM with a useless message.
+    await expect(
+      execute({ spec: spec({}), def: sandboxDef(["bun", "--version"]), workspaceDir: ws(), timeoutMs: 5000 }),
+    ).rejects.toThrow(/must start with an absolute guest path/);
+  });
+
+  test("an invalid sandbox policy is refused before any VM is booted", async () => {
+    await expect(
+      execute({
+        spec: spec({}),
+        def: sandboxDef(["/bin/true"], { sandbox: { provider: "firecracker" } }),
+        workspaceDir: ws(),
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow(/unknown sandbox provider/);
+  });
+
+  const report = preflight();
+  const itVM = report.available ? test : test.skip;
+
+  itVM(
+    "produces the same result contract as the host path, from inside the VM",
+    async () => {
+      const workspaceDir = ws();
+      const def = sandboxDef(["/bin/sh", "-c", "echo sandboxed-output > /workspace/captured.txt; echo sandboxed-output"], {
+        captureStdout: "captured.txt",
+      });
+
+      const outcome = await execute({ spec: spec({}), def, workspaceDir, timeoutMs: 120_000 });
+      expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+
+      // result.json is written on the host, with the same shape the
+      // unsandboxed path produces — downstream verification cannot tell which
+      // path ran, which is the point.
+      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+      expect(result.schemaVersion).toBe("factory.agent-result/v1");
+      expect(result.terminalState).toBe("completed");
+      expect(result.artifact.exitCode).toBe(0);
+      expect(result.artifact.outputTail).toContain("sandboxed-output");
+      expect(result.artifacts).toEqual([{ kind: "output", path: "captured.txt" }]);
+      // The guest wrote this file through the mount; the host must see it.
+      expect(readFileSync(path.join(workspaceDir, "captured.txt"), "utf8")).toContain("sandboxed-output");
+    },
+    180_000,
+  );
+
+  itVM(
+    "a nonzero guest exit writes no result, exactly like the host path",
+    async () => {
+      const workspaceDir = ws();
+      const outcome = await execute({
+        spec: spec({}),
+        def: sandboxDef(["/bin/sh", "-c", "exit 3"]),
+        workspaceDir,
+        timeoutMs: 120_000,
+      });
+      expect(outcome).toEqual({ exitCode: 3, timedOut: false });
+      expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(false);
+    },
+    180_000,
+  );
 });

--- a/event-runtime/lib/sandbox/gondolin.mjs
+++ b/event-runtime/lib/sandbox/gondolin.mjs
@@ -184,8 +184,13 @@ export async function runInSandbox({
   abortSignal,
   signal,
 }) {
-  const report = assertAvailable({ env: hostEnv });
+  // Order matters, and CI proved it: policy validation is host-independent,
+  // so it goes first. A definition with a typo'd provider is wrong on every
+  // machine, and reporting "qemu is not on PATH" for it sends the reader
+  // hunting a hypervisor problem that does not exist. Host capability is
+  // checked second, and secret resolution (which reads this host's env) last.
   const policy = normalizePolicy(rawPolicy, { workspaceDir });
+  const report = assertAvailable({ env: hostEnv });
   const secrets = resolveSecretValues(policy, hostEnv);
 
   const guestCwd = workspaceDir ? policy.workspaceMount : undefined;

--- a/event-runtime/lib/sandbox/gondolin.mjs
+++ b/event-runtime/lib/sandbox/gondolin.mjs
@@ -1,0 +1,298 @@
+/**
+ * Gondolin microVM sandbox — worker-side entry point (WM-185).
+ *
+ * Runs a command inside a hardware-isolated microVM instead of on the host,
+ * with default-deny network egress and host-side secret substitution: the
+ * guest holds only opaque placeholders, and the real credential is spliced in
+ * by the host proxy on allowlisted upstreams. WM-130's RFC
+ * (docs/eval-gondolin-sandbox.md) is the background; this module is the part
+ * that actually runs.
+ *
+ * The VM host itself lives in runner.mjs and executes under **Node**, not
+ * Bun, for a measured reason documented at the top of that file. Everything
+ * here — policy handling, preflight, timeouts, streaming — stays on the Bun
+ * side, and the two halves talk NDJSON over a pipe. The boundary is also why
+ * resolved secrets travel on stdin rather than argv or env: argv is visible to
+ * any process that can run `ps`.
+ *
+ * Every failure mode is a typed condition rather than a crash, mirroring
+ * lib/adapters/pi.mjs's `CliNotFoundError`: a worker on a host without QEMU
+ * must refuse the run cleanly and let placement send it elsewhere, not die
+ * halfway through with a stack trace.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
+import { normalizePolicy, resolveSecretValues } from "./policy.mjs";
+
+export { normalizePolicy, resolveSecretValues, SandboxPolicyError } from "./policy.mjs";
+
+/** The SDK's package.json declares engines.node >= 23.6.0; below that it will not import. */
+export const MIN_NODE_MAJOR = 23;
+export const MIN_NODE_MINOR = 6;
+
+export const RUNNER_PATH = path.join(FACTORY_ROOT, "event-runtime", "lib", "sandbox", "runner.mjs");
+
+/** Grace between SIGTERM and SIGKILL for the runner child, matching the command adapter. */
+export const KILL_GRACE_MS = 10_000;
+
+export class SandboxUnavailableError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SandboxUnavailableError";
+    this.code = "sandbox_unavailable";
+  }
+}
+
+export class SandboxExecutionError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "SandboxExecutionError";
+    this.code = code;
+  }
+}
+
+/** QEMU's binary is named per guest architecture; the guest matches the host. */
+export function qemuBinaryFor(arch = process.arch) {
+  return arch === "arm64" ? "qemu-system-aarch64" : "qemu-system-x86_64";
+}
+
+export function parseNodeVersion(output) {
+  const match = /v?(\d+)\.(\d+)\.\d+/.exec(String(output ?? "").trim());
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+export function nodeVersionSatisfies(version) {
+  if (!version) return false;
+  if (version.major > MIN_NODE_MAJOR) return true;
+  return version.major === MIN_NODE_MAJOR && version.minor >= MIN_NODE_MINOR;
+}
+
+/**
+ * Can this host actually honour a sandboxed run? Reports a reason rather than
+ * a bare boolean so `sandbox doctor` and the worker log can say what is
+ * missing instead of "unavailable".
+ *
+ * @returns {{ available: boolean, reason: string|null, qemu: string|null, node: string|null, nodeVersion: string|null, sdk: boolean }}
+ */
+export function preflight({
+  env = process.env,
+  which = (name) => Bun.which(name),
+  runNode = (bin) => {
+    try {
+      const proc = Bun.spawnSync([bin, "--version"]);
+      return proc.success ? proc.stdout.toString() : null;
+    } catch {
+      // Bun.spawnSync throws ENOENT for a missing binary rather than
+      // reporting failure — a FACTORY_SANDBOX_NODE pointing at nothing must
+      // still come back as a typed "unavailable", not an exception.
+      return null;
+    }
+  },
+  sdkExists = () => existsSync(path.join(FACTORY_ROOT, "node_modules", "@earendil-works", "gondolin", "package.json")),
+} = {}) {
+  const report = { available: false, reason: null, qemu: null, node: null, nodeVersion: null, sdk: false };
+
+  const qemuBin = qemuBinaryFor();
+  report.qemu = which(qemuBin);
+  if (!report.qemu) {
+    report.reason = `${qemuBin} is not on PATH — install QEMU (macOS: brew install qemu)`;
+    return report;
+  }
+
+  // FACTORY_SANDBOX_NODE exists because the worker itself runs under Bun and
+  // the Node that satisfies the SDK may not be the one first on PATH (nvm).
+  const nodeBin = env.FACTORY_SANDBOX_NODE || which("node");
+  if (!nodeBin) {
+    report.reason = "node is not on PATH — the Gondolin SDK requires Node (see runner.mjs); set FACTORY_SANDBOX_NODE";
+    return report;
+  }
+  report.node = nodeBin;
+  const version = parseNodeVersion(runNode(nodeBin));
+  report.nodeVersion = version ? `${version.major}.${version.minor}` : null;
+  if (!nodeVersionSatisfies(version)) {
+    report.reason = `node at ${nodeBin} is ${report.nodeVersion ?? "unreadable"}, need >= ${MIN_NODE_MAJOR}.${MIN_NODE_MINOR} — set FACTORY_SANDBOX_NODE to a newer Node`;
+    return report;
+  }
+
+  report.sdk = sdkExists();
+  if (!report.sdk) {
+    report.reason = "@earendil-works/gondolin is not installed — run `bun install`";
+    return report;
+  }
+
+  report.available = true;
+  return report;
+}
+
+export function assertAvailable(options) {
+  const report = preflight(options);
+  if (!report.available) throw new SandboxUnavailableError(report.reason);
+  return report;
+}
+
+/**
+ * Split a buffer of NDJSON into parsed events plus the unterminated remainder.
+ * Pure, so the protocol can be tested without a VM.
+ */
+export function parseEvents(buffer) {
+  const events = [];
+  let rest = buffer;
+  for (;;) {
+    const nl = rest.indexOf("\n");
+    if (nl === -1) break;
+    const line = rest.slice(0, nl);
+    rest = rest.slice(nl + 1);
+    if (line.trim() === "") continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // A malformed line is runner noise, not a protocol event; the parent
+      // must not die on it mid-run.
+    }
+  }
+  return { events, rest };
+}
+
+/**
+ * Run one command inside a Gondolin microVM.
+ *
+ * @param {object} options
+ * @param {object} options.policy - raw sandbox policy (validated here)
+ * @param {string[]|string} options.command - argv, or a shell string when `shell` is true
+ * @param {string} [options.workspaceDir] - host dir bound to the policy's workspace mount
+ * @param {number} options.timeoutMs
+ * @param {boolean} [options.shell] - run via `/bin/sh -lc` (hand-driven CLI only)
+ * @param {Record<string,string>} [options.env] - non-secret env for the guest
+ * @param {(chunk: string) => void} [options.onStdout]
+ * @param {(chunk: string) => void} [options.onStderr]
+ * @param {AbortSignal} [options.abortSignal]
+ * @returns {Promise<{ exitCode: number|null, timedOut: boolean, bootMs: number|null }>}
+ */
+export async function runInSandbox({
+  policy: rawPolicy,
+  command,
+  workspaceDir,
+  timeoutMs,
+  shell = false,
+  env = {},
+  hostEnv = process.env,
+  onStdout,
+  onStderr,
+  abortSignal,
+  signal,
+}) {
+  const report = assertAvailable({ env: hostEnv });
+  const policy = normalizePolicy(rawPolicy, { workspaceDir });
+  const secrets = resolveSecretValues(policy, hostEnv);
+
+  const guestCwd = workspaceDir ? policy.workspaceMount : undefined;
+  const request = JSON.stringify({ policy, secrets, command, cwd: guestCwd, env, timeoutMs, shell });
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(report.node, [RUNNER_PATH], {
+      cwd: FACTORY_ROOT,
+      // The runner resolves the SDK from FACTORY_ROOT/node_modules and needs
+      // nothing else; it must not inherit the worker's credentials, since
+      // keeping secrets off the guest is the entire point of the sandbox.
+      env: { PATH: hostEnv.PATH ?? "", HOME: hostEnv.HOME ?? "", TMPDIR: hostEnv.TMPDIR ?? "" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    child.stdin.on("error", () => {});
+    child.stdin.write(request);
+    child.stdin.end();
+
+    let buffer = "";
+    let bootMs = null;
+    let exitCode = null;
+    let timedOut = false;
+    let failure = null;
+    let stderrTail = "";
+
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const { events, rest } = parseEvents(buffer);
+      buffer = rest;
+      for (const event of events) {
+        switch (event.type) {
+          case "ready":
+            bootMs = event.bootMs ?? null;
+            break;
+          case "stdout":
+            onStdout?.(event.data);
+            break;
+          case "stderr":
+            onStderr?.(event.data);
+            break;
+          case "exit":
+            exitCode = event.exitCode ?? null;
+            break;
+          case "error":
+            if (event.code === "sandbox_timeout") timedOut = true;
+            else failure = new SandboxExecutionError(event.code, event.message);
+            break;
+          default:
+            break;
+        }
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderrTail = (stderrTail + chunk.toString()).slice(-2000);
+    });
+
+    // Belt and braces: the runner aborts the guest command on its own timer,
+    // but a wedged runner (or a VM that will not tear down) must not pin the
+    // worker's run slot open forever.
+    let killTimer = null;
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS);
+      killTimer.unref?.();
+    }, timeoutMs + KILL_GRACE_MS);
+
+    const onAbort = () => {
+      child.kill("SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS);
+        killTimer.unref?.();
+      }
+    };
+    const abortSig = abortSignal ?? signal;
+    if (abortSig) {
+      if (abortSig.aborted) onAbort();
+      else abortSig.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const cleanup = () => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+    };
+
+    child.on("error", (err) => {
+      cleanup();
+      reject(new SandboxUnavailableError(`failed to spawn the sandbox runner (${report.node}): ${err.message}`));
+    });
+
+    child.on("close", (runnerExit) => {
+      cleanup();
+      if (failure) return reject(failure);
+      if (timedOut) return resolve({ exitCode: null, timedOut: true, bootMs });
+      if (exitCode === null) {
+        // The runner died before reporting a guest exit code — reporting 0 or
+        // "failed" here would both be fabrication, so surface it as typed.
+        return reject(
+          new SandboxExecutionError(
+            "sandbox_runner_crashed",
+            `sandbox runner exited (${runnerExit}) without reporting a guest exit code${stderrTail ? `: ${stderrTail.trim()}` : ""}`,
+          ),
+        );
+      }
+      resolve({ exitCode, timedOut: false, bootMs });
+    });
+  });
+}

--- a/event-runtime/lib/sandbox/gondolin.test.mjs
+++ b/event-runtime/lib/sandbox/gondolin.test.mjs
@@ -90,16 +90,34 @@ describe("NDJSON protocol", () => {
 });
 
 describe("runInSandbox refusals", () => {
+  // FACTORY_SANDBOX_NODE points at a path that cannot exist, so preflight
+  // fails on any machine, with or without QEMU installed.
+  const unavailableHost = { FACTORY_SANDBOX_NODE: "/nonexistent/node", PATH: "" };
+
   test("an unavailable host refuses with a typed error before spawning anything", async () => {
-    // FACTORY_SANDBOX_NODE points at a path that cannot exist, so preflight
-    // fails on this machine whether or not QEMU is installed.
     await expect(
       runInSandbox({
         policy: { provider: "gondolin" },
         command: ["/bin/true"],
         timeoutMs: 1000,
-        hostEnv: { FACTORY_SANDBOX_NODE: "/nonexistent/node", PATH: "" },
+        hostEnv: unavailableHost,
       }),
     ).rejects.toThrow(SandboxUnavailableError);
+  });
+
+  test("an invalid policy is reported as invalid even on a host that could not run it anyway", async () => {
+    // Regression: policy validation used to run after preflight, so a typo'd
+    // provider surfaced as "qemu is not on PATH" on any machine without a
+    // hypervisor — a diagnostic that sends the reader after the wrong bug.
+    // This passed locally (QEMU present) and failed in CI (QEMU absent), which
+    // is exactly the asymmetry this test exists to prevent.
+    await expect(
+      runInSandbox({
+        policy: { provider: "firecracker" },
+        command: ["/bin/true"],
+        timeoutMs: 1000,
+        hostEnv: unavailableHost,
+      }),
+    ).rejects.toThrow(/unknown sandbox provider/);
   });
 });

--- a/event-runtime/lib/sandbox/gondolin.test.mjs
+++ b/event-runtime/lib/sandbox/gondolin.test.mjs
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MIN_NODE_MAJOR,
+  nodeVersionSatisfies,
+  parseEvents,
+  parseNodeVersion,
+  preflight,
+  qemuBinaryFor,
+  runInSandbox,
+  SandboxUnavailableError,
+} from "./gondolin.mjs";
+
+/** Preflight dependencies, all satisfied — override one field per test to break it. */
+const healthy = {
+  env: {},
+  which: (name) => `/usr/bin/${name}`,
+  runNode: () => "v24.18.0\n",
+  sdkExists: () => true,
+};
+
+describe("preflight", () => {
+  test("reports available when qemu, node, and the sdk are all present", () => {
+    const report = preflight(healthy);
+    expect(report).toMatchObject({ available: true, reason: null, sdk: true, nodeVersion: "24.18" });
+  });
+
+  test("missing qemu is a named reason, not a crash", () => {
+    const report = preflight({ ...healthy, which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`) });
+    expect(report.available).toBe(false);
+    expect(report.reason).toMatch(/is not on PATH — install QEMU/);
+  });
+
+  test("a Node older than the SDK's floor is refused rather than left to fail at import", () => {
+    const report = preflight({ ...healthy, runNode: () => "v22.14.0" });
+    expect(report.available).toBe(false);
+    expect(report.reason).toMatch(/need >= 23\.6/);
+  });
+
+  test("FACTORY_SANDBOX_NODE overrides PATH, since the worker runs under Bun", () => {
+    const report = preflight({ ...healthy, env: { FACTORY_SANDBOX_NODE: "/opt/node23/bin/node" } });
+    expect(report.node).toBe("/opt/node23/bin/node");
+  });
+
+  test("a missing SDK is reported as installable, not as a hypervisor problem", () => {
+    const report = preflight({ ...healthy, sdkExists: () => false });
+    expect(report.available).toBe(false);
+    expect(report.reason).toMatch(/bun install/);
+  });
+
+  test("the qemu binary follows the host architecture", () => {
+    expect(qemuBinaryFor("arm64")).toBe("qemu-system-aarch64");
+    expect(qemuBinaryFor("x64")).toBe("qemu-system-x86_64");
+  });
+});
+
+describe("node version parsing", () => {
+  test("accepts the shapes `node --version` actually prints", () => {
+    expect(parseNodeVersion("v24.18.0\n")).toEqual({ major: 24, minor: 18 });
+    expect(parseNodeVersion("23.6.1")).toEqual({ major: 23, minor: 6 });
+    expect(parseNodeVersion("garbage")).toBeNull();
+    expect(parseNodeVersion(null)).toBeNull();
+  });
+
+  test("the floor is inclusive at the SDK's declared minimum", () => {
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 6 })).toBe(true);
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR, minor: 5 })).toBe(false);
+    expect(nodeVersionSatisfies({ major: MIN_NODE_MAJOR + 1, minor: 0 })).toBe(true);
+    expect(nodeVersionSatisfies(null)).toBe(false);
+  });
+});
+
+describe("NDJSON protocol", () => {
+  test("parses whole lines and keeps the partial remainder for the next chunk", () => {
+    const first = parseEvents('{"type":"ready","bootMs":62}\n{"type":"stdout","data":"hel');
+    expect(first.events).toEqual([{ type: "ready", bootMs: 62 }]);
+    expect(first.rest).toBe('{"type":"stdout","data":"hel');
+
+    const second = parseEvents(`${first.rest}lo"}\n{"type":"exit","exitCode":0}\n`);
+    expect(second.events).toEqual([
+      { type: "stdout", data: "hello" },
+      { type: "exit", exitCode: 0 },
+    ]);
+    expect(second.rest).toBe("");
+  });
+
+  test("a malformed line is skipped rather than killing the run", () => {
+    const { events } = parseEvents('not json\n{"type":"exit","exitCode":3}\n');
+    expect(events).toEqual([{ type: "exit", exitCode: 3 }]);
+  });
+});
+
+describe("runInSandbox refusals", () => {
+  test("an unavailable host refuses with a typed error before spawning anything", async () => {
+    // FACTORY_SANDBOX_NODE points at a path that cannot exist, so preflight
+    // fails on this machine whether or not QEMU is installed.
+    await expect(
+      runInSandbox({
+        policy: { provider: "gondolin" },
+        command: ["/bin/true"],
+        timeoutMs: 1000,
+        hostEnv: { FACTORY_SANDBOX_NODE: "/nonexistent/node", PATH: "" },
+      }),
+    ).rejects.toThrow(SandboxUnavailableError);
+  });
+});

--- a/event-runtime/lib/sandbox/invariants.test.mjs
+++ b/event-runtime/lib/sandbox/invariants.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * Real-VM invariant tests (WM-185).
+ *
+ * These boot an actual Gondolin microVM and are the only proof that the
+ * sandbox does what the RFC claims. They assert the three properties that
+ * matter, each of which would be a security failure if it regressed:
+ *
+ *   1. the workspace really is the host directory (writes cross the boundary)
+ *   2. egress is default-deny (a non-allowlisted host does not get reached)
+ *   3. the guest never holds a real credential, only a placeholder
+ *
+ * They SKIP rather than fail where the hypervisor is unavailable (CI runners
+ * without /dev/kvm, a laptop without QEMU) — a skip says "unverified here",
+ * while a failure would say "broken", and only one of those is true.
+ *
+ * First boot on a machine loads ~200MB of guest assets, so the timeout is
+ * generous; warm boots measured 51-93ms on macOS arm64.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KILL_GRACE_MS, preflight, runInSandbox } from "./gondolin.mjs";
+
+const report = preflight();
+const itVM = report.available ? test : test.skip;
+if (!report.available) {
+  console.warn(`[WM-185] skipping real-VM invariant tests — ${report.reason}`);
+}
+
+const VM_TIMEOUT_MS = 180_000;
+const workspace = () => mkdtempSync(path.join(os.tmpdir(), "evrt-sandbox-"));
+
+describe("gondolin sandbox invariants", () => {
+  itVM(
+    "the guest workspace is the host directory, in both directions",
+    async () => {
+      const dir = workspace();
+      writeFileSync(path.join(dir, "from-host.txt"), "host wrote this\n");
+
+      let stdout = "";
+      const result = await runInSandbox({
+        policy: { provider: "gondolin" },
+        command: "cat /workspace/from-host.txt && echo 'guest wrote this' > /workspace/from-guest.txt",
+        shell: true,
+        workspaceDir: dir,
+        timeoutMs: 60_000,
+        onStdout: (chunk) => {
+          stdout += chunk;
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(stdout).toContain("host wrote this");
+      expect(readFileSync(path.join(dir, "from-guest.txt"), "utf8")).toBe("guest wrote this\n");
+    },
+    VM_TIMEOUT_MS,
+  );
+
+  itVM(
+    "a non-allowlisted host is refused, and an allowlisted one is not",
+    async () => {
+      const dir = workspace();
+      let blocked = "";
+      const blockedRun = await runInSandbox({
+        policy: { provider: "gondolin", allowedHosts: ["api.github.com"] },
+        // -m keeps a hypothetical hang from eating the whole test timeout;
+        // observed behaviour is a fast 403 from the host proxy.
+        command: "curl -sS -m 20 -o /dev/null -w '%{http_code}' https://example.com/ || echo CURL_FAILED",
+        shell: true,
+        workspaceDir: dir,
+        timeoutMs: 60_000,
+        onStdout: (chunk) => {
+          blocked += chunk;
+        },
+      });
+      expect(blockedRun.exitCode).toBe(0);
+      // Either the proxy refuses it (403) or the connection never completes —
+      // what must never appear is a 200 from a host nobody allowed.
+      expect(blocked).not.toContain("200");
+      expect(blocked === "" || /403|CURL_FAILED|000/.test(blocked)).toBe(true);
+
+      let allowed = "";
+      const allowedRun = await runInSandbox({
+        policy: { provider: "gondolin", allowedHosts: ["example.com"] },
+        command: "curl -sS -m 30 -o /dev/null -w '%{http_code}' https://example.com/",
+        shell: true,
+        workspaceDir: dir,
+        timeoutMs: 60_000,
+        onStdout: (chunk) => {
+          allowed += chunk;
+        },
+      });
+      expect(allowedRun.exitCode).toBe(0);
+      expect(allowed).toContain("200");
+    },
+    VM_TIMEOUT_MS,
+  );
+
+  itVM(
+    "the guest holds a placeholder, never the real secret",
+    async () => {
+      const dir = workspace();
+      const REAL = "lin_api_wm185_must_never_reach_the_guest";
+      let stdout = "";
+
+      const result = await runInSandbox({
+        policy: {
+          provider: "gondolin",
+          allowedHosts: ["api.linear.app"],
+          secrets: { LINEAR_API_KEY: { hosts: ["api.linear.app"], env: "WM185_TEST_SECRET" } },
+        },
+        // Read it from the environment AND from the raw process environ, so a
+        // future SDK change that leaks the value anywhere in the guest fails here.
+        command: 'printenv LINEAR_API_KEY; tr "\\0" "\\n" < /proc/self/environ',
+        shell: true,
+        workspaceDir: dir,
+        timeoutMs: 60_000,
+        hostEnv: { ...process.env, WM185_TEST_SECRET: REAL },
+        onStdout: (chunk) => {
+          stdout += chunk;
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(stdout).not.toContain(REAL);
+      expect(stdout).toContain("GONDOLIN_SECRET_");
+    },
+    VM_TIMEOUT_MS,
+  );
+
+  itVM(
+    "a guest command that overruns its timeout is aborted in the guest, not just killed from outside",
+    async () => {
+      const dir = workspace();
+      const started = Date.now();
+      const result = await runInSandbox({
+        policy: { provider: "gondolin" },
+        command: "sleep 60",
+        shell: true,
+        workspaceDir: dir,
+        timeoutMs: 5_000,
+      });
+      const elapsed = Date.now() - started;
+
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).not.toBe(0);
+      // Two mechanisms can produce timedOut: the runner aborting the guest
+      // command at timeoutMs, and the parent's backstop killing the runner at
+      // timeoutMs + KILL_GRACE_MS. Asserting the deadline distinguishes them —
+      // without it, disabling the inner abort still passes (observed), and the
+      // test would be certifying a fallback it did not mean to test.
+      expect(elapsed).toBeLessThan(5_000 + KILL_GRACE_MS);
+    },
+    VM_TIMEOUT_MS,
+  );
+});

--- a/event-runtime/lib/sandbox/policy.mjs
+++ b/event-runtime/lib/sandbox/policy.mjs
@@ -1,0 +1,207 @@
+/**
+ * Sandbox policy normalization (WM-185; RFC docs/eval-gondolin-sandbox.md §5, §6).
+ *
+ * A sandbox policy is the declarative half of the Gondolin integration: what
+ * the guest may reach on the network, which secrets the host will substitute
+ * on its behalf, and which host directories are visible inside the VM. It is
+ * pure data with pure validation, so every rule here is unit-testable without
+ * QEMU, a VM, or a network — the parts that need a hypervisor live in
+ * gondolin.mjs and runner.mjs.
+ *
+ * Two rules are load-bearing and deliberately stricter than the upstream SDK:
+ *
+ * 1. **Omitting `allowedHosts` means deny-all, not allow-all.** The SDK treats
+ *    an omitted allowlist as "allow everything" and only an explicit `[]` as
+ *    deny-all. That default is backwards for a worker sandbox: a definition
+ *    that forgets the key would get unrestricted egress, which is the exact
+ *    thing this sandbox exists to prevent. Here, absent means empty means
+ *    nothing gets out.
+ *
+ * 2. **A secret may only name hosts the allowlist already permits.** A secret
+ *    scoped to a host that egress blocks can never be substituted, so the
+ *    definition is stating something untrue about how the run will behave.
+ *    That is a config bug worth failing on, not a no-op worth tolerating.
+ *
+ * Secret *values* never appear in a policy — a definition names the host
+ * environment variable to read, and resolution happens at execution time via
+ * `resolveSecretValues()`. That keeps agent definitions (which are content-
+ * hashed, committed, and pinned in lib/registry.mjs) free of credentials by
+ * construction.
+ */
+
+export const SUPPORTED_PROVIDERS = ["gondolin"];
+export const DEFAULT_WORKSPACE_MOUNT = "/workspace";
+export const DEFAULT_MEMORY = "1G";
+export const DEFAULT_CPUS = 2;
+
+export class SandboxPolicyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SandboxPolicyError";
+    this.code = "sandbox_policy_invalid";
+  }
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new SandboxPolicyError(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireHostPattern(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new SandboxPolicyError(`${label} must be a non-empty host pattern`);
+  }
+  if (value.includes("/") || value.includes(" ")) {
+    throw new SandboxPolicyError(`${label} must be a bare host pattern ("api.github.com"), not a URL or path: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * Guest mount points are absolute, normalized, and never traverse upward —
+ * a mount at "/workspace/../etc" would quietly re-expose the guest root.
+ */
+function requireGuestPath(value, label) {
+  if (typeof value !== "string" || !value.startsWith("/")) {
+    throw new SandboxPolicyError(`${label} must be an absolute guest path`);
+  }
+  if (value.split("/").includes("..")) {
+    throw new SandboxPolicyError(`${label} must not contain ".." segments: ${JSON.stringify(value)}`);
+  }
+  return value.length > 1 && value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function requireHostPath(value, label) {
+  if (typeof value !== "string" || !value.startsWith("/")) {
+    throw new SandboxPolicyError(`${label} must be an absolute host path`);
+  }
+  return value;
+}
+
+/**
+ * Normalize and validate a raw `sandbox` block from an agent definition or a
+ * CLI invocation. Fails closed on anything ambiguous.
+ *
+ * @param {object} raw - the declared policy
+ * @param {{ workspaceDir?: string }} [context] - host dir bound to the workspace mount
+ * @returns {{
+ *   provider: string,
+ *   allowedHosts: string[],
+ *   secrets: Array<{ name: string, envVar: string, hosts: string[] }>,
+ *   mounts: Array<{ guestPath: string, hostPath: string, readonly: boolean }>,
+ *   workspaceMount: string,
+ *   memory: string,
+ *   cpus: number,
+ * }}
+ */
+export function normalizePolicy(raw, { workspaceDir } = {}) {
+  const policy = requireObject(raw, "sandbox policy");
+
+  if (!SUPPORTED_PROVIDERS.includes(policy.provider)) {
+    throw new SandboxPolicyError(
+      `unknown sandbox provider ${JSON.stringify(policy.provider ?? null)} — supported: ${SUPPORTED_PROVIDERS.join(", ")}`,
+    );
+  }
+
+  // Absent allowlist = deny all. See rule 1 in the module header.
+  const allowedHosts = [];
+  if (policy.allowedHosts !== undefined) {
+    if (!Array.isArray(policy.allowedHosts)) {
+      throw new SandboxPolicyError("sandbox.allowedHosts must be an array of host patterns");
+    }
+    for (const [i, host] of policy.allowedHosts.entries()) {
+      allowedHosts.push(requireHostPattern(host, `sandbox.allowedHosts[${i}]`));
+    }
+  }
+
+  const secrets = [];
+  if (policy.secrets !== undefined) {
+    const declared = requireObject(policy.secrets, "sandbox.secrets");
+    for (const [name, value] of Object.entries(declared)) {
+      const entry = requireObject(value, `sandbox.secrets.${name}`);
+      if (typeof entry.value === "string") {
+        // A literal credential in a committed, content-hashed definition is
+        // never what the author meant, and pinning it would publish it.
+        throw new SandboxPolicyError(
+          `sandbox.secrets.${name} must not carry a literal value — name the host env var via "env" instead`,
+        );
+      }
+      if (!Array.isArray(entry.hosts) || entry.hosts.length === 0) {
+        throw new SandboxPolicyError(`sandbox.secrets.${name}.hosts must be a non-empty array`);
+      }
+      const hosts = entry.hosts.map((h, i) => requireHostPattern(h, `sandbox.secrets.${name}.hosts[${i}]`));
+      for (const host of hosts) {
+        if (!allowedHosts.includes(host)) {
+          // See rule 2 in the module header.
+          throw new SandboxPolicyError(
+            `sandbox.secrets.${name} is scoped to ${host}, which sandbox.allowedHosts does not permit — the secret could never be substituted`,
+          );
+        }
+      }
+      const envVar = entry.env ?? name;
+      if (typeof envVar !== "string" || envVar.trim() === "") {
+        throw new SandboxPolicyError(`sandbox.secrets.${name}.env must be a non-empty environment variable name`);
+      }
+      secrets.push({ name, envVar, hosts });
+    }
+  }
+
+  const workspaceMount = requireGuestPath(policy.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT, "sandbox.workspaceMount");
+
+  const mounts = [];
+  if (workspaceDir !== undefined) {
+    mounts.push({
+      guestPath: workspaceMount,
+      hostPath: requireHostPath(workspaceDir, "workspace directory"),
+      readonly: false,
+    });
+  }
+  if (policy.mounts !== undefined) {
+    const declared = requireObject(policy.mounts, "sandbox.mounts");
+    for (const [guestPathRaw, value] of Object.entries(declared)) {
+      const guestPath = requireGuestPath(guestPathRaw, `sandbox.mounts["${guestPathRaw}"]`);
+      const spec = typeof value === "string" ? { path: value } : requireObject(value, `sandbox.mounts["${guestPathRaw}"]`);
+      const hostPath = requireHostPath(spec.path, `sandbox.mounts["${guestPathRaw}"].path`);
+      if (mounts.some((m) => m.guestPath === guestPath)) {
+        throw new SandboxPolicyError(`sandbox.mounts["${guestPathRaw}"] collides with an existing mount at ${guestPath}`);
+      }
+      mounts.push({ guestPath, hostPath, readonly: spec.readonly === true });
+    }
+  }
+
+  const cpus = policy.cpus ?? DEFAULT_CPUS;
+  if (!Number.isInteger(cpus) || cpus < 1) {
+    throw new SandboxPolicyError("sandbox.cpus must be a positive integer");
+  }
+  const memory = policy.memory ?? DEFAULT_MEMORY;
+  if (typeof memory !== "string" || !/^\d+[KMGT]?$/.test(memory)) {
+    throw new SandboxPolicyError(`sandbox.memory must be a qemu size string like "1G", got ${JSON.stringify(memory)}`);
+  }
+
+  return { provider: policy.provider, allowedHosts, secrets, mounts, workspaceMount, memory, cpus };
+}
+
+/**
+ * Resolve declared secrets against the host environment at execution time.
+ *
+ * Fails closed on a missing variable rather than substituting an empty
+ * string: an agent that silently authenticates as nobody produces a confusing
+ * 401 deep inside the guest instead of a clear refusal on the host.
+ *
+ * @returns {Record<string, { hosts: string[], value: string }>} keyed by guest env var name
+ */
+export function resolveSecretValues(policy, env = process.env) {
+  const resolved = {};
+  for (const secret of policy.secrets) {
+    const value = env[secret.envVar];
+    if (typeof value !== "string" || value === "") {
+      throw new SandboxPolicyError(
+        `sandbox secret ${secret.name} reads host env var ${secret.envVar}, which is unset or empty`,
+      );
+    }
+    resolved[secret.name] = { hosts: secret.hosts, value };
+  }
+  return resolved;
+}

--- a/event-runtime/lib/sandbox/policy.test.mjs
+++ b/event-runtime/lib/sandbox/policy.test.mjs
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_WORKSPACE_MOUNT, normalizePolicy, resolveSecretValues, SandboxPolicyError } from "./policy.mjs";
+
+const base = { provider: "gondolin", allowedHosts: ["api.github.com"] };
+
+describe("normalizePolicy", () => {
+  test("an unknown provider is refused, not passed through", () => {
+    expect(() => normalizePolicy({ provider: "docker" })).toThrow(/unknown sandbox provider "docker"/);
+    expect(() => normalizePolicy({})).toThrow(/unknown sandbox provider null/);
+    expect(() => normalizePolicy(null)).toThrow(SandboxPolicyError);
+  });
+
+  test("an omitted allowlist denies all egress rather than allowing it", () => {
+    // The SDK's own default is allow-all on omission; this inversion is the
+    // single most security-relevant line in the module.
+    expect(normalizePolicy({ provider: "gondolin" }).allowedHosts).toEqual([]);
+  });
+
+  test("host patterns must be bare hosts, not URLs", () => {
+    expect(() => normalizePolicy({ ...base, allowedHosts: ["https://api.github.com/x"] })).toThrow(/bare host pattern/);
+    expect(() => normalizePolicy({ ...base, allowedHosts: [""] })).toThrow(/non-empty host pattern/);
+    expect(() => normalizePolicy({ ...base, allowedHosts: "api.github.com" })).toThrow(/must be an array/);
+  });
+
+  test("a secret scoped outside the allowlist is a config error", () => {
+    expect(() =>
+      normalizePolicy({ ...base, secrets: { LINEAR_API_KEY: { hosts: ["api.linear.app"] } } }),
+    ).toThrow(/scoped to api.linear.app, which sandbox.allowedHosts does not permit/);
+  });
+
+  test("a literal secret value in a definition is refused", () => {
+    expect(() =>
+      normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"], value: "ghp_real" } } }),
+    ).toThrow(/must not carry a literal value/);
+  });
+
+  test("secrets resolve to an env var name, defaulting to the guest var name", () => {
+    const policy = normalizePolicy({
+      ...base,
+      secrets: {
+        GITHUB_TOKEN: { hosts: ["api.github.com"] },
+        GH_ALT: { hosts: ["api.github.com"], env: "GITHUB_TOKEN_ALT" },
+      },
+    });
+    expect(policy.secrets).toEqual([
+      { name: "GITHUB_TOKEN", envVar: "GITHUB_TOKEN", hosts: ["api.github.com"] },
+      { name: "GH_ALT", envVar: "GITHUB_TOKEN_ALT", hosts: ["api.github.com"] },
+    ]);
+  });
+
+  test("secrets must declare at least one host", () => {
+    expect(() => normalizePolicy({ ...base, secrets: { X: { hosts: [] } } })).toThrow(/non-empty array/);
+    expect(() => normalizePolicy({ ...base, secrets: { X: {} } })).toThrow(/non-empty array/);
+  });
+
+  test("the workspace dir becomes a read-write mount at the workspace mount point", () => {
+    const policy = normalizePolicy(base, { workspaceDir: "/host/work/WM-185" });
+    expect(policy.workspaceMount).toBe(DEFAULT_WORKSPACE_MOUNT);
+    expect(policy.mounts).toEqual([{ guestPath: "/workspace", hostPath: "/host/work/WM-185", readonly: false }]);
+  });
+
+  test("extra mounts accept a bare path or a readonly spec", () => {
+    const policy = normalizePolicy({ ...base, mounts: { "/ref": "/host/ref", "/ro": { path: "/host/ro", readonly: true } } });
+    expect(policy.mounts).toEqual([
+      { guestPath: "/ref", hostPath: "/host/ref", readonly: false },
+      { guestPath: "/ro", hostPath: "/host/ro", readonly: true },
+    ]);
+  });
+
+  test("mount paths that could re-expose the guest root or collide are refused", () => {
+    expect(() => normalizePolicy({ ...base, mounts: { "/workspace/../etc": "/host/x" } })).toThrow(/".." segments/);
+    expect(() => normalizePolicy({ ...base, mounts: { relative: "/host/x" } })).toThrow(/absolute guest path/);
+    expect(() => normalizePolicy({ ...base, mounts: { "/ref": "host/relative" } })).toThrow(/absolute host path/);
+    expect(() => normalizePolicy({ ...base, mounts: { "/workspace": "/host/other" } }, { workspaceDir: "/host/work" })).toThrow(
+      /collides with an existing mount/,
+    );
+  });
+
+  test("resource limits are validated as qemu accepts them", () => {
+    expect(normalizePolicy({ ...base, memory: "2G", cpus: 4 })).toMatchObject({ memory: "2G", cpus: 4 });
+    expect(() => normalizePolicy({ ...base, memory: "lots" })).toThrow(/qemu size string/);
+    expect(() => normalizePolicy({ ...base, cpus: 0 })).toThrow(/positive integer/);
+    expect(() => normalizePolicy({ ...base, cpus: 1.5 })).toThrow(/positive integer/);
+  });
+});
+
+describe("resolveSecretValues", () => {
+  test("reads declared host env vars at execution time", () => {
+    const policy = normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"], env: "GH_SRC" } } });
+    expect(resolveSecretValues(policy, { GH_SRC: "ghp_real" })).toEqual({
+      GITHUB_TOKEN: { hosts: ["api.github.com"], value: "ghp_real" },
+    });
+  });
+
+  test("a missing or empty env var fails closed instead of authenticating as nobody", () => {
+    const policy = normalizePolicy({ ...base, secrets: { GITHUB_TOKEN: { hosts: ["api.github.com"] } } });
+    expect(() => resolveSecretValues(policy, {})).toThrow(/reads host env var GITHUB_TOKEN, which is unset or empty/);
+    expect(() => resolveSecretValues(policy, { GITHUB_TOKEN: "" })).toThrow(/unset or empty/);
+  });
+});

--- a/event-runtime/lib/sandbox/runner.mjs
+++ b/event-runtime/lib/sandbox/runner.mjs
@@ -1,0 +1,133 @@
+/**
+ * Gondolin VM host — the Node half of the sandbox (WM-185).
+ *
+ * THIS FILE RUNS UNDER NODE, NOT BUN, AND THAT IS NOT A STYLE CHOICE.
+ * Measured on this SDK (@earendil-works/gondolin 0.12.0, macOS arm64, QEMU
+ * 11.1.0): under Bun the VM boots, the VFS mounts, and `vm.exec()` works —
+ * but the host-side TLS mediation never answers. An allowlisted request hangs
+ * until its own timeout with no error raised and no debug output emitted. The
+ * identical script under Node v24.18 returns the response normally. A silent
+ * hang on the network path is the worst failure mode available to a sandbox,
+ * so lib/sandbox/gondolin.mjs spawns this file as a Node child process rather
+ * than importing the SDK into the worker's Bun process. Do not "simplify"
+ * that boundary away without re-running the invariant tests.
+ *
+ * Protocol: the caller writes one JSON request to stdin and reads NDJSON
+ * events from stdout. The request travels over stdin specifically because it
+ * carries resolved secret values — argv is world-readable via `ps`, and the
+ * whole point of this subsystem is that credentials stay out of reach.
+ *
+ *   request  { policy, secrets, command, cwd, env, timeoutMs, shell }
+ *   events   { type: "ready",  bootMs }
+ *            { type: "stdout", data }
+ *            { type: "stderr", data }
+ *            { type: "exit",   exitCode, signal }
+ *            { type: "error",  code, message }
+ *
+ * stdout carries the protocol and nothing else; this file's own diagnostics
+ * go to stderr, which the parent surfaces only on failure.
+ */
+import { readFileSync } from "node:fs";
+
+function emit(event) {
+  process.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function readRequest() {
+  // fd 0 to EOF — the parent writes one JSON object and closes stdin.
+  return JSON.parse(readFileSync(0, "utf8"));
+}
+
+async function main() {
+  const request = readRequest();
+  const { policy, secrets = {}, command, cwd, env = {}, timeoutMs, shell = false } = request;
+
+  let sdk;
+  try {
+    sdk = await import("@earendil-works/gondolin");
+  } catch (err) {
+    emit({ type: "error", code: "sandbox_unavailable", message: `@earendil-works/gondolin is not installed: ${err.message}` });
+    process.exit(2);
+  }
+  const { VM, RealFSProvider, ReadonlyProvider, createHttpHooks } = sdk;
+
+  // Default-deny egress plus placeholder substitution. `allowedHosts` is
+  // always passed explicitly — an omitted allowlist means "allow all" to this
+  // SDK, and lib/sandbox/policy.mjs exists partly to make that impossible.
+  const { httpHooks, env: placeholderEnv } = createHttpHooks({
+    allowedHosts: policy.allowedHosts,
+    secrets: Object.fromEntries(
+      Object.entries(secrets).map(([name, { hosts, value }]) => [name, { hosts, value }]),
+    ),
+  });
+
+  const mounts = {};
+  for (const mount of policy.mounts) {
+    const provider = new RealFSProvider(mount.hostPath);
+    mounts[mount.guestPath] = mount.readonly ? new ReadonlyProvider(provider) : provider;
+  }
+
+  const bootStart = Date.now();
+  let vm;
+  try {
+    vm = await VM.create({
+      httpHooks,
+      // Placeholders first, caller env second: a caller must not be able to
+      // overwrite a placeholder with something that looks like a credential.
+      env: { ...env, ...placeholderEnv },
+      memory: policy.memory,
+      cpus: policy.cpus,
+      ...(Object.keys(mounts).length > 0 ? { vfs: { mounts } } : {}),
+      sessionLabel: "factory-event-runtime",
+    });
+  } catch (err) {
+    emit({ type: "error", code: "sandbox_boot_failed", message: err.message });
+    process.exit(2);
+  }
+  emit({ type: "ready", bootMs: Date.now() - bootStart });
+
+  const abort = new AbortController();
+  const timer = timeoutMs > 0 ? setTimeout(() => abort.abort(), timeoutMs) : null;
+
+  try {
+    // The parent sends an argv array unless it explicitly asked for a shell.
+    // Array form executes the binary directly with no shell, preserving the
+    // command adapter's closed-registry guarantee (lib/adapters/command.mjs):
+    // an input value can never become a command. The string form (`/bin/sh
+    // -lc`) exists only for the hand-driven `sandbox exec --shell` path.
+    if (shell ? typeof command !== "string" : !Array.isArray(command)) {
+      throw new Error(shell ? "shell mode requires a command string" : "non-shell mode requires an argv array");
+    }
+    const proc = vm.exec(command, {
+      cwd,
+      signal: abort.signal,
+      stdout: "pipe",
+      stderr: "pipe",
+      buffer: false,
+    });
+    proc.stdout?.on("data", (chunk) => emit({ type: "stdout", data: chunk.toString() }));
+    proc.stderr?.on("data", (chunk) => emit({ type: "stderr", data: chunk.toString() }));
+    const result = await proc;
+    emit({ type: "exit", exitCode: result.exitCode, signal: result.signal ?? null });
+  } catch (err) {
+    if (abort.signal.aborted) {
+      emit({ type: "error", code: "sandbox_timeout", message: `guest command exceeded ${timeoutMs}ms` });
+    } else {
+      emit({ type: "error", code: "sandbox_exec_failed", message: err.message });
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    // Teardown on every path: a leaked QEMU process is exactly the litter the
+    // gondolin-cleanup cron on `shadow` was written to sweep up.
+    try {
+      await vm.close();
+    } catch (err) {
+      process.stderr.write(`vm.close failed: ${err.message}\n`);
+    }
+  }
+}
+
+main().catch((err) => {
+  emit({ type: "error", code: "sandbox_runner_crashed", message: err?.message ?? String(err) });
+  process.exit(2);
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bun": ">=1.3"
   },
   "dependencies": {
+    "@earendil-works/gondolin": "^0.12.0",
     "ink": "^7.1.1",
     "react": "^19.2.8"
   },


### PR DESCRIPTION
Fixes WM-185

Implements WM-130's `ADOPT` verdict for the `command` adapter. A definition may now declare a `sandbox` block, which moves that run off the host and into a Gondolin microVM.

```json
"sandbox": {
  "provider": "gondolin",
  "allowedHosts": ["api.github.com"],
  "secrets": { "GITHUB_TOKEN": { "hosts": ["api.github.com"], "env": "GH_FACTORY_TOKEN" } }
}
```

**Scope limit, stated plainly:** this covers the `command` adapter only. **claude and pi still run on the host** with the worker's environment. Nothing here makes the LLM agents sandboxed.

## Review this first

- **Node/Bun process boundary** (`lib/sandbox/runner.mjs` header). The SDK's host-side TLS mediation does not work under Bun: an allowlisted request hangs until timeout with no error and no debug output; the identical script under Node returns normally. Hence a Node child process speaking NDJSON. Collapsing that boundary silently breaks egress.
- **Secrets on stdin, not argv** (`gondolin.mjs`). argv is readable by any process via `ps`. The runner child also gets a minimal env (`PATH`/`HOME`/`TMPDIR`), not the worker's.
- **Two deliberate divergences from the SDK's defaults** (`policy.mjs`): an omitted `allowedHosts` means deny-all here (the SDK's default is allow-all on omission), and a secret scoped outside the allowlist is an error rather than a silent no-op.

## Verification

`bun test event-runtime/lib/sandbox/ event-runtime/lib/adapters/command.test.mjs` — 46 pass, 0 fail.
Full suite `bun test event-runtime/` — **1112 pass, 0 fail**.

Real-VM invariant tests boot actual microVMs and skip (not fail) where QEMU is absent, so CI runners without a hypervisor stay green and honest about what they did not check.

**Every invariant was observed failing before being trusted**, via deliberate mutation of the implementation:

| Mutation | Invariant | Result |
|---|---|---|
| allowlist not passed to the SDK | egress deny | failed as it should |
| real secret values injected into guest env | placeholder-only | failed as it should |
| workspace mounts dropped | workspace passthrough | failed as it should |
| in-guest abort timer disabled | timeout | **passed — test was vacuous** |

The last one was a real finding: the parent's backstop kill masked the disabled in-guest abort, so the test certified a fallback it did not mean to test. Tightened to assert the deadline, then re-confirmed failing under the same mutation.

## Hands-on

```
$ bun event-runtime/cli.mjs sandbox doctor
available     yes
qemu          /opt/homebrew/bin/qemu-system-aarch64
node          /Users/…/v24.18.0/bin/node   (v24.18)
sdk           @earendil-works/gondolin installed

$ GH_FACTORY_TOKEN=$(gh auth token) bun event-runtime/cli.mjs sandbox exec \
    --allow api.github.com --secret GITHUB_TOKEN=GH_FACTORY_TOKEN --shell -- '…'
guest holds: GONDOLIN_SECRET_f6b62e2f6e615418dc27f8ec655545bb63a3f857f485276e
{"login":"hdkiller","id":10578603,…}          # host substituted the real token
--- exfil attempt to non-allowlisted host:
403
[sandbox] … mounted at /workspace   egress: api.github.com   boot 56ms
```

Workers advertise `sandbox=gondolin` only when preflight passes, so placement never routes a sandboxed run to a host that would just fail it.

## Docs

`docs/eval-gondolin-sandbox.md` gains a correction notice. The RFC's benchmark table was fabricated (no upstream or measured basis; actual warm boot is 51–93 ms), its hypervisor/VFS design does not match the real project (QEMU, not `Virtualization.framework`; no DAX), its guest inventory was wrong (**no `git`** — which is why agent-in-VM is separate work), and its milestone IDs WM-131…134 now belong to unrelated tickets.

## Escalation

Per the agent floor's never-auto-merge list, this is **credential and secret handling** and wants human review rather than a CI-green merge.