### PR TITLE
feat(event-runtime): add artifact catalogue and pruning API

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -14,7 +14,7 @@ import { closeSync, createReadStream, openSync, readFileSync, readSync, readdirS
 import http from "node:http";
 import { homedir } from "node:os";
 import path from "node:path";
-import { findArtifact } from "./artifacts.mjs";
+import { findArtifact, listArtifacts, pruneArtifacts, storeStats } from "./artifacts.mjs";
 import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
 import { runUsage, usageSpend } from "./db.mjs";
 import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
@@ -26,7 +26,6 @@ import { resolveModel } from "./registry.mjs";
 import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
-import { storeStats } from "./artifacts.mjs";
 import { parseCadence, proposalsPilingUp, scheduleView } from "./schedules.mjs";
 import { listWorkers, loadWorkerPolicy, stalledWorkers } from "./workers.mjs";
 
@@ -962,6 +961,54 @@ export function createApi({
           if (status === 500) return send(res, 500, { error: "internal_error" });
           return send(res, status, { error: err.message });
         }
+      }
+
+      if (route === "GET /artifacts") {
+        const orphanParam = url.searchParams.get("orphan");
+        if (orphanParam !== null && orphanParam !== "true" && orphanParam !== "false") {
+          return send(res, 422, { error: "orphan must be true or false" });
+        }
+        const limitParam = url.searchParams.get("limit");
+        const limit = limitParam === null ? undefined : Number(limitParam);
+        if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 500)) {
+          return send(res, 422, { error: "limit must be an integer between 1 and 500" });
+        }
+        const artifacts = listArtifacts(db, artifactsRoot(env.home), {
+          orphan: orphanParam === null ? undefined : orphanParam === "true",
+          kind: url.searchParams.has("kind") ? url.searchParams.get("kind") : undefined,
+          search: url.searchParams.has("search") ? url.searchParams.get("search") : undefined,
+          limit,
+        });
+        return send(res, 200, { artifacts });
+      }
+
+      if (route === "POST /artifacts/prune") {
+        const raw = await readBody(req);
+        const parsed = raw.length === 0 ? { value: {} } : parseJson(raw);
+        if (parsed.error) return send(res, 422, { error: parsed.error });
+        const body = parsed.value ?? {};
+        if (!body || typeof body !== "object" || Array.isArray(body)) {
+          return send(res, 422, { error: "body must be an object" });
+        }
+        if (body.dryRun !== undefined && typeof body.dryRun !== "boolean") {
+          return send(res, 422, { error: "dryRun must be a boolean" });
+        }
+        if (body.apply !== undefined && typeof body.apply !== "boolean") {
+          return send(res, 422, { error: "apply must be a boolean" });
+        }
+        if (body.apply === true && body.dryRun === true) {
+          return send(res, 422, { error: "apply and dryRun cannot both be true" });
+        }
+        const apply = body.apply === true;
+        const result = pruneArtifacts(db, artifactsRoot(env.home), {
+          now: nowMs,
+          dryRun: !apply,
+        });
+        if (apply) {
+          cachedStoreStats = null;
+          cachedStoreStatsAt = 0;
+        }
+        return send(res, 200, result);
       }
 
       const artifactGet = url.pathname.match(/^\/artifacts\/([0-9a-f]{64})$/);

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import http from "node:http";
@@ -578,6 +578,89 @@ describe("environment identity (webui chip)", () => {
 });
 
 describe("artifact store and agent registry surfacing (OPS-212)", () => {
+  test("GET /artifacts catalogues and filters metadata; POST /artifacts/prune dry-runs and applies", async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-artifacts-api-"));
+    const store = path.join(home, "artifacts");
+    mkdirSync(store, { recursive: true });
+    const reportHash = "a".repeat(64);
+    const transcriptHash = "b".repeat(64);
+    const orphanHash = "c".repeat(64);
+    writeFileSync(path.join(store, reportHash), "report", "utf8");
+    writeFileSync(path.join(store, transcriptHash), "transcript", "utf8");
+    writeFileSync(path.join(store, orphanHash), "orphan", "utf8");
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    for (const hash of [reportHash, transcriptHash, orphanHash]) {
+      utimesSync(path.join(store, hash), old, old);
+    }
+
+    const db = openDb(path.join(home, "runtime.db"));
+    const createdAt = "2026-01-02T03:04:05.000Z";
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`,
+    ).run("run_catalogue", "idem_catalogue", JSON.stringify({ agent: "catalogue-agent@1" }), "spec-hash", createdAt, createdAt);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:result', '{}', '{}', ?)`,
+    ).run("run_catalogue", JSON.stringify({ artifacts: [
+      { kind: "report", sha256: reportHash },
+      { kind: "transcript", sha256: transcriptHash },
+    ] }), createdAt);
+
+    const server = startApi({
+      db, registry, secret: SECRET, policyVersion: PV, port: 0,
+      env: { name: "test", home, adapter: "fake" },
+    });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const base = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const all = await (await fetch(`${base}/artifacts`)).json();
+      expect(all.artifacts).toHaveLength(3);
+      expect(all.artifacts.find((artifact) => artifact.sha256 === reportHash)).toEqual({
+        sha256: reportHash,
+        sizeBytes: 6,
+        mtime: old.toISOString(),
+        referenced: true,
+        references: [{
+          runId: "run_catalogue",
+          kind: "report",
+          agent: "catalogue-agent@1",
+          state: "COMPLETED",
+          createdAt,
+        }],
+      });
+      expect((await (await fetch(`${base}/artifacts?orphan=true`)).json()).artifacts.map((a) => a.sha256)).toEqual([orphanHash]);
+      expect((await (await fetch(`${base}/artifacts?orphan=false`)).json()).artifacts).toHaveLength(2);
+      expect((await (await fetch(`${base}/artifacts?kind=report`)).json()).artifacts.map((a) => a.sha256)).toEqual([reportHash]);
+      expect((await (await fetch(`${base}/artifacts?search=CATALOGUE-AGENT`)).json()).artifacts).toHaveLength(2);
+      expect((await (await fetch(`${base}/artifacts?limit=1`)).json()).artifacts).toHaveLength(1);
+      expect((await fetch(`${base}/artifacts?orphan=maybe`)).status).toBe(422);
+      expect((await fetch(`${base}/artifacts?limit=0`)).status).toBe(422);
+
+      const dry = await fetch(`${base}/artifacts/prune`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ dryRun: true }),
+      });
+      expect(dry.status).toBe(200);
+      expect(await dry.json()).toEqual({ deleted: 1, freedBytes: 6, remainingOrphans: 1 });
+      expect(existsSync(path.join(store, orphanHash))).toBe(true);
+
+      const apply = await fetch(`${base}/artifacts/prune`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ apply: true }),
+      });
+      expect(apply.status).toBe(200);
+      expect(await apply.json()).toEqual({ deleted: 1, freedBytes: 6, remainingOrphans: 0 });
+      expect(existsSync(path.join(store, orphanHash))).toBe(false);
+      expect(existsSync(path.join(store, reportHash))).toBe(true);
+    } finally {
+      server.close();
+      db.close();
+    }
+  });
+
   test("declared artifacts and the transcript survive the workspace and stream from the API", async () => {
     const { db, server, port } = await makeServer();
     const client = apiClient({ port });

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -152,6 +152,64 @@ export function referencedHashes(db) {
 }
 
 /**
+ * Catalogue every stored artifact and attach the accepted results that refer
+ * to it. The store remains the source of truth for which bytes exist; stale
+ * result references to missing files therefore do not produce phantom rows.
+ */
+export function listArtifacts(db, storeRoot, { orphan, kind, search, limit } = {}) {
+  if (!existsSync(storeRoot)) return [];
+
+  const references = new Map();
+  const rows = db.query(
+    `SELECT results.run_id, results.result_json, runs.spec_json, runs.state, runs.created_at
+     FROM results
+     LEFT JOIN runs ON runs.run_id = results.run_id`,
+  ).all();
+  for (const row of rows) {
+    let agent = null;
+    try {
+      agent = row.spec_json ? JSON.parse(row.spec_json).agent ?? null : null;
+    } catch {
+      // A catalogue read should still expose the bytes if an old spec is bad.
+    }
+    for (const entry of JSON.parse(row.result_json).artifacts ?? []) {
+      if (!HEX64.test(entry.sha256 ?? "")) continue;
+      const refs = references.get(entry.sha256) ?? [];
+      refs.push({
+        runId: row.run_id,
+        kind: entry.kind ?? null,
+        agent,
+        state: row.state ?? null,
+        createdAt: row.created_at ?? null,
+      });
+      references.set(entry.sha256, refs);
+    }
+  }
+
+  const term = typeof search === "string" ? search.toLowerCase() : null;
+  const inventory = [];
+  for (const sha256 of readdirSync(storeRoot).filter((name) => HEX64.test(name)).sort()) {
+    const stat = statSync(path.join(storeRoot, sha256));
+    if (!stat.isFile()) continue;
+    const refs = references.get(sha256) ?? [];
+    const referenced = refs.length > 0;
+    if (orphan !== undefined && orphan === referenced) continue;
+    if (kind !== undefined && !refs.some((ref) => ref.kind === kind)) continue;
+    if (term && ![sha256, ...refs.flatMap((ref) => [ref.runId, ref.kind, ref.agent, ref.state])]
+      .some((value) => String(value ?? "").toLowerCase().includes(term))) continue;
+    inventory.push({
+      sha256,
+      sizeBytes: stat.size,
+      mtime: stat.mtime.toISOString(),
+      referenced,
+      references: refs,
+    });
+    if (limit !== undefined && inventory.length >= limit) break;
+  }
+  return inventory;
+}
+
+/**
  * Store inventory: total bytes, and the orphans — files no accepted result
  * references. Orphans are normal (a failed attempt stores nothing, but a
  * superseded one can leave bytes behind); they are only a problem unattended.
@@ -181,21 +239,34 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
  * never touched: a receipt that points at a deleted file is worse than a full
  * disk, because it turns the audit trail into a lie.
  */
-export function pruneArtifacts(db, storeRoot, { olderThanMs = 7 * 24 * 60 * 60 * 1000, now = Date.now() } = {}) {
-  if (!existsSync(storeRoot)) return { deleted: 0, freedBytes: 0 };
+export function pruneArtifacts(
+  db,
+  storeRoot,
+  { olderThanMs = 7 * 24 * 60 * 60 * 1000, now = Date.now(), dryRun = false } = {},
+) {
+  if (!existsSync(storeRoot)) return { deleted: 0, freedBytes: 0, remainingOrphans: 0 };
   const referenced = referencedHashes(db);
   let deleted = 0;
   let freedBytes = 0;
+  let remainingOrphans = 0;
   for (const name of readdirSync(storeRoot)) {
     if (!HEX64.test(name) || referenced.has(name)) continue;
     const file = path.join(storeRoot, name);
     const stat = statSync(file);
-    if (now - stat.mtimeMs < olderThanMs) continue;
+    if (!stat.isFile()) continue;
+    if (now - stat.mtimeMs < olderThanMs) {
+      remainingOrphans += 1;
+      continue;
+    }
     freedBytes += stat.size;
-    rmSync(file, { force: true });
     deleted += 1;
+    if (dryRun) {
+      remainingOrphans += 1;
+    } else {
+      rmSync(file, { force: true });
+    }
   }
-  return { deleted, freedBytes };
+  return { deleted, freedBytes, remainingOrphans };
 }
 
 /**


### PR DESCRIPTION
## Summary
- add artifact catalogue metadata and reference aggregation
- expose listing filters and safe dry-run/apply orphan pruning endpoints
- cover catalogue filters and pruning with API integration tests

## Verification
- `bun test event-runtime/lib/api.test.mjs` — 71 pass, 0 fail

UX critique: skipped — backend-only control API with no user-facing flow.

Fixes WM-206