### PR TITLE
feat(event-runtime-web): dynamic and payload-path custom columns in table views (WM-214)

### DIFF
--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -1,0 +1,57 @@
+/**
+ * Reusable cell renderer for dynamic / custom payload columns (WM-214).
+ * Extracts nested path values safely and formats primitives, code badges, and objects.
+ */
+import { extractRowValue } from "../pathExtractor";
+
+export function formatCellValue(value: unknown): { text: string; isComplex: boolean; title?: string } {
+  if (value === undefined || value === null) return { text: "—", isComplex: false };
+  if (typeof value === "boolean") return { text: value ? "true" : "false", isComplex: false };
+  if (typeof value === "number") return { text: String(value), isComplex: false };
+  if (typeof value === "string") {
+    return { text: value, isComplex: false, title: value };
+  }
+  if (Array.isArray(value)) {
+    const preview = `[${value.length}]`;
+    return { text: preview, isComplex: true, title: JSON.stringify(value, null, 2) };
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as object);
+    const preview = `{${keys.slice(0, 2).join(", ")}${keys.length > 2 ? "…" : ""}}`;
+    return { text: preview, isComplex: true, title: JSON.stringify(value, null, 2) };
+  }
+  return { text: String(value), isComplex: false };
+}
+
+export function CustomCell({ row, path }: { row: unknown; path: string }) {
+  const cleanPath = path.replace(/^custom:/, "");
+  const value = extractRowValue(row, cleanPath);
+  const { text, isComplex, title } = formatCellValue(value);
+
+  const isMono =
+    cleanPath.toLowerCase().includes("id") ||
+    cleanPath.toLowerCase().includes("sha") ||
+    cleanPath.toLowerCase().includes("hash") ||
+    cleanPath.toLowerCase().includes("commit") ||
+    cleanPath.toLowerCase().includes("branch") ||
+    cleanPath.toLowerCase().includes("repo");
+
+  return (
+    <td
+      className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 text-[11.5px] text-(--text-dim)"
+      title={title}
+    >
+      {isComplex ? (
+        <span className="mono rounded bg-(--surface-2) px-1 py-0.5 text-[10.5px] text-(--text-faint)">
+          {text}
+        </span>
+      ) : typeof value === "boolean" ? (
+        <span className="mono text-[11px] text-(--text-faint)">{text}</span>
+      ) : typeof value === "number" ? (
+        <span className="mono tabular-nums">{text}</span>
+      ) : (
+        <span className={isMono ? "mono" : ""}>{text}</span>
+      )}
+    </td>
+  );
+}

--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -16,6 +16,11 @@ interface Row {
   id: string;
   state: string;
   agent: string;
+  envelope?: {
+    payload?: {
+      repo?: string;
+    };
+  };
 }
 
 const CONFIG: DisplayConfig<Row> = {
@@ -32,7 +37,13 @@ const CONFIG: DisplayConfig<Row> = {
   ],
 };
 
