### PR TITLE
fix(web): wait for proposals before missing-node warning (WM-181)

### DIFF
--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -222,7 +222,7 @@ export function Graph({
   );
 
   const selected: GraphNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
-  const graphLoaded = Boolean(graph) && !registry.isPending;
+  const graphLoaded = Boolean(graph) && !registry.isPending && !proposalsQ.isPending;
   const staleFocus = missingFocusNode(graph?.nodes, focusNodeId, graphLoaded);
   const agentDef =
     selected?.kind === "agent"


### PR DESCRIPTION
## Summary
- keep the Graph loading gate closed until both registry and proposal data settle
- prevent proposal ghost-node deep links from flashing a stale “Node not found” warning

## Verification
- `bun test event-runtime/web/src/graph/search.test.ts && bun build/emit.mjs --check` — pass (15 tests; generated files match)

## UX critique
- required — NOT-ASSESSED: critic session had no browser/simulator driving tools

Fixes WM-181