### PR TITLE
test(event-runtime): cover SuggestInput ArrowUp navigation (WM-180)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -615,10 +615,29 @@ describe("SuggestInput popover (WM-79)", () => {
     const input = r.getByRole("combobox", { name: "repo" }) as HTMLInputElement;
     fireEvent.focus(input);
     const options = r.getAllByRole("option");
-    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    const expectSelected = (selectedIndex: number) => {
+      options.forEach((option, index) => {
+        expect(option.getAttribute("aria-selected")).toBe(
+          index === selectedIndex ? "true" : "false",
+        );
+      });
+    };
+    expectSelected(0);
 
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(options[1].getAttribute("aria-selected")).toBe("true");
+    expectSelected(1);
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expectSelected(0);
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expectSelected(options.length - 1);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expectSelected(0);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expectSelected(1);
 
     fireEvent.keyDown(input, { key: "Enter" });
     expect(input.value).toBe("factory");


### PR DESCRIPTION
## Summary
- exercise SuggestInput ArrowUp navigation in both directions
- assert ArrowUp wrap-around updates the exclusive `aria-selected` option
- preserve ArrowDown, Enter selection, and Escape dismissal coverage

## Verification
- `bun test event-runtime/web/src/components/ui.test.tsx && bun build/emit.mjs --check`

UX critique: skipped — test-only coverage change; no user-facing behavior changed.

Fixes WM-180