### PR TITLE
Fix stacked-dialog command palette shortcut

### DIFF
--- a/event-runtime/web/src/components/CommandPalette.test.tsx
+++ b/event-runtime/web/src/components/CommandPalette.test.tsx
@@ -93,6 +93,15 @@ describe("CommandPalette", () => {
     expect(modal.depth).toBe(0);
   });
 
+  test("⌘K keeps the palette open while another dialog is stacked above it", () => {
+    const r = renderPalette();
+    chordK();
+    modal.depth += 1;
+    chordK();
+    expect(r.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
+    expect(modal.depth).toBe(2);
+  });
+
   test("opening focuses the search input", () => {
     const r = renderPalette();
     chordK();

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -66,7 +66,7 @@ export function CommandPalette({
       if (e.key !== "k" || !(e.metaKey || e.ctrlKey)) return;
       e.preventDefault();
       setOpen((o) => {
-        if (o) return false;
+        if (o) return modal.depth > 1;
         if (modal.depth > 0) return false;
         return true;
       });


### PR DESCRIPTION
## Summary
- keep the command palette open when another dialog is stacked above it
- preserve ⌘K toggle-close when the palette is the top modal
- cover both modal-depth states with component tests

## Verification
- `cd event-runtime/web && bun test` — 549 pass, 0 fail

## UX critique
- required — NOT-ASSESSED; browser tooling could not start, so the interaction could not be driven visually

Fixes WM-198