### PR TITLE
feat(event-runtime): persist usage observability (WM-66)

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -983,6 +983,11 @@ function countLine(label, counts, order = Object.keys(counts)) {
   return `${pad(label, 11)}${parts.join("   ")}`;
 }
 
+function spendLine(label, usage) {
+  const cost = Number(usage?.costUSD ?? 0);
+  return `${pad(label, 11)}${usage?.totalTokens ?? 0} tokens   input ${usage?.inputTokens ?? 0}   output ${usage?.outputTokens ?? 0}   cache-write ${usage?.cacheCreationInputTokens ?? 0}   cache-read ${usage?.cacheReadInputTokens ?? 0}   $${cost.toFixed(4)}`;
+}
+
 export function getAnomalyLines(s) {
   const a = s?.anomalies ?? {};
   const anomalyLines = [];
@@ -1089,6 +1094,14 @@ export async function status(client) {
   console.log(countLine("proposals", s.proposals, ["open", "expired"]));
   const states = Object.keys(s.runs.byState);
   console.log(states.length ? countLine("runs", s.runs.byState, states) : `${pad("runs", 11)}none`);
+  const spend = s.runs?.spend;
+  if (spend) {
+    console.log(spendLine("spend 1h", spend.rolling1h));
+    console.log(spendLine("spend 24h", spend.rolling24h));
+    for (const row of spend.byAgent24h ?? []) {
+      console.log(spendLine(`  ${row.agent}`, row));
+    }
+  }
   const pool = getPoolLines(readPool(), s);
   if (pool.line) console.log(pool.line);
   const anomalyLines = [...getAnomalyLines(s), ...pool.anomalies];
@@ -1173,6 +1186,13 @@ async function inspect(client, runId) {
   console.log(`agent      ${run.spec.agent}   adapter ${run.spec.adapter}   contract ${run.spec.outputContract}`);
   console.log(`created    ${run.created_at}   updated ${run.updated_at}`);
   console.log(`workspace  ${view.workspace ?? "-"}`);
+  if (view.usage) {
+    console.log("\nusage");
+    console.log(`  ${spendLine("total", view.usage.totals).trimStart()}`);
+    for (const row of view.usage.attempts ?? []) {
+      console.log(`  ${spendLine(`attempt ${row.attempt}`, row).trimStart()}   model ${row.model ?? "-"}   adapter ${row.adapter}`);
+    }
+  }
   console.log("\nlifecycle");
   for (const e of view.lifecycle) {
     console.log(`  ${pad(e.at, 26)}${pad(`${e.from_state ?? "·"} → ${e.to_state}`, 26)}${pad(e.actor, 24)}${e.reason ?? ""}`);

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -284,6 +284,7 @@ export async function execute({
   killGraceMs = KILL_GRACE_MS,
   env = {},
   onTrace,
+  onUsage,
   abortSignal,
   signal,
 }) {
@@ -319,11 +320,26 @@ export async function execute({
     const policyDenials = [];
     let lastTool = null;
     const toolNames = new Map();
+    const tokenKeys = ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"];
+    const assistantUsage = Object.fromEntries(tokenKeys.map((key) => [key, 0]));
+    let finalUsage = null;
+    let observedModel = null;
     if (child.stdout) {
       const lines = createInterface({ input: child.stdout });
       lines.on("line", (line) => {
         try {
           const parsed = JSON.parse(line);
+          if (parsed?.type === "system" && parsed?.subtype === "init" && typeof parsed.model === "string") {
+            observedModel = parsed.model;
+          } else if (parsed?.type === "assistant") {
+            if (!observedModel && typeof parsed.message?.model === "string") observedModel = parsed.message.model;
+            for (const key of tokenKeys) {
+              const value = parsed.message?.usage?.[key];
+              if (typeof value === "number" && Number.isFinite(value) && value >= 0) assistantUsage[key] += value;
+            }
+          } else if (parsed?.type === "result") {
+            finalUsage = parsed;
+          }
           for (const event of mapStreamEvent(parsed)) {
             if (event.kind === "tool_use") {
               lastTool = event.payload?.name ?? null;
@@ -386,6 +402,25 @@ export async function execute({
       // PR, and exited clean). A clean exit outranks the observation — report
       // denials to the worker only when the run also failed; the lifecycle
       // trace events above keep the evidence visible either way.
+      const finalTokens = finalUsage?.usage ?? {};
+      const tokenValue = (key) => {
+        const value = finalTokens[key];
+        return typeof value === "number" && Number.isFinite(value) && value >= 0
+          ? value
+          : assistantUsage[key];
+      };
+      try {
+        onUsage?.({
+          model: observedModel,
+          inputTokens: tokenValue("input_tokens"),
+          outputTokens: tokenValue("output_tokens"),
+          cacheCreationInputTokens: tokenValue("cache_creation_input_tokens"),
+          cacheReadInputTokens: tokenValue("cache_read_input_tokens"),
+          costUSD: typeof finalUsage?.total_cost_usd === "number" ? finalUsage.total_cost_usd : 0,
+        });
+      } catch {
+        // Usage is observability: a consumer failure must not change execution.
+      }
       resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
     });
   });

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { findArtifact } from "./artifacts.mjs";
 import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
+import { runUsage, usageSpend } from "./db.mjs";
 import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
@@ -260,7 +261,7 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
     ? getStoreStats(nowMs)
     : storeStats(db, artifactsRoot(env?.home), { now: nowMs });
   const stalled = stalledWorkers(db, { now: nowMs });
-  const runs = runCounts(db);
+  const runs = { ...runCounts(db), spend: usageSpend(db, { now: nowMs }) };
 
   const configAnomalies = [];
   if (!secret) {
@@ -614,6 +615,7 @@ function runView(db, runId, { artifactsDir } = {}) {
       artifactsDir && transcript?.sha256
         ? observedModelFromTranscript(artifactHead(artifactsDir, transcript.sha256))
         : null,
+    usage: runUsage(db, runId),
   };
 }
 

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -156,6 +156,28 @@ export const MIGRATIONS = [
       db.exec(SCHEMA_V1);
     },
   },
+  {
+    version: 2,
+    name: "run_usage",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS run_usage (
+          run_id                     TEXT NOT NULL,
+          attempt                    INTEGER NOT NULL,
+          adapter                    TEXT NOT NULL,
+          model                      TEXT,
+          input_tokens               INTEGER NOT NULL DEFAULT 0,
+          output_tokens              INTEGER NOT NULL DEFAULT 0,
+          cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
+          cache_read_input_tokens    INTEGER NOT NULL DEFAULT 0,
+          cost_usd                   REAL NOT NULL DEFAULT 0,
+          recorded_at                TEXT NOT NULL,
+          PRIMARY KEY (run_id, attempt)
+        );
+        CREATE INDEX IF NOT EXISTS idx_run_usage_recorded_at ON run_usage (recorded_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION = MIGRATIONS.length > 0 ? MIGRATIONS[MIGRATIONS.length - 1].version : 1;
@@ -171,6 +193,7 @@ export const CORE_TABLES = [
   "workers",
   "counters",
   "attempt_trace",
+  "run_usage",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */
@@ -311,6 +334,152 @@ export function isBusyError(err) {
   return /database is locked|database table is locked|resource temporarily unavailable|\bSQLITE_BUSY\b|\bSQLITE_LOCKED\b/i.test(msg);
 }
 
+
+/** Normalize adapter-supplied usage into durable, non-negative values. */
+function normalizedUsage(usage = {}) {
+  const tokens = (value) => Number.isFinite(value) && value >= 0 ? Math.trunc(value) : 0;
+  const money = (value) => Number.isFinite(value) && value >= 0 ? value : 0;
+  return {
+    model: typeof usage.model === "string" && usage.model !== "" ? usage.model : null,
+    inputTokens: tokens(usage.inputTokens ?? usage.input_tokens),
+    outputTokens: tokens(usage.outputTokens ?? usage.output_tokens),
+    cacheCreationInputTokens: tokens(usage.cacheCreationInputTokens ?? usage.cache_creation_input_tokens),
+    cacheReadInputTokens: tokens(usage.cacheReadInputTokens ?? usage.cache_read_input_tokens),
+    costUSD: money(usage.costUSD ?? usage.cost_usd),
+  };
+}
+
+function usageTimestamp(value) {
+  if (typeof value === "string") return new Date(value).toISOString();
+  return new Date(value ?? Date.now()).toISOString();
+}
+
+/**
+ * Persist one attempt's final usage. Re-writing the same attempt is intentional:
+ * cancellation can first record zero, then the aborting adapter can report the
+ * tokens it consumed before stopping.
+ */
+export function recordRunUsage(db, {
+  runId, attempt, adapter, recordedAt = Date.now(), ...rawUsage
+}) {
+  const usage = normalizedUsage(rawUsage.usage ?? rawUsage);
+  const actualAdapter = adapter ?? db
+    .query(`SELECT json_extract(spec_json, '$.adapter') AS adapter FROM runs WHERE run_id = ?`)
+    .get(runId)?.adapter ?? "unknown";
+  db.query(
+    `INSERT INTO run_usage
+       (run_id, attempt, adapter, model, input_tokens, output_tokens,
+        cache_creation_input_tokens, cache_read_input_tokens, cost_usd, recorded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(run_id, attempt) DO UPDATE SET
+       adapter = excluded.adapter,
+       model = excluded.model,
+       input_tokens = excluded.input_tokens,
+       output_tokens = excluded.output_tokens,
+       cache_creation_input_tokens = excluded.cache_creation_input_tokens,
+       cache_read_input_tokens = excluded.cache_read_input_tokens,
+       cost_usd = excluded.cost_usd,
+       recorded_at = excluded.recorded_at`,
+  ).run(
+    runId, attempt, actualAdapter, usage.model, usage.inputTokens, usage.outputTokens,
+    usage.cacheCreationInputTokens, usage.cacheReadInputTokens, usage.costUSD,
+    usageTimestamp(recordedAt),
+  );
+}
+
+function usageRow(row) {
+  const inputTokens = Number(row.input_tokens ?? 0);
+  const outputTokens = Number(row.output_tokens ?? 0);
+  const cacheCreationInputTokens = Number(row.cache_creation_input_tokens ?? 0);
+  const cacheReadInputTokens = Number(row.cache_read_input_tokens ?? 0);
+  return {
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    totalTokens: inputTokens + outputTokens + cacheCreationInputTokens + cacheReadInputTokens,
+    costUSD: Number(row.cost_usd ?? 0),
+  };
+}
+
+/** Persisted attempt usage plus a per-run total for inspect. */
+export function runUsage(db, runId) {
+  const rows = db.query(
+    `SELECT attempt, adapter, model, input_tokens, output_tokens,
+            cache_creation_input_tokens, cache_read_input_tokens, cost_usd, recorded_at
+     FROM run_usage WHERE run_id = ? ORDER BY attempt`,
+  ).all(runId);
+  const attempts = rows.map((row) => ({
+    attempt: row.attempt,
+    adapter: row.adapter,
+    model: row.model ?? null,
+    ...usageRow(row),
+    recordedAt: row.recorded_at,
+  }));
+  return {
+    totals: attempts.reduce((totals, row) => ({
+      attempts: totals.attempts + 1,
+      inputTokens: totals.inputTokens + row.inputTokens,
+      outputTokens: totals.outputTokens + row.outputTokens,
+      cacheCreationInputTokens: totals.cacheCreationInputTokens + row.cacheCreationInputTokens,
+      cacheReadInputTokens: totals.cacheReadInputTokens + row.cacheReadInputTokens,
+      totalTokens: totals.totalTokens + row.totalTokens,
+      costUSD: totals.costUSD + row.costUSD,
+    }), {
+      attempts: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      totalTokens: 0,
+      costUSD: 0,
+    }),
+    attempts,
+  };
+}
+
+const USAGE_TOTALS_SQL = `
+  COUNT(DISTINCT run_id) AS runs,
+  COUNT(*) AS attempts,
+  COALESCE(SUM(input_tokens), 0) AS input_tokens,
+  COALESCE(SUM(output_tokens), 0) AS output_tokens,
+  COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+  COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
+  COALESCE(SUM(cost_usd), 0) AS cost_usd`;
+
+function spendRow(row) {
+  return {
+    runs: Number(row.runs ?? 0),
+    attempts: Number(row.attempts ?? 0),
+    ...usageRow(row),
+  };
+}
+
+/** Rolling usage windows for GET /status and the status CLI. */
+export function usageSpend(db, { now = Date.now() } = {}) {
+  const nowMs = typeof now === "function" ? now() : now;
+  const nowIso = new Date(nowMs).toISOString();
+  const since = (milliseconds) => new Date(nowMs - milliseconds).toISOString();
+  const totalSince = (cutoff) => spendRow(db.query(
+    `SELECT ${USAGE_TOTALS_SQL} FROM run_usage WHERE recorded_at >= ? AND recorded_at <= ?`,
+  ).get(cutoff, nowIso));
+  const cutoff24h = since(24 * 60 * 60 * 1000);
+  const byAgent24h = db.query(
+    `SELECT COALESCE(json_extract(r.spec_json, '$.agent'), 'unknown') AS agent,
+            ${USAGE_TOTALS_SQL.replaceAll("run_id", "u.run_id")}
+     FROM run_usage u JOIN runs r ON r.run_id = u.run_id
+     WHERE u.recorded_at >= ? AND u.recorded_at <= ?
+     GROUP BY agent
+     ORDER BY (SUM(u.input_tokens) + SUM(u.output_tokens) +
+               SUM(u.cache_creation_input_tokens) + SUM(u.cache_read_input_tokens)) DESC,
+              agent`,
+  ).all(cutoff24h, nowIso).map((row) => ({ agent: row.agent, ...spendRow(row) }));
+  return {
+    rolling1h: totalSince(since(60 * 60 * 1000)),
+    rolling24h: totalSince(cutoff24h),
+    byAgent24h,
+  };
+}
 
 /** Monotonic named counter — fencing tokens come from here (§8). */
 export function nextCounter(db, name) {

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -10,8 +10,11 @@ import {
   getSchemaVersion,
   migrateDb,
   openDb,
+  recordRunUsage,
+  runUsage,
   setSchemaVersion,
   txImmediate,
+  usageSpend,
 } from "./db.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
@@ -139,7 +142,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
 
     expect(() => openDb(file)).toThrow(
-      "Database schema version (999) is newer than code version (1). Please upgrade the runtime.",
+      `Database schema version (999) is newer than code version (${CURRENT_SCHEMA_VERSION}). Please upgrade the runtime.`,
     );
   });
 
@@ -153,13 +156,14 @@ describe("schema migration runner and assertions (OPS-415)", () => {
        VALUES ('github', 'evt-415', 'issue.opened', '2026-08-14T00:00:00Z', '2026-08-14T00:00:01Z', '{}', 'hash1', '2026-08-14T00:00:01Z')`,
     ).run();
 
-    expect(getSchemaVersion(db)).toBe(1);
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
 
-    // Apply a custom migration v2 that adds a column
-    const migrationsV2 = [
-      MIGRATIONS[0],
+    // Apply one custom migration after the real migration chain.
+    const customVersion = CURRENT_SCHEMA_VERSION + 1;
+    const migrationsWithCustom = [
+      ...MIGRATIONS,
       {
-        version: 2,
+        version: customVersion,
         name: "add_priority_to_events",
         up(targetDb) {
           targetDb.exec("ALTER TABLE events ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal';");
@@ -167,8 +171,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       },
     ];
 
-    migrateDb(db, { migrations: migrationsV2, targetVersion: 2 });
-    expect(getSchemaVersion(db)).toBe(2);
+    migrateDb(db, { migrations: migrationsWithCustom, targetVersion: customVersion });
+    expect(getSchemaVersion(db)).toBe(customVersion);
 
     // Verify existing row is preserved and has default value
     const row = db.query("SELECT event_id, priority FROM events WHERE event_id = 'evt-415'").get();
@@ -199,7 +203,102 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     const file = freshFile();
     const db = openDb(file);
     setSchemaVersion(db, 0);
-    expect(() => assertSchema(db)).toThrow("Database schema assertion failed: user_version is 0, expected 1");
+    expect(() => assertSchema(db)).toThrow(
+      `Database schema assertion failed: user_version is 0, expected ${CURRENT_SCHEMA_VERSION}`,
+    );
+    db.close();
+  });
+});
+
+describe("run usage persistence and aggregation (WM-66)", () => {
+  function insertRun(db, runId, agent, at) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
+    ).run(runId, `idem-${runId}`, JSON.stringify({ agent, adapter: "fake" }), at, at);
+  }
+
+  test("persists per-attempt usage across reopen and returns explicit totals", () => {
+    const file = freshFile();
+    const at = "2026-08-15T10:00:00.000Z";
+    let db = openDb(file);
+    insertRun(db, "run-usage-1", "agent-a@1", at);
+    recordRunUsage(db, {
+      runId: "run-usage-1",
+      attempt: 1,
+      adapter: "claude",
+      model: "claude-sonnet-4-6",
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheCreationInputTokens: 30,
+      cacheReadInputTokens: 40,
+      costUSD: 0.5,
+      recordedAt: at,
+    });
+    db.close();
+
+    db = openDb(file);
+    expect(runUsage(db, "run-usage-1")).toEqual({
+      totals: {
+        attempts: 1,
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheCreationInputTokens: 30,
+        cacheReadInputTokens: 40,
+        totalTokens: 100,
+        costUSD: 0.5,
+      },
+      attempts: [{
+        attempt: 1,
+        adapter: "claude",
+        model: "claude-sonnet-4-6",
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheCreationInputTokens: 30,
+        cacheReadInputTokens: 40,
+        totalTokens: 100,
+        costUSD: 0.5,
+        recordedAt: at,
+      }],
+    });
+    db.close();
+  });
+
+  test("rolling windows and per-definition 24h totals exclude older usage", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-15T12:00:00.000Z");
+    const rows = [
+      ["run-recent-a", "agent-a@1", now - 30 * 60_000, 10, 5],
+      ["run-day-a", "agent-a@1", now - 2 * 60 * 60_000, 20, 10],
+      ["run-day-b", "agent-b@2", now - 23 * 60 * 60_000, 7, 3],
+      ["run-old", "agent-b@2", now - 25 * 60 * 60_000, 1000, 1000],
+    ];
+    for (const [runId, agent, atMs, inputTokens, outputTokens] of rows) {
+      const at = new Date(atMs).toISOString();
+      insertRun(db, runId, agent, at);
+      recordRunUsage(db, { runId, attempt: 1, adapter: "fake", inputTokens, outputTokens, recordedAt: at });
+    }
+
+    expect(usageSpend(db, { now })).toEqual({
+      rolling1h: {
+        runs: 1, attempts: 1, inputTokens: 10, outputTokens: 5,
+        cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 15, costUSD: 0,
+      },
+      rolling24h: {
+        runs: 3, attempts: 3, inputTokens: 37, outputTokens: 18,
+        cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 55, costUSD: 0,
+      },
+      byAgent24h: [
+        {
+          agent: "agent-a@1", runs: 2, attempts: 2, inputTokens: 30, outputTokens: 15,
+          cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 45, costUSD: 0,
+        },
+        {
+          agent: "agent-b@2", runs: 1, attempts: 1, inputTokens: 7, outputTokens: 3,
+          cacheCreationInputTokens: 0, cacheReadInputTokens: 0, totalTokens: 10, costUSD: 0,
+        },
+      ],
+    });
     db.close();
   });
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -19,7 +19,7 @@ import { LEASE_HEARTBEAT_MS, leaseDir, liveWorkerLeases, releaseWorkerLease, ren
 import { storeCollected } from "./artifacts.mjs";
 import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, FACTORY_ROOT } from "./config.mjs";
-import { nextCounter, tx, txImmediate } from "./db.mjs";
+import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
 import { worktreeDispatchGate } from "./planner.mjs";
@@ -48,11 +48,13 @@ function iso(now) {
   return new Date(resolveNow(now)).toISOString();
 }
 
-function finishAttempt(db, runId, attempt, terminalState, reasonCode, now) {
+function finishAttempt(db, runId, attempt, terminalState, reasonCode, now, usage = {}) {
+  const finishedAt = iso(now);
   db.query(
     `UPDATE attempts SET terminal_state = ?, reason_code = ?, finished_at = ?
      WHERE run_id = ? AND attempt = ?`,
-  ).run(terminalState, reasonCode, iso(now), runId, attempt);
+  ).run(terminalState, reasonCode, finishedAt, runId, attempt);
+  recordRunUsage(db, { runId, attempt, recordedAt: finishedAt, ...usage });
 }
 
 /** Include ignored files: an agent must not be able to hide a repository write. */
@@ -398,6 +400,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
   let leaseHeartbeat = null;
   let ticketClaimed = false;
+  let attemptUsage = { adapter: adapterOverride ?? spec.adapter };
 
   let dispatchOpts = dispatch;
   if (!dispatchOpts && process.env.FACTORY_EVENT_HOME && !process.env.LINEAR_API_KEY) {
@@ -455,7 +458,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         runId, to, expectFrom: "RUNNING",
         actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
       });
-      finishAttempt(db, runId, attempt, to, reasonCode, currentNow);
+      finishAttempt(db, runId, attempt, to, reasonCode, currentNow, attemptUsage);
       if (requeue && attempt < spec.maxAttempts) {
         transition(db, {
           runId, to: "QUEUED", expectFrom: "FAILED",
@@ -511,7 +514,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         runId, attempt, canonicalJson(result), "none", null,
         canonicalJson(result.verification), canonicalJson(receipt), iso(currentNow),
       );
-      finishAttempt(db, runId, attempt, "REFUSED", reasonCode, currentNow);
+      finishAttempt(db, runId, attempt, "REFUSED", reasonCode, currentNow, attemptUsage);
       return { ok: true, receipt };
     });
 
@@ -623,16 +626,21 @@ export async function executeClaimed(db, registry, adapters, claim, {
       }
     };
 
+    const onUsage = (usage) => {
+      attemptUsage = { adapter: adapterKey, ...(usage ?? {}) };
+    };
     let outcome;
     try {
       outcome = await adapter.execute({
-        spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env, onTrace,
+        spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env, onTrace, onUsage,
         abortSignal: abortController.signal, signal: abortController.signal,
       });
     } finally {
       clearInterval(cancelPoll);
       ACTIVE_EXECUTIONS.delete(runId);
     }
+
+    if (outcome?.usage) attemptUsage = { adapter: adapterKey, ...outcome.usage };
 
     if (abortController.signal.aborted) {
       if (ticketClaimed) {
@@ -646,7 +654,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           return { fenced: true };
         }
         try {
-          finishAttempt(db, runId, attempt, "CANCELLED", "cancelled", currentNow);
+          finishAttempt(db, runId, attempt, "CANCELLED", "cancelled", currentNow, attemptUsage);
         } catch {
           // ignore
         }
@@ -738,7 +746,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           actor: owner, reason: `contract_violation: ${err.violations.join(", ")}`,
           attempt, policyVersion, now: currentNow,
         });
-        finishAttempt(db, runId, attempt, "FAILED", "contract_violation", currentNow);
+        finishAttempt(db, runId, attempt, "FAILED", "contract_violation", currentNow, attemptUsage);
         if (attempt < spec.maxAttempts) {
           transition(db, {
             runId, to: "QUEUED", expectFrom: "FAILED",
@@ -803,7 +811,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           runId, attempt, canonicalJson(refusedResult), "none", null,
           canonicalJson(refusedResult.verification), canonicalJson(receipt), iso(currentNow),
         );
-        finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow);
+        finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow, attemptUsage);
         return { ok: true, receipt };
       });
       destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
@@ -863,7 +871,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         runId, to: "COMPLETED", expectFrom: "VERIFYING",
         actor: owner, reason: "ok", attempt, policyVersion, now: currentNow,
       });
-      finishAttempt(db, runId, attempt, "COMPLETED", "ok", currentNow);
+      finishAttempt(db, runId, attempt, "COMPLETED", "ok", currentNow, attemptUsage);
       return { receipt };
     });
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -9,7 +9,7 @@ import { admitEvent } from "./intake.mjs";
 import { planEvent } from "./planner.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot } from "./config.mjs";
-import { openDb } from "./db.mjs";
+import { openDb, runUsage } from "./db.mjs";
 import { createRun, lifecycleOf, runState, transition, IllegalTransition } from "./lifecycle.mjs";
 import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
@@ -188,12 +188,82 @@ describe("worker", () => {
       runId: spec.runId, attempt: 1,
       artifactHash: result.artifact_hash, outputContract: spec.outputContract,
     });
+    expect(runUsage(db, spec.runId).attempts).toEqual([expect.objectContaining({
+      attempt: 1,
+      adapter: "fake",
+      model: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    })]);
 
     const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
     expect(attempt.terminal_state).toBe("COMPLETED");
     expect(attempt.started_at).toBeTruthy();
     expect(attempt.finished_at).toBeTruthy();
     expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+  });
+
+  test("persists usage returned by an adapter, including model and cache tokens", async () => {
+    const db = openDb(":memory:");
+    const usageAdapter = {
+      async execute(args) {
+        const outcome = await fake.execute(args);
+        args.onUsage?.({
+          model: "claude-sonnet-4-6",
+          inputTokens: 101,
+          outputTokens: 29,
+          cacheCreationInputTokens: 300,
+          cacheReadInputTokens: 700,
+          costUSD: 0.123,
+        });
+        return outcome;
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "usage-stub" }));
+
+    const summary = await runOnce(db, registry, { "usage-stub": usageAdapter }, opts());
+    expect(summary.terminalState).toBe("COMPLETED");
+    expect(runUsage(db, spec.runId)).toEqual({
+      totals: {
+        attempts: 1,
+        inputTokens: 101,
+        outputTokens: 29,
+        cacheCreationInputTokens: 300,
+        cacheReadInputTokens: 700,
+        totalTokens: 1130,
+        costUSD: 0.123,
+      },
+      attempts: [expect.objectContaining({
+        attempt: 1,
+        adapter: "usage-stub",
+        model: "claude-sonnet-4-6",
+        totalTokens: 1130,
+      })],
+    });
+  });
+
+  test("failed adapter outcomes retain tokens consumed before failure", async () => {
+    const db = openDb(":memory:");
+    const consumedThenFailed = {
+      async execute() {
+        return {
+          exitCode: 1,
+          timedOut: false,
+          usage: { model: "claude-sonnet-4-6", inputTokens: 11, outputTokens: 4 },
+        };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "consumed-failure", maxAttempts: 1 }));
+
+    const summary = await runOnce(db, registry, { "consumed-failure": consumedThenFailed }, opts());
+    expect(summary.terminalState).toBe("FAILED");
+    expect(runUsage(db, spec.runId).attempts[0]).toEqual(expect.objectContaining({
+      model: "claude-sonnet-4-6",
+      inputTokens: 11,
+      outputTokens: 4,
+      totalTokens: 15,
+    }));
   });
 
   test("policy denial is terminal and is never retried as an opaque agent exit", async () => {
@@ -535,7 +605,11 @@ describe("worker", () => {
           abortSignal?.addEventListener("abort", () => {
             clearTimeout(timer);
             aborted = true;
-            resolve({ exitCode: null, timedOut: false });
+            resolve({
+              exitCode: null,
+              timedOut: false,
+              usage: { model: "claude-sonnet-4-6", inputTokens: 9, outputTokens: 2 },
+            });
           });
         });
       },
@@ -561,6 +635,12 @@ describe("worker", () => {
     expect(attempt.reason_code).toBe("cancelled");
     expect(attempt.finished_at).toBeTruthy();
     expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    expect(runUsage(db, spec.runId).attempts[0]).toEqual(expect.objectContaining({
+      model: "claude-sonnet-4-6",
+      inputTokens: 9,
+      outputTokens: 2,
+      totalTokens: 11,
+    }));
   });
 
   test("runOnce returns null when nothing is QUEUED", async () => {


### PR DESCRIPTION
## Summary
- persist per-attempt adapter/model/token/cache/cost usage in a journal-safe SQLite migration
- capture Claude final or partial transcript usage on success, failure, timeout, and cancellation; store explicit zero usage for non-model adapters
- expose per-run usage in inspect and rolling 1h/24h plus per-agent-definition 24h spend in status
- cover migration persistence, rolling windows, zero usage, and failure/cancellation retention

## Verification
- `bun test event-runtime/` — 1255 pass, 0 fail

## UX critique
- skipped — internal operator observability only; no user-completable flow or web UI changed

## Follow-up
- WM-255 tracks the docs §3 and web client type updates excluded from this ticket's Owned Paths.

Fixes WM-66