### PR TITLE
Fix repo picker highlight and focus handling (WM-191)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -387,6 +387,93 @@ describe("ContextTabs", () => {
     }
   });
 
+  test("clamps the picker highlight when available repos change while open", () => {
+    const opened: string[] = [];
+    const props = {
+      repos: [repo("alpha"), repo("bravo"), repo("charlie")],
+      reposError: false,
+      active: { kind: "all" } as OperatorContext,
+      onSelect: () => {},
+      onOpen: (name: string) => opened.push(name),
+      onClose: () => {},
+    };
+    const r = render(<ContextTabs {...props} openRepos={[]} />);
+
+    act(() => {
+      fireEvent.click(r.getByRole("button", { name: "Open a repo tab" }));
+    });
+    const listbox = r.getByRole("listbox", { name: "Factory repos" });
+    act(() => {
+      fireEvent.keyDown(listbox, { key: "End" });
+    });
+    expect(r.getAllByRole("option")[2].getAttribute("aria-selected")).toBe("true");
+
+    r.rerender(<ContextTabs {...props} openRepos={["bravo", "charlie"]} />);
+
+    const remaining = r.getByRole("option", { name: "alpha" });
+    expect(remaining.getAttribute("aria-selected")).toBe("true");
+    expect(r.getByRole("listbox").getAttribute("aria-activedescendant")).toBe(remaining.id);
+    act(() => {
+      fireEvent.keyDown(r.getByRole("listbox"), { key: "Enter" });
+    });
+    expect(opened).toEqual(["alpha"]);
+  });
+
+  test("outside mousedown closes the repo picker and returns focus to +", () => {
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={[]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+    act(() => {
+      fireEvent.click(plus);
+    });
+    expect(document.activeElement).toBe(r.getByRole("listbox"));
+
+    act(() => {
+      fireEvent.mouseDown(document.body);
+    });
+    expect(r.queryByRole("listbox")).toBeNull();
+    expect(document.activeElement).toBe(plus);
+  });
+
+  test("Tab and Shift+Tab close the repo picker and return focus to +", () => {
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={[]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+
+    for (const shiftKey of [false, true]) {
+      act(() => {
+        fireEvent.click(plus);
+      });
+      const listbox = r.getByRole("listbox");
+      const tab = createEvent.keyDown(listbox, { key: "Tab", shiftKey });
+      act(() => {
+        fireEvent(listbox, tab);
+      });
+      expect(tab.defaultPrevented).toBe(true);
+      expect(r.queryByRole("listbox")).toBeNull();
+      expect(document.activeElement).toBe(plus);
+    }
+  });
+
   test("Escape closes the repo picker and returns focus to +", () => {
     const opened: string[] = [];
     const r = render(

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -136,6 +136,14 @@ export function ContextTabs({
     () => repos.filter((r) => !openRepos.includes(r.name)),
     [repos, openRepos],
   );
+  const clampedPickerHighlight =
+    available.length === 0 ? 0 : Math.min(pickerHighlight, available.length - 1);
+
+  useEffect(() => {
+    setPickerHighlight((current) =>
+      available.length === 0 ? 0 : Math.min(current, available.length - 1),
+    );
+  }, [available.length]);
 
   const activeId =
     activeRunId && pinnedRuns.includes(activeRunId)
@@ -186,12 +194,15 @@ export function ContextTabs({
     listboxRef.current
       ?.querySelector<HTMLElement>('[role="option"][aria-selected="true"]')
       ?.scrollIntoView({ block: "nearest" });
-  }, [picker, pickerHighlight]);
+  }, [picker, clampedPickerHighlight]);
 
   useEffect(() => {
     if (!picker) return;
     function onDoc(e: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) setPicker(false);
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPicker(false);
+        plusRef.current?.focus();
+      }
     }
     function onKey(e: KeyboardEvent) {
       if (e.key !== "Escape") return;
@@ -253,7 +264,10 @@ export function ContextTabs({
 
   const handlePickerKeyDown = (e: React.KeyboardEvent) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
-    if (e.key === "ArrowDown") {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      closePicker(true);
+    } else if (e.key === "ArrowDown") {
       e.preventDefault();
       if (available.length === 0) return;
       setPickerHighlight((i) => (i + 1) % available.length);
@@ -270,7 +284,7 @@ export function ContextTabs({
       setPickerHighlight(available.length - 1);
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      const choice = available[pickerHighlight];
+      const choice = available[clampedPickerHighlight];
       if (choice) selectPickerRepo(choice.name);
     }
   };
@@ -451,7 +465,9 @@ export function ContextTabs({
             tabIndex={0}
             aria-label="Factory repos"
             aria-activedescendant={
-              available[pickerHighlight] ? `repo-picker-opt-${pickerHighlight}` : undefined
+              available[clampedPickerHighlight]
+                ? `repo-picker-opt-${clampedPickerHighlight}`
+                : undefined
             }
             className="absolute top-full right-0 z-30 mt-1 max-h-72 min-w-48 overflow-auto rounded-md border border-(--border) bg-(--surface-1) py-1 shadow-lg outline-none"
             onKeyDown={handlePickerKeyDown}
@@ -470,9 +486,9 @@ export function ContextTabs({
                   type="button"
                   role="option"
                   tabIndex={-1}
-                  aria-selected={i === pickerHighlight}
+                  aria-selected={i === clampedPickerHighlight}
                   className={`block w-full px-3 py-1.5 text-left text-[12px] text-(--text) ${
-                    i === pickerHighlight
+                    i === clampedPickerHighlight
                       ? "bg-(--surface-2) ring-1 ring-inset ring-(--accent)"
                       : "hover:bg-(--surface-2)"
                   }`}


### PR DESCRIPTION
## Summary
- clamp the active repo-picker option whenever the available list shrinks
- restore focus to the + trigger after outside-click, Tab, or Shift+Tab closure
- add regressions for dynamic list changes and keyboard/mouse close paths

## Verification
- `bun test event-runtime/web/src/components/ContextTabs.test.tsx && bun build/emit.mjs --check`
- `cd event-runtime/web && bun run build`

UX critique: required — NOT-ASSESSED, browser-driving tooling was unavailable to the critic; automated focus and keyboard regressions pass.

Fixes WM-191