### PR TITLE
test(event-runtime): clean ambiguous proposals (OPS-261)

### DIFF
--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -407,20 +407,26 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
        VALUES (?, ?, ?, ?, 'run', ?, 1800)`,
     ).run("prop_extra_ambiguous", prop.eventSource, prop.eventId, prop.runId, at);
 
-    expect(await s.client.cancel(prop.runId, "never mind")).toEqual({
-      cancelled: true,
-      ambiguousOpenProposals: [{ runId: prop.runId, count: 2 }],
-    });
-    expect((await s.client.run(prop.runId)).run.state).toBe("CANCELLED");
+    try {
+      expect(await s.client.cancel(prop.runId, "never mind")).toEqual({
+        cancelled: true,
+        ambiguousOpenProposals: [{ runId: prop.runId, count: 2 }],
+      });
+      expect((await s.client.run(prop.runId)).run.state).toBe("CANCELLED");
 
-    const open = await s.client.proposals();
-    expect(open.proposals.map((p) => p.id)).toContain(prop.id);
-    expect(open.proposals.map((p) => p.id)).toContain("prop_extra_ambiguous");
+      const open = await s.client.proposals();
+      expect(open.proposals.map((p) => p.id)).toContain(prop.id);
+      expect(open.proposals.map((p) => p.id)).toContain("prop_extra_ambiguous");
 
-    const status = await s.client.status();
-    expect(status.anomalies.ambiguousOpenProposals).toEqual([
-      { runId: prop.runId, count: 2 },
-    ]);
+      const status = await s.client.status();
+      expect(status.anomalies.ambiguousOpenProposals).toEqual([
+        { runId: prop.runId, count: 2 },
+      ]);
+    } finally {
+      s.db
+        .query(`DELETE FROM proposals WHERE id IN (?, ?)`)
+        .run(prop.id, "prop_extra_ambiguous");
+    }
   });
 
   test("retry: 404 on unknown run, 409 when attempts are exhausted, queued with force", async () => {


### PR DESCRIPTION
## Summary
- clean both proposals created by the ambiguous cancel test in a `finally` block
- prevent shared test database proposal/anomaly pollution even when an assertion fails

## Verification
- `bun test event-runtime/lib/api.test.mjs` — 71 pass, 0 fail

UX critique: skipped — test-only maintenance with no user-facing flow

Fixes OPS-261