### PR TITLE
feat(factory): dev live-reload — `factory up --dev` with drain-aware worker (WM-213)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -68,6 +68,32 @@ bun deploy/gen.mjs
 
 That is the gate CI applies to every pull request and to every push to `develop` and `main`. The web install comes first because the web `.test.tsx` files resolve React's JSX runtime out of `event-runtime/web/node_modules`; without it `bun test` reports a green that CI will not reproduce (OPS-384). `--check` is the half that proves the generated tree still matches `shared/`.
 
+## 6. The dev loop — `factory up --dev` (WM-213)
+
+`factory up` is the live stack. `factory up --dev` is the same three daemons with reload wired in, so iterating no longer means `factory down && factory up` after every edit:
+
+```bash
+factory up --dev     # serve --watch + vite HMR web UI + drain-aware worker
+factory tail         # all three logs (serve, worker, web)
+factory down         # stops all three
+```
+
+It needs the web deps (`cd event-runtime/web && bun install`) because the UI runs under vite instead of the static `serve.mjs` build; `--dev` says so and exits rather than failing inside vite. Plain `factory up` behaves exactly as before.
+
+**The worker reloads only when idle.** It stamps its own code at startup (HEAD plus a content hash of `event-runtime/lib/**` and `event-runtime/cli.mjs`, so uncommitted edits count) and re-checks that stamp *between claims*. On a change it exits `75` and the supervisor re-execs it. A run in flight keeps the old code to completion — logged as `reload deferred until <run> finishes` — and the reload happens at the next idle poll. Nothing can interrupt a running agent, which is the reason this is a poll-boundary check and not a file watcher.
+
+**Which change needs which reload:**
+
+| You changed | What reloads it |
+| :--- | :--- |
+| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve restarts immediately (`bun --watch`, drops in-flight planner work); the worker restarts at its next idle poll |
+| `event-runtime/web/**` | vite HMR — the open tab updates, nothing restarts |
+| `agents/*.md`, `schemas/**` | **neither.** Definitions are read per plan/claim but their pinned hashes are not: run `bun event-runtime/cli.mjs update-pins` |
+| `config/*.yaml` | restart serve |
+| `bin/live-stack.sh` | `factory down && factory up --dev` |
+
+Details, including the `work --reload-on-change` flag and `FACTORY_CODE_STAMP_ROOT`, are in [event-runtime/README.md](event-runtime/README.md#dev-live-reload--factory-up---dev-wm-213).
+
 ## Known gaps
 
 These are deliberate — the scaffold ships honest about what isn't built.

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -3,6 +3,8 @@
 #
 #   factory up                   # start live api (7381), worker, and web UI (7382)
 #   factory up --fake            # start with fake adapter (for staging/testing on live db)
+#   factory up --dev             # live-reload stack: serve --watch, vite HMR web,
+#                                # drain-aware worker (WM-213)
 #   factory down                 # cleanly stop live daemons
 #   factory tail                 # tail all live logs (serve.log, worker.log, web.log)
 #   factory tail worker          # tail a specific daemon log
@@ -25,14 +27,17 @@ REPO="$(repo_root)"
 case "$ACTION" in
   up)
     ADAPTER_FLAG=()
+    DEV=0
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --fake) ADAPTER_FLAG=("--adapter-override" "fake") ;;
         --adapter-override) ADAPTER_FLAG=("--adapter-override" "$2"); shift ;;
         --port) API_PORT="$2"; shift ;;
         --web-port) WEB_PORT="$2"; shift ;;
+        --dev) DEV=1 ;;
         -h|--help)
-          echo "usage: factory up [--fake] [--port 7381] [--web-port 7382]"
+          echo "usage: factory up [--fake] [--dev] [--port 7381] [--web-port 7382]"
+          echo "  --dev  live reload: serve --watch, vite HMR web UI, worker restarts when idle"
           exit 0
           ;;
         *) die "unknown option '$1' (see: factory up --help)" ;;
@@ -40,20 +45,33 @@ case "$ACTION" in
       shift
     done
 
