### PR TITLE
perf(web): split secondary dashboard surfaces

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -15,16 +15,11 @@ import { keyGuard, THEMES, useHashRoute, useTheme, type Theme } from "./hooks";
 import { goPrefixActive } from "./goSequence";
 import type { EventFocus } from "./types";
 import { CommandPalette, useGoSequences, type PaletteAction } from "./components/CommandPalette";
-import { InjectDialog } from "./components/InjectDialog";
-import { ShortcutsDialog } from "./components/ShortcutsDialog";
 import { ToastContainer, copyLink, copyText } from "./components/ui";
-import { Agents } from "./views/Agents";
 import type { ArtifactFilters } from "./views/Artifacts";
 import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
-import { RunFull } from "./views/RunFull";
 import { Runs } from "./views/Runs";
-import { Workers } from "./views/Workers";
 import { NAV, type NavKey } from "./nav";
 
 type NavBadge = {
@@ -39,6 +34,15 @@ const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph
 const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
 const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
 const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
+const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
+const RunFull = lazy(() => import("./views/RunFull").then((m) => ({ default: m.RunFull })));
+const Workers = lazy(() => import("./views/Workers").then((m) => ({ default: m.Workers })));
+const ShortcutsDialog = lazy(() =>
+  import("./components/ShortcutsDialog").then((m) => ({ default: m.ShortcutsDialog })),
+);
+const InjectDialog = lazy(() =>
+  import("./components/InjectDialog").then((m) => ({ default: m.InjectDialog })),
+);
 
 export function App() {
   const [route, navigateRaw] = useHashRoute();
@@ -516,13 +520,15 @@ export function App() {
               />
             </Suspense>
           ) : view === "run" && fullRunId ? (
-            <RunFull
-              runId={fullRunId}
-              connected={connected}
-              onBack={() => navigate(hashPath("runs", fullRunId))}
-              onJumpAgent={jumpToAgent}
-              onJumpEvent={jumpToEvent}
-            />
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading run…</div>}>
+              <RunFull
+                runId={fullRunId}
+                connected={connected}
+                onBack={() => navigate(hashPath("runs", fullRunId))}
+                onJumpAgent={jumpToAgent}
+                onJumpEvent={jumpToEvent}
+              />
+            </Suspense>
           ) : view === "runs" || view === "run" ? (
             <Runs
               connected={connected}
@@ -555,11 +561,13 @@ export function App() {
               />
             </Suspense>
           ) : view === "agents" ? (
-            <Agents
-              context={context}
-              focusAgentRef={focusAgentRef}
-              onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
-            />
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading agents…</div>}>
+              <Agents
+                context={context}
+                focusAgentRef={focusAgentRef}
+                onSelectAgent={(ref) => navigate(hashPath("agents", ref))}
+              />
+            </Suspense>
           ) : view === "schedules" ? (
             <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading schedules…</div>}>
               <Schedules
@@ -575,11 +583,13 @@ export function App() {
               />
             </Suspense>
           ) : view === "workers" ? (
-            <Workers
-              context={context}
-              focusWorkerId={focusWorkerId}
-              onSelectWorker={(id) => navigate(hashPath("workers", id))}
-            />
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading workers…</div>}>
+              <Workers
+                context={context}
+                focusWorkerId={focusWorkerId}
+                onSelectWorker={(id) => navigate(hashPath("workers", id))}
+              />
+            </Suspense>
           ) : view === "artifacts" ? (
             <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading artifacts…</div>}>
               <Artifacts
@@ -695,20 +705,26 @@ export function App() {
         onJumpProject={jumpToProject}
       />
       {injectOpen && (
-        <InjectDialog
-          initialEnvelope={injectSeed}
-          onClose={() => {
-            setInjectOpen(false);
-            setInjectSeed(undefined);
-          }}
-          onAdmitted={(source, eventId) => {
-            setInjectOpen(false);
-            setInjectSeed(undefined);
-            jumpToEvent(source, eventId);
-          }}
-        />
+        <Suspense fallback={null}>
+          <InjectDialog
+            initialEnvelope={injectSeed}
+            onClose={() => {
+              setInjectOpen(false);
+              setInjectSeed(undefined);
+            }}
+            onAdmitted={(source, eventId) => {
+              setInjectOpen(false);
+              setInjectSeed(undefined);
+              jumpToEvent(source, eventId);
+            }}
+          />
+        </Suspense>
       )}
-      {helpOpen && <ShortcutsDialog onClose={() => setHelpOpen(false)} />}
+      {helpOpen && (
+        <Suspense fallback={null}>
+          <ShortcutsDialog onClose={() => setHelpOpen(false)} />
+        </Suspense>
+      )}
       <GoPrefixHint armed={goArmed} currentView={view} />
       <ToastContainer />
     </div>

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -55,23 +55,17 @@ function vendorChunk(id: string): string | undefined {
 // are fetched on demand, and are deliberately over the limit. kB is 1000 bytes
 // here to match how Vite reports sizes.
 //
-// The budget tracks the measured entry with a little slack, not a round number
-// well above it. Slack this thin means ordinary feature work will eventually
-// trip it; that is the trade, and re-baselining is a normal move.
-// Re-baselined for OPS-513 (after landing 17+ UI feature wave including autocomplete,
-// bulk actions, breadcrumbs, and live graph overlays): 499.82 kB measured on CI Linux.
-// Re-baselined again for WM-214: the custom-column machinery (payload-path columns,
-// CustomCell, the column picker) landing on top of the WM-134/WM-205 Overview
-// overhaul measured 523.44 kB — genuine app growth, with the vendor split intact.
-// Re-baselined again for WM-234: the hotkey wave (WM-236 action hints and dialog
-// chords already on develop at 529.78 kB, plus this branch's display-options `v`,
-// 1–N status-tab keys, and Projects mode tabs) measured 531.86 kB. The xyflow
-// vendor chunk is byte-identical to develop's and every lazy route chunk is still
-// split out, so this is app code, not a chunking regression.
-// Same 540 kB ceiling reached independently by WM-235 (context strip fast jump
-// chords and armed badges, 531.28 kB on CI Linux) and by WM-233's copy chords;
-// the merged hotkey wave still fits under it with the vendor split intact.
-const ENTRY_CHUNK_BUDGET_BYTES = 540 * 1000;
+// This budget protects first paint on the operator dashboard: the shared shell
+// and the primary Overview, Runs, and Events views stay eager, while secondary
+// routes (including Agents, Workers, and full-run detail) and occasional dialogs
+// load on demand. Moving one of those surfaces back into the entry is therefore
+// a first-paint tradeoff, not routine feature growth.
+//
+// WM-257 measured the entry at 472.95 kB locally after restoring those splits;
+// 480 kB leaves about 7 kB of slack while keeping the previous 540 kB ratchet
+// from returning. Keep the xyflow and lazy-route chunks visible in build output
+// before considering any future re-baseline.
+const ENTRY_CHUNK_BUDGET_BYTES = 480 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
## Summary
- lazy-load Inject and keyboard-shortcuts dialogs
- lazy-load secondary Agents, Workers, and full-run routes while keeping Overview, Runs, and Events eager
- reduce the entry bundle from 539.35 kB to 472.95 kB and restore a 480 kB first-paint budget

## Verification
- `cd event-runtime/web && bun run build && bun test src`
- 551 tests passed; entry 472.95 kB; Inject/Agents/Workers/RunFull/Shortcuts and xyflow remain separate chunks

## UX critique
- required — NOT-ASSESSED: critic browser/simulator tooling was unavailable; App tests cover lazy Inject focus/open behavior and all affected component suites pass

Fixes WM-257