### PR TITLE
fix(event-runtime-web): isolate section collapse keys (WM-192)

### DIFF
--- a/event-runtime/web/src/components/sectionKeys.test.ts
+++ b/event-runtime/web/src/components/sectionKeys.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+interface SectionCallsite {
+  file: string;
+  line: number;
+}
+
+/**
+ * Static titles are the persistence fallback when a Section has no explicit id.
+ * Keep those titles globally unique so unrelated views cannot share collapse state.
+ */
+describe("Section collapse keys (WM-192)", () => {
+  test("every static title used as a collapse key is unique across the app", async () => {
+    const callsites = new Map<string, SectionCallsite[]>();
+    const srcDir = fileURLToPath(new URL("..", import.meta.url));
+    const glob = new Bun.Glob("**/*.tsx");
+
+    for await (const file of glob.scan({ cwd: srcDir, onlyFiles: true })) {
+      if (file.includes(".test.")) continue;
+
+      const source = readFileSync(`${srcDir}/${file}`, "utf8");
+      for (const match of source.matchAll(/<Section\b([^>]*?)>/gs)) {
+        const props = match[1];
+        if (/\bid\s*=/.test(props)) continue;
+
+        const title = props.match(/\btitle\s*=\s*(["'])(.*?)\1/s)?.[2];
+        if (!title) continue;
+
+        const line = source.slice(0, match.index).split("\n").length;
+        const entries = callsites.get(title) ?? [];
+        entries.push({ file: `src/${file}`, line });
+        callsites.set(title, entries);
+      }
+    }
+
+    const duplicates = [...callsites.entries()]
+      .filter(([, entries]) => entries.length > 1)
+      .map(
+        ([title, entries]) =>
+          `${JSON.stringify(title)}: ${entries.map(({ file, line }) => `${file}:${line}`).join(", ")}`,
+      )
+      .sort();
+
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -545,7 +545,7 @@ export function Projects({
               </div>
             </Section>
 
-            <Section title="Configuration">
+            <Section id="project-configuration" title="Configuration">
               <KV k="Name" v={sel.name} />
               {sel.project && <KV k="Project" v={sel.project} />}
               {sel.team && <KV k="Team" v={sel.team} />}

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -505,7 +505,7 @@ export function Schedules({
               </div>
             )}
 
-            <Section title="Configuration">
+            <Section id="schedule-configuration" title="Configuration">
               <KV k="loop name" v={<span className="mono">{sel.loop}</span>} />
               <KV
                 k="cadence"


### PR DESCRIPTION
## Summary
- give Projects and Schedules distinct persistence ids for their Configuration sections
- add a source-sweep regression test that rejects duplicate static-title fallback keys

## Verification
- `cd event-runtime/web && bunx tsc --noEmit && bun test src` — 541 pass, 0 fail
- UX critique: required — NOT-ASSESSED; browser/simulator tooling was unavailable, so the critic could not drive the cross-view collapse interaction

Fixes WM-192