### PR TITLE
Share modal tab-cycle helper (WM-197)

### DIFF
--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -6,32 +6,7 @@ import { GO_CHORD_MS, goPrefix, goSequence } from "../goSequence";
 import { keyGuard, modal } from "../hooks";
 import { useContextActions } from "../palette";
 import { health } from "../workerHealth";
-
-const FOCUSABLE =
-  "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
-
-function tabCycle(root: HTMLElement, e: KeyboardEvent) {
-  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
-    (el) => el.offsetParent !== null || el === document.activeElement,
-  );
-  if (nodes.length === 0) {
-    e.preventDefault();
-    root.focus();
-    return;
-  }
-  const first = nodes[0];
-  const last = nodes[nodes.length - 1];
-  const active = document.activeElement;
-  if (e.shiftKey) {
-    if (active === first || !root.contains(active)) {
-      e.preventDefault();
-      last.focus();
-    }
-  } else if (active === last || !root.contains(active)) {
-    e.preventDefault();
-    first.focus();
-  }
-}
+import { tabCycle } from "./ui";
 
 export interface PaletteAction {
   label: string;

--- a/event-runtime/web/src/components/Dialog.test.tsx
+++ b/event-runtime/web/src/components/Dialog.test.tsx
@@ -118,6 +118,27 @@ describe("Dialog", () => {
     expect(document.activeElement).toBe(chip);
   });
 
+  test("Tab cycle ignores a hidden control after the last visible control", () => {
+    const r = render(<OpenDialog onClose={() => {}} />);
+    const panel = r.getByRole("dialog");
+    const envelope = r.getByTestId("envelope");
+    const chip = r.getByTestId("chip");
+    const hidden = document.createElement("button");
+    hidden.type = "button";
+    hidden.hidden = true;
+    panel.appendChild(hidden);
+
+    // happy-dom has no layout engine, so offsetParent must be stamped to make
+    // this browser visibility branch falsifiable rather than accidentally green.
+    Object.defineProperty(envelope, "offsetParent", { configurable: true, value: panel });
+    Object.defineProperty(chip, "offsetParent", { configurable: true, value: panel });
+    Object.defineProperty(hidden, "offsetParent", { configurable: true, value: null });
+
+    chip.focus();
+    expect(fireEvent.keyDown(window, { key: "Tab" })).toBe(false);
+    expect(document.activeElement).toBe(envelope);
+  });
+
   test("overlay backdrop click calls current onClose after parent re-render and ignores inner clicks", () => {
     const closed: string[] = [];
     function Parent({ tag }: { tag: string }) {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1298,7 +1298,8 @@ export function Button({
 const FOCUSABLE =
   "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
-function tabCycle(root: HTMLElement, e: KeyboardEvent) {
+/** Keep Tab focus inside a modal while ignoring controls hidden by layout. */
+export function tabCycle(root: HTMLElement, e: KeyboardEvent) {
   const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
     (el) => el.offsetParent !== null || el === document.activeElement,
   );


### PR DESCRIPTION
## Summary
- remove CommandPalette's duplicate focusable selector and tab-cycle implementation
- export and reuse the Dialog tab-cycle helper
- make hidden-control filtering falsifiable under happy-dom by stamping offsetParent in the regression test

## Verification
- `cd event-runtime/web && bun test` — 548 pass, 0 fail
- negative check: removing the visibility filter makes the new hidden-control test fail

UX critique: skipped — internal deduplication preserves the existing modal interaction.

Fixes WM-197