### PR TITLE
feat(web): add artifact preview inspector

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -5,6 +5,10 @@ import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/re
 import { useState } from "react";
 import type { ArtifactInventoryItem } from "../types";
 import { Artifacts, type ArtifactFilters } from "./Artifacts";
+import { handleRunArtifactClick } from "./Runs";
+
+const originalFetch = globalThis.fetch;
+const originalClipboard = navigator.clipboard;
 
 const ITEMS: ArtifactInventoryItem[] = [
   {
@@ -48,6 +52,9 @@ const ITEMS: ArtifactInventoryItem[] = [
 
 afterEach(() => {
   cleanup();
+  window.location.hash = "#/artifacts";
+  globalThis.fetch = originalFetch;
+  Object.defineProperty(navigator, "clipboard", { configurable: true, value: originalClipboard });
 });
 
 function renderArtifacts(
@@ -55,9 +62,31 @@ function renderArtifacts(
   initialFilters: ArtifactFilters = { kind: null, orphan: null, search: "" },
 ) {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    defaultOptions: { queries: { retry: false, refetchInterval: false, staleTime: Infinity } },
   });
   client.setQueryData(["artifacts"], { artifacts: ITEMS });
+  client.setQueryData(["events", "all-for-artifacts"], {
+    events: [
+      {
+        source: "factory-chain",
+        eventId: "evt_consumer",
+        type: "factory.follow-up.requested",
+        subject: "factory",
+        status: "planned",
+        occurredAt: "2026-01-02T03:05:05.000Z",
+        receivedAt: "2026-01-02T03:05:05.000Z",
+        correlationId: "corr_report",
+        causationId: "run_report",
+        planFailures: 0,
+        lastPlanError: null,
+        admittedAt: "2026-01-02T03:05:05.000Z",
+        proposalId: "proposal_consumer",
+        runId: "run_consumer",
+        envelope: { payload: { inputArtifact: "a".repeat(64) } },
+        repos: [],
+      },
+    ],
+  });
   function Harness() {
     const [filters, setFilters] = useState<ArtifactFilters>(initialFilters);
     return (
@@ -119,5 +148,58 @@ describe("Artifacts inventory (WM-207)", () => {
     const table = view.getByRole("table");
     expect(within(table).queryByText("aaaaaaaaaaaa")).toBeNull();
     expect(within(table).queryByText("cccccccccccc")).toBeNull();
+  });
+
+  test("opens a deep-linked inspector with formatted preview, actions, search, and bidirectional references", async () => {
+    const raw = JSON.stringify({ message: "hello artifact", count: 2 });
+    globalThis.fetch = mock(async () => new Response(raw, { status: 200 })) as unknown as typeof fetch;
+    const writeText = mock(async () => {});
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    window.location.hash = `#/artifacts/${"a".repeat(64)}`;
+    const view = renderArtifacts();
+
+    const preview = await view.findByRole("region", { name: "Artifact content" });
+    expect(preview.textContent).toContain('\"message\": \"hello artifact\"');
+    expect(preview.textContent).toContain("1");
+    expect(preview.textContent).toContain("2");
+
+    const references = view.getByRole("region", { name: "Artifact run references" });
+    fireEvent.click(within(references).getByRole("button", { name: /run_report/ }));
+    expect(view.onJumpRun).toHaveBeenCalledWith("run_report");
+    fireEvent.click(within(references).getByTitle("Open consuming run run_consumer"));
+    expect(view.onJumpRun).toHaveBeenCalledWith("run_consumer");
+    expect(within(references).getByText(/factory-chain:evt_consumer/)).toBeTruthy();
+
+    const download = view.getByRole("link", { name: "Download" });
+    expect(download.getAttribute("href")).toContain(`/api/artifacts/${"a".repeat(64)}`);
+    expect(view.getByRole("combobox", { name: "Search artifact content" })).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: "Copy Raw Content" }));
+    fireEvent.click(view.getByRole("button", { name: "Copy SHA-256" }));
+    expect(writeText).toHaveBeenNthCalledWith(1, raw);
+    expect(writeText).toHaveBeenNthCalledWith(2, "a".repeat(64));
+  });
+
+  test("selects a row into the inspector and routes run artifact links to the same deep link", async () => {
+    globalThis.fetch = mock(async () => new Response("line one\nline two", { status: 200 })) as unknown as typeof fetch;
+    const view = renderArtifacts();
+    const reportRow = view.getByText("1.0 KB").closest("tr");
+    expect(reportRow).toBeTruthy();
+    fireEvent.click(reportRow!);
+    expect(window.location.hash).toBe(`#/${`artifacts/${"a".repeat(64)}`}`);
+    expect(await view.findByRole("region", { name: "Artifact content" })).toBeTruthy();
+
+    window.location.hash = "#/runs/run_report";
+    const runLink = render(
+      <div onClickCapture={handleRunArtifactClick}>
+        <a href={`/api/artifacts/${"b".repeat(64)}?name=transcript`}>Open</a>
+      </div>,
+    );
+    fireEvent.click(runLink.getByRole("link", { name: "Open" }));
+    expect(window.location.hash).toBe(`#/${`artifacts/${"b".repeat(64)}`}`);
   });
 });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,9 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
