### PR TITLE
fix(janitor): batch Linear state queries

### DIFF
--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -207,13 +207,17 @@ export async function survey(repo, { apply }, {
   let states = {};
   if (tickets.length) {
     const nums = tickets.map((t) => Number(t.split("-")[1]));
-    let nodes = [];
-    if (queryIssues) {
-      nodes = await queryIssues(repo.team, nums);
-    } else {
-      const q = `query($n:[Float!]){ issues(first:250, filter:{ number:{in:$n}, team:{key:{eq:"${repo.team}"}} }){ nodes{ identifier state{name type} } } }`;
-      nodes = (await gql(q, { n: nums }))?.issues?.nodes ?? [];
-    }
+    const queryBatch = queryIssues ?? (async (team, batch) => {
+      const q = `query($n:[Float!]){ issues(first:250, filter:{ number:{in:$n}, team:{key:{eq:"${team}"}} }){ nodes{ identifier state{name type} } } }`;
+      return (await gql(q, { n: batch }))?.issues?.nodes ?? [];
+    });
+
+    // Linear caps this connection at 250 nodes. Keep each filter at or below
+    // that cap and run the independent requests together so every worktree is
+    // resolved without turning a large checkout into a serial API crawl.
+    const batches = [];
+    for (let i = 0; i < nums.length; i += 250) batches.push(nums.slice(i, i + 250));
+    const nodes = (await Promise.all(batches.map((batch) => queryBatch(repo.team, batch)))).flat();
     states = Object.fromEntries(nodes.map((n) => [n.identifier, n.state]));
   }
 

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -217,6 +217,43 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
     getOpenPrs: () => [{ number: 261, headRefName: "feat/CLNT-520" }],
   };
 
+  test("batches more than 250 ticket numbers and categorizes every worktree", async () => {
+    const worktrees = Array.from({ length: 501 }, (_, i) => `CLNT-${i + 1}`);
+    const calls = [];
+    let active = 0;
+    let maxActive = 0;
+    const queryIssues = async (_team, nums) => {
+      calls.push(nums);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      // Match Linear's `issues(first: 250)` response limit. Passing all numbers
+      // in one request silently omits every worktree after the first 250.
+      return nums.slice(0, 250).map((number) => ({
+        identifier: `CLNT-${number}`,
+        state: number % 2 === 0
+          ? { name: "Done", type: "completed" }
+          : { name: "In Progress", type: "started" },
+      }));
+    };
+
+    const res = await survey(repo, { apply: false }, {
+      readdir: () => worktrees,
+      exists: () => true,
+      queryIssues,
+      getBranches: () => ({}),
+      getOpenPrs: () => [],
+    });
+
+    expect(calls.map((nums) => nums.length)).toEqual([250, 250, 1]);
+    expect(maxActive).toBe(3);
+    expect(res.unknown).toEqual([]);
+    expect(res.reclaimable).toHaveLength(250);
+    expect(res.kept).toHaveLength(251);
+    expect(res.kept.at(-1)).toEqual({ id: "CLNT-501", state: "In Progress" });
+  });
+
   test("an open-PR hold populates the held array and is excluded from reclaimable (dry run)", () => {
     const res = survey(repo, { apply: false }, defaultDeps);
     return res.then((surveyRes) => {


### PR DESCRIPTION
## Summary
- split janitor ticket-number lookups into 250-item GraphQL batches
- execute independent batches concurrently and combine every returned state
- cover 501 worktrees with a regression test that verifies request sizes, concurrency, and complete categorization

## Verification
- `bun test orchestrator/janitor.test.mjs && bun build/emit.mjs --check`

UX critique: skipped — internal janitor behavior with no user-completable flow or UI change.

Fixes WM-240