### PR TITLE
fix(reconcile): ignore merged PRs on unworked tickets (WM-237)

### DIFF
--- a/orchestrator/reconcile.mjs
+++ b/orchestrator/reconcile.mjs
@@ -124,8 +124,10 @@ export function evaluateTicketDrift(issue, repoGithub, prStates, { quietMin = 25
     };
   }
 
-  // Active ticket
+  // Only worked tickets can be reconciled from a merged PR. Unstarted and
+  // held tickets may link historical PRs as context without being complete.
   if (!open.length) {
+    if (!["In Review", "In Progress"].includes(issue.state?.name)) return null;
     const merged = prStates.filter((pr) => pr.state === "MERGED").map((pr) => pr.number);
     if (!merged.length) return null;
     return {

--- a/orchestrator/reconcile.test.mjs
+++ b/orchestrator/reconcile.test.mjs
@@ -125,20 +125,35 @@ describe("evaluateTicketDrift (WM-11, WM-16)", () => {
     expect(evaluateTicketDrift(issue, "watt-mind/legalease", prStates)).toBeNull();
   });
 
-  test("Active ticket with MERGED PR detects drift to Done", () => {
-    const issue = {
-      identifier: "CLNT-400",
-      state: { name: "In Review", type: "started" },
-    };
-    const prStates = [
-      { number: 100, state: "MERGED" },
-    ];
-    const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates);
-    expect(res).not.toBeNull();
-    expect(res.type).toBe("merged-not-done");
-    expect(res.merged).toEqual([100]);
-    expect(res.targetState).toBe("Done");
-  });
+  test.each(["In Review", "In Progress"])(
+    "%s ticket with MERGED PR detects drift to Done",
+    (stateName) => {
+      const issue = {
+        identifier: "CLNT-400",
+        state: { name: stateName, type: "started" },
+      };
+      const prStates = [{ number: 100, state: "MERGED" }];
+
+      const res = evaluateTicketDrift(issue, "watt-mind/legalease", prStates);
+      expect(res).not.toBeNull();
+      expect(res.type).toBe("merged-not-done");
+      expect(res.merged).toEqual([100]);
+      expect(res.targetState).toBe("Done");
+    },
+  );
+
+  test.each(["Todo", "Triage", "Backlog", "Blocked"])(
+    "%s ticket with MERGED PR is ignored",
+    (stateName) => {
+      const issue = {
+        identifier: "CLNT-401",
+        state: { name: stateName, type: "unstarted" },
+      };
+      const prStates = [{ number: 100, state: "MERGED" }];
+
+      expect(evaluateTicketDrift(issue, "watt-mind/legalease", prStates)).toBeNull();
+    },
+  );
 
   test("In Progress ticket with OPEN PR and quiet time >= quietMin detects drift to In Review", () => {
     const issue = {


### PR DESCRIPTION
## Summary
- restrict merged-not-done reconciliation to In Review and In Progress tickets
- preserve Todo, Triage, Backlog, and Blocked tickets that link historical merged PRs
- add regression coverage for eligible and ignored lifecycle states

## Verification
- `bun test orchestrator/reconcile.test.mjs && bun build/emit.mjs --check`

UX critique: skipped — internal backend state-reconciliation behavior only.

Fixes WM-237