### PR TITLE
Center full-page run trace on wide viewports (WM-194)

### DIFF
--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -32,6 +32,30 @@ function renderRunFull(runId: string) {
   );
 }
 
+describe("RunFull layout (WM-194)", () => {
+  test("centers the capped trace container on wide viewports", async () => {
+    const runId = "run_centered_trace";
+    const detail = createRunDetailFixture({ run: { runId, state: "COMPLETED" } as RunDetail["run"] });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({ runs: [createRunListItemFixture({ runId, state: "COMPLETED" })] }),
+      },
+      async () => {
+        const { container } = renderRunFull(runId);
+
+        await waitFor(() => {
+          const traceContainer = container.querySelector("main > div");
+          expect(traceContainer).toBeTruthy();
+          expect(traceContainer!.classList.contains("xl:mx-auto")).toBe(true);
+          expect(traceContainer!.classList.contains("xl:max-w-[900px]")).toBe(true);
+          expect(traceContainer!.classList.contains("p-6")).toBe(true);
+        });
+      },
+    );
+  });
+});
+
 describe("RunFull cancel dialog (WM-144)", () => {
   test("a simulated 409 on cancel shows a persistent inline message in the dialog", async () => {
     const runId = "run_cancel_race";

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -234,7 +234,7 @@ export function RunFull({
           {/* Main column: the trace, at a readable measure — the point of the
               page — scrolling on its own so the sidebar never moves with it. */}
           <main className="min-w-0 flex-1 overflow-y-auto">
-            <div className="p-6 xl:max-w-[900px]">
+            <div className="p-6 xl:mx-auto xl:max-w-[900px]">
               {/* The failure first (WM-93) — renders nothing for other states. */}
               <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} className="mb-6" />
               <RunTrace key={runId} runId={runId} state={d.run.state} variant="full" />


### PR DESCRIPTION
## Summary
- center the capped full-page trace container within its flexible main column at `xl` widths
- preserve the existing 900px readability cap and padding
- add regression coverage for centering, max-width, and padding classes

## Verification
- `bun test event-runtime/web/src/views/RunFull.test.tsx && bun build/emit.mjs --check` — pass (3 tests; 90 generated files match)

UX critique: skipped — isolated styling adjustment with no changed interaction or user-completable flow.

Fixes WM-194