### PR TITLE
feat(event-runtime): make pi the default LLM harness — flip claude-routed event types to the pi adapter

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -250,7 +250,7 @@ returns the existing admission record and never spawns a second run.
     "type": "ephemeral",
     "retainOnFailure": true
   },
-  "adapter": "claude",
+  "adapter": "pi",
   "promptVersion": "git:7d91d88",
   "policyVersion": "git:7d91d88",
   "outputContract": "factory.status-report/v1",
@@ -378,9 +378,9 @@ is readable in `GET /registry`.
 optional `"model_tier": "strong" | "standard" | "light"` — a statement of
 intent, never a concrete model id. What each tier means is operator policy:
 the `models:` block in `config/policy.yaml`, keyed per adapter
-(`models.claude.standard: sonnet`), so retiering the fleet is a one-line
-policy PR instead of an edit fanned across definitions. The literal value
-`default` is a sentinel meaning "pass no model flag — ride the CLI's own
+(`models.pi.standard: openai-codex/gpt-5.6-terra`), so retiering the fleet is
+a one-line policy PR instead of an edit fanned across definitions. The literal
+value `default` is a sentinel meaning "pass no model flag — ride the CLI's own
 default"; any other value is passed verbatim as `--model`. The **planner
 resolves tier → model at plan time and pins the result into the RunSpec**
 (`modelTier` + `model`, the same pattern as `repoPin`), so the proposal the
@@ -391,23 +391,40 @@ per-route resolved value. Resolution order: per-definition `"model"` override
 wins) > tier map > adapter default (absent fields = no spec fields = today's
 behavior). A declared tier with no mapping for a routed model-consuming
 adapter is a **load error, fail closed** — never a silent fall-through to the
-adapter default. Only the `claude` adapter consumes models; on
+adapter default. Only the LLM adapters (`claude`, `pi`) consume models; on
 `command`/`actions`/`fake` routes a declared tier is recorded as not
-applicable (`model: null`), never an error. Tier assignments are intent the
-runtime cannot yet audit: per-run usage observability (WM-66) is what will
+applicable (`model: null`), never an error. Since WM-215 every committed LLM
+route is `pi`, so `models.pi` is the map that has to cover every tier the
+registry declares (`strong`/`standard`/`light` → sol/terra/luna);
+`models.claude` stays populated for the per-route exception and for
+`--adapter-override claude`. Tier assignments are intent the runtime cannot
+yet audit: per-run usage observability (WM-66) is what will
 show whether a tier is over- or under-provisioned and inform re-mapping.
 
-**Adapters are a registry, not a flag.** `"adapter": "claude"` in the run spec
+**Adapters are a registry, not a flag.** `"adapter": "pi"` in the run spec
 names an entry in a small adapter registry, one per harness the runtime has
 actually tested. The emit pipeline targets several harnesses (Claude Code,
 Codex, Gemini, Cursor, Pi); the event runtime admits only adapters with a
 passing conformance test covering structured output, timeout and shutdown
-behavior, and workspace confinement. The registry has entries for `claude`
-(the primary LLM harness), `pi` (OPS-296, a second LLM harness on the Codex
-subscription window), `command` (a closed argv template), `actions` (an
-approved action list resolved against a closed registry, remote-SSH or
-local-argv), and `fake` (tests and demo environments). It does not inherit the
-current runner's entire adapter surface.
+behavior, and workspace confinement. The registry has entries for `pi`
+(OPS-296, the default LLM harness on the Codex subscription window, WM-215),
+`claude` (Claude Code, still fully supported), `command` (a closed argv
+template), `actions` (an approved action list resolved against a closed
+registry, remote-SSH or local-argv), and `fake` (tests and demo
+environments). It does not inherit the current runner's entire adapter
+surface.
+
+**pi is the default harness, per route, not per mode (WM-215).** Every
+LLM-routed event type in `event-runtime/event-types.json` declares
+`"adapter": "pi"`; `command`/`actions` routes are untouched. The choice lives
+in one field per route, so routing a single event type back to Claude Code is
+a one-line edit of that route — there is no global harness mode to flip, and
+no route inherits a default. `claude` remains a first-class adapter: it is
+what the per-route exception selects, and `--adapter-override claude`
+(`cli.mjs serve`/`work`) forces runs onto it without touching the
+registry. Note that an adapter override changes execution only — the model
+still resolves against the **registered** route's adapter (§6, WM-135), so an
+overridden run carries the pinned `models.pi` value.
 
 **The `pi` adapter (`lib/adapters/pi.mjs`, OPS-296) mirrors `claude.mjs`,
 adapted to a different CLI shape.** `pi -p --mode json` (prompt piped to

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -34,7 +34,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:cf84c0cc41ce4ed84cd179f8bc8f52f73919e8187073254b86ee58c27a7e0828",
+    "agents/dispatch.md": "sha256:ed2330097936e9f9aac39bf8705f5d691ab3db5cc7f2a20fa9c9ef86e4f0650d",
     "schemas/dispatch.input.json": "sha256:66898f48608fff53f07f2b59e9df9d41c15aae69615c2383c22d3978ca9807b2",
     "schemas/dispatch.output.json": "sha256:56ea5a82df4bce92d5f22b60d173a03bbb9e139491abeff3c01a96524ef49a4d"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -47,6 +47,17 @@ steal a claim, never queue behind the holder.
    touched, risks), then move it to `In Review` + `ai:needs-review`, removing
    `ai:in-progress`.
 
