### PR TITLE
fix(web): preserve dialog focus return from palette

### DIFF
--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -2,8 +2,10 @@ import "../test-dom";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
 import { modal } from "../hooks";
 import { CommandPalette, type PaletteAction } from "./CommandPalette";
+import { Dialog } from "./ui";
 
 const ACTIONS: PaletteAction[] = [
   { label: "Overview", hint: "g g", group: "Go", run: () => {} },
@@ -40,6 +42,38 @@ function renderPalette(actions: PaletteAction[] = ACTIONS) {
         onJumpWorker={NOOP}
       />
     </QueryClientProvider>,
+  );
+}
+
+function PaletteDialogHost() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: { queries: { retry: false, refetchInterval: false } },
+      }),
+  );
+  return (
+    <QueryClientProvider client={client}>
+      <button type="button" data-testid="dialog-opener">
+        nav
+      </button>
+      <CommandPalette
+        actions={[{ label: "Keyboard shortcuts", run: () => setDialogOpen(true) }]}
+        onJumpRun={NOOP}
+        onJumpProposal={NOOP}
+        onJumpEvent={NOOP}
+        onJumpAgent={NOOP}
+        onJumpWorker={NOOP}
+      />
+      {dialogOpen ? (
+        <Dialog title="Keyboard shortcuts" onClose={() => setDialogOpen(false)}>
+          <button type="button" autoFocus>
+            Done
+          </button>
+        </Dialog>
+      ) : null}
+    </QueryClientProvider>
   );
 }
 
@@ -168,6 +202,22 @@ describe("CommandPalette", () => {
     fireEvent.click(r.getByText("Focus filter"));
     expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
     expect(document.activeElement).toBe(r.getByTestId("view-filter"));
+  });
+
+  test("a dialog opened by a palette action returns focus to the palette opener", () => {
+    const r = render(<PaletteDialogHost />);
+    const opener = r.getByTestId("dialog-opener");
+    opener.focus();
+    chordK();
+    expect(document.activeElement).toBe(r.getByPlaceholderText("Type a command…"));
+
+    fireEvent.click(r.getByText("Keyboard shortcuts"));
+    expect(r.queryByRole("dialog", { name: "Command palette" }) == null).toBe(true);
+    expect(r.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(r.queryByRole("dialog", { name: "Keyboard shortcuts" }) == null).toBe(true);
+    expect(document.activeElement).toBe(opener);
   });
 
   test("search input uses an accent focus border and no outline", () => {

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -3,7 +3,7 @@ import { Command } from "cmdk";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import { GO_CHORD_MS, goPrefix, goSequence } from "../goSequence";
-import { keyGuard, modal } from "../hooks";
+import { keyGuard, modal, registerFocusReturnScope } from "../hooks";
 import { useContextActions } from "../palette";
 import { health } from "../workerHealth";
 
@@ -109,11 +109,15 @@ export function CommandPalette({
     };
     window.addEventListener("keydown", onKey);
     const root = panelRef.current;
+    const unregisterFocusReturn = root
+      ? registerFocusReturnScope(root, previousFocusRef.current)
+      : () => {};
     const input = root?.querySelector<HTMLElement>("input");
     (input ?? root)?.focus();
     return () => {
       modal.depth -= 1;
       window.removeEventListener("keydown", onKey);
+      unregisterFocusReturn();
       const active = document.activeElement;
       const claimed =
         active instanceof HTMLElement && active !== document.body && active.isConnected;

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -256,14 +256,43 @@ export function useNow(): number {
 }
 
 /**
+ * A transient modal can name the live element that should stand in for focus
+ * captured inside it. This matters when selecting a command closes the palette
+ * and mounts another dialog in the same commit: during render the palette input
+ * is still active, but it is about to be detached.
+ */
+const focusReturnScopes = new WeakMap<HTMLElement, HTMLElement>();
+
+export function registerFocusReturnScope(
+  root: HTMLElement,
+  returnTarget: HTMLElement | null,
+): () => void {
+  if (returnTarget) focusReturnScopes.set(root, returnTarget);
+  return () => focusReturnScopes.delete(root);
+}
+
+function resolveFocusReturn(active: HTMLElement): HTMLElement {
+  let node: HTMLElement | null = active;
+  while (node) {
+    const target = focusReturnScopes.get(node);
+    if (target) return target;
+    node = node.parentElement;
+  }
+  return active;
+}
+
+/**
  * Preserves the active element on mount and restores keyboard focus on unmount.
- * Handles edge cases cleanly when the triggering element is no longer in DOM.
+ * An enclosing focus-return scope may substitute a live opener for a transient
+ * active element. Handles edge cases when the target is no longer in the DOM.
  */
 export function useFocusReturn(): void {
   const previousRef = useRef<HTMLElement | null>(null);
   if (previousRef.current === null && typeof document !== "undefined") {
     previousRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      document.activeElement instanceof HTMLElement
+        ? resolveFocusReturn(document.activeElement)
+        : null;
   }
   useEffect(() => {
     const previous = previousRef.current;


### PR DESCRIPTION
## Summary
- register the command palette as an explicit focus-return scope tied to its live opener
- let dialogs opened during palette dismissal resolve focus return through that scope
- cover the palette → dialog → Escape journey without changing ordinary dialog behavior

## Verification
- `cd event-runtime/web && bun test` — 548 pass, 0 fail

## UX critique
- required — NOT-ASSESSED: browser tooling could not start because the configured Chrome CDP script was missing; the focus journey could not be driven visually

Fixes WM-196