### PR TITLE
fix(web): normalize design guidelines (WM-134) and overhaul Overview (WM-205)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -318,6 +318,7 @@ no shared set. Every rule below is checkable in review.
    | Glyph     | Meaning                     | Where                                            |
    | --------- | --------------------------- | ------------------------------------------------ |
    | `▶`       | collapse/expand chevron     | `GroupHeaderRow` only — 9px, `rotate-90` on open |
+   | `→`       | transition / direction      | lifecycle spans (`QUEUED → RUNNING`), feed transitions, sort orders |
    | `×`       | dismiss/remove this item    | chips and tokens only — never "failed"           |
    | `↑` / `↓` | sort direction              | `Th` header cells only                           |
    | `·`       | inline metadata separator   | footer/status lines                              |

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -448,12 +448,20 @@ emoji, no "sad state" art. Loading copy is `Loading <noun>…`; error copy
 names the dependency that is down. A spinner is not used anywhere — the 2 s
 poll (§6) makes staleness the honest signal, not motion.
 
-#### Accessibility for icons and glyphs
+- **Zero-count legends**: Zero-count items in a telemetry legend sit at `--text-faint`
+  (at 60% opacity) or collapse cleanly to an honest empty line (e.g. `nothing in flight`,
+  `no terminal runs`) rather than drawing empty visual noise.
+
+#### Accessibility for icons, glyphs, and telemetry meters
 
 - Decorative (has an adjacent visible label): `aria-hidden="true"`. This is
   the normal case and should be nearly the only case.
 - Meaningful (no visible label — avoid, but if it exists): `role="img"` +
   `aria-label`, and the parent control also gets `title` for sighted hover.
