### PR TITLE
feat(event-runtime): report unmatched placement runs

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -27,7 +27,7 @@ import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { parseCadence, proposalsPilingUp, scheduleView } from "./schedules.mjs";
-import { listWorkers, loadWorkerPolicy, stalledWorkers } from "./workers.mjs";
+import { listWorkers, loadWorkerPolicy, satisfiesPlacement, stalledWorkers } from "./workers.mjs";
 
 /**
  * Repo names a run or event actually names — optional spec input, not a
@@ -255,6 +255,18 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
 
   const fleet = workerCapacityView(db, nowMs, { workerPolicy, runDir: workerRunDir });
   const workers = fleet.workers;
+  const liveWorkers = workers.filter((worker) => worker.state !== "stopped" && !worker.stale);
+  const unmatchedPlacementRuns = db
+    .query(`SELECT run_id, spec_json FROM runs WHERE state = 'QUEUED' ORDER BY created_at, rowid`)
+    .all()
+    .flatMap((row) => {
+      const placement = JSON.parse(row.spec_json).placement;
+      // Unconstrained runs are covered by noWorkers; this anomaly explains why
+      // an apparently healthy fleet still cannot claim a constrained run.
+      if (!placement || Object.keys(placement).length === 0) return [];
+      if (liveWorkers.some((worker) => satisfiesPlacement(worker.labels, placement))) return [];
+      return [{ runId: row.run_id, placement }];
+    });
   const schedules = scheduleView(db, registry, { now: nowMs });
   const store = getStoreStats
     ? getStoreStats(nowMs)
@@ -305,7 +317,8 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
       stoppedSchedules: schedules
         .filter((s) => s.stopped || s.error)
         .map((s) => ({ loop: s.loop, every: s.every, lastSlot: s.lastSlot, intervalsLate: s.intervalsLate, error: s.error })),
-      noWorkers: workers.filter((w) => w.state !== "stopped" && !w.stale).length === 0 && (runs.byState.QUEUED ?? 0) > 0,
+      unmatchedPlacementRuns,
+      noWorkers: liveWorkers.length === 0 && (runs.byState.QUEUED ?? 0) > 0,
       // Two or more open proposals on one run: cancel fail-closes and leaves
       // them open (OPS-245). Unreachable on the TTL replan path.
       ambiguousOpenProposals: ambiguousOpenProposalRuns(db),

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1751,9 +1751,11 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
         expect(typeof item.count).toBe("number");
       }
 
-      // noWorkers is boolean false because live workers exist
+      // noWorkers is boolean false because live workers exist; the queued run
+      // has no placement requirements, so it is not a placement anomaly.
       expect(typeof status.anomalies.noWorkers).toBe("boolean");
       expect(status.anomalies.noWorkers).toBe(false);
+      expect(status.anomalies.unmatchedPlacementRuns).toEqual([]);
 
       // StoppedSchedule keys match if present
       const stoppedSchedBlock = extractInterfaceBlock(typesSrc, "StoppedSchedule");
@@ -1894,6 +1896,49 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
       const status2 = await s.client.status();
       expect(status2.workers.live).toBe(1);
       expect(status2.anomalies.noWorkers).toBe(false);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("GET /status identifies queued runs whose placement matches no active, non-stale worker", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-unmatched-placement-contract-"));
+    const db = openDb(path.join(dir, "runtime.db"));
+    const nowMs = 100000000;
+    const atIso = new Date(nowMs).toISOString();
+    const queue = (runId, placement) => {
+      db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_hash, spec_json, state, attempts, created_at, updated_at)
+         VALUES (?, ?, "dummy", ?, "QUEUED", 1, ?, ?)`,
+      ).run(runId, `idem-${runId}`, JSON.stringify({ placement }), atIso, atIso);
+    };
+
+    queue("run-matched", { node: "lab" });
+    queue("run-unmatched", { node: "gpu", class: "heavy" });
+    queue("run-unconstrained", undefined);
+
+    registerWorker(db, { workerId: "w-live-lab", labels: { node: "lab" }, adapters: ["claude"], now: nowMs });
+    registerWorker(db, { workerId: "w-stale-gpu", labels: { node: "gpu", class: "heavy" }, adapters: ["claude"], now: nowMs - 120000 });
+    registerWorker(db, { workerId: "w-stopped-gpu", labels: { node: "gpu", class: "heavy" }, adapters: ["claude"], now: nowMs });
+    deregisterWorker(db, "w-stopped-gpu", { now: nowMs });
+
+    const s = await makeServer({ db, secret: "sec", now: () => nowMs });
+    try {
+      const status1 = await s.client.status();
+      expect(status1.workers.live).toBe(1);
+      expect(status1.anomalies.noWorkers).toBe(false);
+      expect(status1.anomalies.unmatchedPlacementRuns).toEqual([
+        { runId: "run-unmatched", placement: { node: "gpu", class: "heavy" } },
+      ]);
+
+      registerWorker(db, {
+        workerId: "w-live-gpu",
+        labels: { node: "gpu", class: "heavy" },
+        adapters: ["claude"],
+        now: nowMs,
+      });
+      const status2 = await s.client.status();
+      expect(status2.anomalies.unmatchedPlacementRuns).toEqual([]);
     } finally {
       s.close();
     }

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -390,6 +390,12 @@ export interface ProposalPilingUp {
   threshold: number;
 }
 
+/** A queued run whose placement requirements match no live worker. */
+export interface UnmatchedPlacementRun {
+  runId: string;
+  placement: Record<string, unknown>;
+}
+
 export interface StatusView {
   env: EnvIdentity;
   events: Record<string, number>;
@@ -409,6 +415,8 @@ export interface StatusView {
     deadLettered: { source: string; eventId: string; lastError: string | null }[];
     stalledWorkers: StalledWorker[];
     stoppedSchedules?: StoppedSchedule[];
+    /** Placement-constrained queued runs that no active, non-stale worker can claim. */
+    unmatchedPlacementRuns?: UnmatchedPlacementRun[];
     /** Queued runs with no live worker to claim them. */
     noWorkers: boolean;
     ambiguousOpenProposals: { runId: string; count: number }[];

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -328,6 +328,16 @@ export function buildAnomalyRows(
       ],
     });
   }
+  for (const run of anomalies.unmatchedPlacementRuns ?? []) {
+    rows.push({
+      kind: "capacity",
+      text: `queued run ${run.runId} requires placement ${JSON.stringify(run.placement)}, but no live worker matches`,
+      links: [
+        { label: "View run", go: () => callbacks.onJumpRun(run.runId) },
+        { label: "View workers", go: () => callbacks.onNavigate("workers") },
+      ],
+    });
+  }
   if (anomalies.noWorkers && (s?.runs.byState?.QUEUED ?? 0) > 0) {
     rows.push({
       kind: "capacity",


### PR DESCRIPTION
## Summary
- detect placement-constrained QUEUED runs that match no active, non-stale worker
- expose run IDs and placement requirements in `GET /status`
- render linked capacity anomalies in the Overview doctor panel

## Verification
- `bun test event-runtime && bun --cwd event-runtime/web build` — pass (1284 tests, TypeScript check, Vite production build)

## UX critique
- required — NOT-ASSESSED: browser-driving tooling was unavailable, so the anomaly row and its View run/View workers actions could not be exercised

Fixes OPS-273