### PR TITLE
ui(event-runtime-web): show worker pool capacity

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -10,8 +10,9 @@
  * no signature. Operator verbs record "operator" as actor — authenticated
  * actor identity is the web-app step, not this one.
  */
-import { closeSync, createReadStream, openSync, readFileSync, readSync } from "node:fs";
+import { closeSync, createReadStream, openSync, readFileSync, readSync, readdirSync } from "node:fs";
 import http from "node:http";
+import { homedir } from "node:os";
 import path from "node:path";
 import { findArtifact } from "./artifacts.mjs";
 import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
@@ -26,7 +27,7 @@ import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { storeStats } from "./artifacts.mjs";
 import { parseCadence, proposalsPilingUp, scheduleView } from "./schedules.mjs";
-import { listWorkers, stalledWorkers } from "./workers.mjs";
+import { listWorkers, loadWorkerPolicy, stalledWorkers } from "./workers.mjs";
 
 /**
  * Repo names a run or event actually names — optional spec input, not a
@@ -129,8 +130,112 @@ function runCounts(db) {
   return { byState };
 }
 
+/** Node-local pool state: pidfile liveness and workers carrying drain requests. */
+function runtimePoolState(runDir) {
+  const drainingIds = new Set();
+  let names = [];
+  try {
+    names = readdirSync(runDir);
+  } catch {
+    return { drainingIds, supervisor: "absent" };
+  }
+  for (const name of names) {
+    const match = /^(worker-\d+)\.drain$/.exec(name);
+    if (!match) continue;
+    try {
+      const workerId = readFileSync(path.join(runDir, `${match[1]}.id`), "utf8").trim();
+      if (workerId) drainingIds.add(workerId);
+    } catch {
+      // A slot can disappear between directory read and id read; next poll heals it.
+    }
+  }
+  let supervisor = "absent";
+  try {
+    const pid = Number(readFileSync(path.join(runDir, "supervisor.pid"), "utf8").trim());
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+        supervisor = "active";
+      } catch (err) {
+        // EPERM still proves the process exists; only ESRCH means a stale pid.
+        supervisor = err?.code === "EPERM" ? "active" : "stopped";
+      }
+    }
+  } catch {
+    // No pidfile means the fixed-worker fallback, not an error.
+  }
+  return { drainingIds, supervisor };
+}
+
+/**
+ * One projection powers both API surfaces so Overview and Workers cannot show
+ * contradictory numbers. Policy max is the concurrency ceiling after WM-226;
+ * without pool policy the live registry remains the honest capacity fallback.
+ */
+export function workerCapacityView(db, nowMs, { workerPolicy = () => loadWorkerPolicy(), runDir } = {}) {
+  const pool = runtimePoolState(runDir ?? process.env.FACTORY_RUN_DIR ?? path.join(homedir(), ".factory", "run"));
+  const workers = listWorkers(db, { now: nowMs }).map((worker) => ({
+    ...worker,
+    draining: !worker.stale && worker.state !== "stopped" && pool.drainingIds.has(worker.workerId),
+  }));
+  const liveWorkers = workers.filter((worker) => worker.state !== "stopped" && !worker.stale);
+  const running = liveWorkers.filter((worker) => worker.state === "busy").length;
+  const draining = liveWorkers.filter((worker) => worker.draining).length;
+  const idle = liveWorkers.filter((worker) => worker.state !== "busy" && !worker.draining).length;
+  const queued = db.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'QUEUED'`).get().n;
+
+  let policy = null;
+  let policyError = null;
+  try {
+    policy = workerPolicy?.() ?? null;
+  } catch (err) {
+    policyError = `worker policy unavailable: ${err.message}`;
+  }
+  const hasPolicy = Number.isInteger(policy?.max) && policy.max > 0;
+  const supervised = pool.supervisor === "active" && hasPolicy;
+  const capacity = supervised ? policy.max : liveWorkers.length;
+  const target = Math.max(0, liveWorkers.length - draining);
+  let limitingFactor = null;
+  if (queued > 0 && idle === 0) {
+    limitingFactor = supervised && liveWorkers.length >= capacity ? "at worker max" : "no idle worker";
+  }
+
+  const classes = [];
+  if (policy?.classes && typeof policy.classes === "object" && !Array.isArray(policy.classes)) {
+    for (const [name, config] of Object.entries(policy.classes)) {
+      const classCapacity = Number.isInteger(config) ? config : config?.max;
+      if (!Number.isInteger(classCapacity) || classCapacity < 0) continue;
+      classes.push({
+        name,
+        capacity: classCapacity,
+        running: liveWorkers.filter((worker) => worker.state === "busy" && worker.labels?.class === name).length,
+      });
+    }
+  }
+
+  return {
+    workers,
+    policyError,
+    capacity: {
+      running,
+      capacity,
+      queued,
+      live: liveWorkers.length,
+      idle,
+      draining,
+      target,
+      min: hasPolicy && Number.isInteger(policy.min) ? policy.min : null,
+      max: hasPolicy ? policy.max : null,
+      supervisor: pool.supervisor,
+      source: supervised ? "worker-policy" : "live-workers",
+      limitingFactor,
+      classes,
+    },
+  };
+}
+
 /** §13 status + doctor view: aggregates plus anomalies, all read-only SQL. */
-function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, env, getStoreStats } = {}) {
+function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, env, getStoreStats, workerPolicy, workerRunDir } = {}) {
   const open = openProposals(db, { now: nowMs });
   const expiredOpen = open.filter((p) => p.expired);
   const staleLeases = db
@@ -148,7 +253,8 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
     .all()
     .map((row) => ({ source: row.source, eventId: row.event_id, lastError: row.last_plan_error }));
 
-  const workers = listWorkers(db, { now: nowMs });
+  const fleet = workerCapacityView(db, nowMs, { workerPolicy, runDir: workerRunDir });
+  const workers = fleet.workers;
   const schedules = scheduleView(db, registry, { now: nowMs });
   const store = getStoreStats
     ? getStoreStats(nowMs)
@@ -166,16 +272,18 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
   if (policyVersion === "unknown") {
     configAnomalies.push("policyVersion is unknown");
   }
+  if (fleet.policyError) configAnomalies.push(fleet.policyError);
 
   return {
     events: eventCounts(db),
     proposals: { open: open.length, expired: expiredOpen.length },
     runs,
     workers: {
-      live: workers.filter((w) => w.state !== "stopped" && !w.stale).length,
-      busy: workers.filter((w) => w.state === "busy" && !w.stale).length,
+      live: fleet.capacity.live,
+      busy: fleet.capacity.running,
       stale: workers.filter((w) => w.stale).length,
     },
+    capacity: fleet.capacity,
     artifacts: {
       files: store.files,
       bytes: store.bytes,
@@ -597,6 +705,8 @@ export function createApi({
   // until someone restarted serve. Injectable so tests can point at a fixture
   // instead of whichever repos exist on the machine.
   repos = () => loadRepos(),
+  workerPolicy = () => loadWorkerPolicy(),
+  workerRunDir = process.env.FACTORY_RUN_DIR ?? path.join(homedir(), ".factory", "run"),
   // Host-side janitor spawn (OPS-301). Tests inject a fake; production
   // shells out to orchestrator/janitor.mjs --json, never --force.
   janitor = spawnFactoryJanitor,
@@ -710,7 +820,9 @@ export function createApi({
       if (route === "GET /status") {
         return send(res, 200, {
           env,
-          ...statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, env, getStoreStats }),
+          ...statusView(db, registry, nowMs, {
+            secret, githubSecret, policyVersion, env, getStoreStats, workerPolicy, workerRunDir,
+          }),
         });
       }
 
@@ -794,7 +906,8 @@ export function createApi({
       }
 
       if (route === "GET /workers") {
-        return send(res, 200, { workers: listWorkers(db, { now: nowMs }) });
+        const fleet = workerCapacityView(db, nowMs, { workerPolicy, runDir: workerRunDir });
+        return send(res, 200, { workers: fleet.workers, capacity: fleet.capacity });
       }
 
       if (route === "GET /agents") {

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -307,6 +307,38 @@ export interface AgentsView {
 /** A worker's own report of what it is doing; "stopped" is a clean exit. */
 export type WorkerState = "idle" | "busy" | "stopped";
 
+export type CapacityLimitingFactor =
+  | "at worker max"
+  | "no idle worker"
+  | "per-repo max_in_flight reached"
+  | "owned-paths collision"
+  | "budget ceiling";
+
+export interface WorkerClassCapacity {
+  name: string;
+  running: number;
+  capacity: number;
+}
+
+/** One consistent capacity projection shared by GET /status and GET /workers. */
+export interface WorkerCapacity {
+  running: number;
+  capacity: number;
+  queued: number;
+  live: number;
+  idle: number;
+  draining: number;
+  /** Current non-draining pool size; becomes the supervisor target when persisted. */
+  target: number;
+  min: number | null;
+  max: number | null;
+  supervisor: "active" | "absent" | "stopped";
+  source: "live-workers" | "worker-policy";
+  limitingFactor: CapacityLimitingFactor | null;
+  /** Empty until class-aware worker policy ships. */
+  classes: WorkerClassCapacity[];
+}
+
 /** One registered worker process (GET /workers) — the fleet, not the leases. */
 export interface Worker {
   workerId: string;
@@ -322,6 +354,8 @@ export interface Worker {
   stale: boolean;
   startedAt: string;
   stoppedAt: string | null;
+  /** The pool supervisor has asked this worker to exit at its next idle boundary. */
+  draining?: boolean;
 }
 
 /** A stale worker still holding a run — the doctor's projection, not the row. */
@@ -363,6 +397,8 @@ export interface StatusView {
   runs: { byState: Partial<Record<RunState, number>> };
   /** Fleet counts; `live` and `busy` exclude stale workers, as the API does. */
   workers: { live: number; busy: number; stale: number };
+  /** Absent only when the UI is talking to a pre-WM-228 control API. */
+  capacity?: WorkerCapacity;
   /** Artifact store rollup; `orphans` counts files no result references. Cached ~10s server-side (`at` = when computed). */
   artifacts: { files: number; bytes: number; orphans: number; orphanBytes: number; at?: string };
   anomalies: {

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -29,6 +29,21 @@ function baseStatus(overrides: Partial<StatusView["anomalies"]> = {}): StatusVie
     proposals: { open: 0, expired: 1 },
     runs: { byState: {} },
     workers: { live: 0, busy: 0, stale: 0 },
+    capacity: {
+      running: 0,
+      capacity: 0,
+      queued: 0,
+      live: 0,
+      idle: 0,
+      draining: 0,
+      target: 0,
+      min: null,
+      max: null,
+      supervisor: "absent",
+      source: "live-workers",
+      limitingFactor: null,
+      classes: [],
+    },
     artifacts: { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 },
     anomalies: {
       expiredOpenProposals: [],
@@ -637,7 +652,23 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     const origJournal = api.journal;
     api.status = async () => ({
       ...baseStatus(),
+      runs: { byState: { QUEUED: 2 } },
       workers: { live: 3, busy: 1, stale: 0 },
+      capacity: {
+        running: 1,
+        capacity: 4,
+        queued: 2,
+        live: 3,
+        idle: 2,
+        draining: 0,
+        target: 3,
+        min: 1,
+        max: 4,
+        supervisor: "active",
+        source: "worker-policy",
+        limitingFactor: "per-repo max_in_flight reached",
+        classes: [{ name: "light", running: 1, capacity: 3 }],
+      },
     });
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({
@@ -665,10 +696,13 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     });
 
     try {
-      const { getByText, getByTitle } = renderOverview();
+      const { getByText, getByTitle, getByRole } = renderOverview();
 
       await waitFor(() => getByText(/Worker Fleet Capacity/));
       expect(getByText(/3 live · 1 busy · 2 idle/)).toBeTruthy();
+      expect(getByRole("button", { name: "worker capacity: 1 running of 4, 2 queued" })).toBeTruthy();
+      expect(getByText("per-repo max_in_flight reached")).toBeTruthy();
+      expect(getByText("light 1/3")).toBeTruthy();
 
       // Recent outcomes strip displays completed & failed terminal entries (2 total)
       expect(getByText(/Recent Outcomes · last 2/)).toBeTruthy();

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -639,6 +639,23 @@ export function Overview({
   const finishedTotal = terminalSegs.reduce((a, x) => a + x.value, 0);
   const okTotal = terminalSegs.find((x) => x.key === "COMPLETED")?.value ?? 0;
   const idleWorkers = Math.max(0, (s?.workers.live ?? 0) - (s?.workers.busy ?? 0));
+  const capacity = s
+    ? (s.capacity ?? {
+        running: s.workers.busy,
+        capacity: s.workers.live,
+        queued: s.runs.byState.QUEUED ?? 0,
+        live: s.workers.live,
+        idle: idleWorkers,
+        draining: 0,
+        target: s.workers.live,
+        min: null,
+        max: null,
+        supervisor: "absent" as const,
+        source: "live-workers" as const,
+        limitingFactor: null,
+        classes: [],
+      })
+    : null;
 
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
@@ -924,13 +941,36 @@ export function Overview({
 
             {/* Sub-row 3: Worker Fleet Capacity */}
             <div className="mt-3.5 border-t border-(--border) pt-2.5">
-              <div className="mb-1.5 flex items-baseline justify-between text-[11px]">
+              <div className="mb-1.5 flex flex-wrap items-center justify-between gap-2 text-[11px]">
                 <span className="font-semibold text-(--text)">
                   Worker Fleet Capacity{factoryWide ? " · factory-wide" : ""}
                 </span>
-                <span className="mono text-(--text-dim)">
-                  {s.workers.live} live · {s.workers.busy} busy · {idleWorkers} idle{s.workers.stale > 0 ? ` · ${s.workers.stale} stale` : ""}
-                </span>
+                <button
+                  type="button"
+                  onClick={() => onNavigate("workers")}
+                  aria-label={`worker capacity${factoryWide ? " · factory-wide" : ""}: ${capacity!.running} running of ${capacity!.capacity}, ${capacity!.queued} queued`}
+                  className="mono cursor-pointer rounded-full border border-(--border) bg-(--surface-2) px-2.5 py-1 text-(--text-dim) hover:text-(--text)"
+                >
+                  <strong className="text-(--text)">{capacity!.running}/{capacity!.capacity}</strong> capacity · {capacity!.queued} queued
+                  {capacity!.draining > 0 ? ` · ${capacity!.draining} draining` : ""}
+                </button>
+              </div>
+              {capacity!.queued > 0 && capacity!.limitingFactor && (
+                <div className="mb-2 text-[11px] text-(--hue-warn)">
+                  Queue is waiting: <strong>{capacity!.limitingFactor}</strong>
+                </div>
+              )}
+              {capacity!.classes.length > 0 && (
+                <div className="mb-2 flex flex-wrap gap-1.5 text-[11px] text-(--text-dim)">
+                  {capacity!.classes.map((workerClass) => (
+                    <span key={workerClass.name} className="mono rounded-full bg-(--surface-2) px-2 py-0.5">
+                      {workerClass.name} {workerClass.running}/{workerClass.capacity}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="mb-1.5 mono text-[11px] text-(--text-dim)">
+                {s.workers.live} live · {s.workers.busy} busy · {idleWorkers} idle{s.workers.stale > 0 ? ` · ${s.workers.stale} stale` : ""}
               </div>
               <SegmentMeter
                 segments={[

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -2,9 +2,17 @@ import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Workers, defaultWorkerTab, fleetBanner, isLive, partitionWorkers } from "./Workers";
+import {
+  Workers,
+  capacityFromWorkers,
+  defaultWorkerTab,
+  fleetBanner,
+  isLive,
+  partitionWorkers,
+  workerDisplayState,
+} from "./Workers";
 import { api } from "../api";
-import type { Worker, WorkerState } from "../types";
+import type { Worker, WorkerCapacity, WorkerState } from "../types";
 
 afterEach(() => {
   cleanup();
@@ -43,9 +51,9 @@ function renderWorkers() {
   );
 }
 
-function withWorkers(workers: Worker[], fn: () => Promise<void>) {
+function withWorkers(workers: Worker[], fn: () => Promise<void>, capacity?: WorkerCapacity) {
   const orig = api.workers;
-  api.workers = async () => ({ workers });
+  api.workers = async () => ({ workers, capacity: capacity ?? capacityFromWorkers(workers) });
   return fn().finally(() => {
     api.workers = orig;
   });
@@ -85,6 +93,47 @@ describe("default worker tab (WM-98)", () => {
   test("opens on All when every worker is stopped, and when the registry is empty", () => {
     expect(defaultWorkerTab([stubWorker("w_stopped", "stopped")])).toBe("ALL");
     expect(defaultWorkerTab([])).toBe("ALL");
+  });
+});
+
+describe("worker capacity and draining state (WM-228)", () => {
+  test("draining is explicit unless stale overrides the supervisor request", () => {
+    expect(workerDisplayState({ ...stubWorker("w_drain", "idle"), draining: true })).toBe("draining");
+    expect(workerDisplayState({ ...stubWorker("w_stale", "busy", true), draining: true })).toBe("stale");
+  });
+
+  test("shows running/capacity, queue limiter, class caps, and an explicit draining row", async () => {
+    const worker = {
+      ...stubWorker("w_drain", "busy"),
+      draining: true,
+      currentRun: "run_capacity_123456",
+      labels: { class: "heavy", node: "lab" },
+    };
+    const capacity: WorkerCapacity = {
+      running: 1,
+      capacity: 2,
+      queued: 4,
+      live: 1,
+      idle: 0,
+      draining: 1,
+      target: 0,
+      min: 1,
+      max: 2,
+      supervisor: "active",
+      source: "worker-policy",
+      limitingFactor: "at worker max",
+      classes: [{ name: "heavy", running: 1, capacity: 2 }],
+    };
+    await withWorkers([worker], async () => {
+      const { getByText, getAllByText, getByTitle } = renderWorkers();
+      await waitFor(() => expect(getByText("1 running / 2 capacity")).toBeTruthy());
+      expect(getByText("4 queued runs")).toBeTruthy();
+      expect(getByText("at worker max")).toBeTruthy();
+      expect(getByText("heavy 1/2")).toBeTruthy();
+      expect(getAllByText("draining").length).toBeGreaterThan(0);
+      expect(getByTitle("Open run_capacity_123456")).toBeTruthy();
+      expect(getByTitle(new RegExp(`Started ${NOW}`))).toBeTruthy();
+    }, capacity);
   });
 });
 

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -15,7 +15,7 @@ import {
 import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
-import type { Worker } from "../types";
+import type { Worker, WorkerCapacity } from "../types";
 import type { OperatorContext } from "../context";
 import {
   dur,
@@ -48,6 +48,38 @@ import { health, WORKER_HUES } from "../workerHealth";
 
 export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
 export type WorkerTab = (typeof WORKER_TABS)[number];
+export type WorkerDisplayState = ReturnType<typeof health> | "draining";
+
+const WORKER_STATE_HUES: Record<WorkerDisplayState, string> = {
+  ...WORKER_HUES,
+  draining: "var(--hue-warn)",
+};
+
+/** Stale remains the strongest signal; otherwise a drain request is explicit. */
+export const workerDisplayState = (worker: Worker): WorkerDisplayState =>
+  worker.stale ? "stale" : worker.draining && worker.state !== "stopped" ? "draining" : health(worker);
+
+/** Compatibility projection for an older API that has not added capacity yet. */
+export function capacityFromWorkers(rows: Worker[]): WorkerCapacity {
+  const live = rows.filter((worker) => worker.state !== "stopped" && !worker.stale);
+  const running = live.filter((worker) => worker.state === "busy").length;
+  const draining = live.filter((worker) => worker.draining).length;
+  return {
+    running,
+    capacity: live.length,
+    queued: 0,
+    live: live.length,
+    idle: live.filter((worker) => worker.state !== "busy" && !worker.draining).length,
+    draining,
+    target: Math.max(0, live.length - draining),
+    min: null,
+    max: null,
+    supervisor: "absent",
+    source: "live-workers",
+    limitingFactor: null,
+    classes: [],
+  };
+}
 
 /**
  * Live = anything that could still be holding or claiming work: idle, busy, or
@@ -105,9 +137,9 @@ const WORKERS_DISPLAY: DisplayConfig<Worker> = {
     {
       key: "state",
       label: "State",
-      get: health,
-      order: ["busy", "idle", "stale", "stopped"],
-      hue: WORKER_HUES,
+      get: workerDisplayState,
+      order: ["busy", "draining", "idle", "stale", "stopped"],
+      hue: WORKER_STATE_HUES,
     },
     { key: "host", label: "Host", get: (w) => w.host },
   ],
@@ -125,6 +157,7 @@ const WORKERS_DISPLAY: DisplayConfig<Worker> = {
     { key: "labels", label: "Labels" },
     { key: "adapters", label: "Adapters" },
     { key: "run", label: "Current run" },
+    { key: "uptime", label: "Uptime" },
     { key: "heartbeat", label: "Heartbeat" },
   ],
 };
@@ -218,6 +251,52 @@ const openRun = (runId: string) => {
   window.location.hash = `#/runs/${runId}`;
 };
 