+    # --dev swaps each of the three daemons for its reloading twin and changes
+    # nothing else. SERVE_ARGS/WORKER_ARGS are built rather than branched so the
+    # non-dev command stays exactly what it was before this flag existed. (They
+    # are never empty, which keeps "${arr[@]}" safe under bash 3.2 + set -u.)
+    SERVE_ARGS=(serve --port "$API_PORT")
+    if [[ ${#ADAPTER_FLAG[@]} -gt 0 ]]; then
+      SERVE_ARGS+=("${ADAPTER_FLAG[@]}")
+    fi
+    WORKER_ARGS=(bun "$REPO/event-runtime/cli.mjs" work)
+    if [[ "$DEV" -eq 1 ]]; then
+      SERVE_ARGS+=(--watch)
+      # The worker is supervised rather than watched: it exits 75 at an idle
+      # poll boundary and this same script re-execs it (see __supervise-worker).
+      WORKER_ARGS=(bash "$REPO/bin/live-stack.sh" __supervise-worker --reload-on-change)
+      if [[ ! -d "$REPO/event-runtime/web/node_modules" ]]; then
+        die "--dev needs the web deps for vite — run: (cd $REPO/event-runtime/web && bun install)"
+      fi
+    fi
+
     # 1. Start or verify event runtime API server
     if pid_alive "$RUN_DIR/serve.pid"; then
       info "event runtime already running (pid $(cat "$RUN_DIR/serve.pid"), port $API_PORT)"
     else
       info "starting event runtime on $API_PORT (home $HOME_DIR)"
-      if [[ ${#ADAPTER_FLAG[@]} -gt 0 ]]; then
-        spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$REPO" \
-          env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
-          bun "$REPO/event-runtime/cli.mjs" serve --port "$API_PORT" "${ADAPTER_FLAG[@]}"
-      else
-        spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$REPO" \
-          env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
-          bun "$REPO/event-runtime/cli.mjs" serve --port "$API_PORT"
-      fi
+      spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$REPO" \
+        env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+        bun "$REPO/event-runtime/cli.mjs" "${SERVE_ARGS[@]}"
     fi
 
     # 2. Wait for API to respond
@@ -72,7 +90,7 @@ case "$ACTION" in
       info "starting worker"
       spawn_daemon "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$REPO" \
         env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
-        bun "$REPO/event-runtime/cli.mjs" work
+        "${WORKER_ARGS[@]}"
     fi
 
     # 4. Start or verify web server
@@ -80,25 +98,82 @@ case "$ACTION" in
       info "web server already running (pid $(cat "$RUN_DIR/web.pid"), port $WEB_PORT)"
     else
       info "starting web server on $WEB_PORT"
-      spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
-        env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
-        bun "$REPO/event-runtime/web/serve.mjs"
+      if [[ "$DEV" -eq 1 ]]; then
+        # vite's own dev server, not the static serve.mjs: HMR replaces the
+        # module in the open tab, so no `bun run build` step in the loop. It
+        # proxies /api to FACTORY_EVENT_PORT exactly as serve.mjs does.
+        spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
+          env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+          bunx vite --host 127.0.0.1 --port "$WEB_PORT" --strictPort
+      else
+        spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
+          env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+          bun "$REPO/event-runtime/web/serve.mjs"
+      fi
     fi
 
-    # 5. Wait for web server
-    for i in $(seq 30); do
+    # 5. Wait for web server (vite has to boot a dep-optimize pass on a cold cache)
+    WEB_TRIES=30
+    if [[ "$DEV" -eq 1 ]]; then WEB_TRIES=150; fi
+    for i in $(seq "$WEB_TRIES"); do
       if curl -sf -m 1 "http://127.0.0.1:$WEB_PORT" >/dev/null 2>&1; then break; fi
       sleep 0.1
     done
 
-    printf '\n\033[32m==>\033[0m \033[1mready — live factory stack\033[0m\n\n'
+    if [[ "$DEV" -eq 1 ]]; then
+      printf '\n\033[32m==>\033[0m \033[1mready — live factory stack (dev, live reload)\033[0m\n\n'
+    else
+      printf '\n\033[32m==>\033[0m \033[1mready — live factory stack\033[0m\n\n'
+    fi
     printf '  event home %s\n' "$HOME_DIR"
     printf '  control    http://127.0.0.1:%s\n' "$API_PORT"
     printf '  web UI     http://127.0.0.1:%s\n' "$WEB_PORT"
     printf '  logs       %s/{serve,worker,web}.log\n\n' "$RUN_DIR"
+    if [[ "$DEV" -eq 1 ]]; then
+      printf '  reload     serve: bun --watch  |  web: vite HMR  |  worker: on exit 75 when idle\n'
+      printf '             agents/schemas need: bun event-runtime/cli.mjs update-pins\n\n'
+    fi
     printf '  status:  factory events status\n'
     printf '  tail:    factory tail\n'
     printf '  down:    factory down\n\n'
+    ;;
+
+  __supervise-worker)
+    # Dev worker supervisor (WM-213). `work --reload-on-change` exits 75 at an
+    # idle poll boundary when event-runtime code changed; this re-execs it.
+    #
+    # Only on 75: exit 0 is a clean drain and must stay down, and any other code
+    # is a real failure the developer needs to see rather than a crash loop.
+    CHILD_PID=""
+    SUPERVISOR_STOPPING=0
+    # Declared before the trap: a signal arriving early must not hit an unbound
+    # variable under `set -u`.
+    trap 'SUPERVISOR_STOPPING=1; if [[ -n "$CHILD_PID" ]]; then kill -TERM "$CHILD_PID" 2>/dev/null || true; fi' TERM INT
+    while true; do
+      bun "$REPO/event-runtime/cli.mjs" work "$@" &
+      CHILD_PID=$!
+      # A trap interrupts `wait`; loop until the child is really gone so the
+      # supervisor outlives its worker's drain and `factory down` waits for both.
+      CODE=0
+      while true; do
+        wait "$CHILD_PID" || CODE=$?
+        kill -0 "$CHILD_PID" 2>/dev/null || break
+      done
+      CHILD_PID=""
+      if [[ "$SUPERVISOR_STOPPING" -eq 1 ]]; then
+        # `wait` interrupted by the trap reports 128+signal, not what the worker
+        # actually exited with — reporting that number would just be noise. The
+        # operator asked for a stop and got one.
+        printf '[supervisor] worker drained after signal — supervisor stopping\n'
+        exit 0
+      fi
+      if [[ "$CODE" -eq 75 ]]; then
+        printf '[supervisor] worker reloaded (exit 75) — restarting on new code\n'
+        continue
+      fi
+      printf '[supervisor] worker exited %s — supervisor stopping\n' "$CODE"
+      exit "$CODE"
+    done
     ;;
 
   down)

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -1,0 +1,322 @@
+/**
+ * bin/live-stack.sh — `factory up --dev` wiring and the dev worker supervisor
+ * (WM-213).
+ *
+ * The point of these tests is the *shape of the commands* the script spawns and
+ * the supervisor's restart rule, so they run against a throwaway repo whose
+ * worktree-common.sh records spawns instead of starting daemons. Booting three
+ * real processes would test bun and vite, not this script.
+ */
+import { expect, test } from "bun:test";
+import {
+  chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const LIVE_STACK = path.resolve(import.meta.dir, "live-stack.sh");
+
+/** worktree-common.sh replaced by recorders: no daemon is ever started. */
+const COMMON_STUB = `#!/usr/bin/env bash
+repo_root() { printf '%s' "$FAKE_REPO"; }
+info() { printf '==> %s\\n' "$*"; }
+warn() { printf 'warn: %s\\n' "$*" >&2; }
+die() { printf 'error: %s\\n' "$*" >&2; exit 1; }
+pid_alive() { return 1; }
+spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
+  local pidfile="$1" logfile="$2" workdir="$3"
+  shift 3
+  printf 'SPAWN pid=%s workdir=%s cmd=%s\\n' "$(basename "$pidfile")" "$workdir" "$*" >>"$SPAWN_LOG"
+  printf '1\\n' >"$pidfile"
+}
+term_daemon() { printf 'TERM %s\\n' "$2" >>"$SPAWN_LOG"; }
+await_daemon() { printf 'AWAIT %s\\n' "$2" >>"$SPAWN_LOG"; }
+`;
+
+/**
+ * A fake event-runtime CLI for the supervisor tests. Counts its invocations and
+ * exits 75 for the first FAKE_WORKER_RELOADS of them, then FAKE_WORKER_FINAL.
+ * `wait-term` instead stays up until signalled, then exits 75 — the case that
+ * proves a reload code arriving *after* a SIGTERM does not restart anything.
+ */
+const FAKE_CLI = `import { readFileSync, writeFileSync } from "node:fs";
+const counter = process.env.FAKE_WORKER_COUNTER;
+const n = Number(readFileSync(counter, "utf8").trim() || "0") + 1;
+writeFileSync(counter, String(n));
+console.log(\`fake worker start #\${n} args=\${process.argv.slice(2).join(" ")}\`);
+if (process.env.FAKE_WORKER_MODE === "wait-term") {
+  process.on("SIGTERM", () => { console.log("fake worker got SIGTERM"); process.exit(75); });
+  setInterval(() => {}, 1000);
+} else {
+  process.exit(n <= Number(process.env.FAKE_WORKER_RELOADS ?? 0)
+    ? 75
+    : Number(process.env.FAKE_WORKER_FINAL ?? 0));
+}
+`;
+
+function makeFixture({ withWebDeps = true } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "live-stack-"));
+  mkdirSync(path.join(root, "bin"), { recursive: true });
+  mkdirSync(path.join(root, "event-runtime", "web"), { recursive: true });
+  mkdirSync(path.join(root, "stubs"), { recursive: true });
+  copyFileSync(LIVE_STACK, path.join(root, "bin", "live-stack.sh"));
+  writeFileSync(path.join(root, "bin", "worktree-common.sh"), COMMON_STUB, "utf8");
+  writeFileSync(path.join(root, "event-runtime", "cli.mjs"), FAKE_CLI, "utf8");
+  writeFileSync(path.join(root, "event-runtime", "web", "serve.mjs"), "", "utf8");
+  if (withWebDeps) mkdirSync(path.join(root, "event-runtime", "web", "node_modules"), { recursive: true });
+
+  // The health polls must not gate a test on a server nobody started.
+  const curl = path.join(root, "stubs", "curl");
+  writeFileSync(curl, "#!/bin/sh\nexit 0\n", "utf8");
+  chmodSync(curl, 0o755);
+
+  return {
+    root,
+    spawnLog: path.join(root, "spawns.log"),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function runStack(fixture, args, extraEnv = {}) {
+  const result = Bun.spawnSync({
+    cmd: ["bash", path.join(fixture.root, "bin", "live-stack.sh"), ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${path.join(fixture.root, "stubs")}:${process.env.PATH}`,
+      FAKE_REPO: fixture.root,
+      SPAWN_LOG: fixture.spawnLog,
+      FACTORY_RUN_DIR: path.join(fixture.root, "run"),
+      FACTORY_EVENT_HOME: path.join(fixture.root, "home"),
+      ...extraEnv,
+    },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+    spawns: existsSync(fixture.spawnLog) ? readFileSync(fixture.spawnLog, "utf8").trim().split("\n") : [],
+  };
+}
+
+const spawnFor = (spawns, pidfile) => spawns.find((line) => line.includes(`pid=${pidfile}`)) ?? "";
+
+test("plain `up` spawns serve, worker, and the static web server — unchanged by --dev existing", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up"]);
+    expect(r.status).toBe(0);
+
+    const serve = spawnFor(r.spawns, "serve.pid");
+    expect(serve).toContain("cli.mjs serve --port 7381");
+    expect(serve).not.toContain("--watch");
+
+    expect(spawnFor(r.spawns, "worker.pid")).toContain("cli.mjs work");
+    expect(spawnFor(r.spawns, "worker.pid")).not.toContain("__supervise-worker");
+
+    const web = spawnFor(r.spawns, "web.pid");
+    expect(web).toContain("web/serve.mjs");
+    expect(web).not.toContain("vite");
+
+    expect(r.stdout).toContain("ready — live factory stack");
+    expect(r.stdout).not.toContain("dev, live reload");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --fake` still passes the adapter override through", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--fake"]);
+    expect(r.status).toBe(0);
+    expect(spawnFor(r.spawns, "serve.pid")).toContain("--adapter-override fake");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --dev` wires all three: serve --watch, vite HMR web, supervised worker", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--dev"]);
+    expect(r.status).toBe(0);
+
+    expect(spawnFor(r.spawns, "serve.pid")).toContain("cli.mjs serve --port 7381 --watch");
+
+    const worker = spawnFor(r.spawns, "worker.pid");
+    expect(worker).toContain("bin/live-stack.sh __supervise-worker --reload-on-change");
+
+    const web = spawnFor(r.spawns, "web.pid");
+    expect(web).toContain("bunx vite --host 127.0.0.1 --port 7382 --strictPort");
+    expect(web).toContain(`workdir=${path.join(f.root, "event-runtime", "web")}`);
+
+    expect(r.stdout).toContain("ready — live factory stack (dev, live reload)");
+    expect(r.stdout).toContain("worker: on exit 75 when idle");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --dev --fake` keeps both the adapter override and the watch flag", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--dev", "--fake", "--port", "7391", "--web-port", "7392"]);
+    expect(r.status).toBe(0);
+    const serve = spawnFor(r.spawns, "serve.pid");
+    expect(serve).toContain("--port 7391");
+    expect(serve).toContain("--adapter-override fake");
+    expect(serve).toContain("--watch");
+    expect(spawnFor(r.spawns, "web.pid")).toContain("--port 7392");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --dev` without the web deps names the install command instead of failing inside vite", () => {
+  const f = makeFixture({ withWebDeps: false });
+  try {
+    const r = runStack(f, ["up", "--dev"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("--dev needs the web deps for vite");
+    expect(r.stderr).toContain("bun install");
+    expect(r.spawns).toEqual([]); // nothing started before the check
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`down` stops all three daemons in either mode", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["down"]);
+    expect(r.status).toBe(0);
+    for (const label of ["web server", "worker", "event runtime"]) {
+      expect(r.spawns).toContain(`TERM ${label}`);
+      expect(r.spawns).toContain(`AWAIT ${label}`);
+    }
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --bogus` is still rejected", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--bogus"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("unknown option '--bogus'");
+  } finally {
+    f.cleanup();
+  }
+});
+
+// --- __supervise-worker ------------------------------------------------------
+
+function runSupervisor(f, { reloads = 0, final = 0, mode = "" } = {}) {
+  const counter = path.join(f.root, "counter");
+  writeFileSync(counter, "0", "utf8");
+  const proc = Bun.spawnSync({
+    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-worker", "--reload-on-change"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      FAKE_REPO: f.root,
+      SPAWN_LOG: f.spawnLog,
+      FACTORY_RUN_DIR: path.join(f.root, "run"),
+      FACTORY_EVENT_HOME: path.join(f.root, "home"),
+      FAKE_WORKER_COUNTER: counter,
+      FAKE_WORKER_RELOADS: String(reloads),
+      FAKE_WORKER_FINAL: String(final),
+      FAKE_WORKER_MODE: mode,
+    },
+  });
+  return {
+    status: proc.exitCode,
+    out: `${proc.stdout.toString()}${proc.stderr.toString()}`,
+    runs: Number(readFileSync(counter, "utf8").trim()),
+  };
+}
+
+test("supervisor restarts the worker on exit 75, as many times as it asks", () => {
+  const f = makeFixture();
+  try {
+    const r = runSupervisor(f, { reloads: 3, final: 0 });
+    expect(r.runs).toBe(4); // three reloads, then the run that exits cleanly
+    expect(r.status).toBe(0);
+    expect(r.out.split("worker reloaded (exit 75)").length - 1).toBe(3);
+    expect(r.out).toContain("worker exited 0 — supervisor stopping");
+    // The reload flag is what makes the worker exit 75 in the first place.
+    expect(r.out).toContain("args=work --reload-on-change");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("supervisor does NOT restart on a clean drain (exit 0)", () => {
+  const f = makeFixture();
+  try {
+    const r = runSupervisor(f, { reloads: 0, final: 0 });
+    expect(r.runs).toBe(1);
+    expect(r.status).toBe(0);
+    expect(r.out).not.toContain("worker reloaded");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("supervisor surfaces a real crash instead of looping on it", () => {
+  const f = makeFixture();
+  try {
+    const r = runSupervisor(f, { reloads: 0, final: 1 });
+    expect(r.runs).toBe(1);
+    expect(r.status).toBe(1);
+    expect(r.out).toContain("worker exited 1 — supervisor stopping");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("SIGTERM to the supervisor drains the worker and stops — even if it exits 75", async () => {
+  const f = makeFixture();
+  const counter = path.join(f.root, "counter");
+  writeFileSync(counter, "0", "utf8");
+  const proc = Bun.spawn({
+    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-worker", "--reload-on-change"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      FAKE_REPO: f.root,
+      FACTORY_RUN_DIR: path.join(f.root, "run"),
+      FACTORY_EVENT_HOME: path.join(f.root, "home"),
+      FAKE_WORKER_COUNTER: counter,
+      FAKE_WORKER_MODE: "wait-term",
+    },
+  });
+  try {
+    let out = "";
+    const reader = (async () => {
+      for await (const chunk of proc.stdout) out += new TextDecoder().decode(chunk);
+    })();
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline && !out.includes("fake worker start #1")) await Bun.sleep(50);
+    expect(out).toContain("fake worker start #1");
+
+    proc.kill("SIGTERM");
+    const status = await proc.exited;
+    await reader;
+
+    // The child saw the signal (the supervisor forwarded it), and its 75 was
+    // treated as "we are going down", not "restart me".
+    expect(out).toContain("fake worker got SIGTERM");
+    expect(out).not.toContain("worker reloaded");
+    expect(out).toContain("worker drained after signal — supervisor stopping");
+    expect(status).toBe(0);
+    expect(Number(readFileSync(counter, "utf8").trim())).toBe(1);
+  } finally {
+    f.cleanup();
+  }
+}, 30_000);

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -24,6 +24,53 @@ all-in-one for a demo. Start `serve` first and let it reach `/health` before
 starting `work`: on a brand-new database both processes race the WAL
 journal-mode switch (OPS-376). `bin/worktree-up.sh` already sequences them.
 
+## Dev live reload — `factory up --dev` (WM-213)
+
+```bash
+factory up --dev   # serve --watch + vite HMR web UI + drain-aware worker
+factory tail       # all three logs, same as always
+factory down       # stops all three, same as always
+```
+
+Plain `factory up` is untouched by this flag; `--dev` only swaps each of the
+three daemons for its reloading twin.
+
+The worker is the interesting one. A naive watch-restart would kill an agent
+mid-dispatch, so the worker does **not** watch the filesystem: it records a
+**code stamp** at startup (`git rev-parse HEAD` plus a content hash of
+`event-runtime/lib/**` and `event-runtime/cli.mjs`, so uncommitted edits count)
+and re-computes it **between claims**. On a change it exits `75` and
+`bin/live-stack.sh __supervise-worker` re-execs it on the new code. If a run is
+in flight the reload is latched and logged once —
+
+```
+code changed (a1b2c3d4e5f6:9f8e7d6c5b4a → a1b2c3d4e5f6:11223344aabb) — reload deferred until run_x finishes
+```
+
+— and taken at the next idle poll. A run in flight when code changes therefore
+**finishes on the old code**, which is correct: its RunSpec and pins were made
+under that code. Reload latency is bounded by the poll interval; a running
+agent can never be interrupted by construction, because the idle check and the
+reload are the same branch.
+
+`bun event-runtime/cli.mjs work --reload-on-change` is the flag by itself, for
+a worker you supervise some other way. `FACTORY_CODE_STAMP_ROOT` points the
+stamp at a checkout other than the one the worker was started from.
+
+**Which change needs which reload:**
+
+| You changed | What reloads it | How fast |
+| :--- | :--- | :--- |
+| `event-runtime/lib/**`, `event-runtime/cli.mjs` | serve: `bun --watch` (in-flight planner work is dropped). worker: exit 75 at the next **idle** poll, then supervisor re-exec | serve immediately; worker after the current run |
+| `event-runtime/web/**` | vite HMR — the open tab updates, no restart | immediate |
+| `agents/*.md`, `schemas/**` | **neither** — definitions are read per plan/claim, but the pinned content hash is not. Run `bun event-runtime/cli.mjs update-pins` | on the next plan/claim after re-pinning |
+| `config/repos.yaml`, `config/schedule.yaml` | serve re-reads on restart — `--watch` covers it only if the edit also touches `event-runtime/` | restart serve |
+| `bin/live-stack.sh` itself | nothing — `factory down && factory up --dev` | manual |
+
+Two things `--dev` does not do: it does not restart the worker for an edit
+under `event-runtime/web/**` (vite owns that), and it does not touch a run
+already dispatched to an agent subprocess.
+
 Operator verbs (clients of the control API — they need `serve` running):
 
 ```bash
@@ -65,7 +112,8 @@ bun event-runtime/web/serve.mjs                        # http://127.0.0.1:7382 (
 ```
 
 Dev loop: `cd event-runtime/web && bunx vite` (proxies /api to the control
-API). Keyboard-first: `⌘K` palette, `g` + a view letter to navigate (the armed
+API), or `factory up --dev` to get it wired into the whole stack — see
+[Dev live reload](#dev-live-reload--factory-up---dev-wm-213). Keyboard-first: `⌘K` palette, `g` + a view letter to navigate (the armed
 prefix shows on screen), `j/k` + `Enter` on lists, `a`/`x` to approve/reject the
 selected proposal, `?` for the full legend.
 

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -37,7 +37,9 @@ import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
 import { approveProposal } from "./lib/proposals.mjs";
 import { startApi } from "./lib/api.mjs";
-import { claimNext, executeClaimed, runOnce } from "./lib/worker.mjs";
+import {
+  claimNext, CODE_RELOAD_EXIT, createReloadWatcher, executeClaimed, RELOAD_CHECK_INTERVAL_MS, runOnce,
+} from "./lib/worker.mjs";
 import { reapExpiredLeases } from "./lib/reaper.mjs";
 import { deregisterWorker, heartbeat, registerWorker } from "./lib/workers.mjs";
 
@@ -53,8 +55,12 @@ usage: bun event-runtime/cli.mjs <command>
                                  never kill a running agent.
                                  --watch restarts on event-runtime/ changes
   work [--label k=v ...] [--adapter-override fake] [--drain-timeout N]
+       [--reload-on-change]
                                  worker process: claim, execute, verify, and publish
                                  runs from the database
+                                 --reload-on-change exits ${CODE_RELOAD_EXIT} for a supervisor to
+                                 restart when event-runtime code changes, but
+                                 only between claims (dev; see factory up --dev)
   status                         events, proposals, runs, anomalies
   doctor                         system health check: anomaly report (exits non-zero on anomalies)
   events [status]                admitted events, optionally filtered by status
@@ -463,6 +469,7 @@ async function serve(args) {
  * claiming correct; Postgres is what remote nodes need, not this.
  *
  *   bun event-runtime/cli.mjs work [--label k=v ...] [--adapter-override fake] [--poll-ms 500]
+ *                                 [--reload-on-change]
  */
 async function work(args) {
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
@@ -499,6 +506,11 @@ async function work(args) {
   let draining = false;
   let inFlight = null;
 
+  // Dev live-reload (WM-213). Off unless asked for: a production worker must
+  // never decide on its own that it is out of date.
+  const watcher = args.includes("--reload-on-change") ? createReloadWatcher() : null;
+  if (watcher) log(`reload-on-change: armed at code stamp ${watcher.from} (reloads only between claims)`);
+
   // The heartbeat runs on its own timer, NOT inside the claim loop: that loop
   // blocks for the whole duration of an agent run (up to the spec timeout),
   // so a loop-driven heartbeat would mark every legitimately busy worker as
@@ -510,9 +522,30 @@ async function work(args) {
   );
   beat.unref?.();
 
+  /**
+   * True when this worker should exit for a supervisor to restart it. Consulted
+   * from two places for one reason each: the timer notices a change *during* a
+   * run so the deferral is logged while it is still true, and the loop top is
+   * the idle boundary where acting on it is safe.
+   */
+  function reloadWanted() {
+    if (!watcher || draining) return false;
+    const r = watcher.check(inFlight);
+    if (r.action === "deferred") {
+      if (r.first) log(`code changed (${r.from} → ${r.to}) — reload deferred until ${r.runId} finishes`);
+      return false;
+    }
+    if (r.action === "reload") {
+      log(`code changed (${r.from} → ${r.to}) — reloading worker (exit ${CODE_RELOAD_EXIT})`);
+      return true;
+    }
+    return false;
+  }
+
   async function loop() {
     while (!draining) {
       try {
+        if (reloadWanted()) return finish("code_reload", CODE_RELOAD_EXIT);
         heartbeat(db, workerId, { state: inFlight ? "busy" : "idle", runId: inFlight });
         const claim = claimNext(db, {
           owner: workerId, policyVersion: pv, labels,
@@ -549,12 +582,21 @@ async function work(args) {
   // the grace period the worker leaves honestly and says what happens next —
   // the lease expires and the reaper requeues the run.
   const drainTimeoutMs = Number(flagValue(args, "--drain-timeout") ?? 60) * 1000;
-  const finish = (reason) => {
+  const finish = (reason, code = 0) => {
     clearInterval(beat);
     deregisterWorker(db, workerId);
     log(`worker stopped (${reason})`);
-    process.exit(0);
+    process.exit(code);
   };
+
+  // Armed only after `finish` exists — this timer is the path that notices a
+  // change while a run is in flight, which is where the deferral line comes from.
+  if (watcher) {
+    const reloadTimer = setInterval(() => {
+      if (reloadWanted()) finish("code_reload", CODE_RELOAD_EXIT);
+    }, RELOAD_CHECK_INTERVAL_MS);
+    reloadTimer.unref?.();
+  }
   const drain = (signal) => {
     if (draining) {
       // A second signal means "now": the operator has decided.

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,6 +32,7 @@ describe("cli", () => {
     }
     expect(r.all).toContain("usage:");
     expect(r.all).toContain("--watch");
+    expect(r.all).toContain("--reload-on-change");
   });
 
   test("unknown command → usage text, non-zero exit", () => {
@@ -606,4 +607,156 @@ describe("cli", () => {
     expect(docRes.status).not.toBe(0);
     expect(docRes.stdout).toContain("stalled worker w-stalled-test");
   });
+});
+
+// ---------------------------------------------------------------------------
+// work --reload-on-change (WM-213)
+// ---------------------------------------------------------------------------
+
+/** A throwaway checkout for the code stamp to watch, so tests never dirty this repo. */
+function makeStampRoot() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-src-"));
+  mkdirSync(path.join(root, "event-runtime", "lib"), { recursive: true });
+  writeFileSync(path.join(root, "event-runtime", "cli.mjs"), "// cli\n", "utf8");
+  writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), "// v1\n", "utf8");
+  return root;
+}
+
+function editStampRoot(root, body) {
+  writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), body, "utf8");
+}
+
+/** Spawn a worker, collecting stdout+stderr into one buffer. */
+function spawnWorker(args, env) {
+  const child = spawn("bun", [CLI, "work", ...args], {
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const box = { out: "", child };
+  child.stdout.on("data", (b) => { box.out += b; });
+  child.stderr.on("data", (b) => { box.out += b; });
+  return box;
+}
+
+async function waitFor(box, needle, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && !box.out.includes(needle)) await Bun.sleep(50);
+  return box.out.includes(needle);
+}
+
+function exitOf(child) {
+  return new Promise((resolve) => child.once("exit", (code, signal) => resolve({ code, signal })));
+}
+
+describe("work --reload-on-change (WM-213)", () => {
+  test("plain work never arms the watcher", async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-off-"));
+    const stampRoot = makeStampRoot();
+    const box = spawnWorker(["--adapter-override", "fake", "--poll-ms", "50"], {
+      FACTORY_EVENT_HOME: home, FACTORY_CODE_STAMP_ROOT: stampRoot,
+    });
+    try {
+      expect(await waitFor(box, "adapter override")).toBe(true);
+      editStampRoot(stampRoot, "// v2\n");
+      await Bun.sleep(2500); // well past two reload-check intervals
+      expect(box.out).not.toContain("reload-on-change");
+      expect(box.out).not.toContain("reloading worker");
+      expect(box.child.exitCode).toBe(null); // still running
+    } finally {
+      box.child.kill("SIGTERM");
+      await exitOf(box.child);
+      rmSync(stampRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("an idle worker exits 75 within a poll interval of an uncommitted edit", async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-idle-"));
+    const stampRoot = makeStampRoot();
+    const box = spawnWorker(["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"], {
+      FACTORY_EVENT_HOME: home, FACTORY_CODE_STAMP_ROOT: stampRoot,
+    });
+    try {
+      expect(await waitFor(box, "reload-on-change: armed at code stamp")).toBe(true);
+      // No commit — only a working-tree write. HEAD is unchanged (this tree has
+      // no git at all), so a HEAD-only stamp would sit here forever.
+      editStampRoot(stampRoot, "// v2\n");
+      const { code } = await exitOf(box.child);
+      expect(code).toBe(75);
+      expect(box.out).toContain("reloading worker (exit 75)");
+      // The log names both stamps so the developer can see what moved.
+      expect(box.out).toMatch(/code changed \(nogit:[0-9a-f]+ → nogit:[0-9a-f]+\)/);
+      expect(box.out).toContain("worker stopped (code_reload)");
+    } finally {
+      box.child.kill("SIGKILL");
+      rmSync(stampRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("a run in flight defers the reload; the worker restarts only once it is idle", async () => {
+    const { openDb } = await import("./lib/db.mjs");
+    const { createRun, transition } = await import("./lib/lifecycle.mjs");
+    const { canonicalJson, hashJson } = await import("./lib/canonical.mjs");
+
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-reload-busy-"));
+    const stampRoot = makeStampRoot();
+    const db = openDb(path.join(home, "runtime.db"));
+
+    // The fake adapter's "hang" mode occupies the worker for the whole spec
+    // timeout — the in-flight window this reload must not interrupt.
+    const input = { repos: ["hang"] };
+    const spec = {
+      schemaVersion: "factory.run-spec/v1",
+      runId: "run_reload_busy",
+      agent: "factory-status-report@1",
+      input,
+      inputHash: hashJson(input),
+      workspace: { type: "ephemeral", retainOnFailure: false },
+      adapter: "fake",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.status-report/v1",
+      capabilities: ["linear:read"],
+      timeoutSeconds: 4,
+      maxAttempts: 1,
+      idempotencyKey: "idem_reload_busy",
+    };
+    createRun(db, {
+      runId: spec.runId, idempotencyKey: spec.idempotencyKey,
+      spec, specJson: canonicalJson(spec), specHash: hashJson(spec),
+      actor: "test", policyVersion: "test", now: Date.now(),
+    });
+    transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now: Date.now() });
+    transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now: Date.now() });
+    db.close();
+
+    const box = spawnWorker(["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"], {
+      FACTORY_EVENT_HOME: home, FACTORY_CODE_STAMP_ROOT: stampRoot,
+    });
+    try {
+      expect(await waitFor(box, "claimed run_reload_busy")).toBe(true);
+      editStampRoot(stampRoot, "// v2\n");
+
+      expect(await waitFor(box, "reload deferred until run_reload_busy finishes")).toBe(true);
+      // Proven, not assumed: the deferral was logged while the run was still
+      // going, and the worker was still alive at that point.
+      expect(box.out).not.toContain("run_reload_busy → ");
+      expect(box.child.exitCode).toBe(null);
+
+      const { code } = await exitOf(box.child);
+      expect(code).toBe(75);
+      // Order is the guarantee: the run reached a terminal state BEFORE the reload.
+      expect(box.out.indexOf("run_reload_busy → ")).toBeGreaterThan(-1);
+      expect(box.out.indexOf("run_reload_busy → ")).toBeLessThan(box.out.indexOf("reloading worker"));
+      // And exactly one deferral line, however many intervals it spanned.
+      expect(box.out.split("reload deferred until").length - 1).toBe(1);
+    } finally {
+      box.child.kill("SIGKILL");
+      rmSync(stampRoot, { recursive: true, force: true });
+    }
+
+    const verifyDb = openDb(path.join(home, "runtime.db"));
+    const row = verifyDb.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_reload_busy");
+    expect(["TIMED_OUT", "FAILED", "COMPLETED"]).toContain(row?.state);
+    verifyDb.close();
+  }, 45_000);
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -11,7 +11,8 @@
  * publishing nothing.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { LEASE_HEARTBEAT_MS, leaseDir, liveWorkerLeases, releaseWorkerLease, renewWorkerLease, writeWorkerLease } from "../../lib/worker-leases.mjs";
@@ -201,6 +202,128 @@ export function acquireClaimLock(lockFile, { pid = process.pid, now = Date.now()
 
 export function releaseClaimLock(lockFile) {
   try { unlinkSync(lockFile); } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Dev live-reload: code stamp + drain-aware reload watcher (WM-213)
+// ---------------------------------------------------------------------------
+
+/**
+ * Exit code the worker uses to ask its supervisor for a restart. Distinct from
+ * 0 (drained cleanly — stay down) and from any crash, so `bin/live-stack.sh
+ * __supervise-worker` re-execs on exactly this and nothing else.
+ */
+export const CODE_RELOAD_EXIT = 75;
+
+/** What "the worker's code" is: everything the claim loop actually executes. */
+export const CODE_STAMP_PATHS = ["event-runtime/lib", "event-runtime/cli.mjs"];
+
+/** Re-stamping cadence. The poll loop is faster (500ms) and must not re-hash twice a second. */
+export const RELOAD_CHECK_INTERVAL_MS = 1_000;
+
+/**
+ * Which checkout the stamp describes. `FACTORY_CODE_STAMP_ROOT` exists because
+ * a worker can be started from a different checkout than the one it watches —
+ * and because tests must be able to dirty a tree that is not this repo.
+ */
+export function codeStampRoot() {
+  return process.env.FACTORY_CODE_STAMP_ROOT || FACTORY_ROOT;
+}
+
+function walkStampFiles(dir, out) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const entry of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkStampFiles(abs, out);
+    else if (entry.isFile()) out.push(abs);
+  }
+  return out;
+}
+
+/** Repo-relative, sorted list of the files the stamp covers. */
+export function codeStampFiles(repoRoot = codeStampRoot(), paths = CODE_STAMP_PATHS) {
+  const files = [];
+  for (const rel of paths) {
+    const abs = path.join(repoRoot, rel);
+    let st;
+    try { st = statSync(abs); } catch { continue; }
+    if (st.isDirectory()) walkStampFiles(abs, files);
+    else if (st.isFile()) files.push(abs);
+  }
+  return files.map((f) => path.relative(repoRoot, f)).sort();
+}
+
+function gitHead(repoRoot) {
+  const result = spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim().slice(0, 12) : "nogit";
+}
+
+/**
+ * A short, stable identity for the code this worker is running: HEAD plus a
+ * content hash of the stamp paths.
+ *
+ * Contents, not mtimes — a `git checkout` that rewrites a file back to what it
+ * already was must NOT bounce the worker, and an uncommitted edit must, which
+ * a HEAD-only stamp misses entirely. Reading ~1MB once a second is free next
+ * to the agent runs this loop supervises.
+ */
+export function codeStamp(repoRoot = codeStampRoot(), paths = CODE_STAMP_PATHS) {
+  const hash = createHash("sha256");
+  for (const rel of codeStampFiles(repoRoot, paths)) {
+    hash.update(rel);
+    hash.update("\0");
+    try { hash.update(readFileSync(path.join(repoRoot, rel))); } catch { hash.update("<unreadable>"); }
+    hash.update("\0");
+  }
+  return `${gitHead(repoRoot)}:${hash.digest("hex").slice(0, 12)}`;
+}
+
+/**
+ * Poll-boundary reload detection. `check(inFlight)` is called by the claim
+ * loop *between* claims and returns one of:
+ *
+ *   none      nothing changed (or it is not time to re-stamp yet)
+ *   deferred  code changed but this worker holds a lease — keep going
+ *   reload    code changed and the worker is idle — exit CODE_RELOAD_EXIT
+ *
+ * `deferred` can never become `reload` inside the same call, so a running
+ * agent cannot be killed by a code change *by construction* — that is the
+ * whole reason this is a poll-boundary check and not an fs watcher. Once a
+ * change is seen it is latched (`pending`), so the reload happens on the very
+ * next idle check rather than one interval later, and the stamp is not
+ * recomputed while it waits.
+ */
+export function createReloadWatcher({
+  repoRoot = codeStampRoot(),
+  intervalMs = RELOAD_CHECK_INTERVAL_MS,
+  stamp = () => codeStamp(repoRoot),
+  now = () => Date.now(),
+} = {}) {
+  const from = stamp();
+  let lastCheck = now();
+  let pending = null;
+  let deferredSeen = false;
+
+  return {
+    from,
+    check(inFlight = null) {
+      if (!pending) {
+        const at = now();
+        if (at - lastCheck < intervalMs) return { action: "none", from, to: from };
+        lastCheck = at;
+        const to = stamp();
+        if (to === from) return { action: "none", from, to };
+        pending = to;
+      }
+      if (inFlight) {
+        const first = !deferredSeen;
+        deferredSeen = true;
+        return { action: "deferred", from, to: pending, runId: inFlight, first };
+      }
+      return { action: "reload", from, to: pending };
+    },
+  };
 }
 
 const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -14,7 +14,8 @@ import { createRun, lifecycleOf, runState, transition, IllegalTransition } from 
 import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import {
-  acquireClaimLock, cancelRun, claimNext, defaultLocksDir, dispatchLockPath, executeClaimed, reapExpiredLeases,
+  acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
+  createReloadWatcher, defaultLocksDir, dispatchLockPath, executeClaimed, reapExpiredLeases,
   releaseClaimLock, repositoryIsClean, repositoryStatus, retryRun, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
@@ -1242,5 +1243,170 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }));
     expect(sum2.terminalState).toBe("TIMED_OUT");
     expect(rollbacks).toContainEqual(expect.objectContaining({ ticket: "WM-741", why: "timeout" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dev live-reload: code stamp + drain-aware reload watcher (WM-213)
+// ---------------------------------------------------------------------------
+
+function stampRepo() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "evrt-stamp-"));
+  mkdirSync(path.join(root, "event-runtime", "lib", "adapters"), { recursive: true });
+  writeFileSync(path.join(root, "event-runtime", "cli.mjs"), "// cli\n", "utf8");
+  writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), "// worker\n", "utf8");
+  writeFileSync(path.join(root, "event-runtime", "lib", "adapters", "fake.mjs"), "// fake\n", "utf8");
+  writeFileSync(path.join(root, "README.md"), "# outside the stamp\n", "utf8");
+  return root;
+}
+
+describe("code stamp (WM-213)", () => {
+  test("covers event-runtime/lib/** and cli.mjs, and nothing else", () => {
+    const root = stampRepo();
+    try {
+      expect(codeStampFiles(root)).toEqual([
+        "event-runtime/cli.mjs",
+        "event-runtime/lib/adapters/fake.mjs",
+        "event-runtime/lib/worker.mjs",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("is stable across calls and changes on an uncommitted edit", () => {
+    const root = stampRepo();
+    try {
+      const before = codeStamp(root);
+      expect(codeStamp(root)).toBe(before);
+
+      // No commit, no git at all — the stamp must still notice a working-tree edit.
+      writeFileSync(path.join(root, "event-runtime", "lib", "worker.mjs"), "// worker v2\n", "utf8");
+      const after = codeStamp(root);
+      expect(after).not.toBe(before);
+
+      // A new file under lib/ counts too, and a file outside the paths does not.
+      writeFileSync(path.join(root, "event-runtime", "lib", "new.mjs"), "// new\n", "utf8");
+      expect(codeStamp(root)).not.toBe(after);
+      const withNew = codeStamp(root);
+      writeFileSync(path.join(root, "README.md"), "# edited\n", "utf8");
+      expect(codeStamp(root)).toBe(withNew);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a tree with no git still stamps (nogit), rather than throwing", () => {
+    const root = stampRepo();
+    try {
+      expect(codeStamp(root).startsWith("nogit:")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("FACTORY_CODE_STAMP_ROOT overrides the watched checkout", () => {
+    const root = stampRepo();
+    const previous = process.env.FACTORY_CODE_STAMP_ROOT;
+    try {
+      process.env.FACTORY_CODE_STAMP_ROOT = root;
+      expect(codeStampRoot()).toBe(root);
+      expect(codeStamp()).toBe(codeStamp(root));
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_CODE_STAMP_ROOT;
+      else process.env.FACTORY_CODE_STAMP_ROOT = previous;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("reload watcher (WM-213)", () => {
+  /** Watcher over a stamp and clock the test drives by hand. */
+  function harness(intervalMs = 1000) {
+    let stamp = "a";
+    let clock = 0;
+    const watcher = createReloadWatcher({
+      intervalMs,
+      stamp: () => stamp,
+      now: () => clock,
+    });
+    return {
+      watcher,
+      change: (to) => { stamp = to; },
+      advance: (ms) => { clock += ms; },
+    };
+  }
+
+  test("unchanged code never reloads", () => {
+    const h = harness();
+    h.advance(5000);
+    expect(h.watcher.check(null).action).toBe("none");
+    expect(h.watcher.check("run_1").action).toBe("none");
+  });
+
+  test("re-stamps at most once per interval", () => {
+    let calls = 0;
+    const watcher = createReloadWatcher({ intervalMs: 1000, stamp: () => { calls += 1; return "a"; }, now: () => 0 });
+    expect(calls).toBe(1); // the startup stamp
+    for (let i = 0; i < 20; i += 1) watcher.check(null);
+    expect(calls).toBe(1); // the clock never moved, so nothing re-hashed
+  });
+
+  test("idle worker reloads, reporting old → new", () => {
+    const h = harness();
+    h.change("b");
+    h.advance(1000);
+    const r = h.watcher.check(null);
+    expect(r.action).toBe("reload");
+    expect(r.from).toBe("a");
+    expect(r.to).toBe("b");
+  });
+
+  test("in-flight run defers the reload, then reloads at the next idle check", () => {
+    const h = harness();
+    h.change("b");
+    h.advance(1000);
+
+    // Busy: deferred, and flagged `first` exactly once so the log says it once.
+    const first = h.watcher.check("run_busy");
+    expect(first).toMatchObject({ action: "deferred", from: "a", to: "b", runId: "run_busy", first: true });
+    h.advance(1000);
+    expect(h.watcher.check("run_busy")).toMatchObject({ action: "deferred", first: false });
+
+    // The run finishes. The very next check reloads — no extra interval of wait,
+    // because the pending change was latched rather than re-detected.
+    expect(h.watcher.check(null)).toMatchObject({ action: "reload", from: "a", to: "b" });
+  });
+
+  test("a change that reverts before the next check is never seen", () => {
+    const h = harness();
+    h.change("b");
+    h.change("a");
+    h.advance(1000);
+    expect(h.watcher.check(null).action).toBe("none");
+  });
+
+  test("once latched, the pending stamp is not re-read", () => {
+    let stamp = "a";
+    let reads = 0;
+    let clock = 0;
+    const watcher = createReloadWatcher({
+      intervalMs: 1000,
+      stamp: () => { reads += 1; return stamp; },
+      now: () => clock,
+    });
+    stamp = "b";
+    clock += 1000;
+    expect(watcher.check("run_busy").action).toBe("deferred");
+    const afterLatch = reads;
+    stamp = "c"; // a second edit while busy must not un-latch the reload
+    clock += 5000;
+    expect(watcher.check("run_busy").action).toBe("deferred");
+    expect(watcher.check(null)).toMatchObject({ action: "reload", to: "b" });
+    expect(reads).toBe(afterLatch);
+  });
+
+  test("CODE_RELOAD_EXIT is a code no ordinary worker exit uses", () => {
+    expect(CODE_RELOAD_EXIT).toBe(75);
   });
 });


### PR DESCRIPTION
Fixes WM-213

## What

One command for the dev loop. `factory up --dev` starts the same three daemons as `factory up`, each swapped for its reloading twin:

| daemon | plain `up` | `up --dev` |
| :--- | :--- | :--- |
| serve | `cli.mjs serve` | `cli.mjs serve --watch` |
| web | `web/serve.mjs` (static build) | `bunx vite` (HMR) |
| worker | `cli.mjs work` | `live-stack.sh __supervise-worker` → `cli.mjs work --reload-on-change` |

Plain `factory up`, `factory down`, and `factory tail` take the same code path they did before.

## The worker — the piece that did not exist

A naive watch-restart kills an agent mid-dispatch, so the worker does **not** watch the filesystem. It records a **code stamp** at startup — `git rev-parse HEAD` plus a content hash of `event-runtime/lib/**` and `event-runtime/cli.mjs` — and re-checks it **between claims**:

- **idle + changed** → exit `75`, supervisor re-execs on the new code
- **in-flight + changed** → latched, logged once, taken at the next idle poll

```
code changed (888f6a3fca51:5f057076c18e → 888f6a3fca51:28887c58e199) — reload deferred until run_x finishes
```

A run in flight finishes on the **old** code, which is correct: its RunSpec and pins were made under that code. The idle check and the reload are the same branch, so a running agent cannot be interrupted by construction — no fs-watcher dependency, and reload latency bounded by the poll interval.

Two decisions worth reviewing:

- **Content hash, not mtime.** A `git checkout` that rewrites a file to what it already was must not bounce the worker, and a HEAD-only stamp misses the uncommitted edit that is the entire point of a dev loop. ~1MB read once a second, next to agent runs.
- **Supervisor restarts on `75` and nothing else.** `0` is a clean drain and must stay down; any other code is a real failure the developer needs to see, not a crash loop. It forwards SIGTERM to the worker and waits out its drain, so `factory down`'s `term_daemon`/`await_daemon` still stops both.

## Acceptance criteria

| AC | Where |
| :--- | :--- |
| `up --dev` starts all three; `down` stops all three; plain `up` unchanged | `bin/live-stack.test.mjs` (7 tests, spawn-shape assertions) |
| In-flight run does not restart; restarts at next idle poll | `event-runtime/cli.test.mjs` — real worker + fake adapter `hang` mode, asserts the run reaches terminal state *before* the reload |
| Idle worker restarts within a poll interval; old→new stamp in worker.log | `cli.test.mjs` + verified live |
| Uncommitted edits trigger the reload | `worker.test.mjs` (stamp) + `cli.test.mjs` (a tree with no git at all) |
| Docs: mode + change-class → reload-mechanism table | `SETUP.md` §6, `event-runtime/README.md` |

## Verification

```
bun test event-runtime/ bin/
→ 1178 pass, 0 fail (91 files)

bun test && bun build/emit.mjs --check   # the repo gate
→ 1462 pass, 0 fail; emit exit 0
```

Also smoked live on isolated ports (7481/7482) with `--dev --fake`: serve healthy, vite serving `@vite/client`, worker armed; an edit under `event-runtime/lib` restarted the idle worker with the old→new stamp in `worker.log` and a stable supervisor pid; `factory down` freed both ports.

## Risks

- `--dev` needs `event-runtime/web/node_modules` for vite — the script says so and exits rather than failing inside vite.
- `serve --watch` drops in-flight planner work; that is pre-existing `--watch` behaviour, documented in the change-class table.
- `bunx vite --strictPort` means a busy web port now fails loudly in dev instead of silently drifting to another port.