### PR TITLE
fix(ui): make scope caption subjects explicit (WM-190)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -452,17 +452,14 @@ describe("ScopeCaption", () => {
     expect(r.container.textContent).toBe("");
   });
 
-  test("Workers/Agents/Schedules/Overview/Graph use view names, not fleet or registry", () => {
-    const cases: Array<{ hash: string; surface: "fleet" | "registry" | "graph" | "overview"; expect: string }> = [
-      { hash: "#/workers", surface: "fleet", expect: "Workers are not scoped to factory" },
-      { hash: "#/agents", surface: "registry", expect: "Agents are not scoped to factory" },
-      { hash: "#/schedules", surface: "registry", expect: "Schedules are not scoped to factory" },
-      { hash: "#/overview", surface: "overview", expect: "Overview counts are not scoped to factory" },
-      { hash: "#/graph", surface: "graph", expect: "Graph is not scoped to factory" },
+  test("fixed surfaces use view names, not internal surface names", () => {
+    const cases = [
+      { surface: "fleet" as const, expect: "Workers are not scoped to factory" },
+      { surface: "overview" as const, expect: "Overview counts are not scoped to factory" },
+      { surface: "graph" as const, expect: "Graph is not scoped to factory" },
     ];
 
     for (const c of cases) {
-      window.location.hash = c.hash;
       const r = render(<ScopeCaption context={repoCtx} surface={c.surface} />);
       const text = r.container.textContent ?? "";
       expect(text).toContain(c.expect);
@@ -472,23 +469,32 @@ describe("ScopeCaption", () => {
     }
   });
 
-  test("surface fallback still avoids jargon when hash is empty", () => {
-    window.location.hash = "";
-    const fleet = render(<ScopeCaption context={repoCtx} surface="fleet" />);
-    expect(fleet.container.textContent).toContain("Workers are not scoped to factory");
-    expect(fleet.container.textContent?.toLowerCase()).not.toContain("fleet");
-    cleanup();
+  test("registry captions use their explicit subject instead of the current hash", () => {
+    const cases = [
+      {
+        hash: "#/schedules",
+        subject: { label: "Agents", plural: true },
+        expect: "Agents are not scoped to factory",
+      },
+      {
+        hash: "#/projects",
+        subject: { label: "Schedules", plural: true },
+        expect: "Schedules are not scoped to factory",
+      },
+      {
+        hash: "#/agents",
+        subject: { label: "registry", plural: false },
+        expect: "registry is not scoped to factory",
+      },
+    ];
 
-    // Empty hash is not Agents/Schedules — keep the factory-wide registry copy (WM-157 Projects).
-    const registry = render(<ScopeCaption context={repoCtx} surface="registry" />);
-    expect(registry.container.textContent).toContain("registry is not scoped to factory");
-    expect(registry.container.textContent).not.toContain("Agents");
-  });
-
-  test("Projects hash keeps factory-wide registry copy, not Agents", () => {
-    window.location.hash = "#/projects";
-    const r = render(<ScopeCaption context={repoCtx} surface="registry" />);
-    expect(r.container.textContent).toContain("registry is not scoped to factory");
-    expect(r.container.textContent).not.toContain("Agents");
+    for (const c of cases) {
+      window.location.hash = c.hash;
+      const r = render(
+        <ScopeCaption context={repoCtx} surface="registry" subject={c.subject} />,
+      );
+      expect(r.container.textContent).toContain(c.expect);
+      cleanup();
+    }
   });
 });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { OperatorContext } from "../context";
 import { INFLIGHT, toggleInflight } from "../context";
-import { hashView } from "../hash";
 import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
 
@@ -30,36 +29,21 @@ const getHashRunId = () => {
 };
 
 type CaptionSurface = "fleet" | "registry" | "graph" | "overview";
+type FixedCaptionSurface = Exclude<CaptionSurface, "registry">;
+type CaptionSubject = { label: string; plural: boolean };
+type ScopeCaptionProps = { context: OperatorContext } & (
+  | { surface: "registry"; subject: CaptionSubject }
+  | { surface: FixedCaptionSurface; subject?: never }
+);
 
-const SURFACE_SUBJECT: Record<CaptionSurface, { subject: string; plural: boolean }> = {
-  fleet: { subject: "Workers", plural: true },
-  // Projects also passes surface="registry"; only agents/schedules hashes map to view names below.
-  registry: { subject: "registry", plural: false },
-  graph: { subject: "Graph", plural: false },
-  overview: { subject: "Overview counts", plural: true },
+const SURFACE_SUBJECT: Record<FixedCaptionSurface, CaptionSubject> = {
+  fleet: { label: "Workers", plural: true },
+  graph: { label: "Graph", plural: false },
+  overview: { label: "Overview counts", plural: true },
 };
 
-/** Agents and Schedules both pass surface="registry"; hash is the only discriminator without editing views. */
-const REGISTRY_VIEW_SUBJECT: Record<string, { subject: string; plural: boolean }> = {
-  agents: { subject: "Agents", plural: true },
-  schedules: { subject: "Schedules", plural: true },
-};
-
-function captionSubject(surface: CaptionSurface) {
-  if (surface === "registry" && typeof window !== "undefined") {
-    const fromHash = REGISTRY_VIEW_SUBJECT[hashView(window.location.hash)];
-    if (fromHash) return fromHash;
-  }
-  return SURFACE_SUBJECT[surface];
-}
-
-export function ScopeCaption({
-  context,
-  surface,
-}: {
-  context: OperatorContext;
-  surface: CaptionSurface;
-}) {
+export function ScopeCaption(props: ScopeCaptionProps) {
+  const { context, surface } = props;
   if (context.kind === "all") return null;
   const n = context.kind === "inflight" ? "In flight" : context.name;
   if (context.kind === "inflight") {
@@ -71,10 +55,11 @@ export function ScopeCaption({
       </p>
     );
   }
-  const { subject, plural } = captionSubject(surface);
+  const { label, plural } =
+    surface === "registry" ? props.subject : SURFACE_SUBJECT[surface];
   return (
     <p className="mb-3 text-[11px] text-(--text-faint)">
-      {`${subject} ${plural ? "are" : "is"} not scoped to ${n}.`}
+      {`${label} ${plural ? "are" : "is"} not scoped to ${n}.`}
     </p>
   );
 }

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -258,7 +258,11 @@ export function Agents({
         chrome={
           <>
         <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
-        <ScopeCaption context={context} surface="registry" />
+        <ScopeCaption
+          context={context}
+          surface="registry"
+          subject={{ label: "Agents", plural: true }}
+        />
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <span className="ml-auto">
             <DisplayOptions

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -324,7 +324,11 @@ export function Projects({
         chrome={
           <>
             <h1 className="display mb-4 text-lg font-semibold">Projects</h1>
-            <ScopeCaption context={context} surface="registry" />
+            <ScopeCaption
+              context={context}
+              surface="registry"
+              subject={{ label: "registry", plural: false }}
+            />
             <div className="mb-3">
               <FilterInput
                 value={filter}

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -254,7 +254,11 @@ export function Schedules({
         chrome={
           <>
             <h1 className="display mb-4 text-lg font-semibold">Schedules</h1>
-            <ScopeCaption context={context} surface="registry" />
+            <ScopeCaption
+              context={context}
+              surface="registry"
+              subject={{ label: "Schedules", plural: true }}
+            />
             <div className="mb-3">
               <FilterInput
                 value={filter}


### PR DESCRIPTION
## Summary
- replace ScopeCaption's render-time hash inference with caller-owned registry subjects
- pass explicit Agents, Schedules, and registry subjects from each registry view
- cover hash-independent caption selection with a regression test

## Verification
- `cd event-runtime/web && bun test` — 540 pass, 0 fail
- `cd event-runtime/web && bun run build` — TypeScript and Vite build passed

UX critique: skipped — internal maintenance refactor preserves the existing caption copy and introduces no new interaction or user-completable flow.

Fixes WM-190