-function Harness({ onState }: { onState?: (s: DisplayState) => void }) {
+function Harness({
+  onState,
+  rows,
+}: {
+  onState?: (s: DisplayState) => void;
+  rows?: Row[];
+}) {
   const [state, setState] = useState(() => defaultDisplayState(CONFIG));
   const update = (next: DisplayState | ((s: DisplayState) => DisplayState)) => {
     setState((prev) => {
@@ -41,7 +52,7 @@ function Harness({ onState }: { onState?: (s: DisplayState) => void }) {
       return value;
     });
   };
-  return <DisplayOptions config={CONFIG} state={state} onChange={update} />;
+  return <DisplayOptions config={CONFIG} state={state} onChange={update} rows={rows} />;
 }
 
 afterEach(() => {
@@ -83,6 +94,38 @@ describe("DisplayOptions panel", () => {
     fireEvent.click(pill);
     expect(latest?.hiddenColumns).toEqual(["agent"]);
     expect(pill.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("adds and removes dynamic custom column via input", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+
+    const input = r.getByPlaceholderText(/e\.g\. payload\.repo/i);
+    fireEvent.change(input, { target: { value: "payload.repo" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(latest?.customColumns).toEqual(["payload.repo"]);
+    expect(r.getByRole("button", { name: "payload.repo" })).toBeTruthy();
+
+    const removeBtn = r.getByLabelText("Remove column payload.repo");
+    fireEvent.click(removeBtn);
+    expect(latest?.customColumns).toEqual([]);
+  });
+
+  test("discovered fields suggestion chip adds column", () => {
+    let latest: DisplayState | undefined;
+    const sampleRows: Row[] = [
+      { id: "r1", state: "RUNNING", agent: "a", envelope: { payload: { repo: "watt-mind/factory" } } },
+    ];
+    const r = render(<Harness onState={(s) => (latest = s)} rows={sampleRows} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+
+    const chip = r.getByRole("button", { name: /\+ payload\.repo/i });
+    expect(chip).toBeTruthy();
+    fireEvent.click(chip);
+
+    expect(latest?.customColumns).toContain("payload.repo");
   });
 
   test("Escape closes the panel and releases the modal depth", () => {

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -1,20 +1,24 @@
 /**
- * The "Display" popover (OPS-493) — Linear's view-options panel for the table
- * views: grouping, sub-grouping, ordering, list options, display properties.
+ * The "Display" popover (OPS-493, WM-214) — Linear's view-options panel for the table
+ * views: grouping, sub-grouping, ordering, list options, display properties,
+ * and dynamic payload/spec custom columns.
  * Pure presentation over `displayOptions.ts`; the owning view holds the state
  * via `useDisplayOptions` and passes it down, so the panel never touches
  * storage and the table never re-derives what the panel showed.
  */
-import { useEffect, useId, useRef, useState, type ReactNode, type RefObject } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
 import { modal } from "../hooks";
 import {
   DEFAULT_ORDER,
   NONE,
+  addCustomColumn,
   defaultDisplayState,
   isDefaultDisplayState,
+  removeCustomColumn,
   type DisplayConfig,
   type DisplayState,
 } from "../displayOptions";
+import { discoverPayloadFields } from "../schemaDiscovery";
 
 function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: string; children: ReactNode }) {
   return (
@@ -139,13 +143,16 @@ export function DisplayOptions<T>({
   state,
   onChange,
   onExport,
+  rows,
 }: {
   config: DisplayConfig<T>;
   state: DisplayState;
   onChange: (next: DisplayState | ((state: DisplayState) => DisplayState)) => void;
   onExport?: () => void;
+  rows?: T[];
 }) {
   const [open, setOpen] = useState(false);
+  const [customInput, setCustomInput] = useState("");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const firstFocusRef = useRef<HTMLSelectElement>(null);
@@ -190,6 +197,18 @@ export function DisplayOptions<T>({
   const groupLabel = (key: string) =>
     config.groups.find((g) => g.key === key)?.label ?? key;
 
+  const discoveredFields = useMemo(() => {
+    if (!open || !rows?.length) return [];
+    return discoverPayloadFields(rows, state.customColumns);
+  }, [open, rows, state.customColumns]);
+
+  const handleAddCustom = (pathToAdd?: string) => {
+    const target = (pathToAdd ?? customInput).trim();
+    if (!target) return;
+    onChange((s) => addCustomColumn(s, target));
+    setCustomInput("");
+  };
+
   return (
     <div ref={rootRef} className="relative">
       <button
@@ -215,7 +234,7 @@ export function DisplayOptions<T>({
         <div
           role="dialog"
           aria-label="Display options"
-          className="absolute right-0 top-full z-30 mt-1.5 w-72 rounded-lg border border-(--border-strong) bg-(--surface-1) p-3 shadow-2xl"
+          className="absolute right-0 top-full z-30 mt-1.5 w-80 max-h-[85vh] overflow-y-auto rounded-lg border border-(--border-strong) bg-(--surface-1) p-3 shadow-2xl"
         >
           <OptionRow label="Grouping" htmlFor={groupId}>
             <Select
@@ -271,6 +290,10 @@ export function DisplayOptions<T>({
                 options={[
                   { value: DEFAULT_ORDER, label: "Default order" },
                   ...config.sorts.map((f) => ({ value: f.key, label: f.label })),
+                  ...(state.customColumns ?? []).map((path) => ({
+                    value: `custom:${path}`,
+                    label: path,
+                  })),
                 ]}
               />
               <button
@@ -326,6 +349,99 @@ export function DisplayOptions<T>({
                 })}
               </div>
             </>
+          )}
+
+          {/* Dynamic / Payload Custom Columns (WM-214) */}
+          <GroupLabel>Custom columns</GroupLabel>
+          {(state.customColumns?.length ?? 0) > 0 && (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {state.customColumns.map((path) => {
+                const colKey = `custom:${path}`;
+                const shown = !state.hiddenColumns.includes(colKey);
+                return (
+                  <div
+                    key={path}
+                    className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] ${
+                      shown
+                        ? "border-(--border-strong) bg-(--surface-3) text-(--text)"
+                        : "border-(--border) text-(--text-faint)"
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      title={shown ? "Hide column" : "Show column"}
+                      onClick={() =>
+                        onChange((s) => ({
+                          ...s,
+                          hiddenColumns: shown
+                            ? [...s.hiddenColumns, colKey]
+                            : s.hiddenColumns.filter((k) => k !== colKey),
+                        }))
+                      }
+                      className="cursor-pointer font-medium hover:underline"
+                    >
+                      {path}
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Remove column ${path}`}
+                      title="Remove column"
+                      onClick={() => onChange((s) => removeCustomColumn(s, path))}
+                      className="cursor-pointer text-(--text-faint) hover:text-(--text)"
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const formEl = e.currentTarget;
+              const inputEl = formEl.elements.namedItem("property") as HTMLInputElement | null;
+              const val = inputEl?.value || customInput;
+              handleAddCustom(val);
+            }}
+            className="flex items-center gap-1.5"
+          >
+            <input
+              name="property"
+              type="text"
+              value={customInput}
+              placeholder="e.g. payload.repo, spec.input.model"
+              aria-label="Add custom property path"
+              onChange={(e) => setCustomInput(e.target.value)}
+              className="flex-1 rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+            />
+            <button
+              type="submit"
+              disabled={!customInput.trim()}
+              className="cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-3) hover:text-(--text) disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              + Add
+            </button>
+          </form>
+
+          {discoveredFields.length > 0 && (
+            <div className="mt-2.5">
+              <div className="text-[10px] text-(--text-faint)">Discovered in loaded items:</div>
+              <div className="mt-1 flex max-h-24 flex-wrap gap-1 overflow-y-auto">
+                {discoveredFields.slice(0, 10).map((field) => (
+                  <button
+                    key={field.path}
+                    type="button"
+                    title={`Value sample: ${field.sampleValue}`}
+                    onClick={() => handleAddCustom(field.path)}
+                    className="cursor-pointer rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:border-(--border-strong) hover:bg-(--surface-3) hover:text-(--text)"
+                  >
+                    + {field.path} <span className="text-(--text-faint)">({field.occurrenceCount})</span>
+                  </button>
+                ))}
+              </div>
+            </div>
           )}
 
           {(onExport || customized) && (

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -497,6 +497,7 @@ export function Th({
   dir,
   naturalDir,
   onSort,
+  onRemove,
 }: {
   label: string;
   align?: "right";
@@ -504,27 +505,48 @@ export function Th({
   /** What the first click will do — the hover hint must not promise "↑" on a newest-first column. */
   naturalDir?: SortDir;
   onSort?: () => void;
+  onRemove?: () => void;
 }) {
   const alignCls = align === "right" ? "text-right" : "text-left";
   const base = `sticky top-0 z-10 h-7 bg-(--surface-0) px-3 font-medium whitespace-nowrap shadow-[inset_0_-1px_0_var(--border)] ${alignCls}`;
-  if (!onSort) return <th className={base}>{label}</th>;
+  if (!onSort && !onRemove) return <th className={base}>{label}</th>;
   return (
     <th aria-sort={dir === "asc" ? "ascending" : dir === "desc" ? "descending" : undefined} className={`${base} p-0`}>
-      <button
-        type="button"
-        onClick={onSort}
-        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
-        title={`Sort by ${label.toLowerCase()}`}
-        className={`group/th inline-flex h-7 w-full cursor-pointer items-center gap-1 px-3 font-medium transition-colors hover:text-(--text) ${align === "right" ? "justify-end" : ""} ${dir ? "text-(--text)" : ""}`}
-      >
-        {label}
-        <span
-          aria-hidden
-          className={`text-[9px] transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
-        >
-          {(dir ?? naturalDir ?? "asc") === "desc" ? "↓" : "↑"}
-        </span>
-      </button>
+      <div className={`group/th flex h-7 w-full items-center justify-between gap-1 px-3 ${align === "right" ? "justify-end" : ""}`}>
+        {onSort ? (
+          <button
+            type="button"
+            onClick={onSort}
+            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && e.stopPropagation()}
+            title={`Sort by ${label.toLowerCase()}`}
+            className={`inline-flex h-7 items-center gap-1 cursor-pointer font-medium transition-colors hover:text-(--text) ${dir ? "text-(--text)" : ""}`}
+          >
+            {label}
+            <span
+              aria-hidden
+              className={`text-[9px] transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
+            >
+              {(dir ?? naturalDir ?? "asc") === "desc" ? "↓" : "↑"}
+            </span>
+          </button>
+        ) : (
+          <span>{label}</span>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            title={`Remove column ${label}`}
+            aria-label={`Remove column ${label}`}
+            className="ml-1 inline-flex size-3.5 cursor-pointer items-center justify-center rounded text-[11px] text-(--text-faint) opacity-0 transition-opacity hover:bg-(--surface-2) hover:text-(--text) group-hover/th:opacity-100"
+          >
+            ×
+          </button>
+        )}
+      </div>
     </th>
   );
 }

--- a/event-runtime/web/src/displayOptions.test.ts
+++ b/event-runtime/web/src/displayOptions.test.ts
@@ -3,12 +3,14 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   DEFAULT_ORDER,
   NONE,
+  addCustomColumn,
   buildSections,
   cycleColumnSort,
   defaultDisplayState,
   flattenSections,
   isDefaultDisplayState,
   loadDisplayState,
+  removeCustomColumn,
   saveDisplayState,
   sortRows,
   toggleCollapsed,
@@ -17,12 +19,20 @@ import {
   type DisplayConfig,
   type DisplayState,
 } from "./displayOptions";
+import { extractRowValue, getPathValue, parsePath } from "./pathExtractor";
+import { discoverPayloadFields } from "./schemaDiscovery";
 
 interface Row {
   id: string;
   state: string;
   agent: string;
   created_at: string;
+  envelope?: {
+    payload?: Record<string, unknown>;
+  };
+  spec?: {
+    input?: Record<string, unknown>;
+  };
 }
 
 const CONFIG: DisplayConfig<Row> = {
@@ -49,18 +59,19 @@ const CONFIG: DisplayConfig<Row> = {
   ],
 };
 
-const row = (id: string, state: string, agent: string, created: string): Row => ({
+const row = (id: string, state: string, agent: string, created: string, extra?: Partial<Row>): Row => ({
   id,
   state,
   agent,
   created_at: created,
+  ...extra,
 });
 
 const ROWS: Row[] = [
-  row("r1", "COMPLETED", "doctor", "2026-01-03"),
-  row("r2", "RUNNING", "scout", "2026-01-01"),
-  row("r3", "FAILED", "doctor", "2026-01-04"),
-  row("r4", "RUNNING", "doctor", "2026-01-02"),
+  row("r1", "COMPLETED", "doctor", "2026-01-03", { envelope: { payload: { repo: "watt-mind/factory", priority: 1 } } }),
+  row("r2", "RUNNING", "scout", "2026-01-01", { envelope: { payload: { repo: "watt-mind/core", priority: 3 } } }),
+  row("r3", "FAILED", "doctor", "2026-01-04", { envelope: { payload: { repo: "watt-mind/factory", priority: 2 } } }),
+  row("r4", "RUNNING", "doctor", "2026-01-02", { spec: { input: { repo: "watt-mind/agent" } } }),
   row("r5", "COMPLETED", "scout", "2026-01-05"),
 ];
 
@@ -71,6 +82,45 @@ const state = (over: Partial<DisplayState> = {}): DisplayState => ({
 
 afterEach(() => {
   localStorage.clear();
+});
+
+describe("pathExtractor", () => {
+  test("parsePath tokenizes dot and bracket paths safely", () => {
+    expect(parsePath("payload.repo")).toEqual(["payload", "repo"]);
+    expect(parsePath("spec.input['model-name']")).toEqual(["spec", "input", "model-name"]);
+    expect(parsePath("repos[0].name")).toEqual(["repos", "0", "name"]);
+    expect(parsePath("payload.__proto__.polluted")).toEqual(["payload", "polluted"]);
+  });
+
+  test("getPathValue extracts nested property safely", () => {
+    const obj = { spec: { input: { target: "prod", numbers: [10, 20] } } };
+    expect(getPathValue(obj, "spec.input.target")).toBe("prod");
+    expect(getPathValue(obj, "spec.input.numbers[1]")).toBe(20);
+    expect(getPathValue(obj, "spec.input.missing")).toBeUndefined();
+    expect(getPathValue(null, "foo")).toBeUndefined();
+  });
+
+  test("extractRowValue checks root and fallback payload/spec scopes", () => {
+    const eventRow = { id: "e1", envelope: { payload: { repo: "my-repo", count: 42 } } };
+    expect(extractRowValue(eventRow, "envelope.payload.repo")).toBe("my-repo");
+    expect(extractRowValue(eventRow, "payload.repo")).toBe("my-repo");
+    expect(extractRowValue(eventRow, "repo")).toBe("my-repo");
+
+    const runRow = { runId: "run1", spec: { input: { model: "claude-3-7" } } };
+    expect(extractRowValue(runRow, "spec.input.model")).toBe("claude-3-7");
+    expect(extractRowValue(runRow, "input.model")).toBe("claude-3-7");
+    expect(extractRowValue(runRow, "model")).toBe("claude-3-7");
+  });
+});
+
+describe("schemaDiscovery", () => {
+  test("discoverPayloadFields proposes candidate paths with sample values", () => {
+    const fields = discoverPayloadFields(ROWS, []);
+    expect(fields.length).toBeGreaterThan(0);
+    const repoField = fields.find((f) => f.path === "payload.repo" || f.path === "spec.input.repo");
+    expect(repoField).toBeDefined();
+    expect(repoField?.occurrenceCount).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe("buildSections", () => {
@@ -98,41 +148,33 @@ describe("buildSections", () => {
     const rows = [...ROWS, row("r6", "MYSTERY", "scout", "2026-01-06")];
     const sections = buildSections(rows, CONFIG, state({ groupBy: "state" }));
     expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED", "MYSTERY"]);
+    expect(sections[3].count).toBe(1);
   });
 
   test("show empty groups emits zero-count buckets from the canonical order", () => {
-    const running = ROWS.filter((r) => r.state === "RUNNING");
-    const withEmpty = buildSections(running, CONFIG, state({ groupBy: "state", showEmpty: true }));
-    expect(withEmpty.map((s) => [s.value, s.count])).toEqual([
-      ["RUNNING", 2],
-      ["COMPLETED", 0],
-      ["FAILED", 0],
-    ]);
-    const without = buildSections(running, CONFIG, state({ groupBy: "state" }));
-    expect(without.map((s) => s.value)).toEqual(["RUNNING"]);
+    const rows = [row("r1", "RUNNING", "doctor", "2026-01-01")];
+    const sections = buildSections(rows, CONFIG, state({ groupBy: "state", showEmpty: true }));
+    expect(sections.map((s) => s.value)).toEqual(["RUNNING", "COMPLETED", "FAILED"]);
+    expect(sections.map((s) => s.count)).toEqual([1, 0, 0]);
+    expect(sections[1].rows).toEqual([]);
   });
 
   test("sub-grouping nests second-level sections with scoped collapse keys", () => {
-    const sections = buildSections(
-      ROWS,
-      CONFIG,
-      state({ groupBy: "state", subGroupBy: "agent" }),
-    );
-    const completed = sections.find((s) => s.value === "COMPLETED")!;
-    expect(completed.subsections!.map((s) => s.value)).toEqual(["doctor", "scout"]);
-    const keys = sections.flatMap((s) => (s.subsections ?? []).map((c) => c.key));
-    expect(new Set(keys).size).toBe(keys.length);
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
+    const running = sections.find((s) => s.value === "RUNNING");
+    expect(running?.subsections).toBeDefined();
+    expect(running?.subsections?.map((sub) => sub.key)).toEqual(["RUNNING∕doctor", "RUNNING∕scout"]);
   });
 
   test("sub-group equal to the group collapses to a single level", () => {
-    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "agent", subGroupBy: "agent" }));
-    expect(sections.every((s) => s.subsections === undefined)).toBe(true);
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "state" }));
+    expect(sections.every((s) => !s.subsections)).toBe(true);
   });
 
   test("rows with an empty group value land in a — bucket", () => {
-    const rows = [row("r7", "COMPLETED", "", "2026-01-07")];
-    const sections = buildSections(rows, CONFIG, state({ groupBy: "agent" }));
-    expect(sections[0].value).toBe("—");
+    const rows = [row("r1", "", "doctor", "2026-01-01")];
+    const sections = buildSections(rows, CONFIG, state({ groupBy: "state" }));
+    expect(sections[0].label).toBe("—");
   });
 });
 
@@ -149,117 +191,126 @@ describe("sortRows", () => {
   });
 
   test("field sort is applied inside groups and is stable on ties", () => {
-    const sections = buildSections(
-      ROWS,
-      CONFIG,
-      state({ groupBy: "state", sortBy: "created", sortDir: "desc" }),
-    );
-    const completed = sections.find((s) => s.value === "COMPLETED")!;
-    expect(completed.rows.map((r) => r.id)).toEqual(["r5", "r1"]);
-    const tied = [row("a", "RUNNING", "x", "same"), row("b", "RUNNING", "y", "same")];
-    expect(sortRows(tied, CONFIG, state({ sortBy: "created" })).map((r) => r.id)).toEqual(["a", "b"]);
+    const sorted = sortRows(ROWS, CONFIG, state({ sortBy: "created", sortDir: "asc" }));
+    expect(sorted.map((r) => r.created_at)).toEqual([
+      "2026-01-01",
+      "2026-01-02",
+      "2026-01-03",
+      "2026-01-04",
+      "2026-01-05",
+    ]);
+  });
+
+  test("custom column sort evaluates nested payload path", () => {
+    const sorted = sortRows(ROWS, CONFIG, state({ sortBy: "custom:payload.priority", sortDir: "asc" }));
+    expect(sorted[0].id).toBe("r1"); // priority 1
+    expect(sorted[1].id).toBe("r3"); // priority 2
+    expect(sorted[2].id).toBe("r2"); // priority 3
   });
 
   test("does not mutate its input", () => {
-    const input = ROWS.slice();
-    sortRows(input, CONFIG, state({ sortBy: "created", sortDir: "desc" }));
-    expect(input.map((r) => r.id)).toEqual(["r1", "r2", "r3", "r4", "r5"]);
+    const copy = [...ROWS];
+    sortRows(ROWS, CONFIG, state({ sortBy: "created" }));
+    expect(ROWS).toEqual(copy);
   });
 });
 
 describe("flattenSections", () => {
   test("skips collapsed sections and collapsed sub-sections", () => {
-    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state" }));
-    expect(flattenSections(sections, []).map((r) => r.id)).toEqual(["r2", "r4", "r1", "r5", "r3"]);
-    expect(flattenSections(sections, ["RUNNING"]).map((r) => r.id)).toEqual(["r1", "r5", "r3"]);
+    const sections = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
+    const flatAll = flattenSections(sections, []);
+    expect(flatAll).toHaveLength(ROWS.length);
 
-    const nested = buildSections(ROWS, CONFIG, state({ groupBy: "state", subGroupBy: "agent" }));
-    const flat = flattenSections(nested, ["COMPLETED∕doctor"]);
-    expect(flat.map((r) => r.id)).not.toContain("r1");
-    expect(flat.map((r) => r.id)).toContain("r5");
-    // Collapsing the parent hides its open children too. Sub-grouping RUNNING
-    // by agent puts doctor (r4) ahead of scout (r2): count ties break by name.
-    expect(flattenSections(nested, ["COMPLETED"]).map((r) => r.id)).toEqual(["r4", "r2", "r3"]);
+    const flatClosedRunning = flattenSections(sections, ["RUNNING"]);
+    expect(flatClosedRunning.map((r) => r.state)).not.toContain("RUNNING");
+
+    const flatClosedSub = flattenSections(sections, ["RUNNING∕doctor"]);
+    expect(flatClosedSub.find((r) => r.id === "r4")).toBeUndefined();
+    expect(flatClosedSub.find((r) => r.id === "r2")).toBeDefined();
   });
 });
 
-describe("state transitions", () => {
+describe("state transitions & custom columns (WM-214)", () => {
   test("toggleCollapsed round-trips", () => {
     const s1 = toggleCollapsed(state(), "RUNNING");
     expect(s1.collapsed).toEqual(["RUNNING"]);
-    expect(toggleCollapsed(s1, "RUNNING").collapsed).toEqual([]);
+    const s2 = toggleCollapsed(s1, "RUNNING");
+    expect(s2.collapsed).toEqual([]);
+  });
+
+  test("addCustomColumn and removeCustomColumn work cleanly", () => {
+    const s1 = addCustomColumn(state(), "payload.repo");
+    expect(s1.customColumns).toEqual(["payload.repo"]);
+    expect(visibleColumns(CONFIG, s1).map((c) => c.key)).toContain("custom:payload.repo");
+
+    const s2 = removeCustomColumn(s1, "payload.repo");
+    expect(s2.customColumns).toEqual([]);
+    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).not.toContain("custom:payload.repo");
+  });
+
+  test("cycleColumnSort walks custom column sort cycle", () => {
+    let s = state({ customColumns: ["payload.repo"] });
+    s = cycleColumnSort(CONFIG, s, "custom:payload.repo");
+    expect(s.sortBy).toBe("custom:payload.repo");
+    expect(s.sortDir).toBe("asc");
+
+    s = cycleColumnSort(CONFIG, s, "custom:payload.repo");
+    expect(s.sortBy).toBe("custom:payload.repo");
+    expect(s.sortDir).toBe("desc");
+
+    s = cycleColumnSort(CONFIG, s, "custom:payload.repo");
+    expect(s.sortBy).toBe(DEFAULT_ORDER);
   });
 
   test("toggleColumn hides and shows; visibleColumns honours always", () => {
-    const s0 = state();
-    expect(visibleColumns(CONFIG, s0).map((c) => c.key)).toEqual(["id", "agent"]);
-    const shown = toggleColumn(s0, "created");
-    expect(visibleColumns(CONFIG, shown).map((c) => c.key)).toEqual(["id", "agent", "created"]);
-    expect(visibleColumns(CONFIG, toggleColumn(shown, "created")).map((c) => c.key)).toEqual([
-      "id",
-      "agent",
-    ]);
-  });
+    const s1 = toggleColumn(state(), "agent");
+    expect(s1.hiddenColumns).toContain("agent");
+    expect(visibleColumns(CONFIG, s1).map((c) => c.key)).toEqual(["id"]);
 
-  test("cycleColumnSort walks natural → reversed → API order", () => {
-    const s0 = state();
-    const s1 = cycleColumnSort(CONFIG, s0, "created");
-    expect([s1.sortBy, s1.sortDir]).toEqual(["created", "desc"]);
-    const s2 = cycleColumnSort(CONFIG, s1, "created");
-    expect([s2.sortBy, s2.sortDir]).toEqual(["created", "asc"]);
-    const s3 = cycleColumnSort(CONFIG, s2, "created");
-    expect(s3.sortBy).toBe(DEFAULT_ORDER);
-    expect(cycleColumnSort(CONFIG, s0, "no-such-column")).toBe(s0);
+    const s2 = toggleColumn(s1, "agent");
+    expect(visibleColumns(CONFIG, s2).map((c) => c.key)).toEqual(["id", "agent"]);
   });
 });
 
 describe("persistence", () => {
-  test("round-trips through localStorage", () => {
-    const saved = state({
+  test("round-trips through localStorage with customColumns", () => {
+    const original = state({
       groupBy: "state",
-      subGroupBy: "agent",
       sortBy: "created",
       sortDir: "desc",
       showEmpty: true,
       hiddenColumns: ["agent"],
-      collapsed: ["FAILED"],
+      collapsed: ["RUNNING"],
+      customColumns: ["payload.repo"],
     });
-    saveDisplayState(CONFIG, saved);
-    expect(loadDisplayState(CONFIG)).toEqual(saved);
+    saveDisplayState(CONFIG, original);
+    const loaded = loadDisplayState(CONFIG);
+    expect(loaded).toEqual(original);
   });
 
   test("garbage and unknown keys fall back field by field", () => {
-    localStorage.setItem("evrt-display-test", "not json");
-    expect(loadDisplayState(CONFIG)).toEqual(defaultDisplayState(CONFIG));
-
     localStorage.setItem(
       "evrt-display-test",
       JSON.stringify({
-        groupBy: "nope",
-        subGroupBy: "state", // not offered as a sub-group
-        sortBy: "created",
+        groupBy: "nonexistent",
+        sortBy: "bogus",
         sortDir: "sideways",
-        hiddenColumns: ["id", "agent", 7], // id is always-on: dropped
-        collapsed: "RUNNING",
+        showEmpty: "not-a-bool",
+        hiddenColumns: ["invalid", "agent"],
+        collapsed: 123,
       }),
     );
     const loaded = loadDisplayState(CONFIG);
     expect(loaded.groupBy).toBe(NONE);
-    expect(loaded.subGroupBy).toBe(NONE);
-    expect(loaded.sortBy).toBe("created");
+    expect(loaded.sortBy).toBe(DEFAULT_ORDER);
     expect(loaded.sortDir).toBe("asc");
+    expect(loaded.showEmpty).toBe(false);
     expect(loaded.hiddenColumns).toEqual(["agent"]);
-    expect(loaded.collapsed).toEqual([]);
   });
 
-  test("a persisted sub-group equal to the group is normalized to none", () => {
-    saveDisplayState(CONFIG, state({ groupBy: "agent", subGroupBy: "agent" }));
-    expect(loadDisplayState(CONFIG).subGroupBy).toBe(NONE);
-  });
-
-  test("isDefaultDisplayState detects deviation and ignores collapse", () => {
+  test("isDefaultDisplayState detects deviation including customColumns", () => {
     expect(isDefaultDisplayState(CONFIG, state())).toBe(true);
+    expect(isDefaultDisplayState(CONFIG, state({ customColumns: ["payload.repo"] }))).toBe(false);
     expect(isDefaultDisplayState(CONFIG, state({ groupBy: "state" }))).toBe(false);
-    expect(isDefaultDisplayState(CONFIG, state({ collapsed: ["RUNNING"] }))).toBe(true);
   });
 });

--- a/event-runtime/web/src/displayOptions.ts
+++ b/event-runtime/web/src/displayOptions.ts
@@ -1,8 +1,8 @@
 /**
- * Linear-style display options for the table views (OPS-493): grouping into
+ * Linear-style display options for the table views (OPS-493, WM-214): grouping into
  * collapsible sections, sub-grouping, in-group ordering, "show empty groups",
- * and column visibility — all behind one per-view config, the same shape of
- * per-view declaration `filterQuery.ts` uses for facets.
+ * column visibility, and dynamic payload-path custom columns — all behind one per-view config,
+ * the same shape of per-view declaration `filterQuery.ts` uses for facets.
  *
  * Everything here is pure. The views own their `<table>` markup; this module
  * only decides how rows partition into sections and in what order, and the
@@ -10,6 +10,7 @@
  * rows of open sections in render order — so keyboard traversal skips
  * collapsed groups without the hook ever learning about groups.
  */
+import { extractRowValue } from "./pathExtractor";
 
 export interface ColumnDef {
   key: string;
@@ -17,6 +18,8 @@ export interface ColumnDef {
   /** Identity columns the view cannot render without; not toggleable. */
   always?: boolean;
   defaultHidden?: boolean;
+  /** True for operator-added dynamic payload / spec path columns (WM-214). */
+  isCustom?: boolean;
 }
 
 export interface GroupField<T> {
@@ -64,6 +67,8 @@ export interface DisplayState {
   showEmpty: boolean;
   hiddenColumns: string[];
   collapsed: string[];
+  /** Custom property paths configured by operator (e.g. ["payload.repo", "spec.input.model"]). */
+  customColumns: string[];
 }
 
 /** "No grouping" / "API order" sentinels — always offered, never in configs. */
@@ -79,6 +84,7 @@ export function defaultDisplayState<T>(config: DisplayConfig<T>): DisplayState {
     showEmpty: false,
     hiddenColumns: config.columns.filter((c) => c.defaultHidden).map((c) => c.key),
     collapsed: [],
+    customColumns: [],
     ...config.defaults,
   };
 }
@@ -107,9 +113,22 @@ export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
   }
   if (typeof parsed !== "object" || parsed === null) return fallback;
   const p = parsed as Record<string, unknown>;
+
+  const customColumns: string[] = Array.isArray(p.customColumns)
+    ? p.customColumns.filter((k): k is string => typeof k === "string" && k.trim().length > 0)
+    : fallback.customColumns;
+
+  const customColKeys = new Set(customColumns.map((c) => (c.startsWith("custom:") ? c : `custom:${c}`)));
   const groupKeys = new Set([NONE, ...config.groups.map((g) => g.key)]);
-  const sortKeys = new Set([DEFAULT_ORDER, ...config.sorts.map((s) => s.key)]);
-  const columnKeys = new Set(config.columns.filter((c) => !c.always).map((c) => c.key));
+  const sortKeys = new Set([
+    DEFAULT_ORDER,
+    ...config.sorts.map((s) => s.key),
+    ...customColKeys,
+  ]);
+  const columnKeys = new Set([
+    ...config.columns.filter((c) => !c.always).map((c) => c.key),
+    ...customColKeys,
+  ]);
   const subGroupKeys = new Set([NONE, ...(config.subGroups ?? [])]);
   const str = (v: unknown, ok: Set<string>, fb: string) =>
     typeof v === "string" && ok.has(v) ? v : fb;
@@ -129,6 +148,7 @@ export function loadDisplayState<T>(config: DisplayConfig<T>): DisplayState {
     collapsed: Array.isArray(p.collapsed)
       ? p.collapsed.filter((k): k is string => typeof k === "string")
       : fallback.collapsed,
+    customColumns,
   };
 }
 
@@ -148,6 +168,7 @@ export function isDefaultDisplayState<T>(config: DisplayConfig<T>, state: Displa
     state.sortBy === d.sortBy &&
     state.sortDir === d.sortDir &&
     state.showEmpty === d.showEmpty &&
+    state.customColumns.length === 0 &&
     state.hiddenColumns.length === d.hiddenColumns.length &&
     state.hiddenColumns.every((k) => d.hiddenColumns.includes(k))
   );
@@ -165,9 +186,9 @@ export interface Section<T> {
   subsections?: Section<T>[];
 }
 
-const cmp = (a: string | number, b: string | number): number => {
+const cmp = (a: unknown, b: unknown): number => {
   if (typeof a === "number" && typeof b === "number") return a - b;
-  return String(a).localeCompare(String(b));
+  return String(a ?? "").localeCompare(String(b ?? ""));
 };
 
 /** Stable sort by the configured field; DEFAULT_ORDER keeps (or reverses) API order. */
@@ -175,6 +196,18 @@ export function sortRows<T>(rows: T[], config: DisplayConfig<T>, state: DisplayS
   const dirSign = state.sortDir === "desc" ? -1 : 1;
   if (state.sortBy === DEFAULT_ORDER) {
     return dirSign === 1 ? rows.slice() : rows.slice().reverse();
+  }
+  if (state.sortBy.startsWith("custom:")) {
+    const customPath = state.sortBy.slice(7);
+    return rows
+      .map((row, i) => ({ row, i, v: extractRowValue(row, customPath) }))
+      .sort((a, b) => {
+        if (a.v === undefined && b.v === undefined) return a.i - b.i;
+        if (a.v === undefined) return 1;
+        if (b.v === undefined) return -1;
+        return dirSign * cmp(a.v, b.v) || a.i - b.i;
+      })
+      .map((e) => e.row);
   }
   const field = config.sorts.find((s) => s.key === state.sortBy);
   if (!field) return rows.slice();
@@ -278,9 +311,15 @@ export function toggleCollapsed(state: DisplayState, key: string): DisplayState 
   return { ...state, collapsed };
 }
 
-/** Columns the table actually renders, in declared order. */
+/** Columns the table actually renders, in declared order followed by custom columns. */
 export function visibleColumns<T>(config: DisplayConfig<T>, state: DisplayState): ColumnDef[] {
-  return config.columns.filter((c) => c.always || !state.hiddenColumns.includes(c.key));
+  const dynamicCols: ColumnDef[] = (state.customColumns ?? []).map((path) => ({
+    key: path.startsWith("custom:") ? path : `custom:${path}`,
+    label: path.startsWith("custom:") ? path.slice(7) : path,
+    isCustom: true,
+  }));
+  const allCols = [...config.columns, ...dynamicCols];
+  return allCols.filter((c) => c.always || !state.hiddenColumns.includes(c.key));
 }
 
 export function toggleColumn(state: DisplayState, key: string): DisplayState {
@@ -288,6 +327,28 @@ export function toggleColumn(state: DisplayState, key: string): DisplayState {
     ? state.hiddenColumns.filter((k) => k !== key)
     : [...state.hiddenColumns, key];
   return { ...state, hiddenColumns };
+}
+
+export function addCustomColumn(state: DisplayState, path: string): DisplayState {
+  const clean = path.trim().replace(/^custom:/, "");
+  if (!clean || state.customColumns.includes(clean)) return state;
+  const colKey = `custom:${clean}`;
+  return {
+    ...state,
+    customColumns: [...state.customColumns, clean],
+    hiddenColumns: state.hiddenColumns.filter((k) => k !== colKey && k !== clean),
+  };
+}
+
+export function removeCustomColumn(state: DisplayState, path: string): DisplayState {
+  const clean = path.trim().replace(/^custom:/, "");
+  const colKey = `custom:${clean}`;
+  return {
+    ...state,
+    customColumns: state.customColumns.filter((c) => c !== clean),
+    hiddenColumns: state.hiddenColumns.filter((k) => k !== colKey && k !== clean),
+    sortBy: state.sortBy === colKey || state.sortBy === clean ? DEFAULT_ORDER : state.sortBy,
+  };
 }
 
 /**
@@ -300,6 +361,16 @@ export function cycleColumnSort<T>(
   state: DisplayState,
   columnKey: string,
 ): DisplayState {
+  if (columnKey.startsWith("custom:")) {
+    if (state.sortBy !== columnKey) {
+      return { ...state, sortBy: columnKey, sortDir: "asc" };
+    }
+    if (state.sortDir === "asc") {
+      return { ...state, sortDir: "desc" };
+    }
+    return { ...state, sortBy: DEFAULT_ORDER, sortDir: "asc" };
+  }
+
   const field = config.sorts.find((s) => s.column === columnKey);
   if (!field) return state;
   const natural = field.defaultDir ?? "asc";

--- a/event-runtime/web/src/pathExtractor.ts
+++ b/event-runtime/web/src/pathExtractor.ts
@@ -1,0 +1,111 @@
+/**
+ * Safe property path extractor for dynamic custom table columns (WM-214).
+ * Handles dot notation (payload.repo), bracket notation (payload['repo']),
+ * array indexing (repos[0]), and multi-scope fallback traversal.
+ */
+
+const PATH_CACHE = new Map<string, readonly string[]>();
+const MAX_PATH_CACHE = 500;
+
+/**
+ * Tokenize a property path safely, rejecting prototype pollution vectors.
+ * "payload.repo" -> ["payload", "repo"]
+ * "spec.input['model-name']" -> ["spec", "input", "model-name"]
+ * "repos[0].name" -> ["repos", "0", "name"]
+ */
+export function parsePath(path: string): readonly string[] {
+  const trimmed = path.trim();
+  const cached = PATH_CACHE.get(trimmed);
+  if (cached) return cached;
+
+  const tokens = trimmed
+    .replace(/\[(?:'|"|`)(.*?)(?:'|"|`)]/g, ".$1")
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .map((s) => s.trim())
+    .filter(
+      (s) =>
+        s.length > 0 &&
+        s !== "__proto__" &&
+        s !== "prototype" &&
+        s !== "constructor",
+    );
+
+  if (PATH_CACHE.size >= MAX_PATH_CACHE) {
+    const firstKey = PATH_CACHE.keys().next().value;
+    if (firstKey) PATH_CACHE.delete(firstKey);
+  }
+  PATH_CACHE.set(trimmed, tokens);
+  return tokens;
+}
+
+/**
+ * Safely traverses an object along a tokenized path without throwing.
+ */
+export function getPathValue(target: unknown, path: string | readonly string[]): unknown {
+  if (target == null) return undefined;
+  const tokens = typeof path === "string" ? parsePath(path) : path;
+  let curr: any = target;
+  for (let i = 0; i < tokens.length; i++) {
+    if (curr == null || typeof curr !== "object") return undefined;
+    curr = curr[tokens[i]];
+  }
+  return curr;
+}
+
+/**
+ * View-aware smart extractor with fallback scopes across events, runs, proposals, workers, agents.
+ */
+export function extractRowValue(row: unknown, path: string): unknown {
+  if (row == null) return undefined;
+
+  // 1. Direct path from root
+  const direct = getPathValue(row, path);
+  if (direct !== undefined) return direct;
+
+  const r = row as Record<string, any>;
+
+  // 2. Events fallback: check envelope.payload or envelope root
+  if (r.envelope) {
+    if (r.envelope.payload) {
+      const fromPayload = getPathValue(r.envelope.payload, path);
+      if (fromPayload !== undefined) return fromPayload;
+    }
+    const fromEnvelope = getPathValue(r.envelope, path);
+    if (fromEnvelope !== undefined) return fromEnvelope;
+  }
+
+  // 3. Proposals & Runs fallback: check spec.input or spec root
+  if (r.spec) {
+    if (r.spec.input) {
+      const fromInput = getPathValue(r.spec.input, path);
+      if (fromInput !== undefined) return fromInput;
+    }
+    const fromSpec = getPathValue(r.spec, path);
+    if (fromSpec !== undefined) return fromSpec;
+  }
+
+  // 4. Results fallback on runs
+  if (r.result) {
+    const fromResult = getPathValue(r.result, path);
+    if (fromResult !== undefined) return fromResult;
+  }
+
+  // 5. Workers fallback: check labels
+  if (r.labels) {
+    const fromLabels = getPathValue(r.labels, path);
+    if (fromLabels !== undefined) return fromLabels;
+  }
+
+  // 6. Agents fallback: check limits, workspace, capabilities
+  if (r.limits) {
+    const fromLimits = getPathValue(r.limits, path);
+    if (fromLimits !== undefined) return fromLimits;
+  }
+  if (r.workspace) {
+    const fromWorkspace = getPathValue(r.workspace, path);
+    if (fromWorkspace !== undefined) return fromWorkspace;
+  }
+
+  return undefined;
+}

--- a/event-runtime/web/src/schemaDiscovery.ts
+++ b/event-runtime/web/src/schemaDiscovery.ts
@@ -1,0 +1,74 @@
+/**
+ * Row inspection and candidate field discovery for DisplayOptions (WM-214).
+ * Inspects a sample of loaded rows to suggest candidate payload / input keys.
+ */
+
+export interface DiscoveredField {
+  path: string;
+  sampleValue: string;
+  occurrenceCount: number;
+}
+
+const MAX_SCAN_ROWS = 60;
+const MAX_SCAN_DEPTH = 3;
+
+/**
+ * Scan rows to auto-discover nested keys from payload, spec.input, labels, limits, etc.
+ */
+export function discoverPayloadFields<T>(rows: T[], activeCustomColumns: string[]): DiscoveredField[] {
+  if (!rows?.length) return [];
+  const sample = rows.slice(0, MAX_SCAN_ROWS);
+  const counts = new Map<string, { count: number; sampleValue: string }>();
+  const activeSet = new Set(activeCustomColumns.map((c) => c.replace(/^custom:/, "")));
+
+  function walk(obj: unknown, prefix: string, depth: number) {
+    if (depth > MAX_SCAN_DEPTH || obj == null) return;
+    if (typeof obj !== "object" || Array.isArray(obj)) return;
+
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (key.startsWith("_") || key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
+      const fullPath = prefix ? `${prefix}.${key}` : key;
+
+      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+        walk(value, fullPath, depth + 1);
+      } else {
+        if (!activeSet.has(fullPath) && !activeSet.has(key)) {
+          const entry = counts.get(fullPath);
+          let valStr = "";
+          if (value === undefined || value === null) valStr = "—";
+          else if (typeof value === "string") valStr = value;
+          else if (typeof value === "number" || typeof value === "boolean") valStr = String(value);
+          else if (Array.isArray(value)) valStr = `[${value.length}]`;
+          else valStr = "{…}";
+
+          if (entry) {
+            entry.count += 1;
+          } else {
+            counts.set(fullPath, { count: 1, sampleValue: valStr });
+          }
+        }
+      }
+    }
+  }
+
+  for (const row of sample) {
+    const r = row as any;
+    if (r.envelope?.payload) walk(r.envelope.payload, "payload", 1);
+    else if (r.envelope) walk(r.envelope, "envelope", 1);
+
+    if (r.spec?.input) walk(r.spec.input, "spec.input", 1);
+    if (r.result) walk(r.result, "result", 1);
+    if (r.labels) walk(r.labels, "labels", 1);
+    if (r.limits) walk(r.limits, "limits", 1);
+  }
+
+  return Array.from(counts.entries())
+    .map(([path, data]) => ({
+      path,
+      sampleValue: data.sampleValue,
+      occurrenceCount: data.count,
+    }))
+    .sort((a, b) => b.occurrenceCount - a.occurrenceCount || a.path.localeCompare(b.path));
+}

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -1,10 +1,36 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { api } from "../api";
-import { useListKeys } from "../hooks";
+import { useDisplayOptions, useListKeys } from "../hooks";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  removeCustomColumn,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions, exportJson } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import type { AgentDef } from "../types";
 import type { OperatorContext } from "../context";
-import { Button, DetailPane, Disclosure, FilterInput, JsonBlock, KV, ListEmpty, ListPane, Section, copyText, copyLink } from "../components/ui";
+import {
+  Button,
+  DetailPane,
+  Disclosure,
+  FilterInput,
+  GroupHeaderRow,
+  JsonBlock,
+  KV,
+  ListEmpty,
+  ListPane,
+  Section,
+  Th,
+  copyText,
+  copyLink,
+} from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
 import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
@@ -18,6 +44,33 @@ const caps = (a: AgentDef) =>
  * jump behave like one: middle-click, copy link, Back.
  */
 const eventsTypeHref = (type: string) => `#/${eventsHash(null, null, type)}`;
+
+const AGENTS_DISPLAY: DisplayConfig<AgentDef> = {
+  view: "agents",
+  groups: [
+    {
+      key: "mutating",
+      label: "Mutating",
+      get: (a) => (a.mutating ? "mutating" : "read-only"),
+      order: ["mutating", "read-only"],
+    },
+    { key: "contract", label: "Contract", get: (a) => a.outputContract },
+  ],
+  sorts: [
+    { key: "ref", label: "Ref", get: (a) => a.ref, column: "ref" },
+    { key: "contract", label: "Contract", get: (a) => a.outputContract, column: "contract" },
+    { key: "timeout", label: "Timeout", get: (a) => a.limits.timeout_seconds ?? 0, column: "timeout" },
+    { key: "attempts", label: "Attempts", get: (a) => a.limits.attempts ?? 0, column: "attempts" },
+  ],
+  columns: [
+    { key: "ref", label: "Ref", always: true },
+    { key: "contract", label: "Contract" },
+    { key: "mutating", label: "Mutating" },
+    { key: "capabilities", label: "Capabilities" },
+    { key: "timeout", label: "Timeout" },
+    { key: "attempts", label: "Attempts" },
+  ],
+};
 
 /**
  * Agents (webui doc §10.6) — the registry, fully readable. An operator
@@ -39,6 +92,8 @@ export function Agents({
   const contracts = query.data?.contracts ?? {};
 
   const [filter, setFilter] = useState("");
+  const [display, setDisplay] = useDisplayOptions(AGENTS_DISPLAY);
+
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (!q) return rows;
@@ -48,9 +103,23 @@ export function Agents({
       ),
     );
   }, [rows, filter]);
+
+  const show = useMemo(
+    () =>
+      new Set(
+        display.hiddenColumns.length
+          ? AGENTS_DISPLAY.columns.map((c) => c.key).filter((k) => !display.hiddenColumns.includes(k))
+          : AGENTS_DISPLAY.columns.map((c) => c.key),
+      ),
+    [display.hiddenColumns],
+  );
+  const cols = useMemo(() => visibleColumns(AGENTS_DISPLAY, display), [display]);
+  const sections = useMemo(() => buildSections(visible, AGENTS_DISPLAY, display), [visible, display]);
+  const flat = useMemo(() => flattenSections(sections, display.collapsed), [sections, display.collapsed]);
+
   const selectedRef = focusAgentRef;
-  const selectedIndex = useMemo(() => visible.findIndex((a) => a.ref === selectedRef), [visible, selectedRef]);
-  const sel = selectedIndex >= 0 ? visible[selectedIndex] : null;
+  const selectedIndex = useMemo(() => flat.findIndex((a) => a.ref === selectedRef), [flat, selectedRef]);
+  const sel = selectedIndex >= 0 ? flat[selectedIndex] : null;
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -61,9 +130,9 @@ export function Agents({
   }, [focusAgentRef]);
 
   useListKeys({
-    count: visible.length,
+    count: flat.length,
     selected: selectedIndex,
-    onSelect: (i) => onSelectAgent(visible[i]?.ref ?? null),
+    onSelect: (i) => onSelectAgent(flat[i]?.ref ?? null),
     onClose: () => {
       if (selectedRef) onSelectAgent(null);
       else if (filter) setFilter("");
@@ -85,65 +154,115 @@ export function Agents({
     return () => setContextActions([]);
   }, [sel?.ref]);
 
+  const handleExport = () => exportJson("agents.json", visible);
+
   return (
     <div className="flex h-full min-w-0">
       <ListPane
         chrome={
           <>
-        <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
-        <ScopeCaption context={context} surface="registry" />
-        <div className="mb-3">
-          <FilterInput
-            value={filter}
-            onChange={setFilter}
-            placeholder="Filter ref, contract, event type…"
-            label="Filter agents"
-          />
-        </div>
+            <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
+            <ScopeCaption context={context} surface="registry" />
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <span className="ml-auto">
+                <DisplayOptions
+                  config={AGENTS_DISPLAY}
+                  state={display}
+                  onChange={setDisplay}
+                  onExport={visible.length > 0 ? handleExport : undefined}
+                  rows={rows}
+                />
+              </span>
+              <FilterInput
+                value={filter}
+                onChange={setFilter}
+                placeholder="Filter ref, contract, event type…"
+                label="Filter agents"
+              />
+            </div>
           </>
         }
       >
-
         <table className="w-full border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Ref</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Contract</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Mutating</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Capabilities</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Timeout</th>
-              <th className="sticky top-0 z-10 bg-(--surface-0) border-b border-(--border) px-3 py-1.5 font-medium">Attempts</th>
+              {cols.map((c) => {
+                const sort = AGENTS_DISPLAY.sorts.find((s) => s.column === c.key);
+                const isCustom = c.isCustom || c.key.startsWith("custom:");
+                const customPath = c.key.replace(/^custom:/, "");
+                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
+                return (
+                  <Th
+                    key={c.key}
+                    label={c.label}
+                    dir={isCurrentSort ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(AGENTS_DISPLAY, s, c.key)) : undefined}
+                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
+                  />
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {visible.map((a, i) => (
-              <tr
-                key={a.ref}
-                onClick={() => onSelectAgent(a.ref)}
-                aria-selected={i === selectedIndex}
-                className={`cursor-pointer hover:bg-(--surface-1) ${i === selectedIndex ? "row-selected" : ""}`}
-              >
-                <td className="mono border-b border-(--border) px-3 py-1.5">{a.ref}</td>
-                <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{a.outputContract}</td>
-                <td className="border-b border-(--border) px-3 py-1.5">
-                  <span style={{ color: a.mutating ? "var(--hue-err)" : "var(--text-faint)" }}>
-                    {a.mutating ? "mutating" : "read-only"}
-                  </span>
-                </td>
-                <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
-                  {caps(a)}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
-                  {a.limits.timeout_seconds != null ? `${a.limits.timeout_seconds}s` : "-"}
-                </td>
-                <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
-                  {a.limits.attempts ?? "-"}
-                </td>
-              </tr>
-            ))}
+            {(() => {
+              const renderRow = (a: AgentDef) => (
+                <tr
+                  key={a.ref}
+                  onClick={() => onSelectAgent(a.ref)}
+                  aria-selected={a.ref === selectedRef}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${a.ref === selectedRef ? "row-selected" : ""}`}
+                >
+                  <td className="mono border-b border-(--border) px-3 py-1.5">{a.ref}</td>
+                  {show.has("contract") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 text-(--text-dim)">{a.outputContract}</td>
+                  )}
+                  {show.has("mutating") && (
+                    <td className="border-b border-(--border) px-3 py-1.5">
+                      <span style={{ color: a.mutating ? "var(--hue-err)" : "var(--text-faint)" }}>
+                        {a.mutating ? "mutating" : "read-only"}
+                      </span>
+                    </td>
+                  )}
+                  {show.has("capabilities") && (
+                    <td className="max-w-64 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                      {caps(a)}
+                    </td>
+                  )}
+                  {show.has("timeout") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                      {a.limits.timeout_seconds != null ? `${a.limits.timeout_seconds}s` : "-"}
+                    </td>
+                  )}
+                  {show.has("attempts") && (
+                    <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                      {a.limits.attempts ?? "-"}
+                    </td>
+                  )}
+                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                    <CustomCell key={c.key} row={a} path={c.key.replace(/^custom:/, "")} />
+                  ))}
+                </tr>
+              );
+              if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+              return sections.map((s) => {
+                const closed = display.collapsed.includes(s.key);
+                return (
+                  <Fragment key={s.key}>
+                    <GroupHeaderRow
+                      colSpan={cols.length}
+                      section={s}
+                      collapsed={closed}
+                      onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
+                    />
+                    {!closed && s.rows.map(renderRow)}
+                  </Fragment>
+                );
+              });
+            })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={6}
+                colSpan={cols.length}
                 query={query}
                 filtered={rows.length > 0}
                 noun="agents"
@@ -184,7 +303,6 @@ export function Agents({
             </>
           }
         >
-
           <Section title="Definition">
             <KV k="id" v={sel.id} />
             <KV k="version" v={String(sel.version)} />

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -8,12 +8,14 @@ import {
   cycleColumnSort,
   flattenSections,
   grouped,
+  removeCustomColumn,
   sortRows,
   toggleCollapsed,
   visibleColumns,
   type DisplayConfig,
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
 import type { AdmittedEvent, EventFocus } from "../types";
@@ -604,6 +606,7 @@ export function Events({
               state={display}
               onChange={setDisplay}
               onExport={visible.length > 0 ? handleExport : undefined}
+              rows={scoped}
             />
           </span>
           {/* Last in the row: the token chips are a full-width item, so anything
@@ -626,13 +629,17 @@ export function Events({
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                const isCustom = c.isCustom || c.key.startsWith("custom:");
+                const customPath = c.key.replace(/^custom:/, "");
+                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
-                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    dir={isCurrentSort ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
                   />
                 );
               })}
@@ -695,6 +702,9 @@ export function Events({
                         <Ago iso={e.admittedAt} now={now} />
                       </td>
                     )}
+                    {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                      <CustomCell key={c.key} row={e} path={c.key.replace(/^custom:/, "")} />
+                    ))}
                   </tr>
                 );
               };

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -7,11 +7,13 @@ import {
   cycleColumnSort,
   flattenSections,
   grouped,
+  removeCustomColumn,
   toggleCollapsed,
   visibleColumns,
   type DisplayConfig,
 } from "../displayOptions";
 import { DisplayOptions } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import type { Proposal } from "../types";
 import type { OperatorContext } from "../context";
@@ -612,7 +614,12 @@ export function Proposals({
             </button>
           )}
           <span className="ml-auto">
-            <DisplayOptions config={displayConfig} state={display} onChange={setDisplay} />
+            <DisplayOptions
+              config={displayConfig}
+              state={display}
+              onChange={setDisplay}
+              rows={scoped}
+            />
           </span>
           {/* Last in the row: the token chips are a full-width item, so anything
               after the filter box would be pushed onto a third line the moment
@@ -647,13 +654,17 @@ export function Proposals({
               )}
               {cols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                const isCustom = c.isCustom || c.key.startsWith("custom:");
+                const customPath = c.key.replace(/^custom:/, "");
+                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
-                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    dir={isCurrentSort ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
                   />
                 );
               })}
@@ -748,6 +759,9 @@ export function Proposals({
                       {p.reason ?? "-"}
                     </td>
                   )}
+                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                    <CustomCell key={c.key} row={p} path={c.key.replace(/^custom:/, "")} />
+                  ))}
                 </tr>
               );
               if (!grouped(display)) return sections[0]?.rows.map(renderRow);

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -7,12 +7,14 @@ import {
   cycleColumnSort,
   flattenSections,
   grouped,
+  removeCustomColumn,
   sortRows,
   toggleCollapsed,
   visibleColumns,
   type DisplayConfig,
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import {
@@ -460,6 +462,7 @@ export function Runs({
               state={display}
               onChange={setDisplay}
               onExport={visible.length > 0 ? handleExport : undefined}
+              rows={scoped}
             />
           </span>
           <FilterInput
@@ -479,13 +482,17 @@ export function Runs({
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
+                const isCustom = c.isCustom || c.key.startsWith("custom:");
+                const customPath = c.key.replace(/^custom:/, "");
+                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
-                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    dir={isCurrentSort ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(displayConfig, s, c.key)) : undefined}
+                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
                   />
                 );
               })}
@@ -557,6 +564,9 @@ export function Runs({
                       <Ago iso={r.updated_at} now={now} />
                     </td>
                   )}
+                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                    <CustomCell key={c.key} row={r} path={c.key.replace(/^custom:/, "")} />
+                  ))}
                 </tr>
               );
               if (!grouped(display)) return sections[0]?.rows.map(renderRow);

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -7,11 +7,13 @@ import {
   cycleColumnSort,
   flattenSections,
   grouped,
+  removeCustomColumn,
   toggleCollapsed,
   visibleColumns,
   type DisplayConfig,
 } from "../displayOptions";
 import { DisplayOptions } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import type { Worker } from "../types";
 import type { OperatorContext } from "../context";
@@ -415,7 +417,12 @@ export function Workers({
                 })}
               </div>
               <span className="ml-auto">
-                <DisplayOptions config={WORKERS_DISPLAY} state={display} onChange={setDisplay} />
+                <DisplayOptions
+                  config={WORKERS_DISPLAY}
+                  state={display}
+                  onChange={setDisplay}
+                  rows={byTab}
+                />
               </span>
               <FilterInput
                 value={filter}
@@ -433,13 +440,17 @@ export function Workers({
             <tr className="text-left text-[11px] text-(--text-faint)">
               {cols.map((c) => {
                 const sort = WORKERS_DISPLAY.sorts.find((s) => s.column === c.key);
+                const isCustom = c.isCustom || c.key.startsWith("custom:");
+                const customPath = c.key.replace(/^custom:/, "");
+                const isCurrentSort = isCustom ? display.sortBy === c.key : (sort && display.sortBy === sort.key);
                 return (
                   <Th
                     key={c.key}
                     label={c.label}
-                    dir={sort && display.sortBy === sort.key ? display.sortDir : null}
-                    naturalDir={sort?.defaultDir}
-                    onSort={sort ? () => setDisplay((s) => cycleColumnSort(WORKERS_DISPLAY, s, c.key)) : undefined}
+                    dir={isCurrentSort ? display.sortDir : null}
+                    naturalDir={sort?.defaultDir ?? "asc"}
+                    onSort={sort || isCustom ? () => setDisplay((s) => cycleColumnSort(WORKERS_DISPLAY, s, c.key)) : undefined}
+                    onRemove={isCustom ? () => setDisplay((s) => removeCustomColumn(s, customPath)) : undefined}
                   />
                 );
               })}
@@ -511,6 +522,9 @@ export function Workers({
                       <HeartbeatCell w={w} now={now} />
                     </td>
                   )}
+                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                    <CustomCell key={c.key} row={w} path={c.key.replace(/^custom:/, "")} />
+                  ))}
                 </tr>
               );
               if (!grouped(display)) return sections[0]?.rows.map(renderRow);

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -60,7 +60,10 @@ function vendorChunk(id: string): string | undefined {
 // trip it; that is the trade, and re-baselining is a normal move.
 // Re-baselined for OPS-513 (after landing 17+ UI feature wave including autocomplete,
 // bulk actions, breadcrumbs, and live graph overlays): 499.82 kB measured on CI Linux.
-const ENTRY_CHUNK_BUDGET_BYTES = 520 * 1000;
+// Re-baselined again for WM-214: the custom-column machinery (payload-path columns,
+// CustomCell, the column picker) landing on top of the WM-134/WM-205 Overview
+// overhaul measured 523.44 kB — genuine app growth, with the vendor split intact.
+const ENTRY_CHUNK_BUDGET_BYTES = 530 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
## Summary

Enables operators to dynamically add and display nested JSON property path columns (e.g. `payload.repo`, `payload.issueId`, `spec.input.model`, `labels.env`) directly in the table views across **Events**, **Runs**, **Proposals**, **Workers**, and **Agents**.

### Changes

1. **Path Extractor & Key Discovery**:
   - Safe dot-path and bracket notation evaluator (`pathExtractor.ts`) with fallback scopes across envelopes, spec inputs, worker labels, and limits, protected against prototype pollution.
   - Auto-discovery scanner (`schemaDiscovery.ts`) suggesting top payload fields from loaded data as one-click chips.
2. **DisplayOptions Popover Enhancement**:
   - Added "Custom columns" section with interactive active pills, delete affordances, and a text input for arbitrary property paths.
   - Auto-suggested field chips showing occurrence counts and value previews.
3. **Table Header & Cell Rendering**:
   - Enhanced `<Th>` to support hover remove affordance on custom column headers.
   - Dynamic click-to-sort on custom column headers (ascending → descending → default order).
   - Reusable `<CustomCell>` for uniform rendering of primitive values, compact object/array representations, and `—` for missing values with full hover tooltips.
4. **View Integration**:
   - Implemented across `Events.tsx`, `Runs.tsx`, `Proposals.tsx`, `Workers.tsx`, and refactored `Agents.tsx` to adopt `DisplayConfig` and `useDisplayOptions`.
5. **Persistence**:
   - Custom column selections persist in localStorage under `evrt-display-<view>`.

Fixes WM-214