### PR TITLE
fix(event-runtime): retain refusal artifacts (WM-231)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -636,6 +636,18 @@ ephemeral workspace could never be rechecked, and slice 2's recompute needs
 the bytes. Evidence too large to inline waits for the content-addressed
 artifact store rather than being silently dropped.
 
+A typed refusal may be bare or may carry an artifact and evidence explaining
+why the agent could not proceed. When present, that context is not an escape
+from the output contract: the verifier validates the artifact against the
+agent's output schema, applies its closed semantic predicates, retains the
+artifact and bounded evidence in the accepted result, and recomputes their
+hashes. An invalid refusal artifact therefore fails as a contract violation;
+a valid one still produces `REFUSED` with its original reason code and no
+completion event. The refusal's verification receipt records a passed
+contract check, while the accepted result supplies the refusal reason and the
+hash-bound explanatory context; bare refusals continue to have no artifact or
+evidence hashes.
+
 Repository work later adds the exact repository verification command, executed
 separately from the implementing agent. GitHub Actions is not required. The
 verification record binds the immutable source ref, command, environment,

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -67,19 +67,47 @@ export function verifyResult({ spec, def, registry, workspaceDir, attempt, journ
   const shape = validate(registry.schemas.agentResult, candidate);
   if (!shape.valid) throw new ContractViolation(shape.errors);
 
-  if (candidate.terminalState === "refused") return verifyRefused({ spec, candidate, attempt });
+  if (candidate.terminalState === "refused") return verifyRefused({ spec, def, candidate, attempt });
   return verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts });
 }
 