-import { artifactUrl, fetchArtifacts } from "../api";
-import { Ago, FilterInput, JumpLink, ListEmpty, ListPane, humanSize } from "../components/ui";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { api, artifactUrl, fetchArtifacts } from "../api";
+import {
+  Ago,
+  Button,
+  DetailPane,
+  FilterInput,
+  JumpLink,
+  ListEmpty,
+  ListPane,
+  copyText,
+  humanSize,
+  shortId,
+} from "../components/ui";
 import { useNow } from "../hooks";
-import type { ArtifactInventoryItem, StatusView } from "../types";
+import type { AdmittedEvent, ArtifactInventoryItem, StatusView } from "../types";
 
 export type ArtifactFilters = {
   kind: string | null;
@@ -29,6 +40,65 @@ function matchesSearch(artifact: ArtifactInventoryItem, search: string): boolean
       reference.state,
     ]),
   ].some((value) => String(value ?? "").toLowerCase().includes(term));
+}
+
+const ARTIFACT_HASH = /^[0-9a-f]{64}$/;
+
+type LinkedEvent = AdmittedEvent & { causationId?: string | null };
+
+function artifactShaFromHash(hash = window.location.hash): string | null {
+  const path = hash.replace(/^#\/?/, "").split("?", 1)[0];
+  const [, encoded] = path.split("/");
+  if (!encoded) return null;
+  try {
+    const sha256 = decodeURIComponent(encoded);
+    return ARTIFACT_HASH.test(sha256) ? sha256 : null;
+  } catch {
+    return null;
+  }
+}
+
+function openArtifactInspector(sha256: string) {
+  if (!ARTIFACT_HASH.test(sha256)) return;
+  window.location.hash = `#/artifacts/${encodeURIComponent(sha256)}`;
+}
+
+function containsArtifactHash(value: unknown, sha256: string, seen = new Set<object>()): boolean {
+  if (typeof value === "string") return value === sha256 || value === `sha256:${sha256}`;
+  if (!value || typeof value !== "object" || seen.has(value)) return false;
+  seen.add(value);
+  return Array.isArray(value)
+    ? value.some((entry) => containsArtifactHash(entry, sha256, seen))
+    : Object.values(value).some((entry) => containsArtifactHash(entry, sha256, seen));
+}
+
+function formattedContent(raw: string, kinds: string[]): string {
+  if (kinds.some((kind) => /json/i.test(kind)) || /^\s*[\[{]/.test(raw)) {
+    try {
+      return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      // NDJSON/log streams that start with JSON still belong in the text viewer.
+    }
+  }
+  return raw;
+}
+
+function highlightedLine(line: string, search: string): ReactNode {
+  const term = search.trim();
+  if (!term) return line || " ";
+  const lower = line.toLowerCase();
+  const needle = term.toLowerCase();
+  const chunks: ReactNode[] = [];
+  let at = 0;
+  let match = lower.indexOf(needle);
+  while (match >= 0) {
+    chunks.push(line.slice(at, match));
+    chunks.push(<mark key={`${match}:${chunks.length}`} className="bg-(--hue-warn) text-inherit">{line.slice(match, match + term.length)}</mark>);
+    at = match + term.length;
+    match = lower.indexOf(needle, at);
+  }
+  chunks.push(line.slice(at));
+  return chunks;
 }
 
 function KindBadge({ kind }: { kind: string }) {
@@ -78,6 +148,35 @@ export function Artifacts({
     refetchInterval: 10_000,
   });
   const artifacts = artifactsQ.data?.artifacts ?? [];
+  const [selectedSha, setSelectedSha] = useState(() => artifactShaFromHash());
+  const [contentSearch, setContentSearch] = useState("");
+
+  useEffect(() => {
+    const syncSelection = () => setSelectedSha(artifactShaFromHash());
+    window.addEventListener("hashchange", syncSelection);
+    return () => window.removeEventListener("hashchange", syncSelection);
+  }, []);
+
+  const selected = useMemo(
+    () => artifacts.find((artifact) => artifact.sha256 === selectedSha) ?? null,
+    [artifacts, selectedSha],
+  );
+  const contentQ = useQuery({
+    queryKey: ["artifact-content", selectedSha],
+    queryFn: async () => {
+      const response = await fetch(artifactUrl(selectedSha as string));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.text();
+    },
+    enabled: selectedSha !== null,
+  });
+  const eventsQ = useQuery({
+    queryKey: ["events", "all-for-artifacts"],
+    queryFn: () => api.events(),
+    enabled: selectedSha !== null,
+    refetchInterval: 10_000,
+  });
+
   const kinds = useMemo(
     () =>
       [...new Set([...COMMON_KINDS, ...artifacts.flatMap(kindsOf)])].sort((a, b) =>
@@ -95,6 +194,45 @@ export function Artifacts({
     [artifacts, filters],
   );
 
+  const linkedEvents = (eventsQ.data?.events ?? []) as LinkedEvent[];
+  const producerRunIds = useMemo(
+    () => new Set(selected?.references.map((reference) => reference.runId) ?? []),
+    [selected],
+  );
+  const consumers = useMemo(
+    () =>
+      selectedSha
+        ? linkedEvents.filter(
+            (event) =>
+              event.runId &&
+              !producerRunIds.has(event.runId) &&
+              containsArtifactHash(event.envelope, selectedSha),
+          )
+        : [],
+    [linkedEvents, producerRunIds, selectedSha],
+  );
+  const causation = useMemo(
+    () => linkedEvents.filter((event) => event.causationId && producerRunIds.has(event.causationId)),
+    [linkedEvents, producerRunIds],
+  );
+  const selectedKinds = selected ? kindsOf(selected) : [];
+  const preview = contentQ.data === undefined ? null : formattedContent(contentQ.data, selectedKinds);
+  const previewLines = preview?.split("\n") ?? [];
+  const matchCount = contentSearch.trim()
+    ? previewLines.filter((line) => line.toLowerCase().includes(contentSearch.trim().toLowerCase())).length
+    : null;
+
+  const selectArtifact = (sha256: string) => {
+    setContentSearch("");
+    setSelectedSha(sha256);
+    openArtifactInspector(sha256);
+  };
+  const closeInspector = () => {
+    setSelectedSha(null);
+    setContentSearch("");
+    window.location.hash = "#/artifacts";
+  };
+
   const fallbackMetrics = useMemo(
     () => ({
       files: artifacts.length,
@@ -111,6 +249,7 @@ export function Artifacts({
   const set = (patch: Partial<ArtifactFilters>) => onFiltersChange({ ...filters, ...patch });
 
   return (
+    <div className="flex h-full min-w-0">
     <ListPane
       chrome={
         <>
@@ -211,11 +350,17 @@ export function Artifacts({
             const artifactKinds = kindsOf(artifact);
             const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
             return (
-              <tr key={artifact.sha256} className="hover:bg-(--surface-1)">
+              <tr
+                key={artifact.sha256}
+                onClick={() => selectArtifact(artifact.sha256)}
+                aria-selected={artifact.sha256 === selectedSha}
+                className={`cursor-pointer hover:bg-(--surface-1) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
+              >
                 <td className="mono max-w-40 border-b border-(--border) px-3 py-2" title={artifact.sha256}>
                   <a
                     href={artifactUrl(artifact.sha256, name)}
                     download={name}
+                    onClick={(event) => event.stopPropagation()}
                     className="text-(--accent) hover:underline"
                     aria-label={`Download artifact ${artifact.sha256}`}
                   >
@@ -288,5 +433,126 @@ export function Artifacts({
         </tbody>
       </table>
     </ListPane>
+
+    {selectedSha && (
+      <DetailPane
+        widthClass="w-full sm:w-[560px]"
+        title={
+          <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <button type="button" onClick={closeInspector} className="text-(--text-dim) hover:text-(--accent)">
+              Artifacts
+            </button>
+            <span aria-hidden="true" className="text-(--text-faint)">/</span>
+            <span className="mono truncate font-semibold text-(--text)" title={selectedSha} aria-current="page">
+              {selectedSha.slice(0, 12)}
+            </span>
+          </nav>
+        }
+        actions={
+          <>
+            <a
+              href={artifactUrl(selectedSha, `${selectedSha.slice(0, 12)}${selectedKinds[0] ? `.${selectedKinds[0]}` : ""}`)}
+              download
+              className="inline-flex rounded-md border border-(--border-strong) px-2.5 py-1.5 text-[12px] font-medium hover:bg-(--surface-2)"
+            >
+              Download
+            </a>
+            <Button disabled={contentQ.data === undefined} onClick={() => copyText(contentQ.data ?? "", "raw artifact content")}>
+              Copy Raw Content
+            </Button>
+            <Button onClick={() => copyText(selectedSha, "SHA-256")}>Copy SHA-256</Button>
+          </>
+        }
+        close={<Button onClick={closeInspector}>Close</Button>}
+      >
+        {!selected && artifactsQ.isPending && <div className="text-(--text-faint)">Loading artifact metadata…</div>}
+        {!selected && !artifactsQ.isPending && (
+          <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
+            Artifact metadata is unavailable. The content may have been pruned.
+          </div>
+        )}
+
+        {selected && (
+          <>
+            <section aria-label="Artifact metadata" className="grid grid-cols-2 gap-2 text-[12px]">
+              <div><span className="text-(--text-faint)">Size</span><div className="mono mt-0.5">{humanSize(selected.sizeBytes)}</div></div>
+              <div><span className="text-(--text-faint)">Modified</span><div className="mono mt-0.5">{new Date(selected.mtime).toLocaleString()}</div></div>
+              <div className="col-span-2">
+                <span className="text-(--text-faint)">Kinds</span>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {selectedKinds.length ? selectedKinds.map((kind) => <KindBadge key={kind} kind={kind} />) : <span>unknown</span>}
+                </div>
+              </div>
+              <div className="col-span-2 min-w-0">
+                <span className="text-(--text-faint)">SHA-256</span>
+                <div className="mono mt-0.5 break-all">{selectedSha}</div>
+              </div>
+            </section>
+
+            <section aria-label="Artifact run references" className="mt-5 border-t border-(--border) pt-4 text-[12px]">
+              <h2 className="display font-semibold">Run references</h2>
+              <div className="mt-3 grid gap-3">
+                <div>
+                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Producing runs</div>
+                  <div className="mt-1.5 flex flex-wrap gap-2">
+                    {selected.references.length ? selected.references.map((reference) => (
+                      <JumpLink key={`${reference.runId}:${reference.kind ?? "unknown"}`} onClick={() => onJumpRun(reference.runId)} title={`Open producing run ${reference.runId}`}>
+                        {shortId(reference.runId)}{reference.kind ? ` · ${reference.kind}` : ""}
+                      </JumpLink>
+                    )) : <span className="text-(--text-faint)">No accepted result references this artifact.</span>}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Consuming runs</div>
+                  <div className="mt-1.5 flex flex-wrap gap-2">
+                    {consumers.length ? consumers.map((event) => (
+                      <JumpLink key={`${event.source}:${event.eventId}:${event.runId}`} onClick={() => onJumpRun(event.runId!)} title={`Open consuming run ${event.runId}`}>
+                        {shortId(event.runId!)}
+                      </JumpLink>
+                    )) : <span className="text-(--text-faint)">{eventsQ.isPending ? "Resolving…" : "No consuming runs found."}</span>}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Causation links</div>
+                  <div className="mt-1.5 grid gap-1">
+                    {causation.length ? causation.map((event) => (
+                      <div key={`${event.source}:${event.eventId}`} className="flex flex-wrap items-center gap-1.5">
+                        <span className="mono text-(--text-faint)">{event.source}:{shortId(event.eventId)}</span>
+                        {event.runId && <><span aria-hidden="true">→</span><JumpLink onClick={() => onJumpRun(event.runId!)} title={`Open caused run ${event.runId}`}>{shortId(event.runId)}</JumpLink></>}
+                      </div>
+                    )) : <span className="text-(--text-faint)">{eventsQ.isPending ? "Resolving…" : "No caused events found."}</span>}
+                  </div>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+
+        <section aria-label="Artifact preview" className="mt-5 border-t border-(--border) pt-4">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <div>
+              <h2 className="display text-[12px] font-semibold">Preview</h2>
+              <p className="mt-0.5 text-[11px] text-(--text-faint)">
+                {matchCount === null ? `${previewLines.length.toLocaleString()} lines` : `${matchCount.toLocaleString()} matching lines`}
+              </p>
+            </div>
+            <FilterInput value={contentSearch} onChange={setContentSearch} placeholder="Find in content…" label="Search artifact content" />
+          </div>
+          {contentQ.isPending && <div className="mt-3 text-[12px] text-(--text-faint)">Loading artifact preview…</div>}
+          {contentQ.isError && <div className="mt-3 text-[12px] text-(--hue-err)">Could not load artifact content: {(contentQ.error as Error).message}</div>}
+          {preview !== null && (
+            <div role="region" aria-label="Artifact content" className="mono mt-3 max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed">
+              {previewLines.map((line, index) => (
+                <div key={index} className={`grid grid-cols-[4rem_minmax(0,1fr)] px-2 ${contentSearch.trim() && line.toLowerCase().includes(contentSearch.trim().toLowerCase()) ? "bg-(--surface-2)" : ""}`}>
+                  <span aria-hidden="true" className="select-none border-r border-(--border) pr-2 text-right text-(--text-faint)">{index + 1}</span>
+                  <span className="min-w-0 whitespace-pre-wrap break-words pl-3">{highlightedLine(line, contentSearch)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </DetailPane>
+    )}
+    </div>
   );
 }

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -15,6 +15,7 @@ import {
   notify,
 } from "../components/ui";
 import { RunDetailBlocks, RunFailureBanner, isCancellable } from "../components/RunDetailBlocks";
+import { handleRunArtifactClick } from "./Runs";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -248,19 +249,21 @@ export function RunFull({
               width below the trace under xl, where there is no room for two
               columns. */}
           <aside className="w-full shrink-0 overflow-y-auto border-(--border) bg-(--surface-1) p-4 xl:w-[460px] xl:border-l">
-            <RunDetailBlocks
-              d={d}
-              now={now}
-              connected={connected}
-              origin={listRow}
-              onJumpAgent={onJumpAgent}
-              onJumpEvent={onJumpEvent}
-              onCancel={() => setConfirm("cancel")}
-              onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
-              onForceRetry={() => setConfirm("force-retry")}
-              retryPending={retry.isPending}
-              verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
-            />
+            <div onClickCapture={handleRunArtifactClick}>
+              <RunDetailBlocks
+                d={d}
+                now={now}
+                connected={connected}
+                origin={listRow}
+                onJumpAgent={onJumpAgent}
+                onJumpEvent={onJumpEvent}
+                onCancel={() => setConfirm("cancel")}
+                onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
+                onForceRetry={() => setConfirm("force-retry")}
+                retryPending={retry.isPending}
+                verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
+              />
+            </div>
           </aside>
         </div>
       )}

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { api, ApiError } from "../api";
 import { keyGuard, useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
 import { goPrefixActive } from "../goSequence";
@@ -179,6 +179,17 @@ function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
 
 const rowWash = (s: string) =>
   s === "FAILED" || s === "TIMED_OUT" ? "row-wash-err" : s === "REFUSED" ? "row-wash-warn" : "";
+
+/** Route raw links rendered by RunDetailBlocks to the deep-linkable artifact inspector. */
+export function handleRunArtifactClick(event: ReactMouseEvent<HTMLElement>) {
+  const target = event.target instanceof Element ? event.target.closest<HTMLAnchorElement>("a[href]") : null;
+  if (!target) return;
+  const match = (target.getAttribute("href") ?? "").match(/\/api\/artifacts\/([0-9a-f]{64})(?=[?#]|$)/);
+  if (!match) return;
+  event.preventDefault();
+  event.stopPropagation();
+  window.location.hash = `#/artifacts/${match[1]}`;
+}
 
 /** Runs (webui spec §4.3): state tabs, lifecycle timeline, guarded verbs. */
 export function Runs({
@@ -883,28 +894,30 @@ export function Runs({
           {d && (
             <>
           <RunFailureBanner state={d.run.state} lifecycle={d.lifecycle} />
-          <RunDetailBlocks
-            d={d}
-            now={now}
-            connected={connected}
-            origin={sel}
-            onJumpAgent={onJumpAgent}
-            onJumpEvent={onJumpEvent}
-            onCancel={() => setConfirm("cancel")}
-            onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
-            onForceRetry={() => setConfirm("force-retry")}
-            retryPending={retry.isPending}
-            verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
-            afterLifecycle={
-              /* key: a run switch must reset the feed's cursor and scroll state. */
-              <RunTrace
-                key={d.run.runId}
-                runId={d.run.runId}
-                state={d.run.state}
-                onExpand={() => onOpenFull(d.run.runId)}
-              />
-            }
-          />
+          <div onClickCapture={handleRunArtifactClick}>
+            <RunDetailBlocks
+              d={d}
+              now={now}
+              connected={connected}
+              origin={sel}
+              onJumpAgent={onJumpAgent}
+              onJumpEvent={onJumpEvent}
+              onCancel={() => setConfirm("cancel")}
+              onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
+              onForceRetry={() => setConfirm("force-retry")}
+              retryPending={retry.isPending}
+              verbError={cancel.error ?? (confirm === "force-retry" ? null : retry.error)}
+              afterLifecycle={
+                /* key: a run switch must reset the feed's cursor and scroll state. */
+                <RunTrace
+                  key={d.run.runId}
+                  runId={d.run.runId}
+                  state={d.run.state}
+                  onExpand={() => onOpenFull(d.run.runId)}
+                />
+              }
+            />
+          </div>
             </>
           )}
         </DetailPane>


### PR DESCRIPTION
## Summary
- add deep-linkable artifact inspector with JSON/text/log preview, line numbers, and in-content search
- add download/copy actions plus producer, consumer, and causation run links
- route artifact links from Runs and RunFull into the inspector and cover the interaction flow

## Verification
- `cd event-runtime/web && bun test` — 553 tests passed
- `cd event-runtime/web && bun run build` — TypeScript and Vite build passed

## UX critique
- required — NOT-ASSESSED: the critic could not launch its configured Chrome CDP script; responsive full-width inspector fallback and automated interaction coverage are included

Fixes WM-208