### PR TITLE
fix(event-runtime-web): add clear-filter empty action (OPS-503)

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -473,6 +473,7 @@ export function ListEmpty({
   noun,
   empty,
   action,
+  onClear,
   escHint,
 }: {
   colSpan: number;
@@ -481,6 +482,7 @@ export function ListEmpty({
   noun: string;
   empty: string;
   action?: ReactNode;
+  onClear?: () => void;
   escHint?: boolean;
 }) {
   let msg = empty;
@@ -495,6 +497,11 @@ export function ListEmpty({
         <div>{msg}</div>
         {showEscHint && (
           <div className="mt-2 text-[11px]">{ESC_CLEARS_FILTER}</div>
+        )}
+        {onClear && filtered && !query.isPending && !query.isError && (
+          <div className="mt-3">
+            <Button onClick={onClear}>Clear filter</Button>
+          </div>
         )}
         {action && !query.isPending && !query.isError && !filtered && <div className="mt-3">{action}</div>}
       </td>

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -779,7 +779,15 @@ export function Events({
               <ListEmpty
                 colSpan={cols.length}
                 query={list}
-                filtered={scoped.length > 0}
+                filtered={tabScoped.length > 0}
+                onClear={
+                  filter.trim()
+                    ? () => {
+                        setFilter("");
+                        onSelectType(null);
+                      }
+                    : undefined
+                }
                 noun="events"
                 empty={
                   context.kind === "repo"

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -851,6 +851,14 @@ export function Proposals({
                 colSpan={cols.length + (tab === "open" ? 1 : 0)}
                 query={tab === "open" ? query : history}
                 filtered={unfilteredCount > 0}
+                onClear={
+                  escClearsFilter
+                    ? () => {
+                        setFilter("");
+                        setExpiredOnly(false);
+                      }
+                    : undefined
+                }
                 noun="proposals"
                 empty={
                   expiredFilter

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -744,7 +744,8 @@ export function Runs({
               <ListEmpty
                 colSpan={cols.length}
                 query={list}
-                filtered={scoped.length > 0}
+                filtered={byTab.length > 0}
+                onClear={filter.trim() ? () => setFilter("") : undefined}
                 noun="runs"
                 empty={
                   context.kind === "inflight"

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -691,7 +691,8 @@ export function Workers({
               <ListEmpty
                 colSpan={cols.length}
                 query={query}
-                filtered={rows.length > 0}
+                filtered={byTab.length > 0}
+                onClear={filter.trim() ? () => setFilter("") : undefined}
                 noun="workers"
                 empty="No workers have registered — start one with bun event-runtime/cli.mjs work"
               />


### PR DESCRIPTION
## Summary
- add an optional clear callback to the shared `ListEmpty` state
- surface a one-click **Clear filter** recovery action in Runs, Events, Proposals, and Workers
- only offer recovery when the current unfiltered view contains rows, preserving genuine backend-empty states

## Verification
- `bun test event-runtime && cd event-runtime/web && bun run build` — pass (1281 tests, production build complete)

UX critique: required — NOT-ASSESSED, browser tooling was unavailable to the critic; no findings were produced.

Fixes OPS-503