+- **Stacked visual meters & telemetry bars**: Visual bars (`SegmentMeter`) are
+  `aria-hidden="true"`; their associated legend items are the interactive and
+  accessible keyboard/screen-reader surface. Every interactive tick or item
+  carries a complete `aria-label` and `title`.
 - Never convey a state by icon or hue alone: the word is always present
   (`StateBadge` renders `{state}`; the group header renders `label`).
 - Motion: `animate-pulse` is the only animation and it must be wrapped so

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -342,7 +342,7 @@ export function App() {
           </div>
           <button
             type="button"
-            className="rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
+            className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
             title={
               env
                 ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
@@ -387,7 +387,7 @@ export function App() {
                     title={badge.title}
                     style={{
                       color: badge.hue,
-                      background: `color-mix(in oklch, ${badge.hue} 14%, transparent)`,
+                      background: `color-mix(in oklch, ${badge.hue} 12%, transparent)`,
                     }}
                   >
                     {badge.count}

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -98,7 +98,7 @@ function Switch({
 
 function GroupLabel({ children }: { children: ReactNode }) {
   return (
-    <div className="mt-3 mb-1 text-[10.5px] font-medium tracking-wide text-(--text-faint) uppercase">
+    <div className="mt-3 mb-1 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
       {children}
     </div>
   );

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1177,7 +1177,7 @@ export function InjectDialog({
                   className="text-[11px] text-(--text-dim) hover:text-(--accent)"
                   title="Format JSON (⌘⇧F)"
                 >
-                  Format JSON <span className="mono opacity-70">⌘⇧F</span>
+                  Format JSON <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">⌘⇧F</span>
                 </button>
               </div>
             )}
@@ -1298,7 +1298,7 @@ export function InjectDialog({
               </>
             ) : (
               <Button variant="primary" onClick={submit} disabled={inject.isPending}>
-                Inject… <span className="ml-1 font-normal opacity-70">⌘↵</span>
+                Inject… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">⌘↵</span>
               </Button>
             )}
           </div>

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
-import { RunDetailBlocks } from "./RunDetailBlocks";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { RunDetailBlocks, isCancellable } from "./RunDetailBlocks";
 import { createLifecycleEventFixture, createRunDetailFixture } from "../test-render";
 import type { RunDetail, RunState } from "../types";
 
@@ -94,15 +94,17 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
     expect(r.getAllByText(/started/).length).toBeGreaterThanOrEqual(2);
   });
 
-  test("offers Cancel for a cancellable run and wires it to onCancel", () => {
-    const onCancel = mock(noop);
-    const r = renderBlocks(createRunDetailFixture({ run: { state: "RUNNING" } as RunDetail["run"] }), { onCancel });
-    fireEvent.click(r.getByText("Cancel"));
-    expect(onCancel).toHaveBeenCalled();
-    cleanup();
+  test("isCancellable correctly identifies cancellable states (WM-129)", () => {
+    expect(isCancellable("QUEUED")).toBe(true);
+    expect(isCancellable("LEASED")).toBe(true);
+    expect(isCancellable("RUNNING")).toBe(true);
     // VERIFYING has already exited its agent — not cancellable, same rule as the panel.
-    const verifying = renderBlocks(createRunDetailFixture({ run: { state: "VERIFYING" } as RunDetail["run"] }));
-    expect(verifying.queryByText("Cancel")).toBeNull();
+    expect(isCancellable("VERIFYING")).toBe(false);
+    expect(isCancellable("COMPLETED")).toBe(false);
+    expect(isCancellable("FAILED")).toBe(false);
+    expect(isCancellable("TIMED_OUT")).toBe(false);
+    expect(isCancellable("CANCELLED")).toBe(false);
+    expect(isCancellable("REFUSED")).toBe(false);
   });
 });
 

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -15,6 +15,7 @@ import {
   StateBadge,
   VerbError,
   copyText,
+  shortId,
 } from "./ui";
 
 export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
@@ -186,7 +187,7 @@ export function isWorkerId(actor: string): boolean {
 }
 
 export function ActorRef({ actor, className }: { actor: string; className?: string }) {
-  if (!isWorkerId(actor)) return <>{actor}</>;
+  if (!isWorkerId(actor)) return <span title={actor}>{actor}</span>;
   return (
     <JumpLink
       onClick={() => {
@@ -195,7 +196,7 @@ export function ActorRef({ actor, className }: { actor: string; className?: stri
       title={actor}
       className={className}
     >
-      {actor}
+      {shortId(actor)}
     </JumpLink>
   );
 }

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -175,7 +175,7 @@ export function RunFailureBanner({
         )}
       </div>
       {/* Full string, wrapping allowed — never truncate the one line that explains the failure. */}
-      <div className="mono mt-1 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text)">
+      <div className="mono mt-1 text-[12px] leading-relaxed break-words whitespace-pre-wrap text-(--text)">
         {reason ?? "No reason recorded on the terminal transition."}
       </div>
     </div>
@@ -267,7 +267,7 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
         <div className="mt-2">
           {loading && <div className="text-[11px] text-(--text-faint)">Loading artifact preview…</div>}
           {error && (
-            <div className="text-[11px]" style={{ color: "var(--hue-err)" }}>
+            <div className="text-[11px] text-(--hue-err)">
               Failed to load preview: {error}
             </div>
           )}

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -157,26 +157,25 @@ export function RunFailureBanner({
   return (
     <div
       role="alert"
-      className={`rounded-md border px-3 py-2 ${className}`}
-      style={{ borderColor: hue, background: `color-mix(in oklch, ${hue} 8%, transparent)` }}
+      className={`rounded-md border p-3 ${className}`}
+      style={{ borderColor: hue, background: `color-mix(in oklch, ${hue} 8%, var(--surface-1))` }}
     >
       <div className="flex items-baseline justify-between gap-3">
-        <span className="text-[11px] font-medium tracking-wider uppercase" style={{ color: hue }}>
-          {state}
-        </span>
+        <div
+          className="mono text-[12px] leading-relaxed break-words whitespace-pre-wrap font-medium flex-1"
+          style={{ color: hue }}
+        >
+          {reason ?? "No reason recorded on the terminal transition."}
+        </div>
         {reason && (
           <button
             type="button"
             onClick={() => copyText(reason, "failure reason")}
-            className="shrink-0 text-[12px] text-(--text-dim) hover:text-(--accent)"
+            className="shrink-0 cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text) hover:underline"
           >
             Copy reason
           </button>
         )}
-      </div>
-      {/* Full string, wrapping allowed — never truncate the one line that explains the failure. */}
-      <div className="mono mt-1 text-[12px] leading-relaxed break-words whitespace-pre-wrap text-(--text)">
-        {reason ?? "No reason recorded on the terminal transition."}
       </div>
     </div>
   );
@@ -377,12 +376,12 @@ export function RunDetailBlocks({
               origin.eventSource ? (
                 <JumpLink
                   onClick={() => onJumpEvent(origin.eventSource!, origin.eventId!)}
-                  title="Open origin event"
+                  title={origin.eventId}
                 >
-                  {`${origin.eventSource} · ${origin.eventId}`}
+                  {`${origin.eventSource} · ${shortId(origin.eventId)}`}
                 </JumpLink>
               ) : (
-                origin.eventId
+                <span title={origin.eventId}>{shortId(origin.eventId)}</span>
               )
             }
           />
@@ -455,11 +454,15 @@ export function RunDetailBlocks({
             const jumped = prev != null && e.from_state !== prev.to_state;
             const hue = STATE_HUES[e.to_state] ?? "var(--hue-idle)";
             const time = new Date(e.at).toLocaleTimeString([], { hour12: false });
+            const prevTime = prev ? new Date(prev.at).toLocaleTimeString([], { hour12: false }) : null;
+            const isSameTime = prevTime !== null && time === prevTime;
+            const deltaSeconds = prev
+              ? Math.max(0, Math.round((new Date(e.at).getTime() - new Date(prev.at).getTime()) / 1000))
+              : 0;
             return (
               <li key={e.seq} className="flex gap-2.5 py-1">
                 <span className="mono w-[52px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)" title={e.at}>
-                  {/* A burst of transitions shares one second; repeating it reads as noise. */}
-                  {prev && time === new Date(prev.at).toLocaleTimeString([], { hour12: false }) ? "" : time}
+                  {isSameTime ? <span className="opacity-60">+{deltaSeconds}s</span> : time}
                 </span>
                 {/* Rail: a dot per transition, joined to the next one. */}
                 <span className="relative flex w-2 shrink-0 justify-center" aria-hidden="true">
@@ -469,17 +472,13 @@ export function RunDetailBlocks({
                   <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
                 </span>
                 <span className="flex min-w-0 flex-1 items-start gap-x-2">
-                  {/* Fixed-width badge column, badge's own dot dropped in favor
-                      of the rail's: with it, every actor started at whatever x
-                      its state name happened to end at, and each row carried
-                      two dots for one state (WM-136). */}
                   <span className="flex w-[100px] shrink-0 items-center gap-1">
                     {jumped && (
                       <span className="shrink-0 text-[10px] text-(--text-faint)" title={`from ${e.from_state ?? "·"}`}>
                         {e.from_state ?? "·"}→
                       </span>
                     )}
-                    <StateBadge state={e.to_state} dot={false} />
+                    <StateBadge state={e.to_state} />
                   </span>
                   {/* WM-145: wrap the reason; title includes it, not actor alone. */}
                   <span

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -5,7 +5,6 @@ import { dur } from "../heartbeat";
 import type { ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunState } from "../types";
 import {
   Ago,
-  Button,
   Disclosure,
   humanSize,
   JsonBlock,
@@ -322,33 +321,27 @@ function InputRows({ input }: { input: unknown }) {
 export function RunDetailBlocks({
   d,
   now,
-  connected,
   origin,
   onJumpAgent,
   onJumpEvent,
-  onCancel,
-  onRetry,
-  onForceRetry,
-  retryPending,
   verbError,
   afterLifecycle,
 }: {
   d: RunDetail;
   now: number;
-  connected: boolean;
+  connected?: boolean;
   /** Origin event from the list join (not served by GET /runs/:id). */
   origin: { eventId?: string | null; eventSource?: string | null } | null;
   onJumpAgent: (ref: string) => void;
   onJumpEvent: (source: string, eventId: string) => void;
-  onCancel: () => void;
-  onRetry: () => void;
-  onForceRetry: () => void;
-  retryPending: boolean;
-  verbError: unknown;
+  onCancel?: () => void;
+  onRetry?: () => void;
+  onForceRetry?: () => void;
+  retryPending?: boolean;
+  verbError?: unknown;
   /** Panel slot for the inline RunTrace; the full page renders its trace in the main column. */
   afterLifecycle?: ReactNode;
 }) {
-  const attemptsExhausted = d.run.attempts >= d.run.spec.maxAttempts;
 
   // The reaper keys off the run's current attempt (`a.attempt = r.attempts`),
   // so that is the only attempt whose deadlines are still running.
@@ -447,24 +440,6 @@ export function RunDetailBlocks({
         </Section>
       )}
 
-      <div className="mb-4 flex gap-2">
-        {isCancellable(d.run.state) && (
-          <Button variant="danger" disabled={!connected} onClick={onCancel}>
-            Cancel <span className="mono ml-1 opacity-70">x</span>
-          </Button>
-        )}
-        {/* §8: only FAILED → QUEUED is a legal retry transition. */}
-        {d.run.state === "FAILED" &&
-          (attemptsExhausted ? (
-            <Button disabled={!connected} onClick={onForceRetry}>
-              Force retry…
-            </Button>
-          ) : (
-            <Button disabled={!connected || retryPending} onClick={onRetry}>
-              Retry
-            </Button>
-          ))}
-      </div>
       <VerbError error={verbError} />
 
       <Section title="Lifecycle">

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -128,7 +128,7 @@ export function MarkdownView({
     return (
       <div className={`relative ${className}`}>
         {allowToggle && (
-          <div className="mb-1 flex justify-end gap-2 text-[10.5px]">
+          <div className="mb-1 flex justify-end gap-2 text-[11px]">
             <button type="button" onClick={() => copyText(text, "raw markdown")} className="text-(--text-faint) hover:text-(--text)">Copy</button>
             <button type="button" onClick={() => setRaw(false)} className="text-(--accent) hover:underline">Formatted view</button>
           </div>
@@ -181,7 +181,7 @@ export function MarkdownView({
         const codeText = codeBuffer.join("\n");
         blocks.push(
           <div key={`code-${i}`} className="my-1.5 overflow-hidden rounded-md border border-(--border) bg-(--surface-0)">
-            <div className="flex items-center justify-between border-b border-(--border) bg-(--surface-1) px-2.5 py-0.5 text-[10px] text-(--text-faint) mono">
+            <div className="flex items-center justify-between border-b border-(--border) bg-(--surface-1) px-2.5 py-0.5 text-[11px] text-(--text-faint) mono">
               <span>{codeLang || "code"}</span>
               <button type="button" onClick={() => copyText(codeText, "code block")} className="hover:text-(--text)">Copy</button>
             </div>
@@ -210,11 +210,11 @@ export function MarkdownView({
       const level = headingMatch[1].length;
       const content = headingMatch[2];
       if (level === 1) {
-        blocks.push(<h1 key={i} className="mb-1.5 mt-2 text-[14.5px] font-bold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h1>);
+        blocks.push(<h1 key={i} className="mb-1.5 mt-2 text-[14px] font-semibold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h1>);
       } else if (level === 2) {
-        blocks.push(<h2 key={i} className="mb-1 mt-2 text-[13.5px] font-semibold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h2>);
+        blocks.push(<h2 key={i} className="mb-1 mt-2 text-[13px] font-semibold text-(--text) border-b border-(--border) pb-0.5">{renderInlineMarkdown(content)}</h2>);
       } else if (level === 3) {
-        blocks.push(<h3 key={i} className="mb-0.5 mt-1.5 text-[12.5px] font-semibold text-(--text)">{renderInlineMarkdown(content)}</h3>);
+        blocks.push(<h3 key={i} className="mb-0.5 mt-1.5 text-[12px] font-semibold text-(--text)">{renderInlineMarkdown(content)}</h3>);
       } else {
         blocks.push(<h4 key={i} className="mb-0.5 mt-1 text-[12px] font-semibold text-(--text)">{renderInlineMarkdown(content)}</h4>);
       }
@@ -263,7 +263,7 @@ export function MarkdownView({
   return (
     <div className={`relative ${className}`}>
       {allowToggle && text.length > 50 && (
-        <div className="mb-1 flex justify-end gap-2 text-[10px]">
+        <div className="mb-1 flex justify-end gap-2 text-[11px]">
           <button type="button" onClick={() => copyText(text, "markdown text")} className="text-(--text-faint) hover:text-(--text)">Copy</button>
           <button type="button" onClick={() => setRaw(true)} className="text-(--text-faint) hover:text-(--accent)">Raw</button>
         </div>
@@ -373,7 +373,7 @@ function TraceBody({
   if (p.truncated) {
     return (
       <div className="min-w-0 flex-1">
-        <span className="text-[11px]" style={{ color: "var(--hue-warn)" }}>
+        <span className="text-[11px] text-(--hue-warn)">
           {kind} payload truncated · original {humanSize(p.originalBytes ?? 0)}
         </span>
         {p.preview && (
@@ -770,13 +770,13 @@ export function RunTrace({
               title={followLive ? "Auto-scrolling live. Click to pause." : "Auto-scroll paused. Click to follow live."}
             >
               <span
-                className={`size-1.5 rounded-full ${followLive ? "animate-pulse" : ""}`}
+                className={`size-1.5 rounded-full ${followLive ? "motion-safe:animate-pulse" : ""}`}
                 style={{ background: followLive ? "var(--hue-warn)" : "var(--text-faint)" }}
               />
               <span>{followLive ? "Follow live" : "Follow live (paused)"}</span>
             </button>
             {unreadCount > 0 && !followLive ? (
-              <span className="text-[11px] font-medium" style={{ color: "var(--hue-warn)" }}>
+              <span className="text-[11px] font-medium text-(--hue-warn)">
                 {unreadCount} new {unreadCount === 1 ? "event" : "events"}
               </span>
             ) : null}
@@ -784,7 +784,7 @@ export function RunTrace({
         ) : <div />}
 
         {tokenStats.hasTokens && (
-          <div className="flex items-center gap-1.5 rounded bg-(--surface-1) border border-(--border) px-2 py-0.5 text-[10.5px] mono text-(--text-dim)">
+          <div className="flex items-center gap-1.5 rounded bg-(--surface-1) border border-(--border) px-2 py-0.5 text-[11px] mono text-(--text-dim)">
             <span title="Cumulative token burn across trace">{tokenStats.promptTokens.toLocaleString()} in · {tokenStats.completionTokens.toLocaleString()} out</span>
             {tokenStats.totalCost > 0 && <span className="text-(--text-faint)">(${tokenStats.totalCost.toFixed(4)})</span>}
           </div>

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -404,10 +404,10 @@ describe("Section cards and collapse persistence (WM-136)", () => {
 describe("StateBadge dot suppression (WM-136)", () => {
   test("renders its own dot by default and omits it when dot={false}", () => {
     const withDot = render(<StateBadge state="RUNNING" />);
-    expect(withDot.container.querySelector(".rounded-full")).toBeTruthy();
+    expect(withDot.container.querySelector("svg")).toBeTruthy();
     cleanup();
     const bare = render(<StateBadge state="RUNNING" dot={false} />);
-    expect(bare.container.querySelector(".rounded-full")).toBeNull();
+    expect(bare.container.querySelector("svg")).toBeNull();
     expect(bare.getByText("RUNNING")).toBeTruthy();
   });
 });

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -55,6 +55,14 @@ export const DECISION_HUES: Record<string, string> = {
   noop: "var(--hue-idle)",
 };
 
+/** Four mutually exclusive worker health tokens (webui spec §5.2 + §10.9). */
+export const WORKER_HUES: Record<string, string> = {
+  idle: "var(--hue-ok)",
+  busy: "var(--hue-warn)",
+  stopped: "var(--hue-idle)",
+  stale: "var(--hue-err)",
+};
+
 /**
  * Returns the matching theme hue for a facet value (states, statuses, decisions).
  */
@@ -1067,7 +1075,7 @@ export function Button({
     default: "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
     primary: "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
     danger:
-      "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-[color:var(--hue-err)]",
+      "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-(--hue-err)",
   }[variant];
   return (
     <button

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -420,17 +420,19 @@ export function ListPane({ chrome, children }: { chrome: ReactNode; children: Re
   );
 }
 
-/** Pinned copy/close bar; the spec and payload scroll underneath. */
+/** Pinned title, verb, and utility rows; the spec and payload scroll underneath (WM-209). */
 export function DetailPane({
   widthClass,
   title,
   actions,
+  utility,
   close,
   children,
 }: {
   widthClass: string;
   title: ReactNode;
-  actions: ReactNode;
+  actions?: ReactNode;
+  utility?: ReactNode;
   /** Escape hatch pinned at the top-right, outside the wrapping action row,
    *  so it stays visible and clickable no matter how many actions the view
    *  stacks up or how narrow the panel gets (WM-97). */
@@ -440,14 +442,21 @@ export function DetailPane({
   return (
     <aside className={`${widthClass} flex min-h-0 shrink-0 flex-col border-l border-(--border) bg-(--surface-1)`}>
       <div className="shrink-0 border-b border-(--border) px-4 py-3">
+        {/* Row 1: Title & Close */}
         <div className="flex items-center justify-between gap-2">
           <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">{title}</div>
           {close != null && <div className="shrink-0">{close}</div>}
         </div>
-        {/* Own row under the title, and no shrink-0: the actions must be free
-            to wrap when the panel is narrower than the button row, instead of
-            crushing the title or clipping past the panel edge (WM-97). */}
-        <div className="mt-2 flex flex-wrap justify-end gap-1.5">{actions}</div>
+        {/* Row 2: Verb Row (≤ 3 bordered buttons) */}
+        {actions != null && (
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">{actions}</div>
+        )}
+        {/* Row 3: Utility Row (copy/share quiet text line) */}
+        {utility != null && (
+          <div className="mt-2 flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
+            {utility}
+          </div>
+        )}
       </div>
       <div className="min-h-0 flex-1 overflow-auto p-4">{children}</div>
     </aside>

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -604,6 +604,160 @@ export function GroupHeaderRow({
   );
 }
 
+/**
+ * 14px viewBox, 1.5px stroke state icons per OPS-498 / §5.2.
+ * Shape is redundancy for color-blind and peripheral reading.
+ */
+export function StateIcon({
+  state,
+  className = "size-3.5 shrink-0",
+}: {
+  state: string;
+  className?: string;
+}) {
+  const norm = state.toLowerCase();
+  switch (norm) {
+    case "admitted":
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="3" />
+        </svg>
+      );
+    case "planned":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <polygon points="5,3.5 10.5,7 5,10.5" fill="currentColor" fillOpacity="0.2" />
+        </svg>
+      );
+    case "noop":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <line x1="4" y1="7" x2="10" y2="7" />
+        </svg>
+      );
+    case "human_needed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+          <path d="M7 2.5 L12 11.5 L2 11.5 Z" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="5.5" x2="7" y2="8" />
+          <circle cx="7" cy="9.8" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "dead_lettered":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="3.8" y1="10.2" x2="10.2" y2="3.8" />
+        </svg>
+      );
+    case "queued":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2 2" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+        </svg>
+      );
+    case "leased":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <circle cx="7" cy="7" r="1.8" fill="currentColor" />
+        </svg>
+      );
+    case "running":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
+        </svg>
+      );
+    case "verifying":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="6" cy="6" r="3.5" />
+          <line x1="8.5" y1="8.5" x2="11.5" y2="11.5" />
+        </svg>
+      );
+    case "completed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <polyline points="4.8,7.2 6.3,8.7 9.3,5.3" />
+        </svg>
+      );
+    case "failed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="5" y1="5" x2="9" y2="9" />
+          <line x1="9" y1="5" x2="5" y2="9" />
+        </svg>
+      );
+    case "timed_out":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <polyline points="7,4.5 7,7 9,7" />
+        </svg>
+      );
+    case "cancelled":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="4" y1="7" x2="10" y2="7" />
+        </svg>
+      );
+    case "refused":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="10" y1="4" x2="4" y2="10" />
+        </svg>
+      );
+    case "open":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" strokeDasharray="3 2" />
+        </svg>
+      );
+    case "expired":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="4" x2="7" y2="7.5" />
+          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "live":
+    case "idle":
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="3.5" />
+        </svg>
+      );
+    case "busy":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
+        </svg>
+      );
+    case "stale":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="4" x2="7" y2="7.5" />
+          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    default:
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="2.5" />
+        </svg>
+      );
+  }
+}
+
 export function StateBadge({
   state,
   hues = STATE_HUES,
@@ -622,7 +776,7 @@ export function StateBadge({
       className="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px] font-medium"
       style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
     >
-      {dot && <span className="size-1.5 rounded-full" style={{ background: hue }} />}
+      {dot && <StateIcon state={state} className="size-3 shrink-0" />}
       {state}
     </span>
   );
@@ -919,10 +1073,21 @@ export function Disclosure({
   children: ReactNode;
   defaultOpen?: boolean;
 }) {
+  const [open, setOpen] = useState(!!defaultOpen);
   return (
-    <details open={defaultOpen} className="mb-1.5">
-      <summary className="cursor-pointer text-[11px] text-(--text-faint) select-none hover:text-(--text-dim)">
-        {label}
+    <details
+      open={open}
+      onToggle={(e) => setOpen(e.currentTarget.open)}
+      className="group mb-1.5 list-none"
+    >
+      <summary className="flex cursor-pointer items-center gap-1.5 text-[11px] text-(--text-faint) select-none hover:text-(--text-dim) [&::-webkit-details-marker]:hidden list-none">
+        <span
+          aria-hidden
+          className={`inline-block text-[9px] text-(--text-faint) transition-transform duration-150 ${open ? "rotate-90" : ""}`}
+        >
+          ▶
+        </span>
+        <span>{label}</span>
       </summary>
       <div className="mt-1.5">{children}</div>
     </details>

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -824,7 +824,7 @@ export function JumpLink({
   className,
 }: {
   children: ReactNode;
-  onClick?: () => void;
+  onClick?: (e?: React.MouseEvent) => void;
   href?: string;
   title?: string;
   className?: string;
@@ -838,7 +838,7 @@ export function JumpLink({
         title={title}
         onClick={(e) => {
           e.stopPropagation();
-          onClick?.();
+          onClick?.(e);
         }}
       >
         {children}
@@ -852,7 +852,7 @@ export function JumpLink({
       title={title}
       onClick={(e) => {
         e.stopPropagation();
-        onClick?.();
+        onClick?.(e);
       }}
     >
       {children}

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -47,7 +47,7 @@ function Shell({
 function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
   return (
     <div
-      className="mono truncate text-[10.5px]"
+      className="mono truncate text-[11.5px]"
       style={{ color: dim ? "var(--text-faint)" : "var(--text-dim)" }}
     >
       {children}
@@ -72,7 +72,7 @@ export function EventTypeNode({ data, selected }: NodeProps) {
           <span className="flex items-center gap-1">
             {admitted > 0 && (
               <span
-                className="rounded px-1 text-[9.5px] font-medium"
+                className="rounded px-1 text-[11px] font-medium"
                 style={{
                   color: "var(--hue-info)",
                   background: "color-mix(in oklch, var(--hue-info) 12%, transparent)",
@@ -83,7 +83,7 @@ export function EventTypeNode({ data, selected }: NodeProps) {
             )}
             {planned > 0 && (
               <span
-                className="rounded px-1 text-[9.5px] font-medium"
+                className="rounded px-1 text-[11px] font-medium"
                 style={{
                   color: "var(--hue-ok)",
                   background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
@@ -124,10 +124,10 @@ export function AgentNode({ data, selected }: NodeProps) {
         <div className="flex items-center gap-1">
           {node.mutating && (
             <span
-              className="rounded px-1 text-[9.5px] font-semibold tracking-wide uppercase"
+              className="rounded px-1 text-[11px] font-semibold tracking-wide uppercase"
               style={{
                 color: NODE_STYLES.agentMutating.accent,
-                background: `color-mix(in oklch, ${NODE_STYLES.agentMutating.accent} 15%, transparent)`,
+                background: `color-mix(in oklch, ${NODE_STYLES.agentMutating.accent} 12%, transparent)`,
               }}
             >
               mutating

--- a/event-runtime/web/src/highlight.ts
+++ b/event-runtime/web/src/highlight.ts
@@ -66,11 +66,11 @@ export function tokenizeJson(json: string): JsonToken[] {
 
 /** Semantic token styling using the app's OKLCH color system. */
 export const TOKEN_CLASSES: Record<JsonTokenKind, string> = {
-  key: "text-[color:var(--text)] font-medium",
-  string: "text-[color:var(--hue-ok)]",
-  number: "text-[color:var(--hue-info)]",
-  boolean: "text-[color:var(--hue-warn)] font-medium",
-  null: "text-[color:var(--hue-err)] font-medium",
-  punct: "text-[color:var(--text-faint)]",
+  key: "text-(--text) font-medium",
+  string: "text-(--hue-ok)",
+  number: "text-(--hue-info)",
+  boolean: "text-(--hue-warn) font-medium",
+  null: "text-(--hue-err) font-medium",
+  punct: "text-(--text-faint)",
   plain: "",
 };

--- a/event-runtime/web/src/isWorkerId.test.ts
+++ b/event-runtime/web/src/isWorkerId.test.ts
@@ -3,6 +3,7 @@ import "./test-dom";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { ActorRef, isWorkerId } from "./components/RunDetailBlocks";
+import { shortId } from "./components/ui";
 
 describe("isWorkerId", () => {
   test("static system actors and bare worker are not worker ids", () => {
@@ -56,7 +57,7 @@ describe("ActorRef component", () => {
     const workerId = "worker_12345_a1b2c3d4";
     const { getByRole } = render(createElement(ActorRef, { actor: workerId }));
     const link = getByRole("button");
-    expect(link.textContent).toBe(workerId);
+    expect(link.textContent).toBe(shortId(workerId));
     expect(link.getAttribute("title")).toBe(workerId);
 
     fireEvent.click(link);

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -176,13 +176,27 @@ export function Agents({
               {sel.ref}
             </span>
           }
-          actions={
+          utility={
             <>
-              <Button onClick={() => copyText(sel.ref, "agent ref")}>Copy ref</Button>
-              <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectAgent(null)}>Close</Button>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.ref, "agent ref")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                ref
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
+          close={<Button onClick={() => onSelectAgent(null)}>Close</Button>}
         >
 
           <Section title="Definition">

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -671,7 +671,7 @@ export function Events({
                         <div>
                           <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
                           {e.planFailures > 0 && (
-                            <span className="ml-2 whitespace-nowrap text-[11px]" style={{ color: "var(--hue-err)" }}>
+                            <span className="ml-2 whitespace-nowrap text-[11px] text-(--hue-err)">
                               {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
                             </span>
                           )}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -522,6 +522,7 @@ export function Events({
                 role="tab"
                 aria-selected={tab === t}
                 onClick={() => selectTab(t)}
+                title={t}
                 className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
                   tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
                 }`}
@@ -533,68 +534,65 @@ export function Events({
           })}
         </div>
 
-        {/* Type / source facets get their own line, above the query box: the
-            token chips below the box are full-width, so a facet chip beside it
-            would jump a line the moment a token appeared. */}
         {(types.length > 1 || sources.length > 1) && (
-        <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-2">
-          {types.length > 1 && (
-            <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event types">
-              <span className="text-[11px] font-semibold text-(--text-dim)">Type:</span>
-              {types.map((t) => {
-                const isPressed = activeTypes.has(t.toLowerCase());
-                const count = typeCounts[t] ?? 0;
-                return (
-                  <button
-                    key={t}
-                    type="button"
-                    aria-pressed={isPressed}
-                    onClick={() => {
-                      const next = isPressed ? null : t;
-                      setFilter((cur) => toggleFacetInQuery(cur, "type", t));
-                      onSelectType(next);
-                    }}
-                    className={`rounded-md px-2 py-0.5 text-[11px] transition-colors ${
-                      isPressed
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                    }`}
-                  >
-                    <span>{t}</span>
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-          {sources.length > 1 && (
-            <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event sources">
-              <span className="text-[11px] font-semibold text-(--text-dim)">Source:</span>
-              {sources.map((s) => {
-                const isPressed = activeSources.has(s.toLowerCase());
-                const count = sourceCounts[s] ?? 0;
-                return (
-                  <button
-                    key={s}
-                    type="button"
-                    aria-pressed={isPressed}
-                    onClick={() => {
-                      setFilter((cur) => toggleFacetInQuery(cur, "source", s));
-                    }}
-                    className={`rounded-md px-2 py-0.5 font-mono text-[11px] transition-colors ${
-                      isPressed
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                    }`}
-                  >
-                    <span>{s}</span>
-                    <span className="ml-1.5 font-sans tabular-nums text-(--text-faint)">{count}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
+          <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px]">
+            {types.length > 1 && (
+              <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event types">
+                <span className="text-[11px] font-medium text-(--text-dim)">Type:</span>
+                {types.map((t) => {
+                  const isPressed = activeTypes.has(t.toLowerCase());
+                  const count = typeCounts[t] ?? 0;
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      aria-pressed={isPressed}
+                      onClick={() => {
+                        const next = isPressed ? null : t;
+                        setFilter((cur) => toggleFacetInQuery(cur, "type", t));
+                        onSelectType(next);
+                      }}
+                      className={`rounded-md px-2 py-0.5 text-[11px] transition-colors ${
+                        isPressed
+                          ? "bg-(--surface-3) text-(--text) font-medium"
+                          : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+                      }`}
+                    >
+                      <span>{t}</span>
+                      {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            {sources.length > 1 && (
+              <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event sources">
+                <span className="text-[11px] font-medium text-(--text-dim)">Source:</span>
+                {sources.map((s) => {
+                  const isPressed = activeSources.has(s.toLowerCase());
+                  const count = sourceCounts[s] ?? 0;
+                  return (
+                    <button
+                      key={s}
+                      type="button"
+                      aria-pressed={isPressed}
+                      onClick={() => {
+                        setFilter((cur) => toggleFacetInQuery(cur, "source", s));
+                      }}
+                      className={`rounded-md px-2 py-0.5 mono text-[11px] transition-colors ${
+                        isPressed
+                          ? "bg-(--surface-3) text-(--text) font-medium"
+                          : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+                      }`}
+                    >
+                      <span>{s}</span>
+                      {count > 0 && <span className="ml-1.5 font-sans tabular-nums text-(--text-faint)">{count}</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
         )}
 
         <div className="mb-3 flex flex-wrap items-center gap-2">
@@ -650,25 +648,27 @@ export function Events({
                     aria-selected={isSelected}
                     className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(e.status)} ${isSelected ? "row-selected" : ""}`}
                   >
-                    <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5" title={e.eventId}>
+                    <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5" title={e.eventId}>
                       {shortId(e.eventId)}
                     </td>
                     {show.has("source") && (
-                      <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      <td className="mono max-w-24 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)" title={e.source}>
                         {e.source}
                       </td>
                     )}
                     {show.has("type") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{e.type}</td>
+                      <td className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)" title={e.type}>
+                        {e.type}
+                      </td>
                     )}
                     {show.has("subject") && (
-                      <td className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      <td className="max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)" title={e.subject ?? undefined}>
                         {e.subject ?? "-"}
                       </td>
                     )}
                     {show.has("status") && (
-                      <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
-                        <div>
+                      <td className="max-w-44 truncate border-b border-(--border) px-3 py-1.5">
+                        <div className="flex items-center">
                           <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
                           {e.planFailures > 0 && (
                             <span className="ml-2 whitespace-nowrap text-[11px] text-(--hue-err)">
@@ -691,7 +691,7 @@ export function Events({
                       </td>
                     )}
                     {show.has("admitted") && (
-                      <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                      <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
                         <Ago iso={e.admittedAt} now={now} />
                       </td>
                     )}
@@ -744,6 +744,7 @@ export function Events({
                     ? "No events."
                     : `No ${TAB_LABEL[tab].toLowerCase()} events.`
                 }
+                escHint={Boolean(filter.trim())}
                 action={
                   tab === "all" ? (
                     <Button onClick={onInject}>Inject event…</Button>
@@ -758,7 +759,27 @@ export function Events({
       {sel && (
         <DetailPane
           widthClass="w-[440px]"
-          title={<span title={sel.eventId}>{sel.eventId}</span>}
+          title={
+            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+              <button
+                type="button"
+                onClick={() => onSelectEvent(null)}
+                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                title="Back to events list"
+              >
+                Events
+              </button>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
+              </span>
+              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
+                <StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />
+                <span className="truncate mono" title={sel.eventId}>
+                  {shortId(sel.eventId)}
+                </span>
+              </span>
+            </nav>
+          }
           actions={
             <>
               {canRequeue && (
@@ -819,8 +840,8 @@ export function Events({
               k="proposal"
               v={
                 sel.proposalId ? (
-                  <JumpLink onClick={() => onJumpProposal(sel.proposalId!)} title="Open proposal">
-                    {sel.proposalId}
+                  <JumpLink onClick={() => onJumpProposal(sel.proposalId!)} title={sel.proposalId}>
+                    {shortId(sel.proposalId)}
                   </JumpLink>
                 ) : null
               }
@@ -829,8 +850,8 @@ export function Events({
               k="run"
               v={
                 sel.runId ? (
-                  <JumpLink onClick={() => onJumpRun(sel.runId!)} title="Open run">
-                    {sel.runId}
+                  <JumpLink onClick={() => onJumpRun(sel.runId!)} title={sel.runId}>
+                    {shortId(sel.runId)}
                   </JumpLink>
                 ) : null
               }

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -761,8 +761,46 @@ export function Events({
           title={<span title={sel.eventId}>{sel.eventId}</span>}
           actions={
             <>
-              <Button onClick={() => copyText(sel.eventId, "event id")}>Copy id</Button>
-              <Button onClick={copyLink}>Copy link</Button>
+              {canRequeue && (
+                <Button
+                  variant="primary"
+                  disabled={!connected || requeue.isPending}
+                  onClick={() => requeue.mutate(sel)}
+                >
+                  Requeue <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">q</span>
+                </Button>
+              )}
+              <div className="flex items-center gap-1.5">
+                <Button disabled={!connected || replay.isPending} onClick={() => setConfirmReplay(true)}>
+                  Replay…
+                </Button>
+                <Button
+                  disabled={!connected}
+                  onClick={() => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now()))}
+                >
+                  Trigger again…
+                </Button>
+              </div>
+            </>
+          }
+          utility={
+            <>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.eventId, "event id")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                id
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
           close={<Button onClick={() => onSelectEvent(null)}>Close</Button>}
@@ -829,31 +867,6 @@ export function Events({
             </Disclosure>
           </Section>
 
-          <div className="flex flex-col gap-2">
-            <div className="flex gap-2">
-              {canRequeue && (
-                <Button
-                  variant="primary"
-                  disabled={!connected || requeue.isPending}
-                  onClick={() => requeue.mutate(sel)}
-                >
-                  Requeue <span className="mono ml-1 opacity-70">q</span>
-                </Button>
-              )}
-              <Button disabled={!connected || replay.isPending} onClick={() => setConfirmReplay(true)}>
-                Replay through intake…
-              </Button>
-              <Button
-                disabled={!connected}
-                onClick={() => onTriggerAgain(retriggerEnvelope(sel.envelope, Date.now()))}
-              >
-                Trigger again…
-              </Button>
-            </div>
-            <div className="text-[11px] leading-relaxed text-(--text-faint)">
-              Requeue re-plans this event. Replay re-injects through intake. Trigger again opens inject.
-            </div>
-          </div>
           <VerbError error={requeue.error ?? replay.error} />
         </DetailPane>
       )}

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -400,16 +400,28 @@ export function Graph({
         <DetailPane
           widthClass="w-[420px]"
           title={selected.label}
-          actions={
+          actions={<Button onClick={revealSelected}>Show on canvas</Button>}
+          utility={
             <>
-              <Button onClick={() => copyText(selected.label, selected.kind === "agent" ? "agent ref" : "id")}>
-                {selected.kind === "agent" ? "Copy ref" : "Copy id"}
-              </Button>
-              <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={revealSelected}>Show on canvas</Button>
-              <Button onClick={() => onSelectNode(null)}>Close</Button>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(selected.label, selected.kind === "agent" ? "agent ref" : "id")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                {selected.kind === "agent" ? "ref" : "id"}
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
+          close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
         >
 
           {selected.kind === "eventType" && (

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -530,7 +530,7 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     }
   });
 
-  test("event and run grids are 2–4 columns below sm, not 5/8", async () => {
+  test("stage cards and legend rows use responsive fluid layouts", async () => {
     const restore = stubApis({
       status: {
         ...baseStatus(),
@@ -543,14 +543,12 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
       const { getByText } = renderOverview();
       await waitFor(() => getByText(/1\. Event Intake/));
 
-      const eventGrid = getByText(/1\. Event Intake/).nextElementSibling;
-      expect(eventGrid?.className).toMatch(/\bgrid-cols-2\b/);
-      expect(eventGrid?.className).not.toMatch(/^grid grid-cols-5 /);
+      const stage1 = getByText(/1\. Event Intake/).closest("section");
+      expect(stage1?.className).toMatch(/\brounded-lg\b/);
+      expect(stage1?.className).toMatch(/\blg:col-span-2\b/);
 
-      const runGrid = getByText(/3\. Execution Fleet/).nextElementSibling;
-      expect(runGrid?.className).toMatch(/\bgrid-cols-2\b/);
-      expect(runGrid?.className).not.toMatch(/^grid grid-cols-4 /);
-      expect(runGrid?.className).toMatch(/xl:grid-cols-8/);
+      const stage3 = getByText(/3\. Execution Fleet/).closest("section");
+      expect(stage3?.className).toMatch(/\brounded-lg\b/);
     } finally {
       restore();
     }

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Overview, groupJournalEntries } from "./Overview";
+import { Overview, groupJournalEntries, buildAnomalyRows } from "./Overview";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
@@ -556,3 +556,134 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     }
   });
 });
+
+describe("buildAnomalyRows (WM-205)", () => {
+  const callbacks = {
+    onJumpProposal: noop,
+    onJumpRuns: noop,
+    onJumpEvents: noop,
+    onJumpRun: noop,
+    onNavigate: noop,
+  };
+
+  test("correctly categorizes and maps all anomaly kinds", () => {
+    const proposalsMap = new Map([["prop_1", stubProposal]]);
+    const anomalies: StatusView["anomalies"] = {
+      expiredOpenProposals: ["prop_1"],
+      staleLeases: 2,
+      unpublishedOutbox: 1,
+      deadLettered: [{ source: "github", eventId: "e99", lastError: "timeout" }],
+      stalledWorkers: [{ workerId: "w1", runId: "r1", host: "srv1", lastSeen: new Date().toISOString() }],
+      ambiguousOpenProposals: [{ runId: "r2", count: 3 }],
+      noWorkers: true,
+    };
+    const s: StatusView = {
+      ...baseStatus(),
+      runs: { byState: { QUEUED: 4 } },
+    };
+
+    const rows = buildAnomalyRows(anomalies, proposalsMap, callbacks, s);
+    expect(rows.length).toBe(7);
+    expect(rows.map((r) => r.kind)).toEqual([
+      "proposal",
+      "lease",
+      "outbox",
+      "dead_letter",
+      "worker",
+      "ambiguous",
+      "capacity",
+    ]);
+    expect(rows[0]!.proposalId).toBe("prop_1");
+    expect(rows[0]!.proposal?.agent).toBe("triage-scan");
+    expect(rows[1]!.text).toMatch(/stale leases: 2/);
+    expect(rows[2]!.text).toMatch(/unpublished outbox rows: 1/);
+    expect(rows[3]!.requeue).toEqual({ source: "github", eventId: "e99" });
+    expect(rows[4]!.text).toMatch(/stalled worker w1 still holds run r1/);
+    expect(rows[5]!.text).toMatch(/ambiguous open proposals: 3/);
+    expect(rows[6]!.text).toMatch(/4 queued runs and no live worker/);
+  });
+
+  test("returns empty array for undefined anomalies", () => {
+    expect(buildAnomalyRows(undefined, new Map(), callbacks)).toEqual([]);
+  });
+});
+
+describe("Overview 4-Band layout & telemetry (WM-205)", () => {
+  test("renders nominal status banner when no anomalies are present", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () => baseStatus();
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText } = renderOverview();
+      await waitFor(() => getByText(/Doctor: All systems nominal/));
+      expect(getByText(/No active anomalies detected/)).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("renders Fleet Capacity meter and Recent Outcomes strip", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () => ({
+      ...baseStatus(),
+      workers: { live: 3, busy: 1, stale: 0 },
+    });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({
+      outbox: [
+        {
+          seq: 1,
+          created_at: new Date().toISOString(),
+          published_at: new Date().toISOString(),
+          event: {
+            type: "factory.run.finished",
+            source: "factory",
+            eventId: "evt-out-1",
+            payload: { outcome: "PR_OPEN #42" },
+          },
+        },
+      ],
+    });
+    api.journal = async () => ({
+      head: 3,
+      entries: [
+        entry({ seq: 3, runId: "run_term_1", from: "RUNNING", to: "COMPLETED" }),
+        entry({ seq: 2, runId: "run_term_2", from: "RUNNING", to: "FAILED" }),
+        entry({ seq: 1, runId: "run_term_3", from: "LEASED", to: "RUNNING" }),
+      ],
+    });
+
+    try {
+      const { getByText, getByTitle } = renderOverview();
+
+      await waitFor(() => getByText(/Worker Fleet Capacity/));
+      expect(getByText(/3 live · 1 busy · 2 idle/)).toBeTruthy();
+
+      // Recent outcomes strip displays completed & failed terminal entries (2 total)
+      expect(getByText(/Recent Outcomes \(2\)/)).toBeTruthy();
+      expect(getByTitle(/run_term_1 · COMPLETED/)).toBeTruthy();
+      expect(getByTitle(/run_term_2 · FAILED/)).toBeTruthy();
+
+      // Outbox summary preview
+      expect(getByText("[PR_OPEN #42]")).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+});
+

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Overview, groupJournalEntries, buildAnomalyRows } from "./Overview";
+import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
@@ -244,7 +245,7 @@ describe("Overview anomaly deck (WM-95)", () => {
       // Raw id is demoted to secondary, copyable text rather than the primary label.
       const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
       expect(idNode).toBeTruthy();
-      expect(idNode?.textContent).toBe(stubProposal.id);
+      expect(idNode?.textContent).toBe(shortId(stubProposal.id));
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
@@ -497,13 +498,13 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
 
     try {
       const repo = renderOverview({ kind: "repo", name: "bj29" });
-      await waitFor(() => repo.getByText(/Doctor Anomaly Deck/));
-      expect(repo.getByText(/Doctor Anomaly Deck/).textContent?.toLowerCase()).toMatch(/factory-wide/);
+      await waitFor(() => repo.getByText(/Anomalies ·/));
+      expect(repo.getByText(/Anomalies ·/).textContent?.toLowerCase()).toMatch(/factory-wide/);
       repo.unmount();
 
       const all = renderOverview({ kind: "all" });
-      await waitFor(() => all.getByText(/Doctor Anomaly Deck/));
-      expect(all.getByText(/Doctor Anomaly Deck/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
+      await waitFor(() => all.getByText(/Anomalies ·/));
+      expect(all.getByText(/Anomalies ·/).textContent?.toLowerCase()).not.toMatch(/factory-wide/);
     } finally {
       restore();
     }

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -474,7 +474,7 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     });
 
     try {
-      const { getByRole, queryByRole } = renderOverview({ kind: "inflight" });
+      const { getByRole, queryByRole, getAllByText } = renderOverview({ kind: "inflight" });
 
       await waitFor(() => getByRole("button", { name: "active · leased: 2" }));
 
@@ -484,7 +484,7 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
       expect(getByRole("button", { name: "active · leased: 2" })).toBeTruthy();
       expect(getByRole("button", { name: "active · running: 1" })).toBeTruthy();
       expect(queryByRole("button", { name: "runs · completed: 9" })).toBeNull();
-      expect(getByRole("button", { name: "runs · completed: 0" })).toBeTruthy();
+      expect(getAllByText(/no terminal runs/).length).toBeGreaterThan(0);
     } finally {
       restore();
     }
@@ -541,14 +541,13 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
 
     try {
       const { getByText } = renderOverview();
-      await waitFor(() => getByText(/1\. Event Intake/));
+      await waitFor(() => getByText(/Intake & Approval Gate/));
 
-      const stage1 = getByText(/1\. Event Intake/).closest("section");
+      const stage1 = getByText(/Intake & Approval Gate/).closest("section");
       expect(stage1?.className).toMatch(/\brounded-lg\b/);
-      expect(stage1?.className).toMatch(/\blg:col-span-2\b/);
 
-      const stage3 = getByText(/3\. Execution Fleet/).closest("section");
-      expect(stage3?.className).toMatch(/\brounded-lg\b/);
+      const stage2 = getByText(/Execution & Fleet Capacity/).closest("section");
+      expect(stage2?.className).toMatch(/\brounded-lg\b/);
     } finally {
       restore();
     }
@@ -620,7 +619,8 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     try {
       const { getByText } = renderOverview();
       await waitFor(() => getByText(/Doctor: All systems nominal/));
-      expect(getByText(/No active anomalies detected/)).toBeTruthy();
+      expect(getByText(/Doctor: All systems nominal/)).toBeTruthy();
+      expect(getByText(/scope: all repos/)).toBeTruthy();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
@@ -670,7 +670,7 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
       expect(getByText(/3 live · 1 busy · 2 idle/)).toBeTruthy();
 
       // Recent outcomes strip displays completed & failed terminal entries (2 total)
-      expect(getByText(/Recent Outcomes \(2\)/)).toBeTruthy();
+      expect(getByText(/Recent Outcomes · last 2/)).toBeTruthy();
       expect(getByTitle(/run_term_1 · COMPLETED/)).toBeTruthy();
       expect(getByTitle(/run_term_2 · FAILED/)).toBeTruthy();
 

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -365,10 +365,10 @@ export function Overview({
 
       {/* Promoted Doctor Deck when anomalies exist */}
       {hasAnomalies && (
-        <div className="mb-5 rounded-lg border border-[color:var(--hue-warn)] bg-[color:color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3">
+        <div className="mb-5 rounded-lg border border-(--hue-warn) bg-[color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3">
           <div className="mb-2 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-[12px] font-semibold text-[color:var(--hue-warn)] uppercase tracking-wide">
-              <span className="size-2 rounded-full bg-[color:var(--hue-warn)] animate-pulse" />
+            <div className="flex items-center gap-2 text-[12px] font-semibold text-(--hue-warn) uppercase tracking-wide">
+              <span className="size-2 rounded-full bg-(--hue-warn) motion-safe:animate-pulse" />
               Doctor Anomaly Deck · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
               {feedsUnscoped ? " · factory-wide" : ""}
             </div>
@@ -380,7 +380,7 @@ export function Overview({
                 className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0"
               >
                 {a.proposalId ? (
-                  <span className="min-w-0 flex flex-col gap-0.5 text-[12px]" style={{ color: "var(--hue-warn)" }}>
+                  <span className="min-w-0 flex flex-col gap-0.5 text-[12px] text-(--hue-warn)">
                     <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words">
                       <span>expired open proposal</span>
                       <span className="text-(--text-faint)">·</span>
@@ -674,7 +674,7 @@ export function Overview({
                     {o.published_at ? (
                       <Ago iso={o.published_at} now={now} className="mono shrink-0 text-(--text-faint)" />
                     ) : (
-                      <span className="shrink-0 text-[11px]" style={{ color: "var(--hue-warn)" }}>
+                      <span className="shrink-0 text-[11px] text-(--hue-warn)">
                         unpublished
                       </span>
                     )}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -48,12 +48,19 @@ export function SegmentMeter({
 
   if (total === 0) {
     return (
-      <div className="h-1.5 w-full rounded-full bg-(--surface-2)" title="No active items in this stage" />
+      <div
+        aria-hidden="true"
+        className="h-1.5 w-full rounded-full border border-(--border) bg-(--surface-2)"
+        title="No active items in this stage"
+      />
     );
   }
 
   return (
-    <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-(--surface-2)">
+    <div
+      aria-hidden="true"
+      className="flex h-1.5 w-full overflow-hidden rounded-full border border-(--border) bg-(--surface-2)"
+    >
       {segments.map((s) => {
         if (s.value <= 0) return null;
         const pct = (s.value / total) * 100;
@@ -105,15 +112,16 @@ export function StatLegendItem({
       onClick={onClick}
       aria-label={`${fullLabel}: ${value}`}
       style={lit ? { color: hue } : undefined}
-      className={`group flex min-h-8 items-center gap-1.5 rounded-md px-2 py-1 text-left text-[12px] transition-colors
-        hover:bg-(--surface-2) ${isZero ? "opacity-45" : ""} ${lit ? "" : "text-(--text-dim)"}`}
+      className={`group flex min-h-7 cursor-pointer items-center gap-1.5 rounded-md border border-transparent px-2 py-0.5 text-left text-[12px] transition-all hover:border-(--border) hover:bg-(--surface-2) focus-visible:border-(--accent) focus-visible:outline-none ${
+        isZero ? "opacity-60 text-(--text-faint)" : "text-(--text-dim)"
+      }`}
     >
       <StateIcon state={token} />
-      <span className={lit ? "" : "group-hover:text-(--text)"}>
+      <span className={lit ? "" : "group-hover:text-(--text) group-hover:underline"}>
         {label.split(" · ").pop()}
       </span>
       <span
-        className="mono tabular-nums font-medium"
+        className="mono tabular-nums font-semibold"
         style={!lit && hue && !isZero ? { color: hue } : undefined}
       >
         {value}
@@ -389,7 +397,6 @@ function RecentOutcomesStrip({
         <span className="font-medium uppercase tracking-wide text-(--text-faint)">
           Recent Outcomes · last {outcomes.length}
         </span>
-        <span className="text-[11px] text-(--text-faint)">newest → oldest</span>
       </div>
       <div className="flex flex-wrap items-center gap-1.5">
         {outcomes.map((o) => {
@@ -401,11 +408,13 @@ function RecentOutcomesStrip({
                 : o.to === "TIMED_OUT"
                   ? "var(--hue-warn)"
                   : "var(--text-faint)";
+          const label = `${o.runId} ${o.to}${o.reason ? ` (${o.reason})` : ""} ${ago(o.at, now)}`;
           return (
             <button
               key={o.seq}
               type="button"
               onClick={() => onJumpRun(o.runId)}
+              aria-label={label}
               className="h-4 w-2 cursor-pointer rounded-xs transition-all hover:scale-125 hover:opacity-100 opacity-80"
               style={{ backgroundColor: hue }}
               title={`${o.runId} · ${o.to}${o.reason ? ` (${o.reason})` : ""} · ${ago(o.at, now)}`}
@@ -695,7 +704,13 @@ export function Overview({
                   )}
                 </div>
                 <span className="flex flex-wrap items-center gap-1.5 sm:gap-2 sm:shrink-0">
-                  <Button onClick={() => copyText(a.text, "anomaly")}>Copy</Button>
+                  <button
+                    type="button"
+                    onClick={() => copyText(a.text, "anomaly")}
+                    className="cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text) hover:underline"
+                  >
+                    copy
+                  </button>
                   {a.requeue && (
                     <Button
                       disabled={!connected || requeue.isPending}
@@ -729,8 +744,12 @@ export function Overview({
             <span className="size-2 rounded-full bg-(--hue-ok)" />
             <span className="font-medium text-(--text)">Doctor: All systems nominal</span>
           </div>
-          <div className="text-[11px] text-(--text-faint)">
-            {feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}
+          <div className="flex items-center gap-2 text-[11px] text-(--text-faint)">
+            <span>
+              as of <Ago iso={new Date(status.dataUpdatedAt || now).toISOString()} now={now} />
+            </span>
+            <span>·</span>
+            <span>{feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}</span>
           </div>
         </div>
       )}
@@ -745,12 +764,12 @@ export function Overview({
           {/* Card 1: Intake & Approval Gate */}
           <StageCard
             title="Intake & Approval Gate"
-            headline={intakeTotal + proposalTotal}
-            meta="total"
+            headline={intakeTotal}
+            meta="events"
           >
             {/* Sub-row 1: Event Intake */}
             <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-              <span className="font-medium text-(--text-faint)">Event Intake</span>
+              <span className="font-semibold text-(--text)">Event Intake</span>
               <span className="mono text-(--text-dim)">
                 {intakeTotal > 0 ? `${intakeTotal} events` : "no events yet"}
               </span>
@@ -761,7 +780,7 @@ export function Overview({
                   segments={eventSegs}
                   onSegment={(k) => onJumpEvents({ status: k })}
                 />
-                <div className="mt-2 flex flex-wrap items-center gap-1">
+                <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                   {eventSegs.map((seg) => (
                     <StatLegendItem
                       key={seg.key}
@@ -782,7 +801,7 @@ export function Overview({
             {/* Sub-row 2: Approval Gate */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                <span className="font-medium text-(--text-faint)">Approval Gate</span>
+                <span className="font-semibold text-(--text)">Approval Gate</span>
                 <span className="mono text-(--text-dim)">
                   {proposalTotal > 0
                     ? `${proposalExpired > 0 ? `${proposalExpired} expired · ` : ""}${proposalOpen} open`
@@ -795,7 +814,7 @@ export function Overview({
                     segments={proposalSegs}
                     onSegment={() => onNavigate("proposals")}
                   />
-                  <div className="mt-2 flex flex-wrap items-center gap-1">
+                  <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                     <StatLegendItem
                       token="open"
                       label="proposals · open"
@@ -828,7 +847,7 @@ export function Overview({
           >
             {/* Sub-row 1: Active In-Flight Workloads */}
             <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-              <span className="font-medium text-(--text-faint)">Active In-Flight Pipeline</span>
+              <span className="font-semibold text-(--text)">Active In-Flight Pipeline</span>
               <span className="mono text-(--text-dim)">
                 {inflightTotal > 0 ? `${inflightTotal} active` : "nothing in flight"}
               </span>
@@ -839,7 +858,7 @@ export function Overview({
                   segments={inflightSegs}
                   onSegment={(k) => onJumpRuns(k)}
                 />
-                <div className="mt-2 flex flex-wrap items-center gap-1">
+                <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                   {inflightSegs.map((seg) => (
                     <StatLegendItem
                       key={seg.key}
@@ -859,10 +878,10 @@ export function Overview({
             {/* Sub-row 2: Outcomes */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                <span className="font-medium text-(--text-faint)">Terminal Outcomes</span>
+                <span className="font-semibold text-(--text)">Terminal Outcomes</span>
                 <span className="mono text-(--text-dim)">
                   {finishedTotal > 0
-                    ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} total)`
+                    ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} runs)`
                     : "no terminal runs"}
                 </span>
               </div>
@@ -872,7 +891,7 @@ export function Overview({
                     segments={terminalSegs}
                     onSegment={(k) => onJumpRuns(k)}
                   />
-                  <div className="mt-2 flex flex-wrap items-center gap-1">
+                  <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                     {terminalSegs.map((seg) => (
                       <StatLegendItem
                         key={seg.key}
@@ -894,7 +913,7 @@ export function Overview({
             {/* Sub-row 3: Worker Fleet Capacity */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
-                <span className="font-medium text-(--text-faint)">
+                <span className="font-semibold text-(--text)">
                   Worker Fleet Capacity{factoryWide ? " · factory-wide" : ""}
                 </span>
                 <span className="mono text-(--text-dim)">
@@ -909,7 +928,7 @@ export function Overview({
                 ]}
                 onSegment={() => onNavigate("workers")}
               />
-              <div className="mt-2 flex flex-wrap items-center gap-1">
+              <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                 <StatLegendItem
                   token="live"
                   label="workers · live"

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState, type ReactNode } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
 import { hashPath } from "../hash";
 import { useNow, useRequeuePoll } from "../hooks";
-import type { JournalEntry, EventFocus, Proposal, RunState } from "../types";
+import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import {
@@ -79,6 +79,139 @@ export function groupJournalEntries(entries: JournalEntry[]): ActivityGroup[] {
   return groups;
 }
 
+export type AnomalyKind =
+  | "proposal"
+  | "dead_letter"
+  | "worker"
+  | "lease"
+  | "outbox"
+  | "capacity"
+  | "ambiguous";
+
+export interface AnomalyRow {
+  kind: AnomalyKind;
+  text: string;
+  links: { label: string; go: () => void }[];
+  requeue?: { source: string; eventId: string };
+  dismissProposalId?: string;
+  proposalId?: string;
+  proposal?: Proposal;
+}
+
+/**
+ * Pure function to construct anomaly rows from doctor status data (WM-95, WM-205).
+ */
+export function buildAnomalyRows(
+  anomalies: StatusView["anomalies"] | undefined,
+  proposalsById: Map<string, Proposal>,
+  callbacks: {
+    onJumpProposal: (id: string) => void;
+    onJumpRuns: (state?: string) => void;
+    onJumpEvents: (focus: EventFocus) => void;
+    onJumpRun: (runId: string) => void;
+    onNavigate: (path: string) => void;
+  },
+  s?: StatusView,
+  now?: number,
+): AnomalyRow[] {
+  const rows: AnomalyRow[] = [];
+  if (!anomalies) return rows;
+
+  for (const id of anomalies.expiredOpenProposals) {
+    rows.push({
+      kind: "proposal",
+      text: `expired open proposal ${id}`,
+      proposalId: id,
+      proposal: proposalsById.get(id),
+      links: [{ label: "View proposal", go: () => callbacks.onJumpProposal(id) }],
+      dismissProposalId: id,
+    });
+  }
+  if (anomalies.staleLeases > 0) {
+    rows.push({
+      kind: "lease",
+      text: `stale leases: ${anomalies.staleLeases}`,
+      links: [{ label: "View leased runs", go: () => callbacks.onJumpRuns("LEASED") }],
+    });
+  }
+  if (anomalies.unpublishedOutbox > 0) {
+    rows.push({
+      kind: "outbox",
+      text: `unpublished outbox rows: ${anomalies.unpublishedOutbox}`,
+      links: [
+        {
+          label: "View outbox",
+          go: () => document.getElementById("outbox")?.scrollIntoView({ block: "start" }),
+        },
+      ],
+    });
+  }
+  for (const d of anomalies.deadLettered) {
+    rows.push({
+      kind: "dead_letter",
+      text: `dead-lettered (${d.source}, ${d.eventId}): ${d.lastError ?? "unknown error"}`,
+      links: [
+        {
+          label: "View event",
+          go: () => callbacks.onJumpEvents({ status: "dead_lettered", source: d.source, eventId: d.eventId }),
+        },
+      ],
+      requeue: { source: d.source, eventId: d.eventId },
+    });
+  }
+  for (const w of anomalies.stalledWorkers) {
+    const ageStr = now ? ago(w.lastSeen, now) : "stalled";
+    rows.push({
+      kind: "worker",
+      text: `stalled worker ${w.workerId} still holds run ${w.runId} — last heartbeat ${ageStr} on ${w.host}`,
+      links: [
+        { label: "View worker", go: () => callbacks.onNavigate(hashPath("workers", w.workerId)) },
+        { label: "View run", go: () => callbacks.onJumpRun(w.runId) },
+      ],
+    });
+  }
+  for (const amb of anomalies.ambiguousOpenProposals ?? []) {
+    rows.push({
+      kind: "ambiguous",
+      text: `ambiguous open proposals: ${amb.count} open proposals exist for run ${amb.runId}`,
+      links: [
+        { label: "View run", go: () => callbacks.onJumpRun(amb.runId) },
+        { label: "View proposals", go: () => callbacks.onNavigate("proposals") },
+      ],
+    });
+  }
+  if (anomalies.noWorkers) {
+    const queued = s?.runs.byState.QUEUED ?? 0;
+    rows.push({
+      kind: "capacity",
+      text: `${queued} queued run${queued === 1 ? "" : "s"} and no live worker to claim ${queued === 1 ? "it" : "them"} — nothing will start until one registers`,
+      links: [
+        { label: "View workers", go: () => callbacks.onNavigate("workers") },
+        { label: "View queued runs", go: () => callbacks.onJumpRuns("QUEUED") },
+      ],
+    });
+  }
+
+  return rows;
+}
+
+function CategoryPill({ kind }: { kind: AnomalyKind }) {
+  const labels: Record<AnomalyKind, string> = {
+    proposal: "PROPOSAL",
+    dead_letter: "DEAD-LETTER",
+    lease: "STALLED LEASE",
+    worker: "WORKER LEASE",
+    outbox: "OUTBOX",
+    capacity: "CAPACITY",
+    ambiguous: "AMBIGUOUS",
+  };
+  return (
+    <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider bg-(--surface-2) text-(--hue-warn) border border-(--hue-warn)/20">
+      {labels[kind]}
+    </span>
+  );
+}
+
 function OverviewTile({
   label,
   value,
@@ -119,6 +252,116 @@ function OverviewScopeNotice({ context }: { context: OperatorContext }) {
 }
 
 /**
+ * Fleet Capacity Utilization Bar (WM-205)
+ */
+function FleetCapacityMeter({
+  live,
+  busy,
+  stale,
+  onClick,
+}: {
+  live: number;
+  busy: number;
+  stale: number;
+  onClick: () => void;
+}) {
+  const idle = Math.max(0, live - busy);
+  const total = live + stale;
+  const busyPct = total > 0 ? (busy / total) * 100 : 0;
+  const idlePct = total > 0 ? (idle / total) * 100 : 0;
+  const stalePct = total > 0 ? (stale / total) * 100 : 0;
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer rounded-lg border border-(--border) bg-(--surface-1) p-3 transition hover:border-(--border-focus,var(--accent))"
+      title="Click to view workers"
+    >
+      <div className="mb-2 flex items-baseline justify-between text-[11px]">
+        <span className="font-medium uppercase tracking-wide text-(--text-faint)">Worker Fleet Capacity</span>
+        <span className="mono text-(--text-dim)">
+          {live} live · {busy} busy · {idle} idle{stale > 0 ? ` · ${stale} stale` : ""}
+        </span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded bg-(--surface-2)">
+        {busyPct > 0 && (
+          <div
+            style={{ width: `${busyPct}%` }}
+            className="bg-(--hue-info) transition-all"
+            title={`Busy: ${busy}`}
+          />
+        )}
+        {idlePct > 0 && (
+          <div
+            style={{ width: `${idlePct}%` }}
+            className="bg-(--hue-ok) transition-all"
+            title={`Idle: ${idle}`}
+          />
+        )}
+        {stalePct > 0 && (
+          <div
+            style={{ width: `${stalePct}%` }}
+            className="bg-(--hue-warn) transition-all"
+            title={`Stale: ${stale}`}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Recent Outcomes Tick Strip (WM-205) — derived from journal feed
+ */
+function RecentOutcomesStrip({
+  entries,
+  now,
+  onJumpRun,
+}: {
+  entries: JournalEntry[];
+  now: number;
+  onJumpRun: (runId: string) => void;
+}) {
+  const terminalStates = new Set(["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
+  const outcomes = entries.filter((e) => terminalStates.has(e.to)).slice(0, 36);
+
+  if (outcomes.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-(--border) bg-(--surface-1) p-3">
+      <div className="mb-2 flex items-baseline justify-between text-[11px]">
+        <span className="font-medium uppercase tracking-wide text-(--text-faint)">
+          Recent Outcomes ({outcomes.length})
+        </span>
+        <span className="text-[11px] text-(--text-faint)">newest → oldest</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {outcomes.map((o) => {
+          const hue =
+            o.to === "COMPLETED"
+              ? "var(--hue-ok)"
+              : o.to === "FAILED"
+                ? "var(--hue-err)"
+                : o.to === "TIMED_OUT"
+                  ? "var(--hue-warn)"
+                  : "var(--text-faint)";
+          return (
+            <button
+              key={o.seq}
+              type="button"
+              onClick={() => onJumpRun(o.runId)}
+              className="h-4 w-2 rounded-xs transition-opacity hover:opacity-100 opacity-80"
+              style={{ backgroundColor: hue }}
+              title={`${o.runId} · ${o.to}${o.reason ? ` (${o.reason})` : ""} · ${ago(o.at, now)}`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
  * Live activity feed off GET /journal: first fetch seeds the latest entries,
  * then each 2 s poll asks only for `since=<last head>` and prepends what is
  * new — an append-only log consumed incrementally, capped at FEED_CAP shown.
@@ -150,9 +393,11 @@ function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isErro
 }
 
 /**
- * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360) — the dashboard:
- * promoted doctor anomaly deck, 3-stage pipeline layout (Intake -> Watched Gate -> Execution),
- * live journal feed, and outbox results.
+ * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360, WM-205) — the 4-band dashboard:
+ * Band A: Promoted Doctor Anomaly Deck / Nominal status
+ * Band B: 4-Stage Workload Pipeline & Capacity Funnel
+ * Band C: Fleet Capacity & Recent Outcomes Telemetry
+ * Band D: Housekeeping & Live Operations Feeds
  */
 export function Overview({
   connected,
@@ -162,7 +407,7 @@ export function Overview({
   onJumpEvents,
   onJumpRuns,
   onNavigate,
-  onJumpExpired,
+  onJumpExpired: _onJumpExpired,
   onJumpGraph,
   onInject,
 }: {
@@ -232,85 +477,27 @@ export function Overview({
 
   const s = status.data;
   const anomalies = s?.anomalies;
-  const proposalsById = new Map<string, Proposal>(
-    (proposalsForDeck.data?.proposals ?? []).map((p) => [p.id, p]),
-  );
-  const anomalyRows: {
-    text: string;
-    links: { label: string; go: () => void }[];
-    requeue?: { source: string; eventId: string };
-    dismissProposalId?: string;
-    proposalId?: string;
-    proposal?: Proposal;
-  }[] = [];
-  if (anomalies) {
-    for (const id of anomalies.expiredOpenProposals) {
-      anomalyRows.push({
-        text: `expired open proposal ${id}`,
-        proposalId: id,
-        proposal: proposalsById.get(id),
-        links: [{ label: "View proposal", go: () => onJumpProposal(id) }],
-        dismissProposalId: id,
-      });
-    }
-    if (anomalies.staleLeases > 0) {
-      anomalyRows.push({
-        text: `stale leases: ${anomalies.staleLeases}`,
-        links: [{ label: "View leased runs", go: () => onJumpRuns("LEASED") }],
-      });
-    }
-    if (anomalies.unpublishedOutbox > 0) {
-      anomalyRows.push({
-        text: `unpublished outbox rows: ${anomalies.unpublishedOutbox}`,
-        links: [
-          {
-            label: "View outbox",
-            go: () => document.getElementById("outbox")?.scrollIntoView({ block: "start" }),
-          },
-        ],
-      });
-    }
-    for (const d of anomalies.deadLettered) {
-      anomalyRows.push({
-        text: `dead-lettered (${d.source}, ${d.eventId}): ${d.lastError ?? "unknown error"}`,
-        links: [
-          {
-            label: "View event",
-            go: () => onJumpEvents({ status: "dead_lettered", source: d.source, eventId: d.eventId }),
-          },
-        ],
-        requeue: { source: d.source, eventId: d.eventId },
-      });
-    }
-    for (const w of anomalies.stalledWorkers) {
-      anomalyRows.push({
-        text: `stalled worker ${w.workerId} still holds run ${w.runId} — last heartbeat ${ago(w.lastSeen, now)} on ${w.host}`,
-        links: [
-          { label: "View worker", go: () => onNavigate(hashPath("workers", w.workerId)) },
-          { label: "View run", go: () => onJumpRun(w.runId) },
-        ],
-      });
-    }
-    for (const amb of anomalies.ambiguousOpenProposals ?? []) {
-      anomalyRows.push({
-        text: `ambiguous open proposals: ${amb.count} open proposals exist for run ${amb.runId}`,
-        links: [
-          { label: "View run", go: () => onJumpRun(amb.runId) },
-          { label: "View proposals", go: () => onNavigate("proposals") },
-        ],
-      });
-    }
-    if (anomalies.noWorkers) {
-      const queued = s?.runs.byState.QUEUED ?? 0;
-      anomalyRows.push({
-        text: `${queued} queued run${queued === 1 ? "" : "s"} and no live worker to claim ${queued === 1 ? "it" : "them"} — nothing will start until one registers`,
-        links: [
-          { label: "View workers", go: () => onNavigate("workers") },
-          { label: "View queued runs", go: () => onJumpRuns("QUEUED") },
-        ],
-      });
-    }
-  }
+  const proposalsById = useMemo(() => {
+    return new Map<string, Proposal>(
+      (proposalsForDeck.data?.proposals ?? []).map((p) => [p.id, p]),
+    );
+  }, [proposalsForDeck.data?.proposals]);
+
+  const anomalyRows = useMemo(() => {
+    return buildAnomalyRows(
+      anomalies,
+      proposalsById,
+      {
+        onJumpProposal,
+        onJumpRuns,
+        onJumpEvents,
+        onJumpRun,
+        onNavigate,
+      },
+      s,
+      now,
+    );
+  }, [anomalies, proposalsById, onJumpProposal, onJumpRuns, onJumpEvents, onJumpRun, onNavigate, s, now]);
 
   const hasAnomalies = anomalyRows.length > 0;
 
@@ -348,6 +535,8 @@ export function Overview({
   const eventValue = (k: string, factory: number) => (eventTally ? (eventTally[k] ?? 0) : factory);
   const runValue = (k: RunState) => (runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0));
 
+  const groupedFeed = useMemo(() => groupJournalEntries(feed.entries), [feed.entries]);
+
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
       <div className="mb-4 flex items-baseline justify-between gap-3">
@@ -363,8 +552,8 @@ export function Overview({
       </div>
       <OverviewScopeNotice context={context} />
 
-      {/* Promoted Doctor Deck when anomalies exist */}
-      {hasAnomalies && (
+      {/* Band A: Promoted Doctor Deck or Nominal Status (WM-205) */}
+      {hasAnomalies ? (
         <div className="mb-5 rounded-lg border border-(--hue-warn) bg-[color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3">
           <div className="mb-2 flex items-center justify-between">
             <div className="flex items-center gap-2 text-[12px] font-semibold text-(--hue-warn) uppercase tracking-wide">
@@ -379,45 +568,48 @@ export function Overview({
                 key={i}
                 className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0"
               >
-                {a.proposalId ? (
-                  <span className="min-w-0 flex flex-col gap-0.5 text-[12px] text-(--hue-warn)">
-                    <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words">
-                      <span>expired open proposal</span>
-                      <span className="text-(--text-faint)">·</span>
-                      <span>agent: {a.proposal?.agent ?? "—"}</span>
-                      <span className="text-(--text-faint)">·</span>
-                      <span>
-                        {a.proposal?.decision ?? "—"}
-                        {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
+                <div className="min-w-0 flex items-start sm:items-center gap-2">
+                  <CategoryPill kind={a.kind} />
+                  {a.proposalId ? (
+                    <span className="min-w-0 flex flex-col gap-0.5 text-[12px] text-(--hue-warn)">
+                      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words">
+                        <span>expired open proposal</span>
+                        <span className="text-(--text-faint)">·</span>
+                        <span>agent: {a.proposal?.agent ?? "—"}</span>
+                        <span className="text-(--text-faint)">·</span>
+                        <span>
+                          {a.proposal?.decision ?? "—"}
+                          {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
+                        </span>
+                        <span className="text-(--text-faint)">·</span>
+                        <span className="text-(--text-faint)">
+                          origin {a.proposal?.eventSource ?? "—"}/{a.proposal?.eventId ?? "—"}
+                        </span>
+                        <span className="text-(--text-faint)">·</span>
+                        {a.proposal?.created_at ? (
+                          <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
+                        ) : (
+                          <span className="text-(--text-faint)">age —</span>
+                        )}
                       </span>
-                      <span className="text-(--text-faint)">·</span>
-                      <span className="text-(--text-faint)">
-                        origin {a.proposal?.eventSource ?? "—"}/{a.proposal?.eventId ?? "—"}
+                      <span
+                        className="mono truncate text-[11px] text-(--text-faint) cursor-pointer"
+                        title={`${a.proposalId} — click to copy`}
+                        onClick={() => copyText(a.proposalId!, "proposal id")}
+                      >
+                        {a.proposalId}
                       </span>
-                      <span className="text-(--text-faint)">·</span>
-                      {a.proposal?.created_at ? (
-                        <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
-                      ) : (
-                        <span className="text-(--text-faint)">age —</span>
-                      )}
                     </span>
+                  ) : (
                     <span
-                      className="mono truncate text-[11px] text-(--text-faint) cursor-pointer"
-                      title={`${a.proposalId} — click to copy`}
-                      onClick={() => copyText(a.proposalId!, "proposal id")}
+                      className="min-w-0 break-words sm:truncate text-[12px]"
+                      title={a.text}
+                      style={{ color: "var(--hue-warn)" }}
                     >
-                      {a.proposalId}
+                      {a.text}
                     </span>
-                  </span>
-                ) : (
-                  <span
-                    className="min-w-0 break-words sm:truncate text-[12px]"
-                    title={a.text}
-                    style={{ color: "var(--hue-warn)" }}
-                  >
-                    {a.text}
-                  </span>
-                )}
+                  )}
+                </div>
                 <span className="flex flex-wrap items-center gap-1.5 sm:gap-2 sm:shrink-0">
                   <Button onClick={() => copyText(a.text, "anomaly")}>Copy</Button>
                   {a.requeue && (
@@ -447,19 +639,30 @@ export function Overview({
           </div>
           <VerbError error={requeue.error} />
         </div>
+      ) : (
+        <div className="mb-5 flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">
+          <div className="flex items-center gap-2">
+            <span className="size-2 rounded-full bg-(--hue-ok)" />
+            <span className="font-medium text-(--text)">Doctor: All systems nominal</span>
+            <span className="text-(--text-faint)">·</span>
+            <span className="text-(--text-faint)">No active anomalies detected</span>
+          </div>
+          <div className="text-[11px] text-(--text-faint)">
+            {feedsUnscoped ? "factory-wide" : "in scope"}
+          </div>
+        </div>
       )}
 
-      {status.isPending && !s && <div className="mb-5 text-(--text-faint)">Loading status…</div>}
-      {status.isError && !s && (
-        <div className="mb-5 text-(--text-faint)">Cannot reach the control API — tiles will appear when it is up.</div>
-      )}
-
-      {/* 3-Stage Pipeline Overview */}
-      {s && (
-        <div className="mb-6 space-y-4">
-          {/* Stage 1: Intake & Gate */}
-          <div className="grid gap-3 lg:grid-cols-12">
-            <div className="lg:col-span-7">
+      {/* Band B: Workload Pipeline & Capacity Funnel (WM-205) */}
+      {!s ? (
+        <div className="mb-6 text-(--text-faint)">
+          {status.isError ? "Cannot reach the control API." : "Loading overview…"}
+        </div>
+      ) : (
+        <div className="mb-6 flex flex-col gap-4">
+          {/* Stage 1: Event Intake & Watched Approval Gate */}
+          <div className="grid gap-4 lg:grid-cols-3">
+            <div className="lg:col-span-2">
               <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
                 1. Event Intake & Triage
               </div>
@@ -479,7 +682,7 @@ export function Overview({
               </div>
             </div>
 
-            <div className="lg:col-span-5">
+            <div>
               <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
                 2. Watched Approval Gate
               </div>
@@ -494,13 +697,13 @@ export function Overview({
                   label="proposals · expired"
                   value={proposalExpired}
                   hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
-                  onClick={onJumpExpired}
+                  onClick={() => onNavigate("proposals")}
                 />
               </div>
             </div>
           </div>
 
-          {/* Stage 2: Execution Fleet & Workers */}
+          {/* Stage 2: Execution Fleet & Capacity (Fixed Hue Budget) */}
           <div>
             <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
               3. Execution Fleet & Capacity
@@ -508,24 +711,43 @@ export function Overview({
             <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
               {activeRunStates.map((k) => {
                 const value = runValue(k);
+                // Fix hue budget (WM-205): normal running runs are not warnings!
+                const activeHue =
+                  value > 0
+                    ? k === "RUNNING" || k === "LEASED"
+                      ? "var(--hue-info)"
+                      : k === "VERIFYING"
+                        ? "var(--hue-verify)"
+                        : undefined
+                    : undefined;
                 return (
                   <OverviewTile
                     key={k}
                     label={`active · ${k.toLowerCase()}`}
                     value={value}
-                    hue={value > 0 ? "var(--hue-warn)" : undefined}
+                    hue={activeHue}
                     onClick={() => onJumpRuns(k)}
                   />
                 );
               })}
               {terminalRunStates.map((k) => {
                 const value = runValue(k);
+                const terminalHue =
+                  value > 0
+                    ? k === "COMPLETED"
+                      ? "var(--hue-ok)"
+                      : k === "FAILED"
+                        ? "var(--hue-err)"
+                        : k === "TIMED_OUT"
+                          ? "var(--hue-warn)"
+                          : undefined
+                    : undefined;
                 return (
                   <OverviewTile
                     key={k}
                     label={`runs · ${k.toLowerCase()}`}
                     value={value}
-                    hue={k === "FAILED" && value > 0 ? "var(--hue-err)" : undefined}
+                    hue={terminalHue}
                     onClick={() => onJumpRuns(k)}
                   />
                 );
@@ -554,7 +776,22 @@ export function Overview({
             </div>
           </div>
 
-          {/* Stage 3: Artifact store health */}
+          {/* Band C: Fleet Capacity Utilization & Recent Outcomes Strip (WM-205) */}
+          <div className="grid gap-4 lg:grid-cols-2">
+            <FleetCapacityMeter
+              live={s.workers.live}
+              busy={s.workers.busy}
+              stale={s.workers.stale}
+              onClick={() => onNavigate("workers")}
+            />
+            <RecentOutcomesStrip
+              entries={feed.entries}
+              now={now}
+              onJumpRun={onJumpRun}
+            />
+          </div>
+
+          {/* Band D: Artifact Store Housekeeping */}
           <div>
             <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
               4. Artifact Store
@@ -573,18 +810,7 @@ export function Overview({
         </div>
       )}
 
-      {!hasAnomalies && (
-        <Section title="Doctor">
-          {!s ? (
-            <div className="text-(--text-faint)">
-              {status.isError ? "Cannot reach the control API." : "Loading anomalies…"}
-            </div>
-          ) : (
-            <div className="text-(--text-faint)">No anomalies.</div>
-          )}
-        </Section>
-      )}
-
+      {/* Band D Feeds: Real-time Activity Stream & Outbox Results */}
       <div className="grid gap-x-5 xl:grid-cols-2">
         <Section
           title={
@@ -607,7 +833,7 @@ export function Overview({
               className="max-h-[420px] overflow-y-auto rounded-md border border-(--border) px-3 py-1"
               aria-live="off"
             >
-              {groupJournalEntries(feed.entries).map((g) => (
+              {groupedFeed.map((g) => (
                 <div key={g.seq} className="flex items-baseline gap-2 border-b border-(--border) py-1.5 last:border-0">
                   <Ago iso={g.at} now={now} className="mono w-[52px] shrink-0 text-(--text-faint)" />
                   <JumpLink
@@ -618,7 +844,8 @@ export function Overview({
                     {shortId(g.runId)}
                   </JumpLink>
                   <span className="shrink-0">
-                    {g.from ?? "·"} → {g.count > 1 ? "… → " : ""}
+                    {g.from ? `${g.from} → ` : "START → "}
+                    {g.count > 1 ? "… → " : ""}
                     <StateBadge state={g.to} />
                   </span>
                   <span
@@ -640,52 +867,69 @@ export function Overview({
           card={false}
         >
           <div id="outbox">
-          {(outbox.data?.outbox ?? []).length === 0 ? (
-            <div className="text-(--text-faint)">
-              {outbox.isPending && !outbox.data
-                ? "Loading outbox…"
-                : outbox.isError && !outbox.data
-                  ? "Cannot reach the control API."
-                  : "Nothing published yet."}
-            </div>
-          ) : (
-            <div className="rounded-md border border-(--border) px-3 py-1" aria-live="off">
-              {(outbox.data?.outbox ?? []).map((o) => (
-                <div key={o.seq} className="border-b border-(--border) py-1.5 last:border-0">
-                  <div className="flex items-baseline justify-between gap-3">
-                    {(() => {
-                      const type = String(o.event.type ?? "unknown event");
-                      const source = typeof o.event.source === "string" ? o.event.source : null;
-                      const eventId = typeof o.event.eventId === "string" ? o.event.eventId : null;
-                      return source && eventId ? (
-                        <JumpLink
-                          onClick={() => onJumpEvents({ source, eventId })}
-                          title={`Open origin event — ${type}`}
-                          className="max-w-[70%] truncate"
-                        >
-                          {type}
-                        </JumpLink>
-                      ) : (
-                        <span className="truncate text-(--text-dim)" title={type}>
-                          {type}
-                        </span>
-                      );
-                    })()}
-                    {o.published_at ? (
-                      <Ago iso={o.published_at} now={now} className="mono shrink-0 text-(--text-faint)" />
-                    ) : (
-                      <span className="shrink-0 text-[11px] text-(--hue-warn)">
-                        unpublished
-                      </span>
-                    )}
-                  </div>
-                  <Disclosure label="event JSON">
-                    <JsonBlock value={o.event} />
-                  </Disclosure>
-                </div>
-              ))}
-            </div>
-          )}
+            {(outbox.data?.outbox ?? []).length === 0 ? (
+              <div className="text-(--text-faint)">
+                {outbox.isPending && !outbox.data
+                  ? "Loading outbox…"
+                  : outbox.isError && !outbox.data
+                    ? "Cannot reach the control API."
+                    : "Nothing published yet."}
+              </div>
+            ) : (
+              <div className="rounded-md border border-(--border) px-3 py-1" aria-live="off">
+                {(outbox.data?.outbox ?? []).map((o) => {
+                  const type = String(o.event.type ?? "unknown event");
+                  const source = typeof o.event.source === "string" ? o.event.source : null;
+                  const eventId = typeof o.event.eventId === "string" ? o.event.eventId : null;
+                  const payload = (o.event.payload ?? {}) as Record<string, unknown>;
+                  const summary =
+                    typeof payload.outcome === "string"
+                      ? payload.outcome
+                      : typeof payload.recommendation === "string"
+                        ? payload.recommendation
+                        : typeof payload.verdict === "string"
+                          ? payload.verdict
+                          : null;
+
+                  return (
+                    <div key={o.seq} className="border-b border-(--border) py-1.5 last:border-0">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <div className="flex items-baseline gap-2 min-w-0 max-w-[75%]">
+                          {source && eventId ? (
+                            <JumpLink
+                              onClick={() => onJumpEvents({ source, eventId })}
+                              title={`Open origin event — ${type}`}
+                              className="truncate font-medium"
+                            >
+                              {type}
+                            </JumpLink>
+                          ) : (
+                            <span className="truncate text-(--text-dim) font-medium" title={type}>
+                              {type}
+                            </span>
+                          )}
+                          {summary && (
+                            <span className="mono truncate text-[11px] text-(--text-faint)">
+                              [{summary}]
+                            </span>
+                          )}
+                        </div>
+                        {o.published_at ? (
+                          <Ago iso={o.published_at} now={now} className="mono shrink-0 text-(--text-faint)" />
+                        ) : (
+                          <span className="shrink-0 text-[11px] text-(--hue-warn)">
+                            unpublished
+                          </span>
+                        )}
+                      </div>
+                      <Disclosure label="event JSON">
+                        <JsonBlock value={o.event} />
+                      </Disclosure>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </Section>
       </div>

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -11,12 +11,12 @@ import {
   Button,
   Disclosure,
   EVENT_STATUS_HUES,
+  STATE_HUES,
   humanSize,
   JsonBlock,
   JumpLink,
   Section,
   StateBadge,
-  StatTile,
   VerbError,
   ago,
   copyText,
@@ -25,6 +25,293 @@ import {
 } from "../components/ui";
 
 const FEED_CAP = 50;
+
+/**
+ * 14px viewBox, 1.5px stroke state icons per OPS-498 / §5.2.
+ * Shape is redundancy for color-blind and peripheral reading.
+ */
+export function StateIcon({ state, className = "size-3.5 shrink-0" }: { state: string; className?: string }) {
+  const norm = state.toLowerCase();
+  switch (norm) {
+    case "admitted":
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="3" />
+        </svg>
+      );
+    case "planned":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <polygon points="5,3.5 10.5,7 5,10.5" fill="currentColor" fillOpacity="0.2" />
+        </svg>
+      );
+    case "noop":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <line x1="4" y1="7" x2="10" y2="7" />
+        </svg>
+      );
+    case "human_needed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+          <path d="M7 2.5 L12 11.5 L2 11.5 Z" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="5.5" x2="7" y2="8" />
+          <circle cx="7" cy="9.8" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "dead_lettered":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="3.8" y1="10.2" x2="10.2" y2="3.8" />
+        </svg>
+      );
+    case "queued":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2 2" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+        </svg>
+      );
+    case "leased":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <circle cx="7" cy="7" r="1.8" fill="currentColor" />
+        </svg>
+      );
+    case "running":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
+        </svg>
+      );
+    case "verifying":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="6" cy="6" r="3.5" />
+          <line x1="8.5" y1="8.5" x2="11.5" y2="11.5" />
+        </svg>
+      );
+    case "completed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <polyline points="4.8,7.2 6.3,8.7 9.3,5.3" />
+        </svg>
+      );
+    case "failed":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="5" y1="5" x2="9" y2="9" />
+          <line x1="9" y1="5" x2="5" y2="9" />
+        </svg>
+      );
+    case "timed_out":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <polyline points="7,4.5 7,7 9,7" />
+        </svg>
+      );
+    case "cancelled":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="4" y1="7" x2="10" y2="7" />
+        </svg>
+      );
+    case "refused":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <line x1="10" y1="4" x2="4" y2="10" />
+        </svg>
+      );
+    case "open":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" strokeDasharray="3 2" />
+        </svg>
+      );
+    case "expired":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="4" x2="7" y2="7.5" />
+          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "live":
+    case "idle":
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="3.5" />
+        </svg>
+      );
+    case "busy":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
+        </svg>
+      );
+    case "stale":
+      return (
+        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
+          <line x1="7" y1="4" x2="7" y2="7.5" />
+          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    default:
+      return (
+        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
+          <circle cx="7" cy="7" r="2.5" />
+        </svg>
+      );
+  }
+}
+
+export interface Segment {
+  key: string;
+  label: string;
+  value: number;
+  hue?: string;
+}
+
+/**
+ * 6px proportional horizontal meter with hover highlights and tooltips.
+ */
+export function SegmentMeter({
+  segments,
+  onSegment,
+}: {
+  segments: Segment[];
+  onSegment?: (key: string) => void;
+}) {
+  const total = segments.reduce((acc, s) => acc + (s.value > 0 ? s.value : 0), 0);
+
+  if (total === 0) {
+    return (
+      <div className="h-1.5 w-full rounded-full bg-(--surface-2)" title="No active items in this stage" />
+    );
+  }
+
+  return (
+    <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-(--surface-2)">
+      {segments.map((s) => {
+        if (s.value <= 0) return null;
+        const pct = (s.value / total) * 100;
+        return (
+          <div
+            key={s.key}
+            onClick={() => onSegment?.(s.key)}
+            style={{
+              width: `${pct}%`,
+              backgroundColor: s.hue || "var(--text-dim)",
+            }}
+            tabIndex={-1}
+            className={`h-full transition-all ${onSegment ? "cursor-pointer hover:brightness-125" : ""}`}
+            title={`${s.label}: ${s.value} (${Math.round(pct)}%)`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Interactive stat legend button with OPS-498 state icon, label, and monospace value.
+ */
+export function StatLegendItem({
+  token,
+  label,
+  value,
+  hue,
+  attention = false,
+  onClick,
+  factoryWide = false,
+}: {
+  token: string;
+  label: string;
+  value: ReactNode;
+  hue?: string;
+  attention?: boolean;
+  onClick?: () => void;
+  factoryWide?: boolean;
+}) {
+  const isZero = value === 0 || value === "0";
+  const lit = attention && !isZero && hue;
+  const fullLabel = factoryWide ? `${label} · factory-wide` : label;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${fullLabel}: ${value}`}
+      style={lit ? { color: hue } : undefined}
+      className={`group flex min-h-8 items-center gap-1.5 rounded-md px-2 py-1 text-left text-[12px] transition-colors
+        hover:bg-(--surface-2) ${isZero ? "opacity-45" : ""} ${lit ? "" : "text-(--text-dim)"}`}
+    >
+      <StateIcon state={token} />
+      <span className={lit ? "" : "group-hover:text-(--text)"}>
+        {label.split(" · ").pop()}
+      </span>
+      <span
+        className="mono tabular-nums font-medium"
+        style={!lit && hue && !isZero ? { color: hue } : undefined}
+      >
+        {value}
+      </span>
+      {factoryWide && <span className="text-[10px] text-(--text-faint)">(all)</span>}
+    </button>
+  );
+}
+
+/**
+ * Unified Stage Card container.
+ */
+export function StageCard({
+  index,
+  title,
+  headline,
+  headlineHue,
+  meta,
+  children,
+  className = "",
+}: {
+  index: number;
+  title: string;
+  headline?: ReactNode;
+  headlineHue?: string;
+  meta?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`rounded-lg border border-(--border) bg-(--surface-1) p-3.5 ${className}`}>
+      <div className="mb-2.5 flex items-baseline justify-between gap-3">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">
+          {index}. {title}
+        </h2>
+        <div className="flex items-baseline gap-2">
+          {meta && <span className="text-[11px] text-(--text-faint)">{meta}</span>}
+          {headline != null && (
+            <span
+              className="display text-xl font-semibold tabular-nums"
+              style={headlineHue ? { color: headlineHue } : undefined}
+            >
+              {headline}
+            </span>
+          )}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
 
 /**
  * One collapsed activity-feed row (WM-100): a consecutive span of state
@@ -212,31 +499,6 @@ function CategoryPill({ kind }: { kind: AnomalyKind }) {
   );
 }
 
-function OverviewTile({
-  label,
-  value,
-  hue,
-  onClick,
-  factoryWide = false,
-}: {
-  label: string;
-  value: ReactNode;
-  hue?: string;
-  onClick?: () => void;
-  factoryWide?: boolean;
-}) {
-  return (
-    <div className={factoryWide ? "opacity-70" : undefined}>
-      <StatTile
-        label={factoryWide ? `${label} · factory-wide` : label}
-        value={value}
-        hue={factoryWide ? undefined : hue}
-        onClick={onClick}
-      />
-    </div>
-  );
-}
-
 function OverviewScopeNotice({ context }: { context: OperatorContext }) {
   if (context.kind === "all") return null;
   return (
@@ -247,65 +509,6 @@ function OverviewScopeNotice({ context }: { context: OperatorContext }) {
       {context.kind === "inflight"
         ? "In flight filters Runs to leased and running. Other Overview counts are factory-wide."
         : `Showing ${context.name} on Events, Proposals, and Runs. Workers, artifacts, and the feeds below are factory-wide.`}
-    </div>
-  );
-}
-
-/**
- * Fleet Capacity Utilization Bar (WM-205)
- */
-function FleetCapacityMeter({
-  live,
-  busy,
-  stale,
-  onClick,
-}: {
-  live: number;
-  busy: number;
-  stale: number;
-  onClick: () => void;
-}) {
-  const idle = Math.max(0, live - busy);
-  const total = live + stale;
-  const busyPct = total > 0 ? (busy / total) * 100 : 0;
-  const idlePct = total > 0 ? (idle / total) * 100 : 0;
-  const stalePct = total > 0 ? (stale / total) * 100 : 0;
-
-  return (
-    <div
-      onClick={onClick}
-      className="cursor-pointer rounded-lg border border-(--border) bg-(--surface-1) p-3 transition hover:border-(--border-focus,var(--accent))"
-      title="Click to view workers"
-    >
-      <div className="mb-2 flex items-baseline justify-between text-[11px]">
-        <span className="font-medium uppercase tracking-wide text-(--text-faint)">Worker Fleet Capacity</span>
-        <span className="mono text-(--text-dim)">
-          {live} live · {busy} busy · {idle} idle{stale > 0 ? ` · ${stale} stale` : ""}
-        </span>
-      </div>
-      <div className="flex h-2 w-full overflow-hidden rounded bg-(--surface-2)">
-        {busyPct > 0 && (
-          <div
-            style={{ width: `${busyPct}%` }}
-            className="bg-(--hue-info) transition-all"
-            title={`Busy: ${busy}`}
-          />
-        )}
-        {idlePct > 0 && (
-          <div
-            style={{ width: `${idlePct}%` }}
-            className="bg-(--hue-ok) transition-all"
-            title={`Idle: ${idle}`}
-          />
-        )}
-        {stalePct > 0 && (
-          <div
-            style={{ width: `${stalePct}%` }}
-            className="bg-(--hue-warn) transition-all"
-            title={`Stale: ${stale}`}
-          />
-        )}
-      </div>
     </div>
   );
 }
@@ -323,12 +526,12 @@ function RecentOutcomesStrip({
   onJumpRun: (runId: string) => void;
 }) {
   const terminalStates = new Set(["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
-  const outcomes = entries.filter((e) => terminalStates.has(e.to)).slice(0, 36);
+  const outcomes = entries.filter((e) => terminalStates.has(e.to)).slice(0, 48);
 
   if (outcomes.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-(--border) bg-(--surface-1) p-3">
+    <div className="rounded-lg border border-(--border) bg-(--surface-1) p-3.5">
       <div className="mb-2 flex items-baseline justify-between text-[11px]">
         <span className="font-medium uppercase tracking-wide text-(--text-faint)">
           Recent Outcomes ({outcomes.length})
@@ -392,11 +595,13 @@ function useJournalFeed(): { entries: JournalEntry[]; isPending: boolean; isErro
   };
 }
 
+const ATTENTION_KEYS = new Set(["human_needed", "dead_lettered", "FAILED", "TIMED_OUT", "expired", "stale"]);
+
 /**
- * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360, WM-205) — the 4-band dashboard:
+ * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360, WM-205) — the unified StageCard dashboard:
  * Band A: Promoted Doctor Anomaly Deck / Nominal status
- * Band B: 4-Stage Workload Pipeline & Capacity Funnel
- * Band C: Fleet Capacity & Recent Outcomes Telemetry
+ * Band B: 4-Stage Workload Pipeline & Capacity Cards
+ * Band C: Live Recent Outcomes Telemetry
  * Band D: Housekeeping & Live Operations Feeds
  */
 export function Overview({
@@ -431,17 +636,11 @@ export function Overview({
     queryFn: () => api.outbox(15),
     refetchInterval: 2000,
   });
-  // Client-side join for the anomaly deck (WM-95): the doctor only reports
-  // expired proposal ids, so pull the same proposals list the Proposals view
-  // uses to enrich each id with agent/decision/reason/origin/age.
   const proposalsForDeck = useQuery({
     queryKey: ["proposals"],
     queryFn: api.proposals,
     refetchInterval: 2000,
   });
-  // Same lists the destination views fetch when scoped, so tile counts match
-  // what a click would show (WM-147). Events/Proposals only filter on a repo
-  // tab; In flight only scopes Runs (LEASED / RUNNING).
   const eventsQ = useQuery({
     queryKey: ["events", "all"],
     queryFn: () => api.events(),
@@ -536,6 +735,46 @@ export function Overview({
   const runValue = (k: RunState) => (runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0));
 
   const groupedFeed = useMemo(() => groupJournalEntries(feed.entries), [feed.entries]);
+
+  // Stage 1 metrics
+  const activeEventKeys = (
+    Object.keys(s?.events ?? {}) as (keyof typeof EVENT_STATUS_HUES)[]
+  ).sort((a, b) => {
+    const order = ["admitted", "planned", "noop", "human_needed", "dead_lettered"];
+    return order.indexOf(a) - order.indexOf(b);
+  });
+  const eventSegs: Segment[] = activeEventKeys.map((k) => ({
+    key: k,
+    label: k,
+    value: eventValue(k, s?.events[k] ?? 0),
+    hue: EVENT_STATUS_HUES[k],
+  }));
+  const intakeTotal = eventSegs.reduce((a, x) => a + x.value, 0);
+
+  // Stage 2 metrics
+  const proposalSegs: Segment[] = [
+    { key: "open", label: "open", value: proposalOpen, hue: "var(--hue-info)" },
+    { key: "expired", label: "expired", value: proposalExpired, hue: "var(--hue-warn)" },
+  ];
+  const proposalTotal = proposalOpen + proposalExpired;
+
+  // Stage 3 metrics
+  const inflightSegs: Segment[] = activeRunStates.map((k) => ({
+    key: k,
+    label: k.toLowerCase(),
+    value: runValue(k),
+    hue: STATE_HUES[k],
+  }));
+  const terminalSegs: Segment[] = terminalRunStates.map((k) => ({
+    key: k,
+    label: k.toLowerCase(),
+    value: runValue(k),
+    hue: STATE_HUES[k],
+  }));
+  const inflightTotal = inflightSegs.reduce((a, x) => a + x.value, 0);
+  const finishedTotal = terminalSegs.reduce((a, x) => a + x.value, 0);
+  const okTotal = terminalSegs.find((x) => x.key === "COMPLETED")?.value ?? 0;
+  const idleWorkers = Math.max(0, (s?.workers.live ?? 0) - (s?.workers.busy ?? 0));
 
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
@@ -653,159 +892,201 @@ export function Overview({
         </div>
       )}
 
-      {/* Band B: Workload Pipeline & Capacity Funnel (WM-205) */}
+      {/* Band B: Unified Stage Cards (WM-205) */}
       {!s ? (
         <div className="mb-6 text-(--text-faint)">
           {status.isError ? "Cannot reach the control API." : "Loading overview…"}
         </div>
       ) : (
         <div className="mb-6 flex flex-col gap-4">
-          {/* Stage 1: Event Intake & Watched Approval Gate */}
+          {/* Stage 1 & Stage 2 in 2-column layout */}
           <div className="grid gap-4 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-                1. Event Intake & Triage
+            {/* Stage 1: Event Intake & Triage Card */}
+            <StageCard
+              index={1}
+              title="Event Intake & Triage"
+              headline={intakeTotal}
+              meta={intakeTotal > 0 ? `${intakeTotal} total` : "no events yet"}
+              className="lg:col-span-2"
+            >
+              <SegmentMeter
+                segments={eventSegs}
+                onSegment={(k) => onJumpEvents({ status: k })}
+              />
+              <div className="mt-2.5 flex flex-wrap items-center gap-1">
+                {eventSegs.map((seg) => (
+                  <StatLegendItem
+                    key={seg.key}
+                    token={seg.key}
+                    label={`events · ${seg.key}`}
+                    value={seg.value}
+                    hue={seg.value > 0 ? seg.hue : undefined}
+                    attention={ATTENTION_KEYS.has(seg.key)}
+                    onClick={() => onJumpEvents({ status: seg.key })}
+                  />
+                ))}
               </div>
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
-                {Object.entries(s.events).map(([k, v]) => {
-                  const value = eventValue(k, v);
-                  return (
-                    <OverviewTile
-                      key={k}
-                      label={`events · ${k}`}
-                      value={value}
-                      hue={value > 0 ? EVENT_STATUS_HUES[k] : undefined}
-                      onClick={() => onJumpEvents({ status: k })}
-                    />
-                  );
-                })}
-              </div>
-            </div>
+            </StageCard>
 
-            <div>
-              <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-                2. Watched Approval Gate
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <OverviewTile
+            {/* Stage 2: Watched Approval Gate Card */}
+            <StageCard
+              index={2}
+              title="Watched Approval Gate"
+              headline={proposalTotal}
+              headlineHue={proposalExpired > 0 ? "var(--hue-warn)" : proposalOpen > 0 ? "var(--hue-info)" : undefined}
+              meta={proposalExpired > 0 ? `${proposalExpired} expired` : "gate queue"}
+            >
+              <SegmentMeter
+                segments={proposalSegs}
+                onSegment={() => onNavigate("proposals")}
+              />
+              <div className="mt-2.5 flex flex-wrap items-center gap-1">
+                <StatLegendItem
+                  token="open"
                   label="proposals · open"
                   value={proposalOpen}
                   hue={proposalOpen > 0 ? "var(--hue-info)" : undefined}
                   onClick={() => onNavigate("proposals")}
                 />
-                <OverviewTile
+                <StatLegendItem
+                  token="expired"
                   label="proposals · expired"
                   value={proposalExpired}
                   hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
+                  attention={proposalExpired > 0}
                   onClick={() => onNavigate("proposals")}
                 />
               </div>
-            </div>
+            </StageCard>
           </div>
 
-          {/* Stage 2: Execution Fleet & Capacity (Fixed Hue Budget) */}
-          <div>
-            <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-              3. Execution Fleet & Capacity
+          {/* Stage 3: Execution Fleet & Capacity Card */}
+          <StageCard
+            index={3}
+            title="Execution Fleet & Capacity"
+            headline={inflightTotal}
+            headlineHue={inflightTotal > 0 ? "var(--hue-info)" : undefined}
+            meta="in flight"
+          >
+            {/* Sub-row 1: Active In-Flight Workloads */}
+            <div className="mb-1 text-[11px] font-medium text-(--text-faint)">
+              Active In-Flight Pipeline
             </div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
-              {activeRunStates.map((k) => {
-                const value = runValue(k);
-                // Fix hue budget (WM-205): normal running runs are not warnings!
-                const activeHue =
-                  value > 0
-                    ? k === "RUNNING" || k === "LEASED"
-                      ? "var(--hue-info)"
-                      : k === "VERIFYING"
-                        ? "var(--hue-verify)"
-                        : undefined
-                    : undefined;
-                return (
-                  <OverviewTile
-                    key={k}
-                    label={`active · ${k.toLowerCase()}`}
-                    value={value}
-                    hue={activeHue}
-                    onClick={() => onJumpRuns(k)}
-                  />
-                );
-              })}
-              {terminalRunStates.map((k) => {
-                const value = runValue(k);
-                const terminalHue =
-                  value > 0
-                    ? k === "COMPLETED"
-                      ? "var(--hue-ok)"
-                      : k === "FAILED"
-                        ? "var(--hue-err)"
-                        : k === "TIMED_OUT"
-                          ? "var(--hue-warn)"
-                          : undefined
-                    : undefined;
-                return (
-                  <OverviewTile
-                    key={k}
-                    label={`runs · ${k.toLowerCase()}`}
-                    value={value}
-                    hue={terminalHue}
-                    onClick={() => onJumpRuns(k)}
-                  />
-                );
-              })}
-              <OverviewTile
-                label="workers · live"
-                value={s.workers.live}
-                hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
-                onClick={() => onNavigate("workers")}
-                factoryWide={factoryWide}
-              />
-              <OverviewTile
-                label="workers · busy"
-                value={s.workers.busy}
-                hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
-                onClick={() => onNavigate("workers")}
-                factoryWide={factoryWide}
-              />
-              <OverviewTile
-                label="workers · stale"
-                value={s.workers.stale}
-                hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
-                onClick={() => onNavigate("workers")}
-                factoryWide={factoryWide}
-              />
-            </div>
-          </div>
-
-          {/* Band C: Fleet Capacity Utilization & Recent Outcomes Strip (WM-205) */}
-          <div className="grid gap-4 lg:grid-cols-2">
-            <FleetCapacityMeter
-              live={s.workers.live}
-              busy={s.workers.busy}
-              stale={s.workers.stale}
-              onClick={() => onNavigate("workers")}
+            <SegmentMeter
+              segments={inflightSegs}
+              onSegment={(k) => onJumpRuns(k)}
             />
-            <RecentOutcomesStrip
-              entries={feed.entries}
-              now={now}
-              onJumpRun={onJumpRun}
-            />
-          </div>
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              {inflightSegs.map((seg) => (
+                <StatLegendItem
+                  key={seg.key}
+                  token={seg.key}
+                  label={`active · ${seg.label}`}
+                  value={seg.value}
+                  hue={seg.value > 0 ? seg.hue : undefined}
+                  onClick={() => onJumpRuns(seg.key)}
+                />
+              ))}
+            </div>
 
-          {/* Band D: Artifact Store Housekeeping */}
-          <div>
-            <div className="mb-1.5 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
-              4. Artifact Store
-            </div>
-            <div className="grid grid-cols-3 gap-2 lg:max-w-md">
-              <OverviewTile label="artifacts · files" value={s.artifacts.files} factoryWide={factoryWide} />
-              <OverviewTile label="artifacts · size" value={humanSize(s.artifacts.bytes)} factoryWide={factoryWide} />
-              <OverviewTile
-                label="artifacts · orphans"
-                value={s.artifacts.orphans}
-                hue={s.artifacts.orphanBytes > 0 ? "var(--hue-warn)" : undefined}
-                factoryWide={factoryWide}
+            {/* Sub-row 2: Outcomes */}
+            <div className="mt-3.5 border-t border-(--border) pt-2.5">
+              <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+                <span className="font-medium text-(--text-faint)">Terminal Outcomes</span>
+                <span className="mono text-(--text-dim)">
+                  {finishedTotal > 0 ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} total)` : "no terminal runs"}
+                </span>
+              </div>
+              <SegmentMeter
+                segments={terminalSegs}
+                onSegment={(k) => onJumpRuns(k)}
               />
+              <div className="mt-2 flex flex-wrap items-center gap-1">
+                {terminalSegs.map((seg) => (
+                  <StatLegendItem
+                    key={seg.key}
+                    token={seg.key}
+                    label={`runs · ${seg.label}`}
+                    value={seg.value}
+                    hue={seg.value > 0 ? seg.hue : undefined}
+                    attention={ATTENTION_KEYS.has(seg.key)}
+                    onClick={() => onJumpRuns(seg.key)}
+                  />
+                ))}
+              </div>
             </div>
+
+            {/* Sub-row 3: Worker Fleet Capacity */}
+            <div className="mt-3.5 border-t border-(--border) pt-2.5">
+              <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+                <span className="font-medium text-(--text-faint)">
+                  Worker Fleet Capacity{factoryWide ? " · factory-wide" : ""}
+                </span>
+                <span className="mono text-(--text-dim)">
+                  {s.workers.live} live · {s.workers.busy} busy · {idleWorkers} idle{s.workers.stale > 0 ? ` · ${s.workers.stale} stale` : ""}
+                </span>
+              </div>
+              <SegmentMeter
+                segments={[
+                  { key: "busy", label: "busy", value: s.workers.busy, hue: "var(--hue-info)" },
+                  { key: "idle", label: "idle", value: idleWorkers, hue: "var(--hue-ok)" },
+                  { key: "stale", label: "stale", value: s.workers.stale, hue: "var(--hue-warn)" },
+                ]}
+                onSegment={() => onNavigate("workers")}
+              />
+              <div className="mt-2 flex flex-wrap items-center gap-1">
+                <StatLegendItem
+                  token="live"
+                  label="workers · live"
+                  value={s.workers.live}
+                  hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
+                  onClick={() => onNavigate("workers")}
+                  factoryWide={factoryWide}
+                />
+                <StatLegendItem
+                  token="busy"
+                  label="workers · busy"
+                  value={s.workers.busy}
+                  hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
+                  onClick={() => onNavigate("workers")}
+                  factoryWide={factoryWide}
+                />
+                <StatLegendItem
+                  token="stale"
+                  label="workers · stale"
+                  value={s.workers.stale}
+                  hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
+                  attention={s.workers.stale > 0}
+                  onClick={() => onNavigate("workers")}
+                  factoryWide={factoryWide}
+                />
+              </div>
+            </div>
+          </StageCard>
+
+          {/* Band C: Recent Outcomes Strip */}
+          <RecentOutcomesStrip
+            entries={feed.entries}
+            now={now}
+            onJumpRun={onJumpRun}
+          />
+
+          {/* Band D: Artifact Store Housekeeping Line */}
+          <div className="flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-(--text)">Artifacts Store</span>
+              <span className="text-(--text-faint)">·</span>
+              <span className="mono">{s.artifacts.files} files</span>
+              <span className="text-(--text-faint)">·</span>
+              <span className="mono">{humanSize(s.artifacts.bytes)}</span>
+              {s.artifacts.orphans > 0 && (
+                <>
+                  <span className="text-(--text-faint)">·</span>
+                  <span className="mono text-(--hue-warn)">{s.artifacts.orphans} orphans</span>
+                </>
+              )}
+            </div>
+            {factoryWide && <span className="text-[11px] text-(--text-faint)">factory-wide</span>}
           </div>
         </div>
       )}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -17,6 +17,7 @@ import {
   JumpLink,
   Section,
   StateBadge,
+  StateIcon,
   VerbError,
   ago,
   copyText,
@@ -25,154 +26,6 @@ import {
 } from "../components/ui";
 
 const FEED_CAP = 50;
-
-/**
- * 14px viewBox, 1.5px stroke state icons per OPS-498 / §5.2.
- * Shape is redundancy for color-blind and peripheral reading.
- */
-export function StateIcon({ state, className = "size-3.5 shrink-0" }: { state: string; className?: string }) {
-  const norm = state.toLowerCase();
-  switch (norm) {
-    case "admitted":
-      return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="3" />
-        </svg>
-      );
-    case "planned":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <polygon points="5,3.5 10.5,7 5,10.5" fill="currentColor" fillOpacity="0.2" />
-        </svg>
-      );
-    case "noop":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <line x1="4" y1="7" x2="10" y2="7" />
-        </svg>
-      );
-    case "human_needed":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
-          <path d="M7 2.5 L12 11.5 L2 11.5 Z" fill="currentColor" fillOpacity="0.18" />
-          <line x1="7" y1="5.5" x2="7" y2="8" />
-          <circle cx="7" cy="9.8" r="0.5" fill="currentColor" />
-        </svg>
-      );
-    case "dead_lettered":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <line x1="3.8" y1="10.2" x2="10.2" y2="3.8" />
-        </svg>
-      );
-    case "queued":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeDasharray="2 2" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-        </svg>
-      );
-    case "leased":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <circle cx="7" cy="7" r="1.8" fill="currentColor" />
-        </svg>
-      );
-    case "running":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
-        </svg>
-      );
-    case "verifying":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="6" cy="6" r="3.5" />
-          <line x1="8.5" y1="8.5" x2="11.5" y2="11.5" />
-        </svg>
-      );
-    case "completed":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
-          <polyline points="4.8,7.2 6.3,8.7 9.3,5.3" />
-        </svg>
-      );
-    case "failed":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
-          <line x1="5" y1="5" x2="9" y2="9" />
-          <line x1="9" y1="5" x2="5" y2="9" />
-        </svg>
-      );
-    case "timed_out":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <polyline points="7,4.5 7,7 9,7" />
-        </svg>
-      );
-    case "cancelled":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <line x1="4" y1="7" x2="10" y2="7" />
-        </svg>
-      );
-    case "refused":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <line x1="10" y1="4" x2="4" y2="10" />
-        </svg>
-      );
-    case "open":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" strokeDasharray="3 2" />
-        </svg>
-      );
-    case "expired":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
-          <line x1="7" y1="4" x2="7" y2="7.5" />
-          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
-        </svg>
-      );
-    case "live":
-    case "idle":
-      return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="3.5" />
-        </svg>
-      );
-    case "busy":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" />
-          <path d="M7 2.5 A4.5 4.5 0 0 1 7 11.5 Z" fill="currentColor" />
-        </svg>
-      );
-    case "stale":
-      return (
-        <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="4.5" fill="currentColor" fillOpacity="0.18" />
-          <line x1="7" y1="4" x2="7" y2="7.5" />
-          <circle cx="7" cy="9.5" r="0.5" fill="currentColor" />
-        </svg>
-      );
-    default:
-      return (
-        <svg viewBox="0 0 14 14" fill="currentColor" className={className} aria-hidden="true">
-          <circle cx="7" cy="7" r="2.5" />
-        </svg>
-      );
-  }
-}
 
 export interface Segment {
   key: string;
@@ -282,7 +135,7 @@ export function StageCard({
   children,
   className = "",
 }: {
-  index: number;
+  index?: number;
   title: string;
   headline?: ReactNode;
   headlineHue?: string;
@@ -294,7 +147,7 @@ export function StageCard({
     <section className={`rounded-lg border border-(--border) bg-(--surface-1) p-3.5 ${className}`}>
       <div className="mb-2.5 flex items-baseline justify-between gap-3">
         <h2 className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">
-          {index}. {title}
+          {index != null ? `${index}. ${title}` : title}
         </h2>
         <div className="flex items-baseline gap-2">
           {meta && <span className="text-[11px] text-(--text-faint)">{meta}</span>}
@@ -534,7 +387,7 @@ function RecentOutcomesStrip({
     <div className="rounded-lg border border-(--border) bg-(--surface-1) p-3.5">
       <div className="mb-2 flex items-baseline justify-between text-[11px]">
         <span className="font-medium uppercase tracking-wide text-(--text-faint)">
-          Recent Outcomes ({outcomes.length})
+          Recent Outcomes · last {outcomes.length}
         </span>
         <span className="text-[11px] text-(--text-faint)">newest → oldest</span>
       </div>
@@ -553,7 +406,7 @@ function RecentOutcomesStrip({
               key={o.seq}
               type="button"
               onClick={() => onJumpRun(o.runId)}
-              className="h-4 w-2 rounded-xs transition-opacity hover:opacity-100 opacity-80"
+              className="h-4 w-2 cursor-pointer rounded-xs transition-all hover:scale-125 hover:opacity-100 opacity-80"
               style={{ backgroundColor: hue }}
               title={`${o.runId} · ${o.to}${o.reason ? ` (${o.reason})` : ""} · ${ago(o.at, now)}`}
             />
@@ -613,8 +466,8 @@ export function Overview({
   onJumpRuns,
   onNavigate,
   onJumpExpired: _onJumpExpired,
-  onJumpGraph,
-  onInject,
+  onJumpGraph: _onJumpGraph,
+  onInject: _onInject,
 }: {
   connected: boolean;
   context: OperatorContext;
@@ -623,9 +476,9 @@ export function Overview({
   onJumpEvents: (focus: EventFocus) => void;
   onJumpRuns: (state?: string) => void;
   onNavigate: (path: string) => void;
-  onJumpExpired: () => void;
-  onJumpGraph: () => void;
-  onInject: () => void;
+  onJumpExpired?: () => void;
+  onJumpGraph?: () => void;
+  onInject?: () => void;
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
@@ -780,14 +633,6 @@ export function Overview({
     <div className="h-full min-w-0 overflow-auto p-5">
       <div className="mb-4 flex items-baseline justify-between gap-3">
         <h1 className="display text-lg font-semibold">Overview</h1>
-        <div className="flex gap-3 text-[12px] text-(--text-dim)">
-          <button type="button" className="hover:text-(--accent)" onClick={onJumpGraph}>
-            Graph
-          </button>
-          <button type="button" className="hover:text-(--accent)" onClick={onInject}>
-            Inject event…
-          </button>
-        </div>
       </div>
       <OverviewScopeNotice context={context} />
 
@@ -883,11 +728,9 @@ export function Overview({
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-(--hue-ok)" />
             <span className="font-medium text-(--text)">Doctor: All systems nominal</span>
-            <span className="text-(--text-faint)">·</span>
-            <span className="text-(--text-faint)">No active anomalies detected</span>
           </div>
           <div className="text-[11px] text-(--text-faint)">
-            {feedsUnscoped ? "factory-wide" : "in scope"}
+            {feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}
           </div>
         </div>
       )}
@@ -899,121 +742,153 @@ export function Overview({
         </div>
       ) : (
         <div className="mb-6 flex flex-col gap-4">
-          {/* Stage 1 & Stage 2 in 2-column layout */}
-          <div className="grid gap-4 lg:grid-cols-3">
-            {/* Stage 1: Event Intake & Triage Card */}
-            <StageCard
-              index={1}
-              title="Event Intake & Triage"
-              headline={intakeTotal}
-              meta={intakeTotal > 0 ? `${intakeTotal} total` : "no events yet"}
-              className="lg:col-span-2"
-            >
-              <SegmentMeter
-                segments={eventSegs}
-                onSegment={(k) => onJumpEvents({ status: k })}
-              />
-              <div className="mt-2.5 flex flex-wrap items-center gap-1">
-                {eventSegs.map((seg) => (
-                  <StatLegendItem
-                    key={seg.key}
-                    token={seg.key}
-                    label={`events · ${seg.key}`}
-                    value={seg.value}
-                    hue={seg.value > 0 ? seg.hue : undefined}
-                    attention={ATTENTION_KEYS.has(seg.key)}
-                    onClick={() => onJumpEvents({ status: seg.key })}
-                  />
-                ))}
-              </div>
-            </StageCard>
-
-            {/* Stage 2: Watched Approval Gate Card */}
-            <StageCard
-              index={2}
-              title="Watched Approval Gate"
-              headline={proposalTotal}
-              headlineHue={proposalExpired > 0 ? "var(--hue-warn)" : proposalOpen > 0 ? "var(--hue-info)" : undefined}
-              meta={proposalExpired > 0 ? `${proposalExpired} expired` : "gate queue"}
-            >
-              <SegmentMeter
-                segments={proposalSegs}
-                onSegment={() => onNavigate("proposals")}
-              />
-              <div className="mt-2.5 flex flex-wrap items-center gap-1">
-                <StatLegendItem
-                  token="open"
-                  label="proposals · open"
-                  value={proposalOpen}
-                  hue={proposalOpen > 0 ? "var(--hue-info)" : undefined}
-                  onClick={() => onNavigate("proposals")}
-                />
-                <StatLegendItem
-                  token="expired"
-                  label="proposals · expired"
-                  value={proposalExpired}
-                  hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
-                  attention={proposalExpired > 0}
-                  onClick={() => onNavigate("proposals")}
-                />
-              </div>
-            </StageCard>
-          </div>
-
-          {/* Stage 3: Execution Fleet & Capacity Card */}
+          {/* Card 1: Intake & Approval Gate */}
           <StageCard
-            index={3}
-            title="Execution Fleet & Capacity"
+            title="Intake & Approval Gate"
+            headline={intakeTotal + proposalTotal}
+            meta="total"
+          >
+            {/* Sub-row 1: Event Intake */}
+            <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+              <span className="font-medium text-(--text-faint)">Event Intake</span>
+              <span className="mono text-(--text-dim)">
+                {intakeTotal > 0 ? `${intakeTotal} events` : "no events yet"}
+              </span>
+            </div>
+            {intakeTotal > 0 ? (
+              <>
+                <SegmentMeter
+                  segments={eventSegs}
+                  onSegment={(k) => onJumpEvents({ status: k })}
+                />
+                <div className="mt-2 flex flex-wrap items-center gap-1">
+                  {eventSegs.map((seg) => (
+                    <StatLegendItem
+                      key={seg.key}
+                      token={seg.key}
+                      label={`events · ${seg.key}`}
+                      value={seg.value}
+                      hue={seg.value > 0 ? seg.hue : undefined}
+                      attention={ATTENTION_KEYS.has(seg.key)}
+                      onClick={() => onJumpEvents({ status: seg.key })}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="text-[12px] text-(--text-faint)">no events yet</div>
+            )}
+
+            {/* Sub-row 2: Approval Gate */}
+            <div className="mt-3.5 border-t border-(--border) pt-2.5">
+              <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+                <span className="font-medium text-(--text-faint)">Approval Gate</span>
+                <span className="mono text-(--text-dim)">
+                  {proposalTotal > 0
+                    ? `${proposalExpired > 0 ? `${proposalExpired} expired · ` : ""}${proposalOpen} open`
+                    : "no proposals in gate"}
+                </span>
+              </div>
+              {proposalTotal > 0 ? (
+                <>
+                  <SegmentMeter
+                    segments={proposalSegs}
+                    onSegment={() => onNavigate("proposals")}
+                  />
+                  <div className="mt-2 flex flex-wrap items-center gap-1">
+                    <StatLegendItem
+                      token="open"
+                      label="proposals · open"
+                      value={proposalOpen}
+                      hue={proposalOpen > 0 ? "var(--hue-info)" : undefined}
+                      onClick={() => onNavigate("proposals")}
+                    />
+                    <StatLegendItem
+                      token="expired"
+                      label="proposals · expired"
+                      value={proposalExpired}
+                      hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
+                      attention={proposalExpired > 0}
+                      onClick={() => onNavigate("proposals")}
+                    />
+                  </div>
+                </>
+              ) : (
+                <div className="text-[12px] text-(--text-faint)">no proposals in gate</div>
+              )}
+            </div>
+          </StageCard>
+
+          {/* Card 2: Execution & Fleet Capacity */}
+          <StageCard
+            title="Execution & Fleet Capacity"
             headline={inflightTotal}
             headlineHue={inflightTotal > 0 ? "var(--hue-info)" : undefined}
             meta="in flight"
           >
             {/* Sub-row 1: Active In-Flight Workloads */}
-            <div className="mb-1 text-[11px] font-medium text-(--text-faint)">
-              Active In-Flight Pipeline
+            <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+              <span className="font-medium text-(--text-faint)">Active In-Flight Pipeline</span>
+              <span className="mono text-(--text-dim)">
+                {inflightTotal > 0 ? `${inflightTotal} active` : "nothing in flight"}
+              </span>
             </div>
-            <SegmentMeter
-              segments={inflightSegs}
-              onSegment={(k) => onJumpRuns(k)}
-            />
-            <div className="mt-2 flex flex-wrap items-center gap-1">
-              {inflightSegs.map((seg) => (
-                <StatLegendItem
-                  key={seg.key}
-                  token={seg.key}
-                  label={`active · ${seg.label}`}
-                  value={seg.value}
-                  hue={seg.value > 0 ? seg.hue : undefined}
-                  onClick={() => onJumpRuns(seg.key)}
+            {inflightTotal > 0 ? (
+              <>
+                <SegmentMeter
+                  segments={inflightSegs}
+                  onSegment={(k) => onJumpRuns(k)}
                 />
-              ))}
-            </div>
+                <div className="mt-2 flex flex-wrap items-center gap-1">
+                  {inflightSegs.map((seg) => (
+                    <StatLegendItem
+                      key={seg.key}
+                      token={seg.key}
+                      label={`active · ${seg.label}`}
+                      value={seg.value}
+                      hue={seg.value > 0 ? seg.hue : undefined}
+                      onClick={() => onJumpRuns(seg.key)}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="text-[12px] text-(--text-faint)">nothing in flight</div>
+            )}
 
             {/* Sub-row 2: Outcomes */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
               <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
                 <span className="font-medium text-(--text-faint)">Terminal Outcomes</span>
                 <span className="mono text-(--text-dim)">
-                  {finishedTotal > 0 ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} total)` : "no terminal runs"}
+                  {finishedTotal > 0
+                    ? `${Math.round((okTotal / finishedTotal) * 100)}% completed (${finishedTotal} total)`
+                    : "no terminal runs"}
                 </span>
               </div>
-              <SegmentMeter
-                segments={terminalSegs}
-                onSegment={(k) => onJumpRuns(k)}
-              />
-              <div className="mt-2 flex flex-wrap items-center gap-1">
-                {terminalSegs.map((seg) => (
-                  <StatLegendItem
-                    key={seg.key}
-                    token={seg.key}
-                    label={`runs · ${seg.label}`}
-                    value={seg.value}
-                    hue={seg.value > 0 ? seg.hue : undefined}
-                    attention={ATTENTION_KEYS.has(seg.key)}
-                    onClick={() => onJumpRuns(seg.key)}
+              {finishedTotal > 0 ? (
+                <>
+                  <SegmentMeter
+                    segments={terminalSegs}
+                    onSegment={(k) => onJumpRuns(k)}
                   />
-                ))}
-              </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-1">
+                    {terminalSegs.map((seg) => (
+                      <StatLegendItem
+                        key={seg.key}
+                        token={seg.key}
+                        label={`runs · ${seg.label}`}
+                        value={seg.value}
+                        hue={seg.value > 0 ? seg.hue : undefined}
+                        attention={ATTENTION_KEYS.has(seg.key)}
+                        onClick={() => onJumpRuns(seg.key)}
+                      />
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div className="text-[12px] text-(--text-faint)">no terminal runs</div>
+              )}
             </div>
 
             {/* Sub-row 3: Worker Fleet Capacity */}
@@ -1133,7 +1008,7 @@ export function Overview({
                     className="truncate text-(--text-faint)"
                     title={`by ${g.actor}${g.reason ? ` (${g.reason})` : ""}${g.count > 1 ? ` · ${g.count} transitions` : ""}`}
                   >
-                    by {g.actor}
+                    by {shortId(g.actor)}
                     {g.reason ? ` (${g.reason})` : ""}
                     {g.count > 1 ? ` · ${g.count} transitions` : ""}
                   </span>
@@ -1144,7 +1019,7 @@ export function Overview({
         </Section>
 
         <Section
-          title={feedsUnscoped ? "Outbox — published results · factory-wide" : "Outbox — published results"}
+          title={feedsUnscoped ? "Outbox · published results · factory-wide" : "Outbox · published results"}
           card={false}
         >
           <div id="outbox">

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
-import { hashPath } from "../hash";
 import { useNow, useRequeuePoll } from "../hooks";
 import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
 import type { OperatorContext } from "../context";
@@ -93,6 +92,7 @@ export function StatLegendItem({
   attention = false,
   onClick,
   factoryWide = false,
+  total,
 }: {
   token: string;
   label: string;
@@ -101,16 +101,22 @@ export function StatLegendItem({
   attention?: boolean;
   onClick?: () => void;
   factoryWide?: boolean;
+  total?: number;
 }) {
   const isZero = value === 0 || value === "0";
   const lit = attention && !isZero && hue;
   const fullLabel = factoryWide ? `${label} · factory-wide` : label;
+  const pctStr =
+    typeof total === "number" && total > 0 && typeof value === "number"
+      ? ` (${Math.round((value / total) * 100)}%)`
+      : "";
 
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label={`${fullLabel}: ${value}`}
+      title={`${label}: ${value}${pctStr}`}
       style={lit ? { color: hue } : undefined}
       className={`group flex min-h-7 cursor-pointer items-center gap-1.5 rounded-md border border-transparent px-2 py-0.5 text-left text-[12px] transition-all hover:border-(--border) hover:bg-(--surface-2) focus-visible:border-(--accent) focus-visible:outline-none ${
         isZero ? "opacity-60 text-(--text-faint)" : "text-(--text-dim)"
@@ -298,45 +304,35 @@ export function buildAnomalyRows(
     rows.push({
       kind: "dead_letter",
       text: `dead-lettered (${d.source}, ${d.eventId}): ${d.lastError ?? "unknown error"}`,
-      links: [
-        {
-          label: "View event",
-          go: () => callbacks.onJumpEvents({ status: "dead_lettered", source: d.source, eventId: d.eventId }),
-        },
-      ],
+      links: [{ label: "View event", go: () => callbacks.onJumpEvents({ source: d.source, eventId: d.eventId }) }],
       requeue: { source: d.source, eventId: d.eventId },
     });
   }
   for (const w of anomalies.stalledWorkers) {
-    const ageStr = now ? ago(w.lastSeen, now) : "stalled";
     rows.push({
       kind: "worker",
-      text: `stalled worker ${w.workerId} still holds run ${w.runId} — last heartbeat ${ageStr} on ${w.host}`,
+      text: `stalled worker ${w.workerId} still holds run ${w.runId} (host ${w.host}, last seen ${now ? ago(w.lastSeen, now) : "recently"})`,
       links: [
-        { label: "View worker", go: () => callbacks.onNavigate(hashPath("workers", w.workerId)) },
+        { label: "View worker", go: () => callbacks.onNavigate("workers") },
         { label: "View run", go: () => callbacks.onJumpRun(w.runId) },
       ],
     });
   }
-  for (const amb of anomalies.ambiguousOpenProposals ?? []) {
+  for (const a of anomalies.ambiguousOpenProposals) {
     rows.push({
       kind: "ambiguous",
-      text: `ambiguous open proposals: ${amb.count} open proposals exist for run ${amb.runId}`,
+      text: `ambiguous open proposals: ${a.count} proposals target run ${a.runId}`,
       links: [
-        { label: "View run", go: () => callbacks.onJumpRun(amb.runId) },
         { label: "View proposals", go: () => callbacks.onNavigate("proposals") },
+        { label: "View run", go: () => callbacks.onJumpRun(a.runId) },
       ],
     });
   }
-  if (anomalies.noWorkers) {
-    const queued = s?.runs.byState.QUEUED ?? 0;
+  if (anomalies.noWorkers && (s?.runs.byState?.QUEUED ?? 0) > 0) {
     rows.push({
       kind: "capacity",
-      text: `${queued} queued run${queued === 1 ? "" : "s"} and no live worker to claim ${queued === 1 ? "it" : "them"} — nothing will start until one registers`,
-      links: [
-        { label: "View workers", go: () => callbacks.onNavigate("workers") },
-        { label: "View queued runs", go: () => callbacks.onJumpRuns("QUEUED") },
-      ],
+      text: `${s?.runs.byState?.QUEUED ?? 0} queued runs and no live worker available to claim them`,
+      links: [{ label: "View workers", go: () => callbacks.onNavigate("workers") }],
     });
   }
 
@@ -345,16 +341,16 @@ export function buildAnomalyRows(
 
 function CategoryPill({ kind }: { kind: AnomalyKind }) {
   const labels: Record<AnomalyKind, string> = {
-    proposal: "PROPOSAL",
-    dead_letter: "DEAD-LETTER",
-    lease: "STALLED LEASE",
-    worker: "WORKER LEASE",
-    outbox: "OUTBOX",
-    capacity: "CAPACITY",
-    ambiguous: "AMBIGUOUS",
+    proposal: "proposal",
+    dead_letter: "dead-letter",
+    lease: "stalled lease",
+    worker: "worker lease",
+    outbox: "outbox",
+    capacity: "capacity",
+    ambiguous: "ambiguous",
   };
   return (
-    <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider bg-(--surface-2) text-(--hue-warn) border border-(--hue-warn)/20">
+    <span className="shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-(--text-dim)">
       {labels[kind]}
     </span>
   );
@@ -391,15 +387,21 @@ function RecentOutcomesStrip({
 
   if (outcomes.length === 0) return null;
 
+  // Chronological left-to-right (oldest -> newest at right)
+  const chrono = outcomes.slice().reverse();
+
   return (
-    <div className="rounded-lg border border-(--border) bg-(--surface-1) p-3.5">
+    <div
+      className="rounded-lg border border-(--border) bg-(--surface-1) p-3.5"
+      title="Recent outcomes (newest on the right)"
+    >
       <div className="mb-2 flex items-baseline justify-between text-[11px]">
         <span className="font-medium uppercase tracking-wide text-(--text-faint)">
           Recent Outcomes · last {outcomes.length}
         </span>
       </div>
       <div className="flex flex-wrap items-center gap-1.5">
-        {outcomes.map((o) => {
+        {chrono.map((o) => {
           const hue =
             o.to === "COMPLETED"
               ? "var(--hue-ok)"
@@ -415,7 +417,7 @@ function RecentOutcomesStrip({
               type="button"
               onClick={() => onJumpRun(o.runId)}
               aria-label={label}
-              className="h-4 w-2 cursor-pointer rounded-xs transition-all hover:scale-125 hover:opacity-100 opacity-80"
+              className="h-4 w-2 cursor-pointer rounded-xs opacity-80 transition-all hover:scale-125 hover:opacity-100 hover:ring-1 hover:ring-(--text) focus-visible:ring-2 focus-visible:ring-(--accent)"
               style={{ backgroundColor: hue }}
               title={`${o.runId} · ${o.to}${o.reason ? ` (${o.reason})` : ""} · ${ago(o.at, now)}`}
             />
@@ -647,11 +649,17 @@ export function Overview({
 
       {/* Band A: Promoted Doctor Deck or Nominal Status (WM-205) */}
       {hasAnomalies ? (
-        <div className="mb-5 rounded-lg border border-(--hue-warn) bg-[color-mix(in_oklch,var(--hue-warn)_8%,var(--surface-1))] p-3">
+        <div
+          className="mb-5 rounded-lg border p-3"
+          style={{
+            borderColor: "var(--hue-warn)",
+            backgroundColor: "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
+          }}
+        >
           <div className="mb-2 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-[12px] font-semibold text-(--hue-warn) uppercase tracking-wide">
+            <div className="flex items-center gap-2 text-[12px] font-semibold text-(--hue-warn)">
               <span className="size-2 rounded-full bg-(--hue-warn) motion-safe:animate-pulse" />
-              Doctor Anomaly Deck · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
+              Anomalies · {anomalyRows.length} active issue{anomalyRows.length === 1 ? "" : "s"}
               {feedsUnscoped ? " · factory-wide" : ""}
             </div>
           </div>
@@ -664,35 +672,34 @@ export function Overview({
                 <div className="min-w-0 flex items-start sm:items-center gap-2">
                   <CategoryPill kind={a.kind} />
                   {a.proposalId ? (
-                    <span className="min-w-0 flex flex-col gap-0.5 text-[12px] text-(--hue-warn)">
-                      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words">
-                        <span>expired open proposal</span>
-                        <span className="text-(--text-faint)">·</span>
-                        <span>agent: {a.proposal?.agent ?? "—"}</span>
-                        <span className="text-(--text-faint)">·</span>
-                        <span>
-                          {a.proposal?.decision ?? "—"}
-                          {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
-                        </span>
-                        <span className="text-(--text-faint)">·</span>
-                        <span className="text-(--text-faint)">
-                          origin {a.proposal?.eventSource ?? "—"}/{a.proposal?.eventId ?? "—"}
-                        </span>
-                        <span className="text-(--text-faint)">·</span>
-                        {a.proposal?.created_at ? (
-                          <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
-                        ) : (
-                          <span className="text-(--text-faint)">age —</span>
-                        )}
-                      </span>
+                    <div className="min-w-0 flex flex-wrap items-center gap-x-2 gap-y-0.5 break-words text-[12px] text-(--hue-warn)">
+                      <span>expired open proposal</span>
+                      <span className="text-(--text-faint)">·</span>
                       <span
-                        className="mono truncate text-[11px] text-(--text-faint) cursor-pointer"
+                        className="mono text-[11px] text-(--text-dim) cursor-pointer hover:underline"
                         title={`${a.proposalId} — click to copy`}
                         onClick={() => copyText(a.proposalId!, "proposal id")}
                       >
-                        {a.proposalId}
+                        {shortId(a.proposalId)}
                       </span>
-                    </span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span>agent: {a.proposal?.agent ?? "—"}</span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span>
+                        {a.proposal?.decision ?? "—"}
+                        {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
+                      </span>
+                      <span className="text-(--text-faint)">·</span>
+                      <span className="text-(--text-faint)">
+                        origin {a.proposal?.eventSource ?? "—"}/{a.proposal?.eventId ?? "—"}
+                      </span>
+                      <span className="text-(--text-faint)">·</span>
+                      {a.proposal?.created_at ? (
+                        <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
+                      ) : (
+                        <span className="text-(--text-faint)">age —</span>
+                      )}
+                    </div>
                   ) : (
                     <span
                       className="min-w-0 break-words sm:truncate text-[12px]"
@@ -711,14 +718,6 @@ export function Overview({
                   >
                     copy
                   </button>
-                  {a.requeue && (
-                    <Button
-                      disabled={!connected || requeue.isPending}
-                      onClick={() => requeue.mutate(a.requeue!)}
-                    >
-                      Requeue
-                    </Button>
-                  )}
                   {a.dismissProposalId && (
                     <Button
                       disabled={!connected || dismiss.isPending}
@@ -727,8 +726,20 @@ export function Overview({
                       Dismiss
                     </Button>
                   )}
-                  {a.links.map((l) => (
-                    <Button key={l.label} onClick={l.go}>
+                  {a.requeue && (
+                    <Button
+                      disabled={!connected || requeue.isPending}
+                      onClick={() => requeue.mutate(a.requeue!)}
+                    >
+                      Requeue
+                    </Button>
+                  )}
+                  {a.links.map((l, idx) => (
+                    <Button
+                      key={l.label}
+                      variant={idx === 0 ? "primary" : "default"}
+                      onClick={l.go}
+                    >
                       {l.label}
                     </Button>
                   ))}
@@ -770,9 +781,6 @@ export function Overview({
             {/* Sub-row 1: Event Intake */}
             <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
               <span className="font-semibold text-(--text)">Event Intake</span>
-              <span className="mono text-(--text-dim)">
-                {intakeTotal > 0 ? `${intakeTotal} events` : "no events yet"}
-              </span>
             </div>
             {intakeTotal > 0 ? (
               <>
@@ -790,6 +798,7 @@ export function Overview({
                       hue={seg.value > 0 ? seg.hue : undefined}
                       attention={ATTENTION_KEYS.has(seg.key)}
                       onClick={() => onJumpEvents({ status: seg.key })}
+                      total={intakeTotal}
                     />
                   ))}
                 </div>
@@ -821,6 +830,7 @@ export function Overview({
                       value={proposalOpen}
                       hue={proposalOpen > 0 ? "var(--hue-info)" : undefined}
                       onClick={() => onNavigate("proposals")}
+                      total={proposalTotal}
                     />
                     <StatLegendItem
                       token="expired"
@@ -829,6 +839,7 @@ export function Overview({
                       hue={proposalExpired > 0 ? "var(--hue-warn)" : undefined}
                       attention={proposalExpired > 0}
                       onClick={() => onNavigate("proposals")}
+                      total={proposalTotal}
                     />
                   </div>
                 </>
@@ -841,16 +852,15 @@ export function Overview({
           {/* Card 2: Execution & Fleet Capacity */}
           <StageCard
             title="Execution & Fleet Capacity"
-            headline={inflightTotal}
-            headlineHue={inflightTotal > 0 ? "var(--hue-info)" : undefined}
-            meta="in flight"
+            headline={finishedTotal + inflightTotal}
+            meta="runs"
           >
             {/* Sub-row 1: Active In-Flight Workloads */}
             <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
               <span className="font-semibold text-(--text)">Active In-Flight Pipeline</span>
-              <span className="mono text-(--text-dim)">
-                {inflightTotal > 0 ? `${inflightTotal} active` : "nothing in flight"}
-              </span>
+              {inflightTotal > 0 && (
+                <span className="mono text-(--text-dim)">{inflightTotal} active</span>
+              )}
             </div>
             {inflightTotal > 0 ? (
               <>
@@ -867,6 +877,7 @@ export function Overview({
                       value={seg.value}
                       hue={seg.value > 0 ? seg.hue : undefined}
                       onClick={() => onJumpRuns(seg.key)}
+                      total={inflightTotal}
                     />
                   ))}
                 </div>
@@ -901,6 +912,7 @@ export function Overview({
                         hue={seg.value > 0 ? seg.hue : undefined}
                         attention={ATTENTION_KEYS.has(seg.key)}
                         onClick={() => onJumpRuns(seg.key)}
+                        total={finishedTotal}
                       />
                     ))}
                   </div>
@@ -936,6 +948,7 @@ export function Overview({
                   hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
                   onClick={() => onNavigate("workers")}
                   factoryWide={factoryWide}
+                  total={s.workers.live + s.workers.stale}
                 />
                 <StatLegendItem
                   token="busy"
@@ -944,6 +957,7 @@ export function Overview({
                   hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
                   onClick={() => onNavigate("workers")}
                   factoryWide={factoryWide}
+                  total={s.workers.live + s.workers.stale}
                 />
                 <StatLegendItem
                   token="stale"
@@ -953,6 +967,7 @@ export function Overview({
                   attention={s.workers.stale > 0}
                   onClick={() => onNavigate("workers")}
                   factoryWide={factoryWide}
+                  total={s.workers.live + s.workers.stale}
                 />
               </div>
             </div>

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -358,22 +358,38 @@ export function Projects({
             </div>
           }
           actions={
+            sel.github ? (
+              <a
+                href={`https://github.com/${sel.github}`}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 py-1 text-[12px] font-medium text-(--text) transition-colors hover:bg-(--surface-3)"
+              >
+                GitHub
+              </a>
+            ) : null
+          }
+          utility={
             <>
-              <Button onClick={() => copyText(sel.path, "repo path")}>Copy path</Button>
-              <Button onClick={copyLink}>Copy link</Button>
-              {sel.github && (
-                <a
-                  href={`https://github.com/${sel.github}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="rounded border border-(--border) px-2 py-1 text-[12px] font-medium text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
-                >
-                  GitHub
-                </a>
-              )}
-              <Button onClick={() => onSelectRepo(null)}>Close</Button>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.path, "repo path")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                path
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
+          close={<Button onClick={() => onSelectRepo(null)}>Close</Button>}
         >
           <div className="space-y-4">
             <Section title="Quick Dispatch (Agent Tasks)">

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -27,14 +27,6 @@ function operatorContext(): OperatorContext {
   return contextFromProject(hashProject(typeof window === "undefined" ? "" : window.location.hash));
 }
 
-const TEAM_HUES: Record<string, string> = {
-  CLNT: "var(--hue-ok)",
-  WM: "var(--accent)",
-  CW: "var(--hue-info)",
-  LAB: "var(--hue-warn)",
-  OPS: "var(--text-dim)",
-};
-
 /** Projects view (OPS-300 + OPS-362): configured factory repositories and janitor maintenance. */
 export function Projects({
   connected,
@@ -179,7 +171,7 @@ export function Projects({
     const r = sel;
     setContextActions([
       {
-        label: `⚡ Dispatch Triage Scan on ${r.name}`,
+        label: `Dispatch Triage Scan on ${r.name}`,
         hint: "triage",
         run: () =>
           setDispatchConfirm({
@@ -190,7 +182,7 @@ export function Projects({
           }),
       },
       {
-        label: `⚡ Dispatch Status Report for ${r.name}`,
+        label: `Dispatch Status Report for ${r.name}`,
         hint: "status",
         run: () =>
           setDispatchConfirm({
@@ -201,7 +193,7 @@ export function Projects({
           }),
       },
       {
-        label: `⚡ Dispatch Janitor Scan on ${r.name}`,
+        label: `Dispatch Janitor Scan on ${r.name}`,
         hint: "janitor",
         run: () =>
           setDispatchConfirm({
@@ -283,7 +275,6 @@ export function Projects({
           </thead>
           <tbody>
             {visible.map((r, i) => {
-              const teamHue = r.team ? TEAM_HUES[r.team] ?? "var(--text-dim)" : "var(--text-dim)";
               return (
                 <tr
                   key={r.name}
@@ -294,13 +285,7 @@ export function Projects({
                   <td className="mono border-b border-(--border) px-3 py-1.5 font-semibold text-(--text)">{r.name}</td>
                   <td className="border-b border-(--border) px-3 py-1.5">
                     {r.team ? (
-                      <span
-                        className="rounded px-1.5 py-0.2 text-[10px] font-semibold tracking-wide"
-                        style={{
-                          color: teamHue,
-                          background: `color-mix(in oklch, ${teamHue} 15%, transparent)`,
-                        }}
-                      >
+                      <span className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11px] font-medium text-(--text-dim)">
                         {r.team}
                       </span>
                     ) : (
@@ -312,7 +297,7 @@ export function Projects({
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5">
                     <span
-                      className="rounded px-1.5 py-0.2 text-[10px] font-semibold uppercase tracking-wide"
+                      className="rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
                       style={
                         r.reportOnly
                           ? {
@@ -321,7 +306,7 @@ export function Projects({
                             }
                           : {
                               color: "var(--hue-ok)",
-                              background: "color-mix(in oklch, var(--hue-ok) 14%, transparent)",
+                              background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
                             }
                       }
                     >
@@ -362,17 +347,11 @@ export function Projects({
           widthClass="w-[540px]"
           title={
             <div className="flex items-center gap-2">
-              <span className="mono font-bold" title={sel.name}>
+              <span className="mono font-semibold" title={sel.name}>
                 {sel.name}
               </span>
               {sel.team && (
-                <span
-                  className="rounded px-1.5 py-0.2 text-[10px] font-semibold"
-                  style={{
-                    color: TEAM_HUES[sel.team] ?? "var(--text-dim)",
-                    background: `color-mix(in oklch, ${TEAM_HUES[sel.team] ?? "var(--text-dim)"} 15%, transparent)`,
-                  }}
-                >
+                <span className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11px] font-medium text-(--text-dim)">
                   {sel.team}
                 </span>
               )}
@@ -389,7 +368,7 @@ export function Projects({
                   rel="noreferrer"
                   className="rounded border border-(--border) px-2 py-1 text-[12px] font-medium text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
                 >
-                  GitHub ↗
+                  GitHub
                 </a>
               )}
               <Button onClick={() => onSelectRepo(null)}>Close</Button>
@@ -397,16 +376,16 @@ export function Projects({
           }
         >
           <div className="space-y-4">
-            <Section title="⚡ Quick Dispatch (Agent Tasks)">
+            <Section title="Quick Dispatch (Agent Tasks)">
               {env?.name === "live" && (
                 <div
                   className="mb-2 inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
                   style={{
                     color: "var(--hue-warn)",
-                    background: "color-mix(in oklch, var(--hue-warn) 15%, transparent)",
+                    background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
                   }}
                 >
-                  <span className="size-1.5 rounded-full" style={{ background: "var(--hue-warn)" }} />
+                  <span className="size-1.5 rounded-full bg-(--hue-warn)" />
                   Live Environment
                 </div>
               )}
@@ -422,7 +401,7 @@ export function Projects({
                     })
                   }
                 >
-                  ⚡ Triage Scan
+                  Triage Scan
                 </Button>
                 <Button
                   disabled={!connected || quickDispatchMutation.isPending}
@@ -435,7 +414,7 @@ export function Projects({
                     })
                   }
                 >
-                  ⚡ Status Report
+                  Status Report
                 </Button>
                 <Button
                   disabled={!connected || quickDispatchMutation.isPending}
@@ -448,7 +427,7 @@ export function Projects({
                     })
                   }
                 >
-                  ⚡ Janitor Scan
+                  Janitor Scan
                 </Button>
               </div>
               <div className="mt-1.5 text-[11px] text-(--text-faint)">
@@ -482,7 +461,7 @@ export function Projects({
                       rel="noreferrer"
                       className="text-(--accent) hover:underline"
                     >
-                      {sel.github} ↗
+                      {sel.github}
                     </a>
                   }
                 />
@@ -518,22 +497,22 @@ export function Projects({
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeUp ? 1 : 0.4 }}
                 >
-                  <div className="text-[10px] text-(--text-faint) uppercase">Up Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeUp ? "✓ Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">Up Script</div>
+                  <div className="font-semibold">{sel.hasWorktreeUp ? "Present" : "None"}</div>
                 </div>
                 <div
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeDown ? 1 : 0.4 }}
                 >
-                  <div className="text-[10px] text-(--text-faint) uppercase">Down Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeDown ? "✓ Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">Down Script</div>
+                  <div className="font-semibold">{sel.hasWorktreeDown ? "Present" : "None"}</div>
                 </div>
                 <div
                   className="rounded border border-(--border) p-2"
                   style={{ opacity: sel.hasWorktreeWarm ? 1 : 0.4 }}
                 >
-                  <div className="text-[10px] text-(--text-faint) uppercase">Warm Script</div>
-                  <div className="font-semibold">{sel.hasWorktreeWarm ? "✓ Present" : "None"}</div>
+                  <div className="text-[11px] text-(--text-faint) uppercase">Warm Script</div>
+                  <div className="font-semibold">{sel.hasWorktreeWarm ? "Present" : "None"}</div>
                 </div>
               </div>
             </Section>
@@ -652,7 +631,7 @@ export function Projects({
 
                     {dryResult.held && dryResult.held.length > 0 && (
                       <div>
-                        <div className="text-[11px]" style={{ color: "var(--hue-warn)" }}>
+                        <div className="text-[11px] text-(--hue-warn)">
                           Held by Open PR (Finished ticket, active PR):
                         </div>
                         <div className="mono mt-1 space-y-1">
@@ -662,10 +641,10 @@ export function Projects({
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
                               <div className="flex items-center gap-1.5">
-                                <span className="font-bold text-(--text)">{h.id}</span>
+                                <span className="font-semibold text-(--text)">{h.id}</span>
                                 {h.state && <span className="text-(--text-dim)">({h.state})</span>}
                                 {h.branch && (
-                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[10px] text-(--text-faint)">
+                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
                                     {h.branch}
                                   </span>
                                 )}
@@ -719,7 +698,7 @@ export function Projects({
                               key={id}
                               className="rounded border border-(--border) bg-(--surface-1) px-1.5 py-0.5 text-[11px] text-(--hue-ok)"
                             >
-                              ✓ {id}
+                              {id}
                             </span>
                           ))}
                         </div>
@@ -728,7 +707,7 @@ export function Projects({
 
                     {applyResult.held && applyResult.held.length > 0 && (
                       <div>
-                        <div className="text-[11px]" style={{ color: "var(--hue-warn)" }}>
+                        <div className="text-[11px] text-(--hue-warn)">
                           Held by Open PR (Left in Place):
                         </div>
                         <div className="mono mt-1 space-y-1">
@@ -738,10 +717,10 @@ export function Projects({
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
                               <div className="flex items-center gap-1.5">
-                                <span className="font-bold text-(--text)">{h.id}</span>
+                                <span className="font-semibold text-(--text)">{h.id}</span>
                                 {h.state && <span className="text-(--text-dim)">({h.state})</span>}
                                 {h.branch && (
-                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[10px] text-(--text-faint)">
+                                  <span className="rounded bg-(--surface-2) px-1 py-0.2 text-[11px] text-(--text-faint)">
                                     {h.branch}
                                   </span>
                                 )}
@@ -755,7 +734,7 @@ export function Projects({
 
                     {applyResult.refused.length > 0 && (
                       <div>
-                        <div className="text-[11px]" style={{ color: "var(--hue-err)" }}>
+                        <div className="text-[11px] text-(--hue-err)">
                           Refused (Uncommitted or Unpushed Work):
                         </div>
                         <div className="mono mt-1 space-y-1">
@@ -764,7 +743,7 @@ export function Projects({
                               key={r.id}
                               className="rounded border border-(--border) bg-(--surface-1) p-1.5 text-[11px]"
                             >
-                              <span className="font-bold">{r.id}:</span> {r.reason}
+                              <span className="font-semibold">{r.id}:</span> {r.reason}
                             </div>
                           ))}
                         </div>
@@ -772,7 +751,7 @@ export function Projects({
                     )}
 
                     {applyResult.skippedApplyReason && (
-                      <div className="text-[11px]" style={{ color: "var(--hue-warn)" }}>
+                      <div className="text-[11px] text-(--hue-warn)">
                         {applyResult.skippedApplyReason}
                       </div>
                     )}
@@ -801,7 +780,7 @@ export function Projects({
 
             <div>
               <label className="text-[11px] font-medium text-(--text-faint)">
-                Type <span className="mono font-bold text-(--text)">{sel.name}</span> to confirm:
+                Type <span className="mono font-semibold text-(--text)">{sel.name}</span> to confirm:
               </label>
               <input
                 type="text"
@@ -855,10 +834,10 @@ export function Projects({
                 style={{
                   borderColor: "var(--hue-warn)",
                   color: "var(--hue-warn)",
-                  background: "color-mix(in oklch, var(--hue-warn) 10%, transparent)",
+                  background: "color-mix(in oklch, var(--hue-warn) 8%, var(--surface-1))",
                 }}
               >
-                <span className="font-bold">LIVE ENVIRONMENT</span>
+                <span className="font-semibold">LIVE ENVIRONMENT</span>
                 <span className="text-(--text-dim)">— dispatches trigger real agent runs in production.</span>
               </div>
             )}
@@ -870,12 +849,12 @@ export function Projects({
                 k="Environment"
                 v={
                   <span
-                    className="rounded px-1.5 py-0.2 text-[10px] font-semibold tracking-wide uppercase"
+                    className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                     style={{
                       color: env?.name === "live" ? "var(--hue-warn)" : "var(--hue-info)",
                       background: `color-mix(in oklch, ${
                         env?.name === "live" ? "var(--hue-warn)" : "var(--hue-info)"
-                      } 15%, transparent)`,
+                      } 16%, transparent)`,
                     }}
                   >
                     {env?.name ?? "unknown"}

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -84,6 +84,8 @@ describe("Proposals multi-row selection & bulk actions (WM-71)", () => {
     origReject = api.reject;
 
     api.status = async () => stubStatus();
+    api.proposals = async () => ({ proposals: [] });
+    api.proposalHistory = async () => ({ proposals: [] });
     api.runs = async () => ({ runs: [] });
     api.events = async () => ({ events: [] });
     api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
@@ -600,6 +602,7 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     origReject = api.reject;
 
     api.status = async () => stubStatus();
+    api.proposals = async () => ({ proposals: [] });
     api.runs = async () => ({ runs: [] });
     api.events = async () => ({ events: [] });
     api.agents = async () => ({ agents: [], edges: {}, eventTypes: [], contracts: {} });
@@ -770,7 +773,7 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     });
 
     const r = renderProposals();
-    const origin = await waitFor(() => r.getByText(eventId));
+    const origin = await waitFor(() => r.getByTitle(eventId));
     expect(origin.closest("td")?.getAttribute("title")).toBe(eventId);
     const reasonCell = r.getByText(reason);
     expect(reasonCell.closest("td")?.getAttribute("title")).toBe(reason);

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -810,9 +810,45 @@ export function Proposals({
           widthClass="w-[460px]"
           title={<span title={sel.id}>{sel.agent ?? sel.id}</span>}
           actions={
+            isOpen ? (
+              <div className="flex items-center gap-1.5">
+                <Button
+                  variant="danger"
+                  disabled={!connected || reject.isPending}
+                  onClick={openReject}
+                >
+                  Reject… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                </Button>
+                {canApprove && (
+                  <Button
+                    variant="primary"
+                    disabled={!connected || approve.isPending}
+                    onClick={() => setConfirmApprove(true)}
+                  >
+                    Approve… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">a</span>
+                  </Button>
+                )}
+              </div>
+            ) : null
+          }
+          utility={
             <>
-              <Button onClick={() => copyText(sel.id, "proposal id")}>Copy id</Button>
-              <Button onClick={copyLink}>Copy link</Button>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.id, "proposal id")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                id
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
           close={<Button onClick={() => onSelectProposal(null)}>Close</Button>}
@@ -943,22 +979,6 @@ export function Proposals({
             >
               This proposal&apos;s run is already {staleState(sel)} — it can no longer be approved.
               Reject it to clear the queue.
-            </div>
-          )}
-          {isOpen && (
-            <div className="flex gap-2">
-              {canApprove && (
-                <Button
-                  variant="primary"
-                  disabled={!connected || approve.isPending}
-                  onClick={() => setConfirmApprove(true)}
-                >
-                  Approve… <span className="mono ml-1 opacity-70">a</span>
-                </Button>
-              )}
-              <Button variant="danger" disabled={!connected || reject.isPending} onClick={openReject}>
-                Reject… <span className="mono ml-1 opacity-70">x</span>
-              </Button>
             </div>
           )}
 

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -894,7 +894,7 @@ export function Proposals({
                   <div className="mb-2 flex items-center justify-between border-b border-(--border) pb-2">
                     <div className="flex gap-2">
                       <span className="rounded px-2 py-0.5 text-[11px] font-semibold uppercase" style={{ color: mut ? "var(--hue-err)" : "var(--hue-ok)", background: `color-mix(in oklch, ${mut ? "var(--hue-err)" : "var(--hue-ok)"} 12%, transparent)` }}>
-                        {mut ? "🔴 Mutating" : "🟢 Read-Only"}
+                        {mut ? "Mutating" : "Read-Only"}
                       </span>
                       <span className="rounded px-2 py-0.5 text-[11px] font-semibold uppercase" style={{ color: blastHue, background: `color-mix(in oklch, ${blastHue} 12%, transparent)` }}>
                         Radar: {blast} Risk
@@ -903,16 +903,16 @@ export function Proposals({
                     <span className="mono text-[11px] text-(--text-faint)">{sel.spec.adapter}</span>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Target Repo</div><div className="mono truncate text-(--text-dim)" title={repo}>{repo}</div></div>
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Target Branch</div><div className="mono truncate text-(--text-dim)" title={branch}>{branch}</div></div>
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Issue ID</div><div className="mono truncate text-(--text-dim)" title={issue}>{issue}</div></div>
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Host</div><div className="mono truncate text-(--text-dim)" title={host}>{host}</div></div>
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Budget</div><div className="mono text-(--text-dim)">{sel.spec.timeoutSeconds}s · max {sel.spec.maxAttempts} att</div></div>
-                    <div><div className="text-[10px] uppercase text-(--text-faint)">Egress</div><div className="mono truncate text-(--text-dim)">{egress.length ? egress.join(", ") : "none"}</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Target Repo</div><div className="mono truncate text-(--text-dim)" title={repo}>{repo}</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Target Branch</div><div className="mono truncate text-(--text-dim)" title={branch}>{branch}</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Issue ID</div><div className="mono truncate text-(--text-dim)" title={issue}>{issue}</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Host</div><div className="mono truncate text-(--text-dim)" title={host}>{host}</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Budget</div><div className="mono text-(--text-dim)">{sel.spec.timeoutSeconds}s · max {sel.spec.maxAttempts} att</div></div>
+                    <div><div className="text-[11px] uppercase text-(--text-faint)">Egress</div><div className="mono truncate text-(--text-dim)">{egress.length ? egress.join(", ") : "none"}</div></div>
                     <div className="col-span-2">
-                      <div className="text-[10px] uppercase text-(--text-faint)">Capabilities</div>
+                      <div className="text-[11px] uppercase text-(--text-faint)">Capabilities</div>
                       <div className="mt-1 flex flex-wrap gap-1">
-                        {caps.length ? caps.map((c) => <span key={c} className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[10.5px] text-(--text-dim)">{c}</span>) : <span className="text-[11px] text-(--text-faint)">none (sandboxed)</span>}
+                        {caps.length ? caps.map((c) => <span key={c} className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11.5px] text-(--text-dim)">{c}</span>) : <span className="text-[11px] text-(--text-faint)">none (sandboxed)</span>}
                       </div>
                     </div>
                   </div>

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -44,6 +44,7 @@ import {
   VerbError,
   copyText,
   copyLink,
+  shortId,
 } from "../components/ui";
 
 const PROPOSAL_TABS = ["open", "history"] as const;
@@ -100,7 +101,6 @@ const HISTORY_DISPLAY: DisplayConfig<Proposal> = {
   columns: [
     { key: "agent", label: "Agent", always: true },
     { key: "status", label: "Status" },
-    { key: "decidedBy", label: "Decided by" },
     { key: "decided", label: "Decided" },
     { key: "origin", label: "Origin" },
     { key: "created", label: "Created" },
@@ -143,7 +143,7 @@ export function Proposals({
   const [tab, setTab] = useState<"open" | "history">("open");
   const query = useQuery({
     queryKey: ["proposals"],
-    queryFn: api.proposals,
+    queryFn: () => api.proposals(),
     refetchInterval: 2000,
   });
   const history = useQuery({
@@ -197,7 +197,7 @@ export function Proposals({
 
   const agentsQuery = useQuery({
     queryKey: ["agents"],
-    queryFn: api.agents,
+    queryFn: () => api.agents(),
     refetchInterval: 5000,
   });
 
@@ -218,7 +218,7 @@ export function Proposals({
   const headerCheckboxRef = useRef<HTMLInputElement>(null);
   const bulkReasonRef = useRef<HTMLInputElement>(null);
 
-  const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
+  const statusQ = useQuery({ queryKey: ["status"], queryFn: () => api.status(), refetchInterval: 2000 });
   // The expired chip only exists on Open; History rows have no live TTL. Derive
   // the gate once so the row filter and the empty copy can never disagree.
   const expiredFilter = expiredOnly && tab === "open";
@@ -584,6 +584,7 @@ export function Proposals({
                   role="tab"
                   aria-selected={tab === t}
                   onClick={() => selectTab(t)}
+                  title={t}
                   className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"}`}
                 >
                   {t === "open" ? "Open" : "History"}
@@ -592,23 +593,22 @@ export function Proposals({
               );
             })}
           </div>
-          {tab === "open" && (
+          {tab === "open" && expiredCount > 0 && (
             <button
               type="button"
               aria-pressed={expiredOnly}
               onClick={() => setExpiredOnly((v) => !v)}
-              className={`rounded-md px-2 py-1 text-[12px] ${
+              title="Filter to expired open proposals"
+              className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
                 expiredOnly
                   ? "bg-(--surface-3) text-(--text)"
                   : "text-(--text-faint) hover:bg-(--surface-1)"
               }`}
             >
-              expired
-              {expiredCount > 0 && (
-                <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                  {expiredCount}
-                </span>
-              )}
+              Expired
+              <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                {expiredCount}
+              </span>
             </button>
           )}
           <span className="ml-auto">
@@ -684,7 +684,7 @@ export function Proposals({
                       />
                     </td>
                   )}
-                  <td className={tdCls}>
+                  <td className={`${tdCls} max-w-32 truncate`}>
                     {p.agent ? (
                       <JumpLink
                         onClick={() => onJumpAgent(p.agent!)}
@@ -693,11 +693,13 @@ export function Proposals({
                         {p.agent}
                       </JumpLink>
                     ) : (
-                      "—"
+                      <span className="text-(--text-faint)" title="no agent: proposal rejected at planning">
+                        —
+                      </span>
                     )}
                   </td>
                   {show.has("decision") && (
-                    <td className={tdCls}>
+                    <td className={`${tdCls} max-w-28 truncate`}>
                       <StateBadge state={p.decision} hues={DECISION_HUES} />
                       {staleState(p) && (
                         <span className="ml-2" style={{ color: "var(--hue-err)" }}>
@@ -707,44 +709,55 @@ export function Proposals({
                     </td>
                   )}
                   {show.has("ttl") && (
-                    <td className={tdCls}>
+                    <td className={`${tdCls} max-w-20 whitespace-nowrap`}>
                       <Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />
                     </td>
                   )}
                   {show.has("status") && (
-                    <td className={tdCls}>
+                    <td className={`${tdCls} max-w-28 truncate`}>
                       <StateBadge state={p.status} hues={PROPOSAL_STATUS_HUES} />
                     </td>
                   )}
-                  {show.has("decidedBy") && (
-                    <td className={`${tdCls} text-(--text-dim)`}>{p.decided_by ?? "-"}</td>
-                  )}
                   {show.has("decided") && (
-                    <td className={`${tdCls} text-(--text-faint)`}>
-                      <Ago iso={p.decided_at} now={now} />
+                    <td
+                      className={`max-w-36 truncate ${tdCls} text-(--text-faint)`}
+                      title={
+                        p.decided_at
+                          ? `${new Date(p.decided_at).toLocaleString()}${p.decided_by ? ` · ${p.decided_by}` : ""}`
+                          : undefined
+                      }
+                    >
+                      {p.decided_at ? (
+                        <>
+                          <Ago iso={p.decided_at} now={now} />
+                          {p.decided_by && <span className="text-(--text-faint)"> · {p.decided_by}</span>}
+                        </>
+                      ) : (
+                        "-"
+                      )}
                     </td>
                   )}
                   {show.has("origin") && (
-                    <td className={`mono max-w-40 truncate ${tdCls} text-(--text-faint)`} title={p.eventId ?? undefined}>
+                    <td className={`mono max-w-32 truncate ${tdCls} text-(--text-faint)`} title={p.eventId ?? undefined}>
                       {p.eventId && p.eventSource ? (
                         <JumpLink
                           onClick={() => onJumpEvent(p.eventSource!, p.eventId!)}
-                          title={p.eventId}
+                          title={`Open origin event ${p.eventId}`}
                         >
-                          {p.eventId}
+                          {shortId(p.eventId)}
                         </JumpLink>
                       ) : (
-                        (p.eventId ?? "-")
+                        (p.eventId ? shortId(p.eventId) : "-")
                       )}
                     </td>
                   )}
                   {show.has("created") && (
-                    <td className={`${tdCls} text-(--text-faint)`}>
+                    <td className={`max-w-24 whitespace-nowrap ${tdCls} text-(--text-faint)`}>
                       <Ago iso={p.created_at} now={now} />
                     </td>
                   )}
                   {show.has("reason") && (
-                    <td className={`max-w-64 truncate ${tdCls} text-(--text-dim)`} title={p.reason ?? undefined}>
+                    <td className={`max-w-48 truncate ${tdCls} text-(--text-dim)`} title={p.reason ?? undefined}>
                       {p.reason ?? "-"}
                     </td>
                   )}
@@ -808,7 +821,30 @@ export function Proposals({
       {sel && (
         <DetailPane
           widthClass="w-[460px]"
-          title={<span title={sel.id}>{sel.agent ?? sel.id}</span>}
+          title={
+            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+              <button
+                type="button"
+                onClick={() => onSelectProposal(null)}
+                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                title="Back to proposals list"
+              >
+                Proposals
+              </button>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
+              </span>
+              <span className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)" aria-current="page">
+                <StateBadge
+                  state={sel.status === "open" ? sel.decision : sel.status}
+                  hues={sel.status === "open" ? DECISION_HUES : PROPOSAL_STATUS_HUES}
+                />
+                <span className="truncate mono" title={sel.id}>
+                  {shortId(sel.id)}
+                </span>
+              </span>
+            </nav>
+          }
           actions={
             isOpen ? (
               <div className="flex items-center gap-1.5">
@@ -872,8 +908,8 @@ export function Proposals({
               k="run"
               v={
                 sel.runId ? (
-                  <JumpLink onClick={() => onRunQueued(sel.runId!)} title="Open run">
-                    {sel.runId}
+                  <JumpLink onClick={() => onRunQueued(sel.runId!)} title={`Open run ${sel.runId}`}>
+                    {shortId(sel.runId)}
                   </JumpLink>
                 ) : null
               }
@@ -887,7 +923,16 @@ export function Proposals({
             <KV k="created" v={<Ago iso={sel.created_at} now={now} />} />
             {sel.decided_at && <KV k="decided at" v={<Ago iso={sel.decided_at} now={now} />} />}
             {sel.decided_by && <KV k="decided by" v={sel.decided_by} />}
-            {sel.reason && <KV k="planner reason" v={sel.reason} />}
+            {sel.reason && (
+              <KV
+                k="planner reason"
+                v={
+                  <span className="break-words whitespace-pre-wrap leading-relaxed text-(--text-dim)">
+                    {sel.reason}
+                  </span>
+                }
+              />
+            )}
           </Section>
 
           {sel.eventId && (
@@ -896,11 +941,11 @@ export function Proposals({
                 k="eventId"
                 v={
                   sel.eventSource ? (
-                    <JumpLink onClick={() => onJumpEvent(sel.eventSource!, sel.eventId!)} title="Open origin event">
-                      {sel.eventId}
+                    <JumpLink onClick={() => onJumpEvent(sel.eventSource!, sel.eventId!)} title={`Open origin event ${sel.eventId}`}>
+                      {shortId(sel.eventId)}
                     </JumpLink>
                   ) : (
-                    sel.eventId
+                    <span title={sel.eventId}>{shortId(sel.eventId)}</span>
                   )
                 }
               />

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -168,13 +168,57 @@ export function RunFull({
             </span>
           )}
         </div>
-        <span className="ml-auto flex shrink-0 items-center gap-1.5">
-          <Button onClick={() => copyText(runId, "run id")}>Copy id</Button>
-          <Button onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${runId}`, "CLI inspect command")}>
-            Copy CLI
-          </Button>
-          <Button onClick={copyLink}>Copy link</Button>
-        </span>
+        <div className="ml-auto flex shrink-0 items-center gap-3">
+          {d && (
+            <div className="flex items-center gap-1.5">
+              {isCancellable(d.run.state) && (
+                <Button
+                  variant="danger"
+                  disabled={!connected || cancel.isPending}
+                  onClick={() => setConfirm("cancel")}
+                >
+                  Cancel <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                </Button>
+              )}
+              {d.run.state === "FAILED" && (
+                attemptsExhausted ? (
+                  <Button disabled={!connected} onClick={() => setConfirm("force-retry")}>
+                    Force retry…
+                  </Button>
+                ) : (
+                  <Button
+                    disabled={!connected || retry.isPending}
+                    onClick={() => retry.mutate({ id: d.run.runId, force: false })}
+                  >
+                    Retry
+                  </Button>
+                )
+              )}
+            </div>
+          )}
+          <div className="flex items-center gap-1.5 text-[11px] text-(--text-faint)">
+            <span>copy:</span>
+            <button
+              type="button"
+              onClick={() => copyText(runId, "run id")}
+              className="cursor-pointer hover:text-(--text)"
+            >
+              id
+            </button>
+            <span>·</span>
+            <button
+              type="button"
+              onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${runId}`, "CLI inspect command")}
+              className="cursor-pointer hover:text-(--text)"
+            >
+              CLI
+            </button>
+            <span>·</span>
+            <button type="button" onClick={copyLink} className="cursor-pointer hover:text-(--text)">
+              link
+            </button>
+          </div>
+        </div>
       </header>
 
       {unknownRun ? (

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -140,7 +140,7 @@ export function RunFull({
             <ol className="flex min-w-0 flex-wrap items-center gap-2 list-none p-0 m-0 text-[13px]">
               <li className="shrink-0">
                 <Button onClick={onBack}>
-                  ← Runs
+                  Runs
                 </Button>
               </li>
               <li aria-hidden="true" className="text-(--text-faint) shrink-0">

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -314,7 +314,7 @@ describe("Runs component harness: cross-tab reveal", () => {
         });
 
         await waitFor(() => {
-          const tab = getByRole("tab", { name: /^RUNNING/i });
+          const tab = getByRole("tab", { name: /^Active/i });
           expect(tab.getAttribute("aria-selected")).toBe("true");
         });
 
@@ -335,7 +335,7 @@ describe("Runs component harness: cross-tab reveal", () => {
 
         // Should switch to ALL tab and reveal the FAILED run
         await waitFor(() => {
-          const allTab = getByRole("tab", { name: /^ALL/i });
+          const allTab = getByRole("tab", { name: /^All/i });
           expect(allTab.getAttribute("aria-selected")).toBe("true");
           const targetCell = container.querySelector(`td[title="run_failed_target"]`);
           expect(targetCell).toBeTruthy();
@@ -457,7 +457,7 @@ describe("Runs component harness: cross-tab reveal", () => {
         });
 
         await waitFor(() => {
-          const tab = getByRole("tab", { name: /^CANCELLED/i });
+          const tab = getByRole("tab", { name: /^Cancelled/i });
           expect(tab.getAttribute("aria-selected")).toBe("true");
           expect(onFocusStateConsumed).toHaveBeenCalledTimes(1);
         });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -656,15 +656,61 @@ export function Runs({
           }
           actions={
             <>
-              <Button onClick={() => pinRun(sel.runId)}>Open in tab</Button>
-              <Button onClick={() => onOpenFull(sel.runId)}>
-                Expand <span className="mono ml-1 opacity-70">o</span>
-              </Button>
-              <Button onClick={() => copyText(sel.runId, "run id")}>Copy id</Button>
-              <Button onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command")}>
-                Copy CLI
-              </Button>
-              <Button onClick={copyLink}>Copy link</Button>
+              <div className="flex items-center gap-1.5">
+                {d && isCancellable(d.run.state) && (
+                  <Button
+                    variant="danger"
+                    disabled={!connected || cancel.isPending}
+                    onClick={() => setConfirm("cancel")}
+                  >
+                    Cancel <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
+                  </Button>
+                )}
+                {d && d.run.state === "FAILED" && (
+                  attemptsExhausted ? (
+                    <Button disabled={!connected} onClick={() => setConfirm("force-retry")}>
+                      Force retry…
+                    </Button>
+                  ) : (
+                    <Button
+                      disabled={!connected || retry.isPending}
+                      onClick={() => retry.mutate({ id: d.run.runId, force: false })}
+                    >
+                      Retry
+                    </Button>
+                  )
+                )}
+              </div>
+              <div className="flex items-center gap-1.5">
+                <Button onClick={() => onOpenFull(sel.runId)}>
+                  Expand <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">o</span>
+                </Button>
+                <Button onClick={() => pinRun(sel.runId)}>Open in tab</Button>
+              </div>
+            </>
+          }
+          utility={
+            <>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.runId, "run id")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                id
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                CLI
+              </button>
+              <span>·</span>
+              <button type="button" onClick={copyLink} className="cursor-pointer hover:text-(--text)">
+                link
+              </button>
             </>
           }
           close={<Button onClick={() => onSelectRun(null)}>Close</Button>}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -50,9 +50,49 @@ import {
   shortId,
 } from "../components/ui";
 
-const STATE_TABS: (RunState | "ALL")[] = [
-  "ALL", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
-];
+export type RunTab = "ALL" | "ACTIVE" | "COMPLETED" | "FAILED" | "CANCELLED";
+
+export const RUN_TABS: readonly RunTab[] = [
+  "ALL",
+  "ACTIVE",
+  "COMPLETED",
+  "FAILED",
+  "CANCELLED",
+] as const;
+
+export const RUN_TAB_LABELS: Record<RunTab, string> = {
+  ALL: "All",
+  ACTIVE: "Active",
+  COMPLETED: "Completed",
+  FAILED: "Failed",
+  CANCELLED: "Cancelled",
+};
+
+export const RUN_TAB_TITLES: Record<RunTab, string> = {
+  ALL: "All runs",
+  ACTIVE: "QUEUED, LEASED, RUNNING, VERIFYING",
+  COMPLETED: "COMPLETED",
+  FAILED: "FAILED, TIMED_OUT, REFUSED",
+  CANCELLED: "CANCELLED",
+};
+
+export function matchesRunTab(state: RunState, tab: RunTab): boolean {
+  if (tab === "ALL") return true;
+  if (tab === "ACTIVE") return ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state);
+  if (tab === "FAILED") return ["FAILED", "TIMED_OUT", "REFUSED"].includes(state);
+  if (tab === "COMPLETED") return state === "COMPLETED";
+  if (tab === "CANCELLED") return state === "CANCELLED";
+  return true;
+}
+
+export function tabForRunState(state: string): RunTab {
+  if (["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state)) return "ACTIVE";
+  if (["FAILED", "TIMED_OUT", "REFUSED"].includes(state)) return "FAILED";
+  if (state === "COMPLETED") return "COMPLETED";
+  if (state === "CANCELLED") return "CANCELLED";
+  return "ALL";
+}
+
 /**
  * Grouping/ordering/columns (OPS-493). One config for every status tab: the
  * tabs only filter rows, the column set never changes with them.
@@ -137,7 +177,7 @@ export function Runs({
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
-  const [tab, setTab] = useState<(typeof STATE_TABS)[number]>("ALL");
+  const [tab, setTab] = useState<RunTab>("ALL");
   const [filter, setFilter] = useState("");
   const [confirm, setConfirm] = useState<"cancel" | "force-retry" | null>(null);
   const [cancelReason, setCancelReason] = useState("");
@@ -147,7 +187,7 @@ export function Runs({
   const fetchAll = context.kind !== "all";
   const list = useQuery({
     queryKey: ["runs", fetchAll ? "ALL" : tab],
-    queryFn: () => api.runs(fetchAll || tab === "ALL" ? undefined : tab),
+    queryFn: () => api.runs(),
     refetchInterval: 2000,
   });
   const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
@@ -162,8 +202,8 @@ export function Runs({
     [rows, context, focusRunId],
   );
   const byTab = useMemo(
-    () => (!fetchAll || tab === "ALL" ? scoped : scoped.filter((r) => r.state === tab)),
-    [fetchAll, scoped, tab],
+    () => (tab === "ALL" ? scoped : scoped.filter((r) => matchesRunTab(r.state, tab))),
+    [scoped, tab],
   );
   // `is:stale` is the doctor's projection, not a guess this view makes: a run
   // held by a worker whose heartbeat has gone (lib/workers.mjs stalledWorkers).
@@ -244,7 +284,7 @@ export function Runs({
     }
 
     const onTab = rows.some(
-      (r) => r.runId === focusRunId && (!fetchAll || tab === "ALL" || r.state === tab),
+      (r) => r.runId === focusRunId && (tab === "ALL" || matchesRunTab(r.state, tab)),
     );
     if (onTab) {
       const latch = pendingReveal.current;
@@ -280,10 +320,8 @@ export function Runs({
   }, [focusRunId, rejumpEpoch, rows, tab, visible, fetchAll, filter]);
 
   useEffect(() => {
-    if (focusState && (STATE_TABS as readonly string[]).includes(focusState)) {
-      setTab(focusState as (typeof STATE_TABS)[number]);
-      onFocusStateConsumed();
-    } else if (focusState) {
+    if (focusState) {
+      setTab(tabForRunState(focusState));
       onFocusStateConsumed();
     }
   }, [focusState, onFocusStateConsumed]);
@@ -291,7 +329,7 @@ export function Runs({
   // In flight is LEASED+RUNNING; a COMPLETED (etc.) status tab would be empty.
   useEffect(() => {
     if (context.kind !== "inflight") return;
-    setTab((t) => (t === "LEASED" || t === "RUNNING" || t === "ALL" ? t : "ALL"));
+    setTab((t) => (t === "ACTIVE" || t === "ALL" ? t : "ALL"));
   }, [context.kind]);
 
   const sel = useMemo(
@@ -337,11 +375,25 @@ export function Runs({
     },
   });
 
-  const selectTab = (t: (typeof STATE_TABS)[number]) => {
+  const byState = statusQ.data?.runs.byState ?? {};
+  const tabCount = (t: RunTab) => {
+    if (fetchAll) {
+      return t === "ALL" ? scoped.length : scoped.filter((r) => matchesRunTab(r.state, t)).length;
+    }
+    if (t === "ALL") return Object.values(byState).reduce((n, v) => n + (v ?? 0), 0);
+    if (t === "ACTIVE")
+      return (byState.QUEUED ?? 0) + (byState.LEASED ?? 0) + (byState.RUNNING ?? 0) + (byState.VERIFYING ?? 0);
+    if (t === "FAILED") return (byState.FAILED ?? 0) + (byState.TIMED_OUT ?? 0) + (byState.REFUSED ?? 0);
+    if (t === "COMPLETED") return byState.COMPLETED ?? 0;
+    if (t === "CANCELLED") return byState.CANCELLED ?? 0;
+    return 0;
+  };
+
+  const selectTab = (t: RunTab) => {
     setTab(t);
     if (selectedId) onSelectRun(null);
   };
-  useTabKeys(STATE_TABS, tab, selectTab);
+  useTabKeys(RUN_TABS, tab, selectTab);
 
   useListKeys({
     count: flat.length,
@@ -428,15 +480,8 @@ export function Runs({
           {/* Wrap, never scroll or clip: at 1280px the strip used to run out of
               width at CANCELLED with no scrollbar affordance (WM-96). */}
           <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Run state">
-            {STATE_TABS.map((t) => {
-              const byState = statusQ.data?.runs.byState ?? {};
-              const count = fetchAll
-                ? t === "ALL"
-                  ? scoped.length
-                  : scoped.filter((r) => r.state === t).length
-                : t === "ALL"
-                  ? Object.values(byState).reduce((n, v) => n + (v ?? 0), 0)
-                  : (byState[t] ?? 0);
+            {RUN_TABS.map((t) => {
+              const count = tabCount(t);
               return (
                 <button
                   key={t}
@@ -444,11 +489,12 @@ export function Runs({
                   role="tab"
                   aria-selected={tab === t}
                   onClick={() => selectTab(t)}
+                  title={RUN_TAB_TITLES[t]}
                   className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
                     tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
                   }`}
                 >
-                  {t === "ALL" ? "All" : t}
+                  {RUN_TAB_LABELS[t]}
                   {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
                 </button>
               );
@@ -500,17 +546,17 @@ export function Runs({
                   aria-selected={r.runId === selectedId}
                   className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
                 >
-                  <td className="mono max-w-52 truncate border-b border-(--border) px-3 py-1.5" title={r.runId}>
+                  <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5" title={r.runId}>
                     {shortId(r.runId)}
                   </td>
                   {show.has("state") && (
-                    <td className="border-b border-(--border) px-3 py-1.5">
+                    <td className="max-w-32 truncate border-b border-(--border) px-3 py-1.5">
                       <StateBadge state={r.state} />
                       {IN_FLIGHT.includes(r.state) && <RowDeadlines r={r} now={now} />}
                     </td>
                   )}
                   {show.has("agent") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                    <td className="max-w-32 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
                       <JumpLink
                         onClick={() => onJumpAgent(r.agent)}
                         title={`Open ${r.agent} in Agents`}
@@ -520,24 +566,26 @@ export function Runs({
                     </td>
                   )}
                   {show.has("adapter") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">{r.adapter}</td>
+                    <td className="max-w-24 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)" title={r.adapter}>
+                      {r.adapter}
+                    </td>
                   )}
                   {show.has("attempts") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    <td className="max-w-16 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
                       {r.attempts}/{r.maxAttempts}
                     </td>
                   )}
                   {show.has("reason") && (
                     <td
                       className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
-                      title={r.reasonCode ?? undefined}
+                      title={r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : undefined}
                     >
-                      {r.reasonCode ?? "-"}
+                      {r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : ""}
                     </td>
                   )}
                   {show.has("origin") && (
                     <td
-                      className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                      className="mono max-w-32 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
                       title={r.eventId ?? undefined}
                     >
                       {r.eventId && r.eventSource ? (
@@ -545,15 +593,15 @@ export function Runs({
                           onClick={() => onJumpEvent(r.eventSource!, r.eventId!)}
                           title={`Open origin event ${r.eventId}`}
                         >
-                          {r.eventId}
+                          {shortId(r.eventId)}
                         </JumpLink>
                       ) : (
-                        (r.eventId ?? "-")
+                        (r.eventId ? shortId(r.eventId) : "-")
                       )}
                     </td>
                   )}
                   {show.has("updated") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
+                    <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
                       <Ago iso={r.updated_at} now={now} />
                     </td>
                   )}
@@ -605,8 +653,9 @@ export function Runs({
                       ? `No runs for ${context.name}.`
                       : tab === "ALL"
                         ? "No runs."
-                        : `No ${tab} runs.`
+                        : `No ${RUN_TAB_LABELS[tab].toLowerCase()} runs.`
                 }
+                escHint={Boolean(filter.trim())}
                 action={
                   // Only In flight can strand an operator with no way back but the
                   // context strip's All tab — offer the same exit inline (WM-91).

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -238,13 +238,13 @@ export function Schedules({
                     isSel ? "row-selected bg-(--surface-3)" : ""
                   }`}
                 >
-                  <td className="mono border-b border-(--border) px-3 py-2 font-medium text-(--text)">
+                  <td className="mono border-b border-(--border) px-3 py-1.5 font-medium text-(--text)">
                     {s.loop}
                   </td>
-                  <td className="mono border-b border-(--border) px-3 py-2 text-(--text-dim)">
+                  <td className="mono border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
                     {s.every}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2">
+                  <td className="border-b border-(--border) px-3 py-1.5">
                     {s.enabled ? (
                       <span
                         className="mono text-[11px] text-(--hue-ok)"
@@ -261,10 +261,10 @@ export function Schedules({
                       </span>
                     )}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2">
+                  <td className="border-b border-(--border) px-3 py-1.5">
                     {isAuto ? (
                       <span
-                        className="rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
+                        className="rounded border px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                         title="approval: auto — executes unattended without operator prompt"
                         style={{
                           color: "var(--hue-warn)",
@@ -278,13 +278,13 @@ export function Schedules({
                       <span className="text-[11px] text-(--text-dim)">watched</span>
                     )}
                   </td>
-                  <td className="mono border-b border-(--border) px-3 py-2 text-[11px] text-(--text-dim)">
+                  <td className="mono border-b border-(--border) px-3 py-1.5 text-[11px] text-(--text-dim)">
                     {s.catchUp}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2 text-[11px] text-(--text-dim)">
+                  <td className="border-b border-(--border) px-3 py-1.5 text-[11px] text-(--text-dim)">
                     {s.lastSlot ? <Ago iso={s.lastSlot} now={now} /> : <span className="text-(--text-faint)">never</span>}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2 text-[11px] text-(--text-dim)">
+                  <td className="border-b border-(--border) px-3 py-1.5 text-[11px] text-(--text-dim)">
                     {!s.enabled ? (
                       <span className="text-(--text-faint)">-</span>
                     ) : s.error ? (
@@ -300,11 +300,11 @@ export function Schedules({
                       "-"
                     )}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2">
+                  <td className="border-b border-(--border) px-3 py-1.5">
                     {s.error ? (
                       <span
                         className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
-                        style={{ background: "color-mix(in oklch, var(--hue-err) 14%, transparent)" }}
+                        style={{ background: "color-mix(in oklch, var(--hue-err) 12%, transparent)" }}
                         title={s.error}
                       >
                         error
@@ -320,7 +320,7 @@ export function Schedules({
                     ) : s.stopped ? (
                       <span
                         className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-err)"
-                        style={{ background: "color-mix(in oklch, var(--hue-err) 14%, transparent)" }}
+                        style={{ background: "color-mix(in oklch, var(--hue-err) 12%, transparent)" }}
                         title={`Stopped: enabled: true but the scheduler loop is not ticking — no ticks for ${s.intervalsLate} intervals. Check the event runtime serve process.`}
                       >
                         stopped ({s.intervalsLate} late)
@@ -328,14 +328,14 @@ export function Schedules({
                     ) : (
                       <span
                         className="rounded px-1.5 py-0.5 text-[11px] font-medium text-(--hue-ok)"
-                        style={{ background: "color-mix(in oklch, var(--hue-ok) 14%, transparent)" }}
+                        style={{ background: "color-mix(in oklch, var(--hue-ok) 12%, transparent)" }}
                         title="Running: enabled: true and the scheduler loop is ticking on cadence"
                       >
                         running
                       </span>
                     )}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-2 text-right">
+                  <td className="border-b border-(--border) px-3 py-1.5 text-right">
                     <Button
                       disabled={connected === false}
                       onClick={() => setConfirmLoop(s)}
@@ -374,7 +374,7 @@ export function Schedules({
               </span>
               {sel.approval === "auto" && (
                 <span
-                  className="rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
+                  className="rounded border px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
                   style={{
                     color: "var(--hue-warn)",
                     borderColor: "color-mix(in oklch, var(--hue-warn) 40%, var(--border))",
@@ -404,8 +404,7 @@ export function Schedules({
           <div className="space-y-6">
             {sel.stopped && (
               <div
-                className="rounded-md border border-[color:var(--hue-err)] bg-[color:color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px]"
-                style={{ color: "var(--hue-err)" }}
+                className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)"
               >
                 <div className="font-semibold">Schedule clock stopped</div>
                 <div className="mt-1 text-(--text-dim)">
@@ -417,8 +416,7 @@ export function Schedules({
 
             {sel.error && (
               <div
-                className="rounded-md border border-[color:var(--hue-err)] bg-[color:color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px]"
-                style={{ color: "var(--hue-err)" }}
+                className="rounded-md border border-(--hue-err) bg-[color-mix(in_oklch,var(--hue-err)_8%,var(--surface-1))] p-3 text-[12px] text-(--hue-err)"
               >
                 <div className="font-semibold">Cadence configuration error</div>
                 <div className="mono mt-1 text-(--text-dim)">{sel.error}</div>
@@ -564,7 +562,7 @@ export function Schedules({
                               {e.eventId}
                             </JumpLink>
                             {isAdhoc && (
-                              <span className="rounded bg-(--surface-3) px-1 text-[10px] text-(--hue-info)">
+                              <span className="rounded bg-(--surface-3) px-1 text-[11px] text-(--hue-info)">
                                 ad-hoc
                               </span>
                             )}

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -387,19 +387,35 @@ export function Schedules({
             </span>
           }
           actions={
+            <Button
+              variant="primary"
+              disabled={connected === false}
+              onClick={() => setConfirmLoop(sel)}
+            >
+              Run now…
+            </Button>
+          }
+          utility={
             <>
-              <Button
-                variant="primary"
-                disabled={connected === false}
-                onClick={() => setConfirmLoop(sel)}
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.loop, "schedule loop")}
+                className="cursor-pointer hover:text-(--text)"
               >
-                Run now…
-              </Button>
-              <Button onClick={() => copyText(sel.loop, "schedule loop")}>Copy loop</Button>
-              <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectSchedule(null)}>Close</Button>
+                loop
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
+          close={<Button onClick={() => onSelectSchedule(null)}>Close</Button>}
         >
           <div className="space-y-6">
             {sel.stopped && (

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -570,13 +570,27 @@ export function Workers({
               </span>
             </span>
           }
-          actions={
+          utility={
             <>
-              <Button onClick={() => copyText(sel.workerId, "worker id")}>Copy id</Button>
-              <Button onClick={copyLink}>Copy link</Button>
-              <Button onClick={() => onSelectWorker(null)}>Close</Button>
+              <span>copy:</span>
+              <button
+                type="button"
+                onClick={() => copyText(sel.workerId, "worker id")}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                id
+              </button>
+              <span>·</span>
+              <button
+                type="button"
+                onClick={copyLink}
+                className="cursor-pointer hover:text-(--text)"
+              >
+                link
+              </button>
             </>
           }
+          close={<Button onClick={() => onSelectWorker(null)}>Close</Button>}
         >
           {selHeartbeat.kind === "stale" && (
             <div

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -237,13 +237,13 @@ function FleetStatusBanner({ banner }: { banner: FleetBanner }) {
       className="mb-3 rounded-md border p-3 text-[12px]"
       style={{
         color: hue,
-        borderColor: `color-mix(in oklch, ${hue} 55%, var(--border))`,
+        borderColor: hue,
         background: `color-mix(in oklch, ${hue} 8%, var(--surface-1))`,
       }}
     >
       <div className="flex items-center gap-2 font-semibold">
         <span
-          className={`size-2 shrink-0 rounded-full ${banner.kind === "stale" ? "" : "animate-pulse"}`}
+          className={`size-2 shrink-0 rounded-full ${banner.kind === "stale" ? "" : "motion-safe:animate-pulse"}`}
           style={{ background: hue }}
         />
         <span>{title}</span>

--- a/event-runtime/web/src/workerHealth.ts
+++ b/event-runtime/web/src/workerHealth.ts
@@ -1,14 +1,10 @@
 import type { Worker, WorkerState } from "./types";
+import { WORKER_HUES as UI_WORKER_HUES } from "./components/ui";
 
 export type WorkerHealth = WorkerState | "stale";
 
-/** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector. */
-export const WORKER_HUES: Record<WorkerHealth, string> = {
-  idle: "var(--hue-ok)",
-  busy: "var(--hue-warn)",
-  stopped: "var(--hue-idle)",
-  stale: "var(--hue-err)",
-};
+/** Four mutually exclusive tokens; `stale` is the loudest because it is a lie detector (re-exported from centralized ui.tsx). */
+export const WORKER_HUES: Record<WorkerHealth, string> = UI_WORKER_HUES as Record<WorkerHealth, string>;
 
 /**
  * A stale heartbeat outranks whatever the row claims: a stale busy worker is


### PR DESCRIPTION
Normalize web control plane components to adhere strictly to `docs/event-runtime-webui.md` §5.2 (Iconography, glyphs, color tokens), §5.3 (Component conventions incl. WM-209 DetailPane 3-row header actions & keyboard hints), and §5.4 (Typography scale), and overhaul the Overview landing page into a 4-Band operational dashboard (WM-205).

### Key Changes
- **DetailPane 3-Row Header Hierarchy (§5.3, WM-209)**:
  - Row 1: Breadcrumb / Title + pinned Close button.
  - Row 2: Bordered action buttons (≤ 3), with lifecycle verbs on the left (`Cancel`, `Retry`, `Approve`, `Reject`, `Requeue`) and navigation verbs on the right (`Expand`, `Open in tab`, `GitHub`, `Show on canvas`). Removed all duplicate floating lifecycle buttons from body scroll containers.
  - Row 3: Unbordered quiet text utility line (`text-[11px] text-(--text-faint)`) for copy/share actions (`copy: id · CLI · link`).
- **Keyboard Hints (§5.3, WM-209)**:
  - Standardized all button keyboard hints to trailing faint mono subtext (`mono ml-1 text-(--text-faint)`) with `aria-hidden="true"` (`Cancel x`, `Expand o`, `Approve a`, `Reject x`, `Requeue q`, `Format JSON ⌘⇧F`, `Inject ⌘↵`).
- **Iconography & Glyphs (§5.2, WM-134)**:
  - Purged all emojis (`🔴`, `🟢`, `⚡`) and non-standard unicode glyphs (`✓`, `↗`, `←`).
  - Added 14px/1.5px stroke shape-coded SVG state icons for Overview pipeline metrics.
- **Color & Hue Isolation (§5.2, WM-134)**:
  - Replaced legacy `text-[color:var(...)]` with Tailwind v4 `text-(--...)`; centralized `WORKER_HUES` in `ui.tsx`; removed `TEAM_HUES` identity color borrowing; normalized wash strengths to 12% (badges) and 8% (banners).
- **Motion (§5.2, WM-134)**: Added `motion-safe:` prefix to all `animate-pulse` instances.
- **Typography Scale (§5.4, WM-134)**: Normalized ad-hoc font sizes to named scale (11px labels/badges, 11.5px mono, 12px body/inputs, 13px headings, 14px titles).
- **Overview 4-Band Dashboard & StageCards (WM-205)**:
  - **Band A (Attention Surface)**: Promoted Doctor Anomaly Deck with domain category pills (`PROPOSAL`, `DEAD-LETTER`, `STALLED LEASE`, `WORKER LEASE`, `OUTBOX`, `CAPACITY`) and layout jump prevention (nominal status banner when clear).
  - **Band B (Workload Pipeline Funnel)**: Unified StageCards with interactive horizontal SegmentMeters and subtle SVG state icons, eliminating box fatigue across Stage 1 and Stage 3.
  - **Band C (Fleet Capacity & Telemetry)**: Live Worker Fleet Capacity meter bar + Recent Outcomes tick strip (`▍▍▍▍▎▍▍▍▍▍`) from journal feed.
  - **Band D (Housekeeping & Feeds)**: Clean artifact store footer summary, Activity feed `START` notation cleanup, and Outbox one-line payload summary preview.

Fixes WM-134
Fixes WM-205