### PR TITLE
feat(event-runtime-web): add Artifacts inventory

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -10,7 +10,7 @@ import {
   rememberOpenRepo,
   type OperatorContext,
 } from "./context";
-import { eventsHash, hashPath, hashProject, hashSearch, withProject } from "./hash";
+import { artifactsHash, eventsHash, hashPath, hashProject, hashSearch, withProject } from "./hash";
 import { keyGuard, THEMES, useHashRoute, useTheme, type Theme } from "./hooks";
 import { goPrefixActive } from "./goSequence";
 import type { EventFocus } from "./types";
@@ -19,6 +19,7 @@ import { InjectDialog } from "./components/InjectDialog";
 import { ShortcutsDialog } from "./components/ShortcutsDialog";
 import { ToastContainer, copyLink, copyText } from "./components/ui";
 import { Agents } from "./views/Agents";
+import type { ArtifactFilters } from "./views/Artifacts";
 import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
 import { RunFull } from "./views/RunFull";
@@ -33,6 +34,7 @@ type NavBadge = {
   title?: string;
 };
 
+const Artifacts = lazy(() => import("./views/Artifacts").then((m) => ({ default: m.Artifacts })));
 const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph })));
 const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
 const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
@@ -114,6 +116,15 @@ export function App() {
   const focusScheduleLoop = view === "schedules" ? (route[1] ?? null) : null;
   const focusWorkerId = view === "workers" ? (route[1] ?? null) : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
+  const artifactQuery = hashSearch(window.location.hash);
+  const artifactFilters: ArtifactFilters = {
+    kind: view === "artifacts" ? artifactQuery.get("kind") : null,
+    orphan:
+      view !== "artifacts" || !artifactQuery.has("orphan")
+        ? null
+        : artifactQuery.get("orphan") === "true",
+    search: view === "artifacts" ? (artifactQuery.get("search") ?? "") : "",
+  };
   const hashEvent: EventFocus | null =
     view === "events" && route[1] && route[2]
       ? { source: route[1], eventId: route[2] }
@@ -210,6 +221,12 @@ export function App() {
     runs: { count: scopedRunsNav ? 0 : activeRuns, hue: "var(--accent)" },
     projects: { count: 0, hue: "var(--accent)" },
     agents: { count: 0, hue: "var(--accent)" },
+    artifacts: {
+      count: status.data?.artifacts.orphans ?? 0,
+      hue: "var(--hue-warn)",
+      word: "orphan",
+      title: `${status.data?.artifacts.orphans ?? 0} unreferenced artifact${status.data?.artifacts.orphans === 1 ? "" : "s"}`,
+    },
     schedules:
       stoppedSchedulesCount > 0
         ? {
@@ -332,6 +349,20 @@ export function App() {
       run: () => selectContext({ kind: "inflight" }),
     },
     { label: "Inject event…", hint: "i", run: () => setInjectOpen(true) },
+    {
+      label: "Show orphan artifacts",
+      group: "Commands" as const,
+      run: () => navigate(artifactsHash({ orphan: true })),
+    },
+    {
+      label: "Search artifacts",
+      hint: "/",
+      group: "Commands" as const,
+      run: () => {
+        setFilterFocus(true);
+        navigate("artifacts");
+      },
+    },
     {
       label: "Focus filter",
       hint: "/",
@@ -549,6 +580,15 @@ export function App() {
               focusWorkerId={focusWorkerId}
               onSelectWorker={(id) => navigate(hashPath("workers", id))}
             />
+          ) : view === "artifacts" ? (
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading artifacts…</div>}>
+              <Artifacts
+                metrics={status.data?.artifacts}
+                filters={artifactFilters}
+                onFiltersChange={(filters) => navigate(artifactsHash(filters))}
+                onJumpRun={jumpToRun}
+              />
+            </Suspense>
           ) : view === "events" ? (
             <Events
               connected={connected}

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   AdmittedEvent,
   AgentsView,
+  ArtifactInventoryItem,
   ApproveOutcome,
   CancelOutcome,
   EnvIdentity,
@@ -46,6 +47,15 @@ async function call<T>(method: string, path: string, body?: unknown): Promise<T>
     throw new ApiError(message, res.status);
   }
   return json as T;
+}
+
+export function fetchArtifacts(filters?: { kind?: string; orphan?: boolean; search?: string }) {
+  const query = new URLSearchParams();
+  if (filters?.kind) query.set("kind", filters.kind);
+  if (filters?.orphan !== undefined) query.set("orphan", String(filters.orphan));
+  if (filters?.search) query.set("search", filters.search);
+  const suffix = query.size > 0 ? `?${query.toString()}` : "";
+  return call<{ artifacts: ArtifactInventoryItem[] }>("GET", `/artifacts${suffix}`);
 }
 
 export const api = {

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -12,7 +12,7 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "⌘K", does: "copy link to this page" },
   { keys: "⌘K · footer theme", does: "cycle theme (dark → light → contrast)" },
   { keys: "i", does: "inject event" },
-  { keys: "/", does: "focus filter (Events, if none on this view)" },
+  { keys: "/", does: "focus this view's filter (Artifacts, Events, Runs, and other lists)" },
   { keys: "v", does: "display options" },
   { keys: "j k  ↑↓", does: "move list (or graph) selection" },
   { keys: "[ ]", does: "previous / next status tab" },

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -5,8 +5,8 @@
  * `#/overview` `#/events` `#/events?type=` `#/events/:source/:eventId`
  * `#/proposals` `#/proposals/:id` `#/runs` `#/runs/:id` `#/run/:id` (the
  * full-page run view — distinct first segment so expand/back get push
- * semantics) `#/agents` `#/agents/:ref` `#/workers` `#/workers/:id`
- * `#/graph` `#/graph/:nodeId`
+ * semantics) `#/agents` `#/agents/:ref` `#/artifacts` `#/artifacts?kind=…`
+ * `#/workers` `#/workers/:id` `#/graph` `#/graph/:nodeId`
  *
  * Optional `?project=` (OPS-356) restores the context-tab filter; `inflight`
  * is reserved. The path still names the view. A pasted `#/runs/:id` without
@@ -179,6 +179,20 @@ export function eventsHash(
 ): string {
   const path = hashPath("events", source, eventId);
   return type ? `${path}?type=${encodeURIComponent(type)}` : path;
+}
+
+/** Shareable Artifacts view filters. Project context is added by `withProject`. */
+export function artifactsHash(filters: {
+  kind?: string | null;
+  orphan?: boolean | null;
+  search?: string | null;
+} = {}): string {
+  const query = new URLSearchParams();
+  if (filters.kind) query.set("kind", filters.kind);
+  if (filters.orphan != null) query.set("orphan", String(filters.orphan));
+  if (filters.search) query.set("search", filters.search);
+  const qs = query.toString();
+  return qs ? `artifacts?${qs}` : "artifacts";
 }
 
 /** `?project=` on the hash — the context strip's active filter, not the view. */

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -1,7 +1,7 @@
 // Agents rides `g t` ("what is this agent?"): o/e/p/r are taken, and `g a`
-// would double-fire the proposals view's `a` (approve) list key — chord
-// suffixes must never collide with single-key verbs. Workers keeps its
-// natural `g w`: `w` is no view's list verb.
+// would double-fire the proposals view's `a` (approve) list key. Artifacts uses
+// `g y` (the last sound in "artifact") so it does not compete with list `k`.
+// Workers keeps its natural `g w`: `w` is no view's list verb.
 export const NAV = [
   { key: "overview", label: "Overview", go: "o" },
   { key: "events", label: "Events", go: "e" },
@@ -9,6 +9,7 @@ export const NAV = [
   { key: "runs", label: "Runs", go: "r" },
   { key: "projects", label: "Projects", go: "f" },
   { key: "agents", label: "Agents", go: "t" },
+  { key: "artifacts", label: "Artifacts", go: "y" },
   { key: "schedules", label: "Schedules", go: "s" },
   { key: "workers", label: "Workers", go: "w" },
   { key: "graph", label: "Graph", go: "g" },

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -206,6 +206,24 @@ export interface ArtifactRef {
   sizeBytes: number;
 }
 
+/** Accepted result that keeps an artifact reachable in the content-addressed store. */
+export interface ArtifactReference {
+  runId: string;
+  kind: string | null;
+  agent: string | null;
+  state: RunState | null;
+  createdAt: string | null;
+}
+
+/** One physical file returned by the artifact inventory endpoint. */
+export interface ArtifactInventoryItem {
+  sha256: string;
+  sizeBytes: number;
+  mtime: string;
+  referenced: boolean;
+  references: ArtifactReference[];
+}
+
 export interface RunDetail {
   run: {
     runId: string;

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -1,0 +1,123 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { useState } from "react";
+import type { ArtifactInventoryItem } from "../types";
+import { Artifacts, type ArtifactFilters } from "./Artifacts";
+
+const ITEMS: ArtifactInventoryItem[] = [
+  {
+    sha256: "a".repeat(64),
+    sizeBytes: 1_024,
+    mtime: "2026-01-02T03:04:05.000Z",
+    referenced: true,
+    references: [
+      {
+        runId: "run_report",
+        kind: "report",
+        agent: "reporter@1",
+        state: "COMPLETED",
+        createdAt: "2026-01-02T03:04:05.000Z",
+      },
+    ],
+  },
+  {
+    sha256: "b".repeat(64),
+    sizeBytes: 2_048,
+    mtime: "2026-01-03T03:04:05.000Z",
+    referenced: true,
+    references: [
+      {
+        runId: "run_trace",
+        kind: "transcript",
+        agent: "ticket-agent@1",
+        state: "COMPLETED",
+        createdAt: "2026-01-03T03:04:05.000Z",
+      },
+    ],
+  },
+  {
+    sha256: "c".repeat(64),
+    sizeBytes: 512,
+    mtime: "2026-01-04T03:04:05.000Z",
+    referenced: false,
+    references: [],
+  },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderArtifacts(
+  onJumpRun = mock(() => {}),
+  initialFilters: ArtifactFilters = { kind: null, orphan: null, search: "" },
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  client.setQueryData(["artifacts"], { artifacts: ITEMS });
+  function Harness() {
+    const [filters, setFilters] = useState<ArtifactFilters>(initialFilters);
+    return (
+      <QueryClientProvider client={client}>
+        <Artifacts
+          metrics={{ files: 3, bytes: 3_584, orphans: 1, orphanBytes: 512 }}
+          filters={filters}
+          onFiltersChange={setFilters}
+          onJumpRun={onJumpRun}
+        />
+      </QueryClientProvider>
+    );
+  }
+  return { ...render(<Harness />), onJumpRun };
+}
+
+describe("Artifacts inventory (WM-207)", () => {
+  test("renders storage metrics, inventory columns, downloads, and run jump links", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const summary = view.getByRole("region", { name: "Artifact storage summary" });
+    expect(summary.textContent).toContain("3");
+    expect(summary.textContent).toContain("3.5 KB");
+    expect(summary.textContent).toContain("1 · 512 B");
+
+    for (const heading of ["SHA", "Kind", "File size", "Age / timestamp", "Referenced by", "Orphan"]) {
+      expect(view.getByRole("columnheader", { name: heading })).toBeTruthy();
+    }
+    const download = view.getByRole("link", { name: `Download artifact ${"a".repeat(64)}` });
+    expect(download.getAttribute("href")).toContain(`/api/artifacts/${"a".repeat(64)}`);
+
+    fireEvent.click(view.getByRole("button", { name: "run_report" }));
+    expect(view.onJumpRun).toHaveBeenCalledWith("run_report");
+  });
+
+  test("filters by kind and orphan status facets", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    fireEvent.click(view.getByRole("button", { name: "report" }));
+    expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy();
+    expect(view.queryByText("bbbbbbbbbbbb")).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: "Any kind" }));
+    fireEvent.click(view.getByRole("button", { name: "Orphans" }));
+    expect(view.getByText("cccccccccccc")).toBeTruthy();
+    expect(view.queryByText("aaaaaaaaaaaa")).toBeNull();
+
+  });
+
+  test("applies a free-text filter across reference metadata", async () => {
+    const view = renderArtifacts(mock(() => {}), {
+      kind: null,
+      orphan: null,
+      search: "ticket-agent",
+    });
+    await waitFor(() => expect(view.getByText("bbbbbbbbbbbb")).toBeTruthy());
+    const table = view.getByRole("table");
+    expect(within(table).queryByText("aaaaaaaaaaaa")).toBeNull();
+    expect(within(table).queryByText("cccccccccccc")).toBeNull();
+  });
+});

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,0 +1,292 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { artifactUrl, fetchArtifacts } from "../api";
+import { Ago, FilterInput, JumpLink, ListEmpty, ListPane, humanSize } from "../components/ui";
+import { useNow } from "../hooks";
+import type { ArtifactInventoryItem, StatusView } from "../types";
+
+export type ArtifactFilters = {
+  kind: string | null;
+  orphan: boolean | null;
+  search: string;
+};
+
+const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
+
+function kindsOf(artifact: ArtifactInventoryItem): string[] {
+  return [...new Set(artifact.references.flatMap((reference) => reference.kind ?? []))];
+}
+
+function matchesSearch(artifact: ArtifactInventoryItem, search: string): boolean {
+  const term = search.trim().toLowerCase();
+  if (!term) return true;
+  return [
+    artifact.sha256,
+    ...artifact.references.flatMap((reference) => [
+      reference.runId,
+      reference.kind,
+      reference.agent,
+      reference.state,
+    ]),
+  ].some((value) => String(value ?? "").toLowerCase().includes(term));
+}
+
+function KindBadge({ kind }: { kind: string }) {
+  return (
+    <span
+      className="mono inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium"
+      style={{
+        color: "var(--hue-info)",
+        background: "color-mix(in oklch, var(--hue-info) 12%, transparent)",
+      }}
+    >
+      {kind}
+    </span>
+  );
+}
+
+function Metric({ label, value, warning }: { label: string; value: string; warning?: boolean }) {
+  return (
+    <div className="min-w-36 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-3">
+      <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
+      <div
+        className="display mt-1 text-xl font-semibold tabular-nums"
+        style={warning ? { color: "var(--hue-warn)" } : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+/** Content-addressed store inventory, with URL-backed kind/orphan/search facets. */
+export function Artifacts({
+  metrics,
+  filters,
+  onFiltersChange,
+  onJumpRun,
+}: {
+  metrics?: StatusView["artifacts"];
+  filters: ArtifactFilters;
+  onFiltersChange: (filters: ArtifactFilters) => void;
+  onJumpRun: (runId: string) => void;
+}) {
+  const now = useNow();
+  const artifactsQ = useQuery({
+    queryKey: ["artifacts"],
+    queryFn: () => fetchArtifacts(),
+    refetchInterval: 10_000,
+  });
+  const artifacts = artifactsQ.data?.artifacts ?? [];
+  const kinds = useMemo(
+    () =>
+      [...new Set([...COMMON_KINDS, ...artifacts.flatMap(kindsOf)])].sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    [artifacts],
+  );
+  const visible = useMemo(
+    () =>
+      artifacts.filter((artifact) => {
+        if (filters.kind && !kindsOf(artifact).includes(filters.kind)) return false;
+        if (filters.orphan != null && filters.orphan === artifact.referenced) return false;
+        return matchesSearch(artifact, filters.search);
+      }),
+    [artifacts, filters],
+  );
+
+  const fallbackMetrics = useMemo(
+    () => ({
+      files: artifacts.length,
+      bytes: artifacts.reduce((sum, artifact) => sum + artifact.sizeBytes, 0),
+      orphans: artifacts.filter((artifact) => !artifact.referenced).length,
+      orphanBytes: artifacts
+        .filter((artifact) => !artifact.referenced)
+        .reduce((sum, artifact) => sum + artifact.sizeBytes, 0),
+    }),
+    [artifacts],
+  );
+  const summary: StatusView["artifacts"] = metrics ?? fallbackMetrics;
+  const filtered = Boolean(filters.kind || filters.orphan != null || filters.search.trim());
+  const set = (patch: Partial<ArtifactFilters>) => onFiltersChange({ ...filters, ...patch });
+
+  return (
+    <ListPane
+      chrome={
+        <>
+          <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+            <div>
+              <h1 className="display text-lg font-semibold">Artifacts</h1>
+              <p className="mt-1 text-[12px] text-(--text-faint)">
+                Physical files in the content-addressed store. Project context does not narrow this factory-wide inventory.
+              </p>
+            </div>
+            {summary.at && (
+              <span className="text-[11px] text-(--text-faint)" title={summary.at}>
+                measured <Ago iso={summary.at} now={now} />
+              </span>
+            )}
+          </div>
+
+          <section aria-label="Artifact storage summary" className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <Metric label="Stored files" value={summary.files.toLocaleString()} />
+            <Metric label="Disk usage" value={humanSize(summary.bytes)} />
+            <Metric
+              label="Orphans"
+              value={`${summary.orphans.toLocaleString()} · ${humanSize(summary.orphanBytes)}`}
+              warning={summary.orphans > 0}
+            />
+          </section>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap gap-1" role="group" aria-label="Artifact status facets">
+              {([
+                { label: "All", value: null },
+                { label: "Referenced", value: false },
+                { label: "Orphans", value: true },
+              ] as const).map((facet) => (
+                <button
+                  key={facet.label}
+                  type="button"
+                  aria-pressed={filters.orphan === facet.value}
+                  onClick={() => set({ orphan: facet.value })}
+                  className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                    filters.orphan === facet.value
+                      ? "bg-(--surface-3) text-(--text)"
+                      : "text-(--text-faint) hover:bg-(--surface-1)"
+                  }`}
+                >
+                  {facet.label}
+                </button>
+              ))}
+            </div>
+            <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="group" aria-label="Artifact kind facets">
+              <button
+                type="button"
+                aria-pressed={filters.kind === null}
+                onClick={() => set({ kind: null })}
+                className={`rounded-md px-2 py-1 text-[11px] ${
+                  filters.kind === null ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                }`}
+              >
+                Any kind
+              </button>
+              {kinds.map((kind) => (
+                <button
+                  key={kind}
+                  type="button"
+                  aria-pressed={filters.kind === kind}
+                  onClick={() => set({ kind: filters.kind === kind ? null : kind })}
+                  className={`mono rounded-md px-2 py-1 text-[11px] ${
+                    filters.kind === kind ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                  }`}
+                >
+                  {kind}
+                </button>
+              ))}
+            </div>
+            <FilterInput
+              value={filters.search}
+              onChange={(search) => set({ search })}
+              placeholder="SHA, kind, run, agent…"
+              label="Search artifacts"
+            />
+          </div>
+        </>
+      }
+    >
+      <table className="w-full border-separate border-spacing-0 text-[12px]">
+        <thead>
+          <tr className="text-left text-[11px] text-(--text-faint)">
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">SHA</th>
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Kind</th>
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">File size</th>
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Age / timestamp</th>
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Referenced by</th>
+            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Orphan</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map((artifact) => {
+            const artifactKinds = kindsOf(artifact);
+            const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
+            return (
+              <tr key={artifact.sha256} className="hover:bg-(--surface-1)">
+                <td className="mono max-w-40 border-b border-(--border) px-3 py-2" title={artifact.sha256}>
+                  <a
+                    href={artifactUrl(artifact.sha256, name)}
+                    download={name}
+                    className="text-(--accent) hover:underline"
+                    aria-label={`Download artifact ${artifact.sha256}`}
+                  >
+                    {artifact.sha256.slice(0, 12)}
+                  </a>
+                </td>
+                <td className="border-b border-(--border) px-3 py-2">
+                  {artifactKinds.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {artifactKinds.map((kind) => <KindBadge key={kind} kind={kind} />)}
+                    </div>
+                  ) : (
+                    <span className="text-(--text-faint)">—</span>
+                  )}
+                </td>
+                <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-2 text-(--text-dim)">
+                  {humanSize(artifact.sizeBytes)}
+                </td>
+                <td className="whitespace-nowrap border-b border-(--border) px-3 py-2">
+                  <div><Ago iso={artifact.mtime} now={now} /></div>
+                  <time dateTime={artifact.mtime} className="mono text-[10px] text-(--text-faint)">
+                    {new Date(artifact.mtime).toLocaleString()}
+                  </time>
+                </td>
+                <td className="border-b border-(--border) px-3 py-2">
+                  {artifact.references.length > 0 ? (
+                    <div className="flex flex-wrap gap-x-2 gap-y-1">
+                      {artifact.references.map((reference) => (
+                        <JumpLink
+                          key={`${reference.runId}:${reference.kind ?? "unknown"}`}
+                          onClick={() => onJumpRun(reference.runId)}
+                          title={`Open run ${reference.runId}`}
+                        >
+                          {reference.runId}
+                        </JumpLink>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-(--text-faint)">—</span>
+                  )}
+                </td>
+                <td className="border-b border-(--border) px-3 py-2">
+                  {!artifact.referenced ? (
+                    <span
+                      className="rounded px-1.5 py-0.5 text-[11px] font-medium"
+                      style={{
+                        color: "var(--hue-warn)",
+                        background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
+                      }}
+                    >
+                      orphan
+                    </span>
+                  ) : (
+                    <span className="text-(--text-faint)">—</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+          {visible.length === 0 && (
+            <ListEmpty
+              colSpan={6}
+              query={artifactsQ}
+              filtered={filtered}
+              noun="artifacts"
+              empty="No artifacts are stored."
+              onClear={() => onFiltersChange({ kind: null, orphan: null, search: "" })}
+            />
+          )}
+        </tbody>
+      </table>
+    </ListPane>
+  );
+}


### PR DESCRIPTION
## Summary
- add the Artifacts sidebar route, `g y` chord, orphan badge, and command-palette actions
- add a URL-synchronized inventory view with storage metrics, kind/orphan facets, search, downloads, and run jump links
- add focused inventory tests and lazy-load the view to stay within the entry-chunk budget

## Verification
- `cd event-runtime/web && bun test src/App.test.tsx`
- `cd event-runtime/web && bun test src/views/Artifacts.test.tsx`
- `cd event-runtime/web && bun run build`

## UX critique
Required — NOT-ASSESSED: the UX critic could not start its browser because the configured `pi-chrome-cdp/scripts/cdp.mjs` module was missing.

Fixes WM-207