### PR TITLE
feat(event-runtime-web): filter worker tile jumps (OPS-309)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -23,7 +23,7 @@ import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
 import { RunFull } from "./views/RunFull";
 import { Runs } from "./views/Runs";
-import { Workers } from "./views/Workers";
+import { Workers, isWorkerHealthFilter, type WorkerHealthFilter } from "./views/Workers";
 import { NAV, type NavKey } from "./nav";
 
 type NavBadge = {
@@ -113,6 +113,8 @@ export function App() {
   const focusAgentRef = view === "agents" ? (route[1] ?? null) : null;
   const focusScheduleLoop = view === "schedules" ? (route[1] ?? null) : null;
   const focusWorkerId = view === "workers" ? (route[1] ?? null) : null;
+  const workerHealthFromHash = view === "workers" ? hashSearch(window.location.hash).get("health") : null;
+  const focusWorkerHealth = isWorkerHealthFilter(workerHealthFromHash) ? workerHealthFromHash : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
   const hashEvent: EventFocus | null =
     view === "events" && route[1] && route[2]
@@ -167,7 +169,12 @@ export function App() {
     navigate("events");
   };
   const jumpToAgent = (ref: string) => navigate(hashPath("agents", ref));
-  const jumpToWorker = (id: string) => navigate(hashPath("workers", id));
+  const workerHash = (id: string | null, health: WorkerHealthFilter | null) => {
+    const path = hashPath("workers", id);
+    return health ? `${path}?health=${encodeURIComponent(health)}` : path;
+  };
+  const jumpToWorker = (id: string) => navigate(workerHash(id, null));
+  const jumpToWorkers = (health: WorkerHealthFilter) => navigate(workerHash(null, health));
   const jumpToProject = (name: string) => navigate(hashPath("projects", name));
   const jumpToGraph = (nodeId?: string) => navigate(hashPath("graph", nodeId));
 
@@ -547,7 +554,9 @@ export function App() {
             <Workers
               context={context}
               focusWorkerId={focusWorkerId}
-              onSelectWorker={(id) => navigate(hashPath("workers", id))}
+              onSelectWorker={(id) => navigate(workerHash(id, focusWorkerHealth))}
+              focusHealth={focusWorkerHealth}
+              onFocusHealthChange={(health) => navigate(workerHash(null, health))}
             />
           ) : view === "events" ? (
             <Events
@@ -578,6 +587,7 @@ export function App() {
               onJumpProposal={jumpToProposal}
               onJumpEvents={jumpToEvents}
               onJumpRuns={jumpToRuns}
+              onJumpWorkers={jumpToWorkers}
               onNavigate={navigate}
               onJumpExpired={() => {
                 setFocusExpired(true);

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -23,8 +23,11 @@ import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
 import { RunFull } from "./views/RunFull";
 import { Runs } from "./views/Runs";
-import { Workers, isWorkerHealthFilter, type WorkerHealthFilter } from "./views/Workers";
 import { NAV, type NavKey } from "./nav";
+
+type WorkerHealthFilter = "live" | "busy" | "stale";
+const isWorkerHealthFilter = (value: string | null): value is WorkerHealthFilter =>
+  value === "live" || value === "busy" || value === "stale";
 
 type NavBadge = {
   count: number;
@@ -37,6 +40,7 @@ const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph
 const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
 const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
 const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
+const Workers = lazy(() => import("./views/Workers").then((m) => ({ default: m.Workers })));
 
 export function App() {
   const [route, navigateRaw] = useHashRoute();
@@ -551,13 +555,15 @@ export function App() {
               />
             </Suspense>
           ) : view === "workers" ? (
-            <Workers
-              context={context}
-              focusWorkerId={focusWorkerId}
-              onSelectWorker={(id) => navigate(workerHash(id, focusWorkerHealth))}
-              focusHealth={focusWorkerHealth}
-              onFocusHealthChange={(health) => navigate(workerHash(null, health))}
-            />
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading workers…</div>}>
+              <Workers
+                context={context}
+                focusWorkerId={focusWorkerId}
+                onSelectWorker={(id) => navigate(workerHash(id, focusWorkerHealth))}
+                focusHealth={focusWorkerHealth}
+                onFocusHealthChange={(health) => navigate(workerHash(null, health))}
+              />
+            </Suspense>
           ) : view === "events" ? (
             <Events
               connected={connected}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -5,6 +5,7 @@ import { useNow, useRequeuePoll } from "../hooks";
 import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
+import type { WorkerHealthFilter } from "./Workers";
 import {
   Ago,
   Button,
@@ -475,6 +476,7 @@ export function Overview({
   onJumpProposal,
   onJumpEvents,
   onJumpRuns,
+  onJumpWorkers,
   onNavigate,
   onJumpExpired: _onJumpExpired,
   onJumpGraph: _onJumpGraph,
@@ -486,6 +488,7 @@ export function Overview({
   onJumpProposal: (id: string) => void;
   onJumpEvents: (focus: EventFocus) => void;
   onJumpRuns: (state?: string) => void;
+  onJumpWorkers?: (health: WorkerHealthFilter) => void;
   onNavigate: (path: string) => void;
   onJumpExpired?: () => void;
   onJumpGraph?: () => void;
@@ -656,6 +659,10 @@ export function Overview({
         classes: [],
       })
     : null;
+  const jumpToWorkerHealth = (health: WorkerHealthFilter) => {
+    if (onJumpWorkers) onJumpWorkers(health);
+    else onNavigate("workers");
+  };
 
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
@@ -978,7 +985,9 @@ export function Overview({
                   { key: "idle", label: "idle", value: idleWorkers, hue: "var(--hue-ok)" },
                   { key: "stale", label: "stale", value: s.workers.stale, hue: "var(--hue-warn)" },
                 ]}
-                onSegment={() => onNavigate("workers")}
+                onSegment={(status) =>
+                  jumpToWorkerHealth(status === "busy" || status === "stale" ? status : "live")
+                }
               />
               <div className="mt-2 grid grid-cols-2 gap-1.5 sm:flex sm:flex-wrap">
                 <StatLegendItem
@@ -986,7 +995,7 @@ export function Overview({
                   label="workers · live"
                   value={s.workers.live}
                   hue={s.workers.live > 0 ? "var(--hue-ok)" : undefined}
-                  onClick={() => onNavigate("workers")}
+                  onClick={() => jumpToWorkerHealth("live")}
                   factoryWide={factoryWide}
                   total={s.workers.live + s.workers.stale}
                 />
@@ -995,7 +1004,7 @@ export function Overview({
                   label="workers · busy"
                   value={s.workers.busy}
                   hue={s.workers.busy > 0 ? "var(--hue-info)" : undefined}
-                  onClick={() => onNavigate("workers")}
+                  onClick={() => jumpToWorkerHealth("busy")}
                   factoryWide={factoryWide}
                   total={s.workers.live + s.workers.stale}
                 />
@@ -1005,7 +1014,7 @@ export function Overview({
                   value={s.workers.stale}
                   hue={s.workers.stale > 0 ? "var(--hue-warn)" : undefined}
                   attention={s.workers.stale > 0}
-                  onClick={() => onNavigate("workers")}
+                  onClick={() => jumpToWorkerHealth("stale")}
                   factoryWide={factoryWide}
                   total={s.workers.live + s.workers.stale}
                 />

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -50,6 +50,17 @@ import { health, WORKER_HUES } from "../workerHealth";
 export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
 export type WorkerTab = (typeof WORKER_TABS)[number];
 export type WorkerDisplayState = ReturnType<typeof health> | "draining";
+export const WORKER_HEALTH_FILTERS = ["live", "busy", "stale"] as const;
+export type WorkerHealthFilter = (typeof WORKER_HEALTH_FILTERS)[number];
+
+export const isWorkerHealthFilter = (value: string | null): value is WorkerHealthFilter =>
+  WORKER_HEALTH_FILTERS.some((filter) => filter === value);
+
+/** Overview health counts are disjoint: live excludes stale and stopped workers. */
+export const workerMatchesHealth = (worker: Worker, filter: WorkerHealthFilter): boolean => {
+  const state = health(worker);
+  return filter === "live" ? state === "idle" || state === "busy" : state === filter;
+};
 
 const WORKER_STATE_HUES: Record<WorkerDisplayState, string> = {
   ...WORKER_HUES,
@@ -362,10 +373,14 @@ export function Workers({
   context,
   focusWorkerId,
   onSelectWorker,
+  focusHealth = null,
+  onFocusHealthChange = () => {},
 }: {
   context: OperatorContext;
   focusWorkerId: string | null;
   onSelectWorker: (id: string | null) => void;
+  focusHealth?: WorkerHealthFilter | null;
+  onFocusHealthChange?: (health: WorkerHealthFilter | null) => void;
 }) {
   const now = useNow();
   const query = useQuery({ queryKey: ["workers"], queryFn: api.workers, refetchInterval: 2000 });
@@ -409,15 +424,28 @@ export function Workers({
   );
 
   const [filter, setFilter] = useState("");
+
+  // A jump from Overview is explicit: pin the lifecycle tab that contains all
+  // three supported health states and remove any stale text query.
+  useEffect(() => {
+    if (!focusHealth) return;
+    setTabChoice("LIVE");
+    setFilter("");
+  }, [focusHealth]);
+
+  const byHealth = useMemo(
+    () => (focusHealth ? byTab.filter((worker) => workerMatchesHealth(worker, focusHealth)) : byTab),
+    [byTab, focusHealth],
+  );
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return byTab;
-    return byTab.filter((w) =>
+    if (!q) return byHealth;
+    return byHealth.filter((w) =>
       [w.workerId, w.host, String(w.pid), workerDisplayState(w), labelText(w.labels), w.adapters.join(","), w.currentRun].some(
         (v) => (v ?? "").toLowerCase().includes(q),
       ),
     );
-  }, [byTab, filter]);
+  }, [byHealth, filter]);
 
   // Display options (OPS-493): partition into sections, order inside them,
   // and feed keyboard navigation only the rows of open sections.
@@ -474,6 +502,7 @@ export function Workers({
     onClose: () => {
       if (selectedId) onSelectWorker(null);
       else if (filter) setFilter("");
+      else if (focusHealth) onFocusHealthChange(null);
     },
     keys: {
       c: () => {
@@ -526,7 +555,10 @@ export function Workers({
                       type="button"
                       role="tab"
                       aria-selected={tab === t}
-                      onClick={() => setTabChoice(t)}
+                      onClick={() => {
+                        setTabChoice(t);
+                        if (focusHealth) onFocusHealthChange(null);
+                      }}
                       title={t === "LIVE" ? "idle, busy, or stale" : t === "STOPPED" ? "cleanly stopped — history" : undefined}
                       className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
                         tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
@@ -546,9 +578,26 @@ export function Workers({
                   config={WORKERS_DISPLAY}
                   state={display}
                   onChange={setDisplay}
-                  rows={byTab}
+                  rows={byHealth}
                 />
               </span>
+              <label className="flex items-center gap-1.5 text-[11px] text-(--text-faint)">
+                <span>Health</span>
+                <select
+                  aria-label="Filter workers by health"
+                  value={focusHealth ?? ""}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    onFocusHealthChange(isWorkerHealthFilter(value) ? value : null);
+                  }}
+                  className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text)"
+                >
+                  <option value="">Any</option>
+                  <option value="live">Live</option>
+                  <option value="busy">Busy</option>
+                  <option value="stale">Stale</option>
+                </select>
+              </label>
               <FilterInput
                 value={filter}
                 onChange={setFilter}
@@ -697,8 +746,15 @@ export function Workers({
               <ListEmpty
                 colSpan={cols.length}
                 query={query}
-                filtered={byTab.length > 0}
-                onClear={filter.trim() ? () => setFilter("") : undefined}
+                filtered={Boolean(focusHealth || (filter.trim() && byTab.length > 0))}
+                onClear={
+                  focusHealth || filter.trim()
+                    ? () => {
+                        setFilter("");
+                        if (focusHealth) onFocusHealthChange(null);
+                      }
+                    : undefined
+                }
                 noun="workers"
                 empty="No workers have registered — start one with bun event-runtime/cli.mjs work"
               />


### PR DESCRIPTION
## Summary
- route Overview worker live/busy/stale tiles through a typed Workers jump handler
- persist the selected worker health in the hash query and preserve it while opening worker details
- expose an accessible Health selector and clear behavior in the Workers list
- lazy-load the Workers view so the new flow stays below the production entry-chunk budget

## Verification
- `bun test event-runtime && cd event-runtime/web && bun run build` — pass (1,282 tests; TypeScript and Vite build green; entry chunk 521.52 kB locally)

## UX critique
- required — NOT-ASSESSED: the critic's Chrome CDP driver could not start, so the interaction and narrow viewport could not be browser-driven; code review returned SHIP with no findings

Fixes OPS-309
