### PR TITLE
fix(event-runtime): pi adapter preserves push credentials for mutating runs (WM-223)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -433,11 +433,14 @@ stdin, matching `runners/run-agent.sh`'s existing invocation) rather than
 directly (`openai-codex/gpt-5.6-terra`), no separate `--provider` flag. There
 is no `--max-budget-usd` equivalent and no per-tool settings/sandbox policy —
 those, and native capability enforcement derived from `spec.capabilities`, are
-deliberately stage 2. `mutating: false` passes `--tools read,grep,find,ls`:
-pi's own documented read-only pattern is omitting bash/edit/write from the
+deliberately stage 2. `mutating: false` passes `--tools read,grep,find,ls,write`:
+pi's own documented read-only pattern is omitting bash/edit from the
 tool allowlist entirely, never exposing them to the model, rather than
 intercepting a call to them at runtime the way claude's settings/sandbox
-policy does — see §14. (An earlier draft of this design read `-r` as pi's
+policy does — see §14. (`write` stays even on a read-only run: every
+agent-result contract requires the model to write `./result.json`, so a run
+without it fails `contract_violation:missing_result` before doing anything —
+the same reasoning that keeps Write/Edit in claude's `READ_ONLY_TOOLS`.) (An earlier draft of this design read `-r` as pi's
 read-only flag; the installed CLI's own `--help` says otherwise — `-r` is
 `--resume`, a session selector, unrelated to tool access. Verify adapter flags
 against the actual CLI before relying on ticket text.) `mutating: true` pi
@@ -455,6 +458,38 @@ message the way claude's `type: "result"` is one, so `usage` is accumulated
 across every assistant turn's own reported tokens/cost and emitted once at
 process close; fields pi never reported land as explicit `null`/`{}`, never a
 guessed value.
+
+**Both LLM adapters apply the same push-credential carve-out (WM-128,
+WM-223).** `safeChildEnvironment(env, def)` in either adapter hands a mutating
+run `SSH_AUTH_SOCK`, `SSH_AGENT_PID`, `GITHUB_TOKEN` and `GH_TOKEN` on top of
+the base inherited set, and strips all four from a non-mutating one — after the
+caller's `env` is merged, so a read-only run cannot be handed a token through
+`env` either. `pi.mjs` imports `PUSH_CREDENTIAL_ENV` from `claude.mjs` rather
+than restating it: one list, no drift. Until WM-223 pi had no
+mutating/non-mutating distinction at all, which meant the runtime's only
+mutating LLM agent (`dispatch@1`, pi-routed since WM-215) reached its push step
+with no credential of any kind — surviving only because `gh` reads its own
+stored OAuth from `~/.config/gh/hosts.yml` through the inherited
+`HOME`/`XDG_CONFIG_HOME`, and git picks up the `gh` credential helper the same
+way. That gh-over-HTTPS route remains the paved road a dispatch run should
+push on (`agents/dispatch.md` step 5); the carve-out is what makes an SSH or
+token push a real fallback rather than a guaranteed failure. The optional
+`gh auth status` preflight refusal considered alongside this was deliberately
+not adopted: with the credentials restored, a mutating run can legitimately
+push without gh being authenticated, so gating the start of the run on it would
+refuse work that would have succeeded.
+
+**One wrinkle the carve-out leaves open: `SSH_AUTH_SOCK` is not only a push
+credential.** It is also how an agent reaches infrastructure over SSH, and a
+read-only infra agent — `disk-diagnose` declares `mutating: false` with
+`services: ["ssh:read:lab", "ssh:read:web"]` — may legitimately want the agent
+socket despite being non-mutating. Both adapters strip it from such a run
+today; `disk-diagnose` works because key-file authentication is reachable
+through the inherited `HOME`, not because the socket survives. The fix, if that
+ever becomes a real failure, is a capability-driven exception (a declared
+`ssh:read` service inheriting the socket), **not** widening the non-mutating
+default — the point of the strip is that a read-only run holds no authority it
+did not declare.
 
 **Live trace is an optional adapter capability (`factory.trace/v1`).** An
 adapter may stream what the agent is doing mid-run — via the `onTrace`

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -41,9 +41,11 @@ import { spawn } from "node:child_process";
 import { createWriteStream, readFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { PROMPT_SUFFIX } from "./claude.mjs";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
 
-export { PROMPT_SUFFIX };
+// PUSH_CREDENTIAL_ENV is imported, not redeclared: the WM-128 carve-out is one
+// list shared by both LLM adapters (WM-223), so it cannot drift between them.
+export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
 
 export const KILL_GRACE_MS = 30_000;
 
@@ -96,9 +98,34 @@ export function buildPiArgv({ def, model }) {
   return args;
 }
 
-/** Keep untrusted model subprocesses from inheriting the worker's authority. */
-export function safeChildEnvironment(env = {}) {
-  const inherited = ["HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM", "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"];
+export const BASE_INHERITED_ENV = [
+  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
+  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+];
+
+/**
+ * Keep untrusted model subprocesses from inheriting the worker's authority.
+ *
+ * Mutating runs additionally inherit `PUSH_CREDENTIAL_ENV` (SSH_AUTH_SOCK,
+ * SSH_AGENT_PID, GITHUB_TOKEN, GH_TOKEN) so a dispatch ticket can actually
+ * push its branch; non-mutating runs have those stripped — the WM-128 carve-out
+ * claude.mjs has always had, brought to pi in WM-223. Before this, a pi-routed
+ * dispatch run had *no* push credentials of any kind and survived only on `gh`'s
+ * own stored OAuth reachable through the inherited HOME/XDG_CONFIG_HOME. That
+ * gh-HTTPS route stays the paved road for pushing (agents/dispatch.md step 5);
+ * this restores the credentials it was never supposed to be doing without.
+ *
+ * The strip runs *after* the caller's `env` is merged in, so a read-only run
+ * cannot be handed a token through `env` either.
+ *
+ * Deliberate divergence from claude.mjs: only an explicit `mutating: true` (or a
+ * boolean argument) counts as mutating here, where claude.mjs also treats any
+ * other non-`undefined` value as mutating. Identical for every real agent
+ * definition — `mutating` is a JSON boolean — but this direction fails closed.
+ */
+export function safeChildEnvironment(env = {}, defOrOpts = {}) {
+  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
   const childEnv = Object.fromEntries(inherited.flatMap((key) => process.env[key] === undefined ? [] : [[key, process.env[key]]]));
   Object.assign(childEnv, env);
   // Subscription auth (Codex/ChatGPT OAuth) is the point of routing through
@@ -110,6 +137,11 @@ export function safeChildEnvironment(env = {}) {
     "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
   ]) {
     delete childEnv[key];
+  }
+  if (!isMutating) {
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      delete childEnv[key];
+    }
   }
   return childEnv;
 }
@@ -216,7 +248,7 @@ export async function execute({
   signal,
 }) {
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
-  const childEnv = safeChildEnvironment(env);
+  const childEnv = safeChildEnvironment(env, def);
 
   const resolved = resolvePiCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
   if (!resolved) {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -1,8 +1,8 @@
-import { describe, expect, test, afterAll } from "bun:test";
+import { describe, expect, test, afterAll, afterEach } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { PROMPT_SUFFIX } from "./claude.mjs";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
 import {
   buildPiArgv,
   CliNotFoundError,
@@ -11,6 +11,7 @@ import {
   isHarnessDenial,
   KILL_GRACE_MS,
   mapStreamEvent,
+  PUSH_CREDENTIAL_ENV,
   READ_ONLY_TOOLS,
   resolvePiCommand,
   safeChildEnvironment,
@@ -170,6 +171,12 @@ describe("resolvePiCommand", () => {
 });
 
 describe("safeChildEnvironment", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   test("strips every provider API key pi recognizes, keeps declared env", () => {
     const env = safeChildEnvironment({
       ANTHROPIC_API_KEY: "a",
@@ -186,6 +193,73 @@ describe("safeChildEnvironment", () => {
       expect(env[key]).toBeUndefined();
     }
     expect(env.CUSTOM_VAR).toBe("kept");
+  });
+
+  // Mirrors claude.test.mjs's "safeChildEnvironment (WM-128)" block: the pi
+  // adapter had no mutating/non-mutating distinction at all until WM-223, so a
+  // pi-routed dispatch run reached the push step with no credentials.
+  test("strips push credentials for non-mutating runs (WM-128 parity, WM-223)", () => {
+    const childEnv = safeChildEnvironment({
+      SSH_AUTH_SOCK: "/tmp/test.sock",
+      SSH_AGENT_PID: "12345",
+      GITHUB_TOKEN: "ghp_secret_token",
+      GH_TOKEN: "ghp_other_token",
+      OPENAI_API_KEY: "sk-secret",
+      CUSTOM_INSPECT_VAR: "allowed",
+    }, { mutating: false });
+
+    expect(childEnv.CUSTOM_INSPECT_VAR).toBe("allowed");
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      expect(childEnv[key]).toBeUndefined();
+    }
+    expect(childEnv.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  test("preserves push credentials while stripping provider keys for mutating runs (WM-128 parity, WM-223)", () => {
+    const childEnv = safeChildEnvironment({
+      SSH_AUTH_SOCK: "/tmp/agent.sock",
+      SSH_AGENT_PID: "54321",
+      GITHUB_TOKEN: "ghp_mutating_token",
+      GH_TOKEN: "ghp_gh_token",
+      OPENAI_API_KEY: "sk-secret",
+      CUSTOM_MUTATING_VAR: "allowed",
+    }, { mutating: true });
+
+    expect(childEnv.CUSTOM_MUTATING_VAR).toBe("allowed");
+    expect(childEnv.SSH_AUTH_SOCK).toBe("/tmp/agent.sock");
+    expect(childEnv.SSH_AGENT_PID).toBe("54321");
+    expect(childEnv.GITHUB_TOKEN).toBe("ghp_mutating_token");
+    expect(childEnv.GH_TOKEN).toBe("ghp_gh_token");
+    expect(childEnv.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  test("inherits push credentials from process.env only when mutating", () => {
+    process.env.SSH_AUTH_SOCK = "/tmp/inherited.sock";
+    process.env.GITHUB_TOKEN = "ghp_inherited_token";
+
+    const mutatingEnv = safeChildEnvironment({}, { mutating: true });
+    expect(mutatingEnv.SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+    expect(mutatingEnv.GITHUB_TOKEN).toBe("ghp_inherited_token");
+
+    const readOnlyEnv = safeChildEnvironment({}, { mutating: false });
+    expect(readOnlyEnv.SSH_AUTH_SOCK).toBeUndefined();
+    expect(readOnlyEnv.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  // The real call site passes the agent definition itself (execute() → def), so
+  // an omitted `mutating` must land on the stripping side, not the inheriting one.
+  test("defaults to stripping when no definition, an empty one, or a boolean is passed", () => {
+    process.env.SSH_AUTH_SOCK = "/tmp/inherited.sock";
+
+    expect(safeChildEnvironment({}).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, {}).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, { mutating: undefined }).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, false).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+  });
+
+  test("shares one push-credential list with the claude adapter (no drift)", () => {
+    expect(PUSH_CREDENTIAL_ENV).toBe(CLAUDE_PUSH_CREDENTIAL_ENV);
   });
 });
 


### PR DESCRIPTION
Fixes WM-223

## What

`event-runtime/lib/adapters/pi.mjs`'s `safeChildEnvironment` had no
mutating/non-mutating distinction at all — it took no `def`/`opts` argument and
inherited a fixed base list. Since WM-215 routed `dispatch@1` (the runtime's
only mutating LLM agent) through pi, that meant every dispatch run reached its
push step with no `SSH_AUTH_SOCK`, no `SSH_AGENT_PID`, and no
`GH_TOKEN`/`GITHUB_TOKEN`. It survived only because `gh` reads its own stored
OAuth from `~/.config/gh/hosts.yml` through the inherited
`HOME`/`XDG_CONFIG_HOME` — an undeclared, unasserted dependency on one config
file, and the observed cause of a pi run blocking on SSH instead of recovering
via `gh`.

This applies the operator's decision on the ticket — **option 1, parity with
claude** (the standing WM-128 ruling):

- `safeChildEnvironment(env, defOrOpts)` gains the second argument. Mutating
  runs inherit `PUSH_CREDENTIAL_ENV`; non-mutating runs have it stripped, and
  the strip runs *after* the caller's `env` is merged, so a read-only run
  cannot be handed a token through `env` either.
- `PUSH_CREDENTIAL_ENV` is **imported from `claude.mjs`** and re-exported (the
  way `PROMPT_SUFFIX` already was) rather than duplicated — one list, no drift.
  `claude.mjs` is outside this ticket's Owned Paths and is untouched.
- `execute()` passes `def` through, matching `claude.mjs:291`.
- Provider-API-key stripping (the subscription-auth guard) is unchanged.

## Reviewer note — this is a credential-propagation diff

It widens what a *mutating* pi child inherits, so it deserves a human read even
though the direction was decided on the ticket in advance. Two judgement calls
worth checking:

1. **Strict `mutating === true`.** `claude.mjs` resolves mutating as
   `mutating === true || (mutating !== false && mutating !== undefined)`, so a
   non-boolean, non-`undefined` value (e.g. `null`) reads as mutating — fail-open.
   pi treats only an explicit `true` (or a boolean argument) as mutating.
   Identical for every real agent definition, since `mutating` is a JSON
   boolean; the divergence only ever fails *closed*. It is called out in the
   function's doc comment. Say the word if you would rather have byte-parity
   with claude's expression instead, at the cost of copying its fail-open edge.
2. **The optional `gh auth status` preflight (ticket's "bonus if cheap") was
   not adopted.** With push credentials restored, a mutating run can push over
   SSH or a token without gh ever being authenticated, so a gh-auth gate at the
   start of the run would refuse work that would have succeeded. The reasoning
   is recorded in the docs rather than left implicit.

## Tests

`event-runtime/lib/adapters/pi.test.mjs` mirrors `claude.test.mjs`'s
`safeChildEnvironment (WM-128)` block for pi — strip on `mutating: false`,
preserve on `mutating: true`, inherit from `process.env` only when mutating —
plus two the claude side does not have:

- the real call site passes the agent definition itself, so no `def`, `{}`,
  `{mutating: undefined}` and `false` must all land on the stripping side;
- a no-drift assertion that pi's `PUSH_CREDENTIAL_ENV` **is** claude's object.

## The wrinkle, documented not solved

`SSH_AUTH_SOCK` doubles as infra-SSH access, and `disk-diagnose` is
`mutating: false` with `services: ["ssh:read:lab", "ssh:read:web"]`. Both
adapters strip the socket from it — this is not a regression from this PR;
`claude.mjs` has always stripped it, and `disk-diagnose` authenticates via key
files reachable through the inherited `HOME`. `docs/event-runtime.md` §6 now
records that, and that the fix if it ever bites is a capability-driven
`ssh:read` exception rather than widening the non-mutating default. Filed as a
follow-up on the ticket rather than scope-crept into this one.

## Verification

```
bun test event-runtime/      →  1130 pass, 0 fail (86 files)
bun test                     →  1469 pass, 0 fail (116 files)
bun build/emit.mjs --check   →  exit 0, "ok — 90 generated files match shared/"
```

(The `FATAL: Database schema version (999)…` line in test output is
`db.test.mjs` asserting that guard, not a failure. `emit --check`'s floor-
delivery warning about `bj29` is pre-existing and unrelated to this branch.)

Files touched — all within the ticket's Owned Paths:
`event-runtime/lib/adapters/pi.mjs`, `event-runtime/lib/adapters/pi.test.mjs`,
`docs/event-runtime.md`.
