### PR TITLE
fix(factory): rebuild stale web bundle on up (WM-232)

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -5,6 +5,7 @@
 #   factory up --fake            # start with fake adapter (for staging/testing on live db)
 #   factory up --dev             # live-reload stack: serve --watch, vite HMR web,
 #                                # drain-aware worker (WM-213)
+#   factory up --no-build        # serve the existing web bundle without checking it
 #   factory up --workers 1:3     # supervised worker pool instead of one worker (WM-226)
 #   factory down                 # cleanly stop live daemons (drains the pool first)
 #   factory tail                 # tail all live logs (serve.log, worker.log, web.log)
@@ -29,6 +30,8 @@ case "$ACTION" in
   up)
     ADAPTER_FLAG=()
     DEV=0
+    NO_BUILD=0
+    WEB_BUILD_MESSAGE=""
     WORKERS_SPEC=""
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -37,11 +40,13 @@ case "$ACTION" in
         --port) API_PORT="$2"; shift ;;
         --web-port) WEB_PORT="$2"; shift ;;
         --dev) DEV=1 ;;
+        --no-build) NO_BUILD=1 ;;
         --workers) WORKERS_SPEC="$2"; shift ;;
         -h|--help)
-          echo "usage: factory up [--fake] [--dev] [--workers min:max] [--port 7381] [--web-port 7382]"
-          echo "  --dev      live reload: serve --watch, vite HMR web UI, worker restarts when idle"
-          echo "  --workers  supervised pool scaling between min and max on queue depth (WM-226);"
+          echo "usage: factory up [--fake] [--dev] [--no-build] [--workers min:max] [--port 7381] [--web-port 7382]"
+          echo "  --dev       live reload: serve --watch, vite HMR web UI, worker restarts when idle"
+          echo "  --no-build  serve the existing web bundle without checking whether it is stale"
+          echo "  --workers   supervised pool scaling between min and max on queue depth (WM-226);"
           echo "             without it, a workers: block in config/policy.yaml selects the pool"
           exit 0
           ;;
@@ -92,6 +97,37 @@ case "$ACTION" in
       WORKER_ARGS=(bash "$REPO/bin/live-stack.sh" __supervise-worker --reload-on-change)
       if [[ ! -d "$REPO/event-runtime/web/node_modules" ]]; then
         die "--dev needs the web deps for vite — run: (cd $REPO/event-runtime/web && bun install)"
+      fi
+    elif [[ "$NO_BUILD" -eq 1 ]]; then
+      warn "--no-build: served web bundle may be stale or missing; rerun without --no-build to rebuild"
+    else
+      WEB_DIR="$REPO/event-runtime/web"
+      DIST_INDEX="$WEB_DIR/dist/index.html"
+      WEB_BUNDLE_STALE=0
+      WEB_BUNDLE_REASON="stale"
+      if [[ ! -f "$DIST_INDEX" ]]; then
+        WEB_BUNDLE_STALE=1
+        WEB_BUNDLE_REASON="missing"
+      elif [[ -n "$(find "$WEB_DIR/src" -type f -newer "$DIST_INDEX" -print -quit)" ]]; then
+        WEB_BUNDLE_STALE=1
+      else
+        for WEB_BUILD_INPUT in "$WEB_DIR/index.html" "$WEB_DIR/vite.config.ts" "$WEB_DIR/package.json"; do
+          if [[ -f "$WEB_BUILD_INPUT" && "$WEB_BUILD_INPUT" -nt "$DIST_INDEX" ]]; then
+            WEB_BUNDLE_STALE=1
+            break
+          fi
+        done
+      fi
+
+      if [[ "$WEB_BUNDLE_STALE" -eq 1 ]]; then
+        info "web bundle $WEB_BUNDLE_REASON — rebuilding"
+        WEB_BUILD_STARTED=$(date +%s)
+        if ! (cd "$WEB_DIR" && bun run build); then
+          die "web bundle build failed — run it manually: cd $WEB_DIR && bun run build"
+        fi
+        [[ -f "$DIST_INDEX" ]] || die "web bundle build completed without creating $DIST_INDEX"
+        WEB_BUILD_SECONDS=$(( $(date +%s) - WEB_BUILD_STARTED ))
+        WEB_BUILD_MESSAGE="web bundle $WEB_BUNDLE_REASON — rebuilt in ${WEB_BUILD_SECONDS}s"
       fi
     fi
 
@@ -159,6 +195,9 @@ case "$ACTION" in
       printf '\n\033[32m==>\033[0m \033[1mready — live factory stack (dev, live reload)\033[0m\n\n'
     else
       printf '\n\033[32m==>\033[0m \033[1mready — live factory stack\033[0m\n\n'