+export function CapacityBand({ capacity }: { capacity: WorkerCapacity }) {
+  const constrained = capacity.queued > 0 && capacity.limitingFactor;
+  const hue = constrained ? "var(--hue-warn)" : "var(--hue-ok)";
+  return (
+    <section
+      aria-label="Worker pool capacity"
+      className="mb-3 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-3"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5">
+        <div className="flex items-baseline gap-2">
+          <span className="display text-xl font-semibold tabular-nums" style={{ color: hue }}>
+            {capacity.running} running / {capacity.capacity} capacity
+          </span>
+          <span className="mono text-[12px] text-(--text-dim)">
+            {capacity.queued} queued run{capacity.queued === 1 ? "" : "s"}
+          </span>
+        </div>
+        <span className="text-[11px] text-(--text-faint)">
+          {capacity.live} live · {capacity.idle} idle
+          {capacity.draining > 0 ? ` · ${capacity.draining} draining` : ""}
+          {capacity.source === "worker-policy"
+            ? ` · target ${capacity.target} · supervisor active`
+            : ` · ${capacity.supervisor === "stopped" ? "supervisor stopped · " : ""}live-worker fallback${capacity.max != null ? ` · policy max ${capacity.max}` : ""}`}
+        </span>
+      </div>
+      {constrained && (
+        <div className="mt-2 flex items-center gap-2 text-[12px]" style={{ color: hue }}>
+          <span className="size-1.5 rounded-full" style={{ background: hue }} />
+          <span>
+            Queue is waiting: <strong>{capacity.limitingFactor}</strong>
+          </span>
+        </div>
+      )}
+      {capacity.classes.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker class capacity">
+          {capacity.classes.map((workerClass) => (
+            <span key={workerClass.name} className="mono rounded-full bg-(--surface-2) px-2 py-0.5 text-[11px] text-(--text-dim)">
+              {workerClass.name} {workerClass.running}/{workerClass.capacity}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 function FleetStatusBanner({ banner }: { banner: FleetBanner }) {
   const hue = banner.kind === "stale" ? "var(--hue-err)" : "var(--hue-warn)";
   const title =
@@ -279,7 +358,11 @@ export function Workers({
 }) {
   const now = useNow();
   const query = useQuery({ queryKey: ["workers"], queryFn: api.workers, refetchInterval: 2000 });
-  const rows = query.data?.workers ?? [];
+  // GET /workers gained capacity without changing the legacy client method's
+  // minimum response contract; older servers simply exercise the fallback.
+  const response = query.data as ({ workers: Worker[]; capacity?: WorkerCapacity } | undefined);
+  const rows = response?.workers ?? [];
+  const capacity = response?.capacity ?? capacityFromWorkers(rows);
 
   const parts = useMemo(() => partitionWorkers(rows), [rows]);
   const banner = useMemo(() => fleetBanner(rows), [rows]);
@@ -304,7 +387,7 @@ export function Workers({
     const q = filter.trim().toLowerCase();
     if (!q) return byTab;
     return byTab.filter((w) =>
-      [w.workerId, w.host, String(w.pid), health(w), labelText(w.labels), w.adapters.join(","), w.currentRun].some(
+      [w.workerId, w.host, String(w.pid), workerDisplayState(w), labelText(w.labels), w.adapters.join(","), w.currentRun].some(
         (v) => (v ?? "").toLowerCase().includes(q),
       ),
     );
@@ -393,6 +476,7 @@ export function Workers({
           <>
             <h1 className="display mb-4 text-lg font-semibold">Workers</h1>
             <ScopeCaption context={context} surface="fleet" />
+            {query.isSuccess && <CapacityBand capacity={capacity} />}
             <div className="mb-3 flex flex-wrap items-center gap-2">
               <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto" role="tablist" aria-label="Worker state">
                 {WORKER_TABS.map((t) => {
@@ -484,7 +568,7 @@ export function Workers({
                   {show.has("state") && (
                     <td className="border-b border-(--border) px-3 py-1.5">
                       <span className="flex items-baseline gap-1.5">
-                        <StateBadge state={health(w)} hues={WORKER_HUES} />
+                        <StateBadge state={workerDisplayState(w)} hues={WORKER_STATE_HUES} />
                         {w.stale && (
                           <span className="text-[11px] text-(--text-faint)" title="What the worker last reported before its heartbeat stopped">
                             reported {w.state}
@@ -515,6 +599,14 @@ export function Workers({
                       ) : (
                         "-"
                       )}
+                    </td>
+                  )}
+                  {show.has("uptime") && (
+                    <td
+                      className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)"
+                      title={`Started ${w.startedAt}`}
+                    >
+                      <Ago iso={w.startedAt} now={now} />
                     </td>
                   )}
                   {show.has("heartbeat") && (
@@ -578,7 +670,7 @@ export function Workers({
           widthClass="w-[460px]"
           title={
             <span className="flex min-w-0 items-center gap-2">
-              <StateBadge state={health(sel)} hues={WORKER_HUES} />
+              <StateBadge state={workerDisplayState(sel)} hues={WORKER_STATE_HUES} />
               <span className="mono truncate" title={sel.workerId}>
                 {sel.workerId}
               </span>
@@ -644,9 +736,9 @@ export function Workers({
             <KV
               k="state"
               v={
-                <span style={{ color: WORKER_HUES[sel.state] ?? "var(--hue-idle)" }}>
-                  {sel.state}
-                  {sel.stale ? " (last reported)" : ""}
+                <span style={{ color: WORKER_STATE_HUES[workerDisplayState(sel)] ?? "var(--hue-idle)" }}>
+                  {workerDisplayState(sel)}
+                  {sel.stale ? ` (last reported ${sel.state})` : ""}
                 </span>
               }
             />


### PR DESCRIPTION
## Summary
- extend `GET /status` and `GET /workers` with one shared worker-capacity projection, including supervisor-aware max/target, queued demand, limiting factor, and class-cap shape
- add a top-level capacity band to Workers and a compact matching capacity chip to Overview
- show draining workers explicitly and add per-row uptime while preserving linked current runs, heartbeat age, and placement labels
- preserve pre-supervisor/older-API behavior with live-worker capacity fallbacks; pool history remains deferred as the ticket's nice-to-have

## Compatibility / placeholders
- without an active supervisor, capacity is the live-worker count and the configured policy max is informational
- with WM-226 active, capacity uses the supervisor policy max and target reflects the non-draining live pool
- class utilization renders when `capacity.classes` is populated; Phase 2 still needs class-aware policy/worker data
- budget ceiling remains a typed future limiting factor pending WM-66 / Phase 3 data

## Verification
- `cd event-runtime/web && bun run build && cd ../.. && bun test event-runtime/`
- pass: build green; 1,244 tests passed, 0 failed

## UX critique
- required — NOT-ASSESSED: the UX critic could not start browser tooling because its Chrome CDP executable was unavailable; focused responsive/view tests pass

Fixes WM-228