+**The paved road for pushing is `gh` over HTTPS.** Authenticate through the
+`gh` CLI's own stored credentials and let git use its credential helper —
+`gh auth status` tells you whether you already have it, and
+`git push -u origin HEAD` then works without any further setup. Do **not**
+reach for an SSH agent: no adapter guarantees `SSH_AUTH_SOCK` inside the run,
+so an SSH remote is the one failure mode with no recovery from in here. If a
+push is rejected for authentication, re-check `gh auth status` and push again
+over HTTPS (`gh repo set-default` / an `https://github.com/...` remote URL) —
+do not treat the first SSH failure as a blocker; it is a wrong-transport
+error, not a missing credential.
+
 **Never merge.** The merge stage reviews and lands PRs; a ticket agent that
 merges its own work bypasses the review gate entirely.
 

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -1,7 +1,7 @@
 {
   "factory.status-report.requested": {
     "agent": "factory-status-report@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "correlationId",
       "inputHash"
@@ -34,7 +34,7 @@
   },
   "keephq.disk-alert.raised": {
     "agent": "disk-diagnose@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "subject",
       "correlationId"
@@ -51,7 +51,7 @@
   },
   "factory.triage.requested": {
     "agent": "triage-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -83,7 +83,7 @@
   },
   "factory.ci-diagnose.requested": {
     "agent": "ci-doctor@2",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -91,7 +91,7 @@
   },
   "factory.run-postmortem.requested": {
     "agent": "run-postmortem@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -123,7 +123,7 @@
   },
   "factory.unblock.requested": {
     "agent": "unblock-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -139,7 +139,7 @@
   },
   "factory.sweep.requested": {
     "agent": "sweep-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -155,7 +155,7 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -187,7 +187,7 @@
   },
   "factory.dispatch.requested": {
     "agent": "dispatch@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -195,7 +195,7 @@
   },
   "factory.work.requested": {
     "agent": "work-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -203,7 +203,7 @@
   },
   "factory.ship.requested": {
     "agent": "ship-scan@1",
-    "adapter": "claude",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -242,9 +242,9 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
   let flowProposalId;
   let flowRunId;
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-api-ws-"));
-  // event-types.json maps to the "claude" adapter; back it with the fake so
-  // no real claude process ever spawns in tests.
-  const adapters = { claude: fake };
+  // event-types.json maps to the "pi" adapter (WM-215); back it with the fake so
+  // no real pi process ever spawns in tests.
+  const adapters = { pi: fake };
   const workerOpts = () => ({ workspacesRoot: workspaces, owner: "w-test", policyVersion: PV });
 
   /** Replay + plan one envelope, then return its open proposal via the API. */
@@ -281,7 +281,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(prop.expired).toBe(false);
     expect(prop.agent).toBe("factory-status-report@1");
     expect(prop.repos).toEqual(["ok"]);
-    expect(prop.spec.adapter).toBe("claude");
+    expect(prop.spec.adapter).toBe("pi");
     expect(prop.ttl_seconds).toBe(1800);
     flowProposalId = prop.id;
 
@@ -420,7 +420,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     const prop = await planned("retry-1");
     const { runId } = await s.client.approve(prop.id);
     // Deterministic terminal FAILED: run with an empty adapters map so the
-    // spec's "claude" adapter is unknown (no requeue, attempts consumed).
+    // spec's "pi" adapter is unknown (no requeue, attempts consumed).
     const summary = await runOnce(s.db, registry, {}, workerOpts());
     expect(summary.runId).toBe(runId);
     expect(summary.terminalState).toBe("FAILED");
@@ -454,7 +454,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
       expect(proposals[0].eventSource).toBe("test");
 
       await client.approve(proposals[0].id);
-      await runOnce(db, registry, { claude: fake, fake }, {
+      await runOnce(db, registry, { pi: fake, fake }, {
         workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
         owner: "test-worker", policyVersion: PV,
       });
@@ -488,7 +488,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
       planAdmittedEvents(db, registry, { policyVersion: PV, adapterOverride: "fake" });
       const { proposals } = await client.proposals();
       await client.approve(proposals[0].id);
-      await runOnce(db, registry, { claude: fake, fake }, {
+      await runOnce(db, registry, { pi: fake, fake }, {
         workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
         owner: "test-worker", policyVersion: PV,
       });
@@ -580,7 +580,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       planAdmittedEvents(db, registry, { policyVersion: PV, adapterOverride: "fake" });
       const { proposals } = await client.proposals();
       await client.approve(proposals[0].id);
-      const summary = await runOnce(db, registry, { claude: fake, fake }, {
+      const summary = await runOnce(db, registry, { pi: fake, fake }, {
         workspacesRoot: path.join(home, "workspaces"),
         artifactStore: path.join(home, "artifacts"),
         owner: "test-worker", policyVersion: PV,
@@ -614,7 +614,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       await client.replay(envelope({ eventId: "art-2", payload: { repos: ["with-artifact"] } }));
       planAdmittedEvents(db, registry, { policyVersion: PV, adapterOverride: "fake" });
       await client.approve((await client.proposals()).proposals[0].id);
-      const summary = await runOnce(db, registry, { claude: fake, fake }, {
+      const summary = await runOnce(db, registry, { pi: fake, fake }, {
         workspacesRoot: path.join(home, "workspaces"),
         artifactStore: path.join(home, "artifacts"),
         owner: "test-worker", policyVersion: PV,
@@ -656,7 +656,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       await client.replay(envelope({ eventId: "trace-1", payload: { repos: ["ok"] } }));
       planAdmittedEvents(db, registry, { policyVersion: PV, adapterOverride: "fake" });
       await client.approve((await client.proposals()).proposals[0].id);
-      const summary = await runOnce(db, registry, { claude: fake, fake }, {
+      const summary = await runOnce(db, registry, { pi: fake, fake }, {
         workspacesRoot: mkdtempSync(path.join(os.tmpdir(), "evrt-ws-")),
         owner: "test-worker", policyVersion: PV,
       });
@@ -709,7 +709,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       // resolved value, straight off the committed registry + policy map.
       expect(def.modelTier).toBe("standard");
       expect(def.model).toBeNull();
-      expect(def.eventTypes[0].resolvedModel).toBe("sonnet");
+      expect(def.eventTypes[0].resolvedModel).toBe("openai-codex/gpt-5.6-terra");
       const commandDef = defs.find((d) => d.ref === "reconcile@1");
       expect(commandDef.modelTier).toBeNull();
       expect(commandDef.eventTypes[0].resolvedModel).toBeNull();

--- a/event-runtime/lib/artifact-inputs.test.mjs
+++ b/event-runtime/lib/artifact-inputs.test.mjs
@@ -172,7 +172,7 @@ describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)"
     const db = openDb(path.join(dir, "runtime.db"));
     const workspaces = tmp("evrt-poc-ws-");
     const artifactStore = tmp("evrt-poc-store-");
-    const adapters = { claude: fake, command: fake };
+    const adapters = { pi: fake, command: fake };
     const opts = { workspacesRoot: workspaces, artifactStore, owner: "w", policyVersion: "git:test" };
 
     admitEvent(db, registry, {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -34,9 +34,9 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-chain-ws-"));
-  // Chain flow under test never spawns real processes: claude AND command
+  // Chain flow under test never spawns real processes: pi AND command
   // both back onto the contract-shaped fake.
-  const adapters = { claude: fake, command: fake };
+  const adapters = { pi: fake, command: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function runToCompletion(eventId) {

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -221,7 +221,7 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
 });
 
 describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", () => {
-  // A local contract-shaped fake for the claude adapter: the run's value here
+  // A local contract-shaped fake for the pi adapter: the run's value here
   // is the pipeline around it — worktree delegation, verification, receipt —
   // not the model. It proves the delegated tree is reachable where the prompt
   // says (./repo) before reporting success.
@@ -267,7 +267,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
 
     const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
-    const summary = await runOnce(db, registry, { claude: dispatchFake }, {
+    const summary = await runOnce(db, registry, { pi: dispatchFake }, {
       workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
     });
 
@@ -304,7 +304,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     const spec = { ...proposal.spec, workspace: { ...proposal.spec.workspace, retainOnFailure: false } };
     db.query(`UPDATE runs SET spec_json = ? WHERE run_id = ?`).run(JSON.stringify(spec), proposal.run_id);
 
-    const summary = await runOnce(db, registry, { claude: crashing }, {
+    const summary = await runOnce(db, registry, { pi: crashing }, {
       workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
     });
     expect(summary.terminalState).toBe("FAILED");

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -87,15 +87,16 @@ describe("planEvent", () => {
       input: payload,
       inputHash: hashJson(payload),
       workspace: { type: "ephemeral", retainOnFailure: true },
-      adapter: "claude",
+      adapter: "pi",
       promptVersion: "git:test",
       policyVersion: "git:test",
       outputContract: "factory.status-report/v1",
       capabilities: ["linear:read"],
       // Model-tier routing (WM-135): the committed definition declares
-      // standard, policy maps it to sonnet, the planner pins the resolution.
+      // standard, policy maps it to models.pi.standard (WM-215 made pi the
+      // default harness), and the planner pins the resolution.
       modelTier: "standard",
-      model: "sonnet",
+      model: "openai-codex/gpt-5.6-terra",
       timeoutSeconds: 600,
       maxAttempts: 1,
       idempotencyKey: `factory-status-report@1:factory.status-report/v1:workflow-01:${hashJson(payload)}`,

--- a/event-runtime/lib/postmortem.test.mjs
+++ b/event-runtime/lib/postmortem.test.mjs
@@ -23,7 +23,7 @@ function harness() {
     owner: "w",
     policyVersion: PV,
   };
-  const adapters = { claude: fake, command: fake };
+  const adapters = { pi: fake, command: fake };
 
   async function runOne(envelope, agentRef) {
     expect(admitEvent(db, registry, envelope).admitted).toBe(true);

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -179,9 +179,10 @@ describe("approveProposal after TTL expiry (§12)", () => {
   test("changed conditions: stale proposal superseded, new open proposal, run stays PROPOSED with fresh spec", () => {
     const { db, proposal, runId } = planned();
     const later = NOW + TTL_MS + 1;
-    // adapterOverride forces the re-planned spec to differ from the stale one.
+    // adapterOverride forces the re-planned spec to differ from the stale one
+    // (the registered route is pi since WM-215, so claude is the off-route value).
     const result = approveProposal(db, registry, proposal.id, {
-      actor: "operator", now: later, policyVersion: "git:test", adapterOverride: "pi",
+      actor: "operator", now: later, policyVersion: "git:test", adapterOverride: "claude",
     });
 
     expect(result.approved).toBe(false);
@@ -189,7 +190,7 @@ describe("approveProposal after TTL expiry (§12)", () => {
     expect(result.proposal.id).not.toBe(proposal.id);
     expect(result.proposal.status).toBe("open");
     expect(result.proposal.run_id).toBe(runId);
-    expect(result.proposal.spec.adapter).toBe("pi");
+    expect(result.proposal.spec.adapter).toBe("claude");
     expect(result.proposal.created_at).toBe(new Date(later).toISOString());
 
     // The stale proposal was never executed.
@@ -198,7 +199,7 @@ describe("approveProposal after TTL expiry (§12)", () => {
 
     // The still-PROPOSED run carries the fresh spec, atomically with the swap.
     const run = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(runId);
-    expect(JSON.parse(run.spec_json).adapter).toBe("pi");
+    expect(JSON.parse(run.spec_json).adapter).toBe("claude");
     expect(run.spec_hash).toBe(result.proposal.spec_hash);
     expect(run.updated_at).toBe(new Date(later).toISOString());
 
@@ -210,7 +211,7 @@ describe("approveProposal after TTL expiry (§12)", () => {
 
     // Approving the fresh proposal (same override, so specs match) queues the run.
     const approved = approveProposal(db, registry, result.proposal.id, {
-      actor: "operator", now: later + 1000, policyVersion: "git:test", adapterOverride: "pi",
+      actor: "operator", now: later + 1000, policyVersion: "git:test", adapterOverride: "claude",
     });
     expect(approved).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -19,6 +19,21 @@ function tempRegistry() {
   return root;
 }
 
+/**
+ * A tier map that satisfies the committed registry: since WM-215 every LLM
+ * route is the pi adapter, so the pi map must cover every tier a routed
+ * definition declares. The claude map stays as the per-route exception's
+ * mapping — no committed route consumes it today.
+ */
+const PI_TIERS = {
+  claude: { strong: "default", standard: "sonnet", light: "haiku" },
+  pi: {
+    strong: "openai-codex/gpt-5.6-sol",
+    standard: "openai-codex/gpt-5.6-terra",
+    light: "openai-codex/gpt-5.6-luna",
+  },
+};
+
 describe("registry", () => {
   test("loads the committed registry (pins verified)", () => {
     const registry = loadRegistry();
@@ -104,12 +119,10 @@ describe("registry", () => {
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "standard" }));
-    // Also covers pi-smoke@1's own event-type-declared tier (OPS-517, adapter
-    // "pi") — event types outside this test's own agent are validated too.
-    const registry = loadRegistry({
-      root,
-      modelTiers: { claude: { strong: "default", standard: "sonnet" }, pi: { light: "openai-codex/gpt-5.6-luna" } },
-    });
+    // Every LLM route is "pi" since WM-215, so the pi map must cover every
+    // tier any routed definition declares — event types outside this test's
+    // own agent are validated too.
+    const registry = loadRegistry({ root, modelTiers: PI_TIERS });
     expect(getAgent(registry, "factory-status-report@1").model_tier).toBe("standard");
     // A definition that declares nothing is untouched — adapter default.
     expect(getAgent(registry, "reconcile@1").model_tier).toBeUndefined();
@@ -133,11 +146,16 @@ describe("registry", () => {
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "light" }));
-    // No claude tier map at all, and a map missing this one tier: both refuse.
-    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/no mapping for adapter "claude"/);
-    expect(() => loadRegistry({ root, modelTiers: { claude: { strong: "default" } } })).toThrow(
-      /model_tier "light" has no mapping/,
-    );
+    // No pi tier map at all, and a map missing this one tier: both refuse.
+    // (factory-status-report is the first routed event type in the file, so
+    // its unmapped "light" is what the load trips on in both cases.)
+    expect(() => loadRegistry({ root, modelTiers: {} })).toThrow(/no mapping for adapter "pi"/);
+    expect(() =>
+      loadRegistry({
+        root,
+        modelTiers: { pi: { strong: "openai-codex/gpt-5.6-sol", standard: "openai-codex/gpt-5.6-terra" } },
+      }),
+    ).toThrow(/model_tier "light" has no mapping/);
   });
 
   test("a tier on a command/actions-routed agent is not applicable, never an error (WM-135)", () => {
@@ -145,12 +163,9 @@ describe("registry", () => {
     const defFile = path.join(root, "agents", "reconcile.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...def, model_tier: "light" }));
-    // reconcile routes via the command adapter — "light" needs no mapping
-    // there, even though the map below deliberately lacks it.
-    const registry = loadRegistry({
-      root,
-      modelTiers: { claude: { strong: "default", standard: "sonnet" }, pi: { light: "openai-codex/gpt-5.6-luna" } },
-    });
+    // reconcile routes via the command adapter — "light" is resolved for no
+    // adapter there, so the command route stays applicable either way.
+    const registry = loadRegistry({ root, modelTiers: PI_TIERS });
     expect(resolveModel(getAgent(registry, "reconcile@1"), "command", registry.modelTiers)).toBeNull();
   });
 
@@ -158,7 +173,7 @@ describe("registry", () => {
     const root = tempRegistry();
     const defFile = path.join(root, "agents", "factory-status-report.json");
     const def = JSON.parse(readFileSync(defFile, "utf8"));
-    const tiers = { claude: { strong: "default", standard: "sonnet" }, pi: { light: "openai-codex/gpt-5.6-luna" } };
+    const tiers = PI_TIERS;
     writeFileSync(defFile, JSON.stringify({ ...def, model: "" }));
     expect(() => loadRegistry({ root, modelTiers: tiers })).toThrow(/"model"/);
     writeFileSync(defFile, JSON.stringify({ ...def, model: 42 }));

--- a/event-runtime/lib/slice2.test.mjs
+++ b/event-runtime/lib/slice2.test.mjs
@@ -39,7 +39,7 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-s2-ws-"));
-  const adapters = { claude: fake, actions: fake };
+  const adapters = { pi: fake, actions: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/lib/sweep.test.mjs
+++ b/event-runtime/lib/sweep.test.mjs
@@ -69,7 +69,7 @@ function harness() {
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-sweep-ws-"));
   fixtures.push(workspaces);
-  const adapters = { claude: fake, actions: fake };
+  const adapters = { pi: fake, actions: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/lib/triage.test.mjs
+++ b/event-runtime/lib/triage.test.mjs
@@ -69,7 +69,7 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-triage-ws-"));
-  const adapters = { claude: fake, actions: fake };
+  const adapters = { pi: fake, actions: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/lib/unblock.test.mjs
+++ b/event-runtime/lib/unblock.test.mjs
@@ -69,7 +69,7 @@ function harness() {
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-unblock-ws-"));
   fixtures.push(workspaces);
-  const adapters = { claude: fake, actions: fake };
+  const adapters = { pi: fake, actions: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -111,11 +111,11 @@ describe("worker", () => {
     expect(repositoryStatus(repo)).not.toBe(baseline);
   });
 
-  test("e2e (WM-135): tiered claude route plans a spec with the model pinned; the fake adapter executes it, ignoring the model", async () => {
+  test("e2e (WM-135): tiered pi route plans a spec with the model pinned; the fake adapter executes it, ignoring the model", async () => {
     const db = openDb(":memory:");
     // The real status-report definition with a declared tier, on a registry
-    // whose policy map says standard → sonnet.
-    const synthetic = { ...registry, agents: new Map(registry.agents), modelTiers: { claude: { standard: "sonnet" } } };
+    // whose policy map says standard → the pi standard model.
+    const synthetic = { ...registry, agents: new Map(registry.agents), modelTiers: { pi: { standard: "openai-codex/gpt-5.6-terra" } } };
     synthetic.agents.set("factory-status-report@1", { ...getAgent(registry, "factory-status-report@1"), model_tier: "standard" });
 
     const envelope = {
@@ -140,9 +140,9 @@ describe("worker", () => {
     );
     expect(outcome.decision).toBe("run");
     // The pinned resolution is what the operator would approve: the
-    // registered claude route's model, even though execution is the fake.
+    // registered pi route's model, even though execution is the fake.
     const spec = JSON.parse(outcome.proposal.spec_json);
-    expect(spec.model).toBe("sonnet");
+    expect(spec.model).toBe("openai-codex/gpt-5.6-terra");
     expect(spec.modelTier).toBe("standard");
     expect(spec.adapter).toBe("fake");
 
@@ -153,7 +153,7 @@ describe("worker", () => {
     expect(summary.terminalState).toBe("COMPLETED");
     // The run's stored spec — what inspect/receipts read — carries the pin.
     const stored = JSON.parse(db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(outcome.runId).spec_json);
-    expect(stored.model).toBe("sonnet");
+    expect(stored.model).toBe("openai-codex/gpt-5.6-terra");
     expect(stored.modelTier).toBe("standard");
   });
 

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -148,7 +148,7 @@ async function dispatchTo(outcome, eventId, ticket) {
   const proposal = openProposals(db, {}).find((p) => p.spec?.agent === "dispatch@1");
   expect(proposal).toBeTruthy();
   const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
-  const summary = await runOnce(db, registry, { claude: dispatchFake(outcome) }, {
+  const summary = await runOnce(db, registry, { pi: dispatchFake(outcome) }, {
     workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
   });
   expect(summary.terminalState).toBe("COMPLETED");

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -71,7 +71,7 @@ async function runApply(plan, { headSha = PINNED_SHA } = {}) {
 }
 
 describe("merge-scan registration (WM-109)", () => {
-  test("merge-scan@1 is a read-only claude agent with no repository workspace", () => {
+  test("merge-scan@1 is a read-only pi agent with no repository workspace", () => {
     const def = registry.agents.get("merge-scan@1");
     expect(def.mutating).toBe(false);
     // It reads PRs via gh, not a source tree — ephemeral, like the other
@@ -81,11 +81,11 @@ describe("merge-scan registration (WM-109)", () => {
     expect(def.capabilities.services).toContain("gh:read");
   });
 
-  test("factory.merge.requested maps to merge-scan@1 on the claude adapter, deduped by inputHash", () => {
+  test("factory.merge.requested maps to merge-scan@1 on the pi adapter, deduped by inputHash", () => {
     const mapping = registry.eventTypes["factory.merge.requested"];
     expect(mapping).toEqual({
       agent: "merge-scan@1",
-      adapter: "claude",
+      adapter: "pi",
       idempotencyScope: ["inputHash"],
       proposalTtlSeconds: 1800,
     });
@@ -174,7 +174,7 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-e2e-ws-"));
-  const adapters = { claude: fake, actions: fake, command: fake };
+  const adapters = { pi: fake, actions: fake, command: fake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/ship.test.mjs
+++ b/event-runtime/ship.test.mjs
@@ -33,7 +33,7 @@ const DEPLOY_SHA = "b".repeat(40);
 const MOVED_SHA = "c".repeat(40);
 
 describe("ship-scan registration (WM-111)", () => {
-  test("ship-scan@1 is a read-only claude agent with no repository workspace", () => {
+  test("ship-scan@1 is a read-only pi agent with no repository workspace", () => {
     const def = registry.agents.get("ship-scan@1");
     expect(def.mutating).toBe(false);
     // It reads branches and CI via gh, not a source tree — ephemeral, like
@@ -43,10 +43,10 @@ describe("ship-scan registration (WM-111)", () => {
     expect(def.capabilities.services).toContain("gh:read");
   });
 
-  test("factory.ship.requested maps to ship-scan@1 on the claude adapter, deduped by inputHash", () => {
+  test("factory.ship.requested maps to ship-scan@1 on the pi adapter, deduped by inputHash", () => {
     expect(registry.eventTypes["factory.ship.requested"]).toEqual({
       agent: "ship-scan@1",
-      adapter: "claude",
+      adapter: "pi",
       idempotencyScope: ["inputHash"],
       proposalTtlSeconds: 1800,
     });
@@ -514,7 +514,7 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-ship-e2e-ws-"));
-  const adapters = { claude: shipFake, actions: shipFake, command: shipFake };
+  const adapters = { pi: shipFake, actions: shipFake, command: shipFake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV };
 
   async function approveNext(agentRef) {

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -19,7 +19,7 @@ import { openDb } from "./lib/db.mjs";
 import { admitEvent } from "./lib/intake.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { approveProposal, openProposals } from "./lib/proposals.mjs";
-import { loadRegistry } from "./lib/registry.mjs";
+import { loadRegistry, resolveModel } from "./lib/registry.mjs";
 import { runOnce } from "./lib/worker.mjs";
 
 const registry = loadRegistry();
@@ -198,7 +198,7 @@ function harness() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-work-"));
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-work-ws-"));
-  const adapters = { claude: workFake };
+  const adapters = { pi: workFake };
   const workerOpts = { workspacesRoot: workspaces, owner: "w-test", policyVersion: PV, dispatch: openWorld };
 
   const planAll = () => planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: openWorld });
@@ -226,7 +226,7 @@ const workEnvelope = (repo, eventId) => ({
 });
 
 describe("work-scan registration (WM-110)", () => {
-  test("work-scan@1 is a read-only claude agent over a repository workspace, like triage-scan", () => {
+  test("work-scan@1 is a read-only pi agent over a repository workspace, like triage-scan", () => {
     const def = registry.agents.get("work-scan@1");
     expect(def.mutating).toBe(false);
     // It verifies Owned Paths globs against real paths, so it reads the
@@ -236,13 +236,56 @@ describe("work-scan registration (WM-110)", () => {
     expect(def.capabilities.services).toEqual(["linear:read", "repo:read"]);
   });
 
-  test("factory.work.requested maps to work-scan@1 on the claude adapter, deduped by inputHash", () => {
+  test("factory.work.requested maps to work-scan@1 on the pi adapter, deduped by inputHash", () => {
     expect(registry.eventTypes["factory.work.requested"]).toEqual({
       agent: "work-scan@1",
-      adapter: "claude",
+      adapter: "pi",
       idempotencyScope: ["inputHash"],
       proposalTtlSeconds: 1800,
     });
+  });
+
+  // WM-215: pi is the default harness, so the one mutating LLM agent in the
+  // registry now rides it. The §14 admission rule that lets a mutating LLM
+  // agent exist at all is the tier-2 worktree carve-out (WM-108, generalized
+  // to any adapter by OPS-296) — assert it holds for dispatch@1 on pi, since
+  // a regression here would refuse the whole registry at load, not just this
+  // route.
+  test("dispatch@1 is admissible as a mutating pi agent over a tier-2 worktree (WM-215)", () => {
+    expect(registry.eventTypes["factory.dispatch.requested"]).toEqual({
+      agent: "dispatch@1",
+      adapter: "pi",
+      idempotencyScope: ["inputHash"],
+      proposalTtlSeconds: 1800,
+    });
+    const def = registry.agents.get("dispatch@1");
+    expect(def.mutating).toBe(true);
+    expect(def.workspace.type).toBe("worktree");
+    // The registry loaded at module scope: loadRegistry() already ran the §14
+    // admission check and the WM-135 fail-closed model resolution over this
+    // route, so a pi+worktree+mutating definition is admitted and its strong
+    // tier resolves against models.pi.
+    expect(def.model_tier).toBe("strong");
+    expect(resolveModel(def, "pi", registry.modelTiers)).toBe(registry.modelTiers.pi.strong);
+  });
+
+  test("every LLM route is the pi adapter; command/actions routes are untouched (WM-215)", () => {
+    const byAdapter = {};
+    for (const mapping of Object.values(registry.eventTypes)) {
+      if (!mapping.agent) continue;
+      (byAdapter[mapping.adapter] ??= []).push(mapping.agent);
+    }
+    // No committed route rides claude. It stays a supported adapter — the
+    // per-route exception and `--adapter-override claude` both select it —
+    // but the default harness is pi.
+    expect(byAdapter.claude).toBeUndefined();
+    expect(byAdapter.pi.length).toBeGreaterThan(0);
+    // Every pi route resolves a model: loadRegistry fails closed otherwise,
+    // but assert the values so a silently-null resolution can't pass.
+    for (const ref of byAdapter.pi) {
+      const resolved = resolveModel(registry.agents.get(ref), "pi", registry.modelTiers);
+      expect(Object.values(registry.modelTiers.pi)).toContain(resolved);
+    }
   });
 
   test("the plan item shape pins {ticket, ownedPaths, reason}; NOOP reasons are the closed set", () => {


### PR DESCRIPTION
Fixes WM-215

Operator decision 2026-08-15: pi is the factory's preferred harness. This flips every LLM-routed event type to it, per route, with no mode.

## What changed

**`event-runtime/event-types.json`** — all **11** `"adapter": "claude"` routes become `"pi"`: `factory-status-report@1`, `disk-diagnose@1`, `triage-scan@1`, `ci-doctor@2`, `run-postmortem@1`, `unblock-scan@1`, `sweep-scan@1`, `merge-scan@1`, `dispatch@1`, `work-scan@1`, `ship-scan@1`. `pi-smoke@1` was already pi → **12 pi routes, 0 claude routes**. Every `command`/`actions` route is untouched; the diff is 11 insertions / 11 deletions of one field, which is the proof.

The mechanism stays per-route on purpose. There is no harness mode to flip — routing a single event type back to Claude Code is a one-line edit of that route, and `--adapter-override claude` (`cli.mjs serve`/`work`) still forces any run onto claude without touching the registry.

**No `config/policy.yaml` change was needed.** Every flipped route declares `strong` or `standard`, and both already map under `models.pi`. WM-135's fail-closed resolution proves this at registry load rather than at dispatch time — a gap would refuse the whole registry. Resolved per route:

| adapter | routes | tiers resolved |
|---|---|---|
| `pi` | 12 | `strong` → `openai-codex/gpt-5.6-sol` (dispatch, merge-scan) · `standard` → `…-terra` (9) · `light` → `…-luna` (pi-smoke) |
| `command` / `actions` | 17 | n/a (`model: null`) |
| `claude` | 0 | — |

**`dispatch@1` is admissible as mutating pi over a tier-2 worktree.** No code change was required: `loadAgentDef`'s §14 carve-out only checks `workspace.type === "worktree"` and was already adapter-agnostic after OPS-296. Now asserted by a test rather than assumed.

**`event-runtime/agents/dispatch.md`** — the ticket asked whether the push instructions were claude-shaped. They were not; the paved road was simply **absent** (step 5 said only "Push and open a PR"). Root cause of the SSH block noted in the ticket: `lib/adapters/pi.mjs`'s `safeChildEnvironment` inherits no `SSH_AUTH_SOCK`/`SSH_AGENT_PID`/`GH_TOKEN`/`GITHUB_TOKEN` — unlike `claude.mjs`, which preserves exactly those for mutating runs under WM-128. SSH therefore *cannot* work under pi, while `gh` over HTTPS does, because gh reads its stored credentials from `~/.config/gh` via the inherited `HOME`/`XDG_CONFIG_HOME`. The prompt now states gh-HTTPS plainly and tells the agent an SSH failure is a wrong-transport error, not a blocker. `dispatch.json`'s pin is updated via `cli.mjs update-pins` (no version bump — content pin, same `@1`).

**`docs/event-runtime.md` §6** — adapter registry paragraph rewritten (pi is the default, claude still fully supported), a new "pi is the default harness, per route, not per mode" paragraph covering the per-route exception and `--adapter-override claude`, the §5.2 RunSpec example updated, and two stale claims corrected: `models.claude.standard: sonnet` as the tier-map example, and "Only the `claude` adapter consumes models" (`MODEL_ADAPTERS` has been `{claude, pi}` since OPS-296).

## Scope note — Owned Paths under-specified this ticket

The ticket's Owned Paths named four e2e fixtures (`loop`/`work`/`merge`/`ship`). The flip actually broke **43 tests across 17 files**, because the adapter name is the key every test registers its contract fake under (`{ claude: fake }` → `{ pi: fake }`), and because `registry`/`planner`/`worker`/`api`/`proposals` tests assert adapter names and resolved models straight off the *real* registry. AC 6 (`bun test event-runtime/` green) is unreachable without them, so they are in this diff.

All of it is test-only — **no runtime `lib/` source is touched**. Reviewer's shortcut: `git diff develop -- event-runtime/lib/` should show only `*.test.mjs` files.

## Known pi caveats — noted, not fixed here

- **Push credentials (filed as [WM-223](https://linear.app/watt-mind/issue/WM-223))**: pi's `safeChildEnvironment` strips push credentials for *all* runs and takes no mutating/non-mutating argument, so it cannot make claude's WM-128 distinction. `dispatch@1` under pi survives only via gh's on-disk credentials. Two defensible fixes (parity with claude, or declare gh-HTTPS the only road and add a `gh auth status` preflight refusal) — worth deciding deliberately.
- **Containment is coarser under pi**: audited-not-enforced, `mutating: false` by tool omission rather than runtime interception. OPS-515 is stage 2. Unchanged by this PR.
- **No `--max-budget-usd` equivalent** on pi. Unchanged by this PR.

## Verification

```
$ bun test event-runtime/
 1111 pass
 0 fail
 4512 expect() calls
Ran 1111 tests across 86 files. [41.44s]
```

Full repo suite also green (`bun test`: 1439 pass, 0 fail) and `bun build/emit.mjs --check` exits 0.