### PR TITLE
fix(event-runtime): pi read-only agents keep bash — scan fleet was structurally broken (WM-301)

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -52,15 +52,23 @@ export const KILL_GRACE_MS = 30_000;
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
 
-// pi's documented read-only pattern omits bash/edit from the tool allowlist
-// rather than intercepting calls at runtime — but `write` must stay: every
-// agent-result contract requires the model to write ./result.json, and a run
-// that cannot write it fails contract_violation:missing_result before doing
-// anything (OPS-518; same reasoning as claude.mjs's READ_ONLY_TOOLS keeping
-// Write/Edit). Containment for mutating: false is therefore bash/edit omission
-// plus the workspace-cwd boundary — audited, not enforced, per §14 until
-// stage 2's native capability enforcement (OPS-515).
-export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write"];
+// Read-only here means "cannot edit the repository", NOT "cannot act". Every
+// tool below is load-bearing for a mutating: false agent, and removing one
+// breaks the run rather than tightening it — this list has been wrong twice:
+//   write  every agent-result contract requires ./result.json; without it a run
+//          fails contract_violation:missing_result before doing anything (OPS-518)
+//   bash   the entire scan fleet works by shelling out — work/triage/sweep/
+//          unblock scans call tools/linear.mjs, merge/ship scans call gh and
+//          git, ci-doctor and disk-diagnose call gh/ssh. Without a shell they
+//          refuse with "reads could not be performed with the available tools"
+//          (WM-301, run_e881a392)
+// `edit` stays out: that is the actual repository-mutation boundary. Same
+// reasoning as claude.mjs, which likewise keeps Bash/Write/Edit for read-only
+// agents and enforces the boundary through workspace confinement instead of
+// tool removal. Containment for mutating: false is therefore the ephemeral or
+// pinned workspace as cwd — audited, not enforced, per §14 until stage 2's
+// native capability enforcement (OPS-515).
+export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write", "bash"];
 
 export class CliNotFoundError extends Error {
   constructor(message) {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -130,11 +130,11 @@ describe("buildPiArgv", () => {
     expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual(["-p", "--mode", "json"]);
   });
 
-  test("mutating: false → --tools read,grep,find,ls,write (pi's own read-only pattern, not -r)", () => {
+  test("mutating: false → --tools read,grep,find,ls,write,bash (pi's own read-only pattern, not -r)", () => {
     const argv = buildPiArgv({ def: { mutating: false }, model: null });
     expect(argv).toContain("--tools");
     expect(argv[argv.indexOf("--tools") + 1]).toBe(READ_ONLY_TOOLS.join(","));
-    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls,write"]);
+    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls,write,bash"]);
   });
 
   test("mutating: true → no --tools restriction", () => {
@@ -422,7 +422,7 @@ process.stdin.on("end", () => {
     expect(record.argv).toContain("--model");
     expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("openai-codex/gpt-5.6-terra");
     expect(record.argv).toContain("--tools");
-    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write");
+    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash");
 
     // 4. .transcript.json artifact capture
     const transcriptPath = path.join(workspaceDir, ".transcript.json");


### PR DESCRIPTION
Fixes WM-301

Live evidence: work-scan run `run_e881a392` refused with `needs_human` — *"Linear reads could not be performed with the available tools."*

pi's `READ_ONLY_TOOLS` was `read,grep,find,ls,write` — no shell. Since WM-215 routed every LLM event type to pi, that silently broke **the entire read-only scan fleet**: work/triage/sweep/unblock scans shell to `tools/linear.mjs`; merge/ship scans shell to `gh`/`git`; ci-doctor, status-report and disk-diagnose shell to `gh`/`ssh`. Only mutating `dispatch@1` kept working (worktree agents get the full tool set), which masked it.

Same class as OPS-518 (read-only pi couldn't write `result.json`) — that fix added `write` and stopped; this is the other half. `claude.mjs` has always kept `Bash`/`Write`/`Edit` for read-only agents deliberately, enforcing the boundary via workspace confinement rather than tool removal.

Fix: add `bash`; keep `edit` excluded (that's the actual repository-mutation boundary). The comment now explains why each tool is load-bearing so the list isn't 'tightened' into a broken state a third time.

Verification: `bun test event-runtime/lib/adapters/pi.test.mjs` → 30 pass / 0 fail; full suite green. Live re-test of a pi work-scan follows this merge.