### PR TITLE
fix(event-runtime-web): keep repo picker highlight visible

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -341,6 +341,52 @@ describe("ContextTabs", () => {
     expect(r.queryByRole("listbox")).toBeNull();
   });
 
+  test("keyboard navigation scrolls each highlighted picker option into view", () => {
+    const scrolls: Array<{ element: HTMLElement; options?: boolean | ScrollIntoViewOptions }> = [];
+    const original = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = function (
+      this: HTMLElement,
+      options?: boolean | ScrollIntoViewOptions,
+    ) {
+      scrolls.push({ element: this, options });
+    };
+
+    try {
+      const r = render(
+        <ContextTabs
+          repos={[repo("alpha"), repo("bravo"), repo("charlie")]}
+          reposError={false}
+          openRepos={[]}
+          active={{ kind: "all" }}
+          onSelect={() => {}}
+          onOpen={() => {}}
+          onClose={() => {}}
+        />,
+      );
+
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: "Open a repo tab" }));
+      });
+      const listbox = r.getByRole("listbox", { name: "Factory repos" });
+      const options = r.getAllByRole("option");
+      scrolls.length = 0;
+
+      for (const [key, expected] of [
+        ["ArrowDown", options[1]],
+        ["End", options[2]],
+        ["ArrowUp", options[1]],
+        ["Home", options[0]],
+      ] as const) {
+        act(() => {
+          fireEvent.keyDown(listbox, { key });
+        });
+        expect(scrolls.at(-1)).toEqual({ element: expected, options: { block: "nearest" } });
+      }
+    } finally {
+      HTMLElement.prototype.scrollIntoView = original;
+    }
+  });
+
   test("Escape closes the repo picker and returns focus to +", () => {
     const opened: string[] = [];
     const r = render(

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -198,6 +198,13 @@ export function ContextTabs({
 
   useEffect(() => {
     if (!picker) return;
+    listboxRef.current
+      ?.querySelector<HTMLElement>('[role="option"][aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [picker, pickerHighlight]);
+
+  useEffect(() => {
+    if (!picker) return;
     function onDoc(e: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPicker(false);
     }


### PR DESCRIPTION
## Summary
- scroll the active repo-picker option into view whenever its highlight changes
- cover ArrowDown, ArrowUp, Home, and End navigation with unit assertions

## Verification
- `bun test event-runtime/web/src/components/ContextTabs.test.tsx && bun build/emit.mjs --check` — pass (21 tests; 90 generated files match)

## UX critique
- required — NOT-ASSESSED: browser-driving unavailable because the UX critic's Chrome CDP module was missing; keyboard behavior is covered by focused DOM tests

Fixes WM-182