### PR TITLE
fix(ci): raise Verify timeout 10 → 25 minutes — green runs were being cancelled (WM-300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,13 @@ jobs:
     # Self-hosted per project-conventions PC-03 / PC-22 — cloud runners are
     # forbidden, and shadow is the dedicated host runner label.
     runs-on: [self-hosted, shadow]
-    timeout-minutes: 10
+    # Runaway guard, not a performance budget: it should trip on a wedged job,
+    # never on a healthy suite under load. Raised 10 -> 25 on 2026-08-15 after
+    # PRs #319 and #325 were both cancelled at 15m0s while green — the suite
+    # grew ~970 -> ~1540 tests in a day and several Verify jobs now share this
+    # host, so wall-clock runs well past solo time (WM-300). Compare against
+    # measured job durations before lowering.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Fixes WM-300

PRs #319 and #325 were both cancelled at exactly 15m0s with `The job has exceeded the maximum execution time of 10m0s` — while green. Two compounding causes: the suite grew from ~970 to ~1540 tests today, and an autonomous dispatch loop merging continuously means several Verify jobs share the self-hosted host, so wall-clock stretches well past solo time.

The cap is a runaway guard, not a performance budget. Raised to 25 minutes with the reasoning inline so the next person knows what to compare against. Concurrency/job-splitting (the other half of WM-300) is deliberately left for a follow-up — this unblocks merges now.

Note: #325 had to be admin-merged because of this exact cancellation loop.