+    fi
+    if [[ -n "$WEB_BUILD_MESSAGE" ]]; then
+      printf '  %s\n\n' "$WEB_BUILD_MESSAGE"
     fi
     printf '  event home %s\n' "$HOME_DIR"
     printf '  control    http://127.0.0.1:%s\n' "$API_PORT"

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -9,7 +9,15 @@
  */
 import { expect, test } from "bun:test";
 import {
-  chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -70,10 +78,11 @@ if (process.env.FAKE_WORKER_MODE === "wait-term") {
 }
 `;
 
-function makeFixture({ withWebDeps = true, policy = null } = {}) {
+function makeFixture({ withWebDeps = true, policy = null, bundle = "fresh" } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "live-stack-"));
+  const webDir = path.join(root, "event-runtime", "web");
   mkdirSync(path.join(root, "bin"), { recursive: true });
-  mkdirSync(path.join(root, "event-runtime", "web"), { recursive: true });
+  mkdirSync(path.join(webDir, "src"), { recursive: true });
   mkdirSync(path.join(root, "stubs"), { recursive: true });
   if (policy !== null) {
     mkdirSync(path.join(root, "config"), { recursive: true });
@@ -82,18 +91,51 @@ function makeFixture({ withWebDeps = true, policy = null } = {}) {
   copyFileSync(LIVE_STACK, path.join(root, "bin", "live-stack.sh"));
   writeFileSync(path.join(root, "bin", "worktree-common.sh"), COMMON_STUB, "utf8");
   writeFileSync(path.join(root, "event-runtime", "cli.mjs"), FAKE_CLI, "utf8");
-  writeFileSync(path.join(root, "event-runtime", "web", "serve.mjs"), "", "utf8");
-  if (withWebDeps) mkdirSync(path.join(root, "event-runtime", "web", "node_modules"), { recursive: true });
+  writeFileSync(path.join(webDir, "serve.mjs"), "", "utf8");
+  for (const relative of ["src/App.tsx", "index.html", "vite.config.ts", "package.json"]) {
+    writeFileSync(path.join(webDir, relative), `${relative}\n`, "utf8");
+  }
+  if (bundle !== "missing") {
+    mkdirSync(path.join(webDir, "dist"), { recursive: true });
+    writeFileSync(path.join(webDir, "dist", "index.html"), "built\n", "utf8");
+    const sourceTime = new Date("2026-01-01T00:00:00Z");
+    const distTime = new Date("2027-01-01T00:00:00Z");
+    for (const relative of ["src/App.tsx", "index.html", "vite.config.ts", "package.json"]) {
+      utimesSync(path.join(webDir, relative), sourceTime, sourceTime);
+    }
+    utimesSync(path.join(webDir, "dist", "index.html"), distTime, distTime);
+    if (bundle === "stale") {
+      const staleTime = new Date("2028-01-01T00:00:00Z");
+      utimesSync(path.join(webDir, "src", "App.tsx"), staleTime, staleTime);
+    }
+  }
+  if (withWebDeps) mkdirSync(path.join(webDir, "node_modules"), { recursive: true });
 
   // The health polls must not gate a test on a server nobody started.
   const curl = path.join(root, "stubs", "curl");
   writeFileSync(curl, "#!/bin/sh\nexit 0\n", "utf8");
   chmodSync(curl, 0o755);
 
+  // Non-dev web builds are recorded and materialize the one artifact the
+  // script checks. Other bun commands are only arguments to spawn_daemon.
+  const bun = path.join(root, "stubs", "bun");
+  writeFileSync(bun, `#!/bin/sh
+if [ "$1 $2" = "run build" ]; then
+  printf 'BUILD cwd=%s cmd=%s\\n' "$PWD" "$*" >>"$BUILD_LOG"
+  mkdir -p "$FAKE_REPO/event-runtime/web/dist"
+  : >"$FAKE_REPO/event-runtime/web/dist/index.html"
+  exit 0
+fi
+printf 'unexpected bun invocation: %s\\n' "$*" >&2
+exit 99
+`, "utf8");
+  chmodSync(bun, 0o755);
+
   return {
     root,
     runDir: path.join(root, "run"),
     spawnLog: path.join(root, "spawns.log"),
+    buildLog: path.join(root, "builds.log"),
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
@@ -108,6 +150,7 @@ function runStack(fixture, args, extraEnv = {}) {
       PATH: `${path.join(fixture.root, "stubs")}:${process.env.PATH}`,
       FAKE_REPO: fixture.root,
       SPAWN_LOG: fixture.spawnLog,
+      BUILD_LOG: fixture.buildLog,
       FACTORY_RUN_DIR: path.join(fixture.root, "run"),
       FACTORY_EVENT_HOME: path.join(fixture.root, "home"),
       ...extraEnv,
@@ -118,6 +161,7 @@ function runStack(fixture, args, extraEnv = {}) {
     stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
     spawns: existsSync(fixture.spawnLog) ? readFileSync(fixture.spawnLog, "utf8").trim().split("\n") : [],
+    builds: existsSync(fixture.buildLog) ? readFileSync(fixture.buildLog, "utf8").trim().split("\n") : [],
   };
 }
 
@@ -147,6 +191,72 @@ test("plain `up` spawns serve, worker, and the static web server — unchanged b
   }
 });
 
+test("plain `up` rebuilds a stale web bundle and reports the elapsed time", () => {
+  const f = makeFixture({ bundle: "stale" });
+  try {
+    const r = runStack(f, ["up"]);
+    expect(r.status).toBe(0);
+    expect(r.builds).toHaveLength(1);
+    expect(r.builds[0]).toContain("cmd=run build");
+    expect(r.builds[0]).toContain(`cwd=${path.join(f.root, "event-runtime", "web")}`);
+    expect(r.stdout).toMatch(/web bundle stale — rebuilt in \d+s/);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("plain `up` skips the build when dist is newer than the web sources", () => {
+  const f = makeFixture({ bundle: "fresh" });
+  try {
+    const r = runStack(f, ["up"]);
+    expect(r.status).toBe(0);
+    expect(r.builds).toEqual([]);
+    expect(r.stdout).not.toContain("web bundle stale");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("each top-level web build input participates in the stale check", () => {
+  for (const relative of ["index.html", "vite.config.ts", "package.json"]) {
+    const f = makeFixture({ bundle: "fresh" });
+    try {
+      const staleTime = new Date("2028-01-01T00:00:00Z");
+      utimesSync(path.join(f.root, "event-runtime", "web", relative), staleTime, staleTime);
+      const r = runStack(f, ["up"]);
+      expect(r.status).toBe(0);
+      expect(r.builds).toHaveLength(1);
+    } finally {
+      f.cleanup();
+    }
+  }
+});
+
+test("plain `up` builds when the web bundle is missing", () => {
+  const f = makeFixture({ bundle: "missing" });
+  try {
+    const r = runStack(f, ["up"]);
+    expect(r.status).toBe(0);
+    expect(r.builds).toHaveLength(1);
+    expect(existsSync(path.join(f.root, "event-runtime", "web", "dist", "index.html"))).toBe(true);
+    expect(r.stdout).toMatch(/web bundle missing — rebuilt in \d+s/);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("`up --no-build` skips a stale bundle check and warns explicitly", () => {
+  const f = makeFixture({ bundle: "stale" });
+  try {
+    const r = runStack(f, ["up", "--no-build"]);
+    expect(r.status).toBe(0);
+    expect(r.builds).toEqual([]);
+    expect(r.stderr).toContain("--no-build: served web bundle may be stale");
+  } finally {
+    f.cleanup();
+  }
+});
+
 test("`up --fake` still passes the adapter override through", () => {
   const f = makeFixture();
   try {
@@ -158,8 +268,8 @@ test("`up --fake` still passes the adapter override through", () => {
   }
 });
 
-test("`up --dev` wires all three: serve --watch, vite HMR web, supervised worker", () => {
-  const f = makeFixture();
+test("`up --dev` wires all three without checking or building a stale dist", () => {
+  const f = makeFixture({ bundle: "stale" });
   try {
     const r = runStack(f, ["up", "--dev"]);
     expect(r.status).toBe(0);
@@ -175,6 +285,8 @@ test("`up --dev` wires all three: serve --watch, vite HMR web, supervised worker
 
     expect(r.stdout).toContain("ready — live factory stack (dev, live reload)");
     expect(r.stdout).toContain("worker: on exit 75 when idle");
+    expect(r.stdout).not.toContain("web bundle stale");
+    expect(r.builds).toEqual([]);
   } finally {
     f.cleanup();
   }


### PR DESCRIPTION
## Summary
- detect stale or missing `event-runtime/web/dist/index.html` before non-dev startup and rebuild automatically
- preserve zero-latency fresh and Vite `--dev` paths, with an actionable `--no-build` opt-out warning
- cover stale, fresh, missing, build-input, opt-out, and dev behavior in isolated CLI fixtures

## Verification
- `bun test bin/` — 68 pass, 0 fail

UX critique: required — FIX-FIRST resolved in 1 round; second-round verdict SHIP. The fresh-bundle banner remains unchanged per acceptance criteria.

Fixes WM-232