-/** Refusal is not failure (§5.3) — but only typed, known reasons are admitted. */
-function verifyRefused({ spec, candidate, attempt }) {
+/**
+ * Refusal is not failure (§5.3) — but only typed, known reasons are admitted.
+ * An optional artifact explains the refusal through the same output contract
+ * as a completion, so useful context is retained without weakening validation.
+ */
+function verifyRefused({ spec, def, candidate, attempt }) {
   const violations = [];
   if (!candidate.reasonCode) violations.push("refused_without_reason_code");
   else if (!REFUSAL_REASONS.includes(candidate.reasonCode)) {
     violations.push(`unknown_refusal_reason: ${candidate.reasonCode}`);
   }
-  if (candidate.artifact !== undefined) violations.push("refused_with_artifact");
   if (violations.length > 0) throw new ContractViolation(violations);
+
+  const context = {};
+  const checks = ["schema_valid"];
+  if (candidate.artifact !== undefined) {
+    const artifactCheck = validate(def.outputSchema, candidate.artifact);
+    if (!artifactCheck.valid) throw new ContractViolation(artifactCheck.errors);
+
+    const semantic = SEMANTIC_CHECKS[spec.outputContract];
+    if (semantic) {
+      const semanticViolations = semantic(candidate);
+      if (semanticViolations.length > 0) throw new ContractViolation(semanticViolations);
+      checks.push("evidence_recomputed");
+    }
+
+    context.artifact = candidate.artifact;
+    context.artifactHash = hashJson(candidate.artifact);
+    checks.push("hash_recomputed");
+  }
+
+  const { evidence, evidenceSetHash } = retainedEvidence(candidate);
+  if (evidence !== undefined) {
+    context.evidence = evidence;
+    context.evidenceSetHash = evidenceSetHash;
+    checks.push("evidence_retained");
+  }
 
   const result = {
     schemaVersion: "factory.run-result/v1",
@@ -88,10 +116,22 @@ function verifyRefused({ spec, candidate, attempt }) {
     terminalState: "refused",
     reasonCode: candidate.reasonCode,
     outputContract: spec.outputContract,
-    verification: { status: "passed", checks: ["schema_valid"] },
+    ...context,
+    verification: { status: "passed", checks },
     artifacts: [],
   };
   return { kind: "refused", reasonCode: candidate.reasonCode, result };
+}
+
+function retainedEvidence(candidate) {
+  if (candidate.evidence === undefined) return { evidence: undefined, evidenceSetHash: null };
+
+  const canonical = canonicalJson(candidate.evidence);
+  const bytes = Buffer.byteLength(canonical, "utf8");
+  if (bytes > EVIDENCE_INLINE_LIMIT_BYTES) {
+    throw new ContractViolation([`evidence_too_large: ${bytes} bytes > ${EVIDENCE_INLINE_LIMIT_BYTES}`]);
+  }
+  return { evidence: candidate.evidence, evidenceSetHash: hashBytes(canonical) };
 }
 
 /** Last integer in a raw probe output — `df --output=used -B1` style. */
@@ -202,17 +242,7 @@ function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalH
 
   const artifactHash = hashJson(candidate.artifact);
 
-  let evidence;
-  let evidenceSetHash = null;
-  if (candidate.evidence !== undefined) {
-    const canonical = canonicalJson(candidate.evidence);
-    const bytes = Buffer.byteLength(canonical, "utf8");
-    if (bytes > EVIDENCE_INLINE_LIMIT_BYTES) {
-      throw new ContractViolation([`evidence_too_large: ${bytes} bytes > ${EVIDENCE_INLINE_LIMIT_BYTES}`]);
-    }
-    evidence = candidate.evidence;
-    evidenceSetHash = hashBytes(canonical);
-  }
+  const { evidence, evidenceSetHash } = retainedEvidence(candidate);
 
   const result = {
     schemaVersion: "factory.run-result/v1",

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -8,6 +8,7 @@ import { ContractViolation, verifyResult } from "./verify.mjs";
 
 const registry = loadRegistry();
 const def = getAgent(registry, "factory-status-report@1");
+const dispatchDef = getAgent(registry, "dispatch@1");
 
 function makeSpec(input = { repos: ["bj29"] }) {
   return {
@@ -139,14 +140,52 @@ describe("verifyResult", () => {
       .toThrow(ContractViolation);
   });
 
-  test("refused carrying an artifact → ContractViolation", () => {
+  test("refused carrying run_6fe0cdb4's dispatch artifact shape → REFUSED with context retained", () => {
+    const artifact = {
+      outcome: "BLOCKED",
+      repo: "factory",
+      ticket: "WM-139",
+      prUrl: null,
+      verification: {
+        command: null,
+        passed: false,
+        output: "Not run: production infrastructure and credential handling require a human.",
+      },
+      summary: "Human approval is required for production launchd and SSH credential changes.",
+    };
+    const evidence = {
+      commands: ["gh auth status", "launchctl print gui/$(id -u)/com.wattmind.factory"],
+    };
     const dir = makeWorkspace({
       schemaVersion: "factory.agent-result/v1",
       terminalState: "refused",
       reasonCode: "needs_human",
-      artifact: VALID_ARTIFACT,
+      artifact,
+      evidence,
     });
-    expect(() => verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 }))
+    const spec = { ...makeSpec({ repo: "factory", ticket: "WM-139" }), outputContract: "factory.dispatch-result/v1" };
+
+    const out = verifyResult({ spec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+
+    expect(out.kind).toBe("refused");
+    expect(out.reasonCode).toBe("needs_human");
+    expect(out.result.terminalState).toBe("refused");
+    expect(out.result.artifact).toEqual(artifact);
+    expect(out.result.artifactHash).toBe(hashJson(artifact));
+    expect(out.result.evidence).toEqual(evidence);
+    expect(out.result.evidenceSetHash).toBe(hashJson(evidence));
+    expect(out.result.verification.checks).toContain("evidence_retained");
+  });
+
+  test("refused carrying an artifact that fails its output schema → ContractViolation", () => {
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "refused",
+      reasonCode: "needs_human",
+      artifact: { outcome: "BLOCKED", repo: "factory" },
+    });
+    const spec = { ...makeSpec({ repo: "factory", ticket: "WM-139" }), outputContract: "factory.dispatch-result/v1" };
+    expect(() => verifyResult({ spec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 }))
       .toThrow(ContractViolation);
   });
 


### PR DESCRIPTION
## Summary
- validate optional refusal artifacts against the agent output contract
- retain refusal artifacts and bounded evidence with recomputed hashes
- keep bare refusals unchanged and document receipt semantics

## Verification
- `bun test event-runtime/` — pass, 1243 tests

UX critique: skipped — internal event-runtime contract behavior with no user-completable UI flow.

Fixes WM-231