### PR TITLE
sec(branch-guard): normalize protected branch refs (WM-241)

### DIFF
--- a/orchestrator/branch-guard.mjs
+++ b/orchestrator/branch-guard.mjs
@@ -35,11 +35,16 @@ export function protectedBranchesFor(repo) {
   return Array.from(list);
 }
 
+/** Normalize branch refs for protected-branch comparisons. */
+function normalizeBranchName(branch) {
+  return String(branch).toLowerCase().replace(/^(?:refs\/heads\/|origin\/|heads\/)/, "");
+}
+
 /** Check if a branch name matches any protected branch for this repo. */
 export function isProtectedBranch(branch, repo) {
   if (!branch) return false;
-  const protectedList = protectedBranchesFor(repo);
-  return protectedList.includes(branch);
+  const candidate = normalizeBranchName(branch);
+  return protectedBranchesFor(repo).some((protectedBranch) => normalizeBranchName(protectedBranch) === candidate);
 }
 
 /**

--- a/orchestrator/branch-guard.test.mjs
+++ b/orchestrator/branch-guard.test.mjs
@@ -58,6 +58,19 @@ describe("protectedBranchesFor & isProtectedBranch", () => {
     expect(isProtectedBranch("feat/CLNT-520", repo)).toBe(false);
     expect(isProtectedBranch("fix/WM-13-test", repo)).toBe(false);
   });
+
+  test("normalizes ref prefixes and case before matching protected branches", () => {
+    expect(isProtectedBranch("refs/heads/develop", repo)).toBe(true);
+    expect(isProtectedBranch("origin/develop", repo)).toBe(true);
+    expect(isProtectedBranch("heads/develop", repo)).toBe(true);
+    expect(isProtectedBranch("Develop", repo)).toBe(true);
+    expect(isProtectedBranch("MASTER", repo)).toBe(true);
+    expect(isProtectedBranch("REFS/HEADS/PRODUCTION", repo)).toBe(true);
+    expect(isProtectedBranch("origin/Staging", repo)).toBe(true);
+    expect(isProtectedBranch("staging", { ...repo, base: "StAgInG" })).toBe(true);
+    expect(isProtectedBranch("upstream/develop", repo)).toBe(false);
+    expect(isProtectedBranch("feature/origin/develop", repo)).toBe(false);
+  });
 });
 
 describe("openPrHold", () => {
@@ -143,6 +156,20 @@ describe("evaluateBranchGuard", () => {
     });
     expect(resMain.ok).toBe(false);
     expect(resMain.exitCode).toBe(EXIT.REFUSED);
+  });
+
+  test("returns REFUSED (2) for prefixed and case-variant protected branches", () => {
+    for (const branch of ["refs/heads/develop", "origin/develop", "heads/develop", "Develop", "Master", "MAIN"]) {
+      const res = evaluateBranchGuard({
+        branch,
+        repo,
+        targetPr: 100,
+        openPrs: [],
+      });
+      expect(res.ok).toBe(false);
+      expect(res.exitCode).toBe(EXIT.REFUSED);
+      expect(res.reason).toContain("protected branch");
+    }
   });
 
   test("returns REFUSED (2) when held by another open PR", () => {


### PR DESCRIPTION
## Summary
- normalize protected branch candidates and configured protected names case-insensitively
- strip supported `refs/heads/`, `origin/`, and `heads/` prefixes before comparison
- add regression coverage at helper and guard-evaluation boundaries

## Verification
- `bun test orchestrator/branch-guard.test.mjs && bun build/emit.mjs --check`

UX critique: skipped — internal branch-deletion safety logic with no user-completable flow or UI.

Fixes WM-241