### PR TITLE
ui(event-runtime-web): make custom columns discoverable

### DIFF
--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -1,9 +1,10 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
 import { useState } from "react";
 import { modal } from "../hooks";
 import { goPrefix } from "../goSequence";
+import { changeInput } from "../test-render";
 import {
   buildSections,
   defaultDisplayState,
@@ -20,8 +21,16 @@ interface Row {
   envelope?: {
     payload?: {
       repo?: string;
+      owner?: string;
+      [key: string]: string | undefined;
     };
   };
+  spec?: {
+    input?: {
+      model?: string;
+    };
+  };
+  labels?: Record<string, string>;
 }
 
 const CONFIG: DisplayConfig<Row> = {
@@ -98,24 +107,79 @@ describe("DisplayOptions panel", () => {
     expect(pill.getAttribute("aria-pressed")).toBe("false");
   });
 
-  test("adds and removes dynamic custom column via input", () => {
-    let latest: DisplayState | undefined;
-    const r = render(<Harness onState={(s) => (latest = s)} />);
+  test("groups every discovered path and derives a view-aware placeholder", () => {
+    const sampleRows: Row[] = [
+      {
+        id: "r1",
+        state: "RUNNING",
+        agent: "a",
+        envelope: { payload: { repo: "watt-mind/factory", owner: "watt-mind" } },
+        spec: { input: { model: "claude-sonnet" } },
+        labels: { priority: "high" },
+      },
+    ];
+    const r = render(<Harness rows={sampleRows} />);
     fireEvent.click(r.getByRole("button", { name: /display/i }));
 
-    const input = r.getByPlaceholderText(/e\.g\. payload\.repo/i);
-    fireEvent.change(input, { target: { value: "payload.repo" } });
-    fireEvent.submit(input.closest("form")!);
+    const input = r.getByRole("combobox", { name: "Add custom property path" });
+    expect(input.getAttribute("placeholder")).toContain("labels.priority");
+    fireEvent.focus(input);
 
-    expect(latest?.customColumns).toEqual(["payload.repo"]);
-    expect(r.getByRole("button", { name: "payload.repo" })).toBeTruthy();
+    const listbox = r.getByRole("listbox", { name: "Discovered property paths" });
+    expect(within(listbox).getByText("payload")).toBeTruthy();
+    expect(within(listbox).getByText("spec")).toBeTruthy();
+    expect(within(listbox).getByText("labels")).toBeTruthy();
+    expect(within(listbox).getAllByRole("option")).toHaveLength(4);
+    expect(within(listbox).getByRole("option", { name: /payload\.repo.*watt-mind\/factory.*1 row/i })).toBeTruthy();
 
-    const removeBtn = r.getByLabelText("Remove column payload.repo");
-    fireEvent.click(removeBtn);
-    expect(latest?.customColumns).toEqual([]);
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(r.queryByRole("listbox", { name: "Discovered property paths" })).toBeNull();
+    expect(r.getByRole("dialog", { name: "Display options" })).toBeTruthy();
   });
 
-  test("discovered fields suggestion chip adds column", () => {
+  test("does not cap the full discovered suggestion list at ten paths", () => {
+    const payload = Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => [`field${index}`, `value${index}`]),
+    );
+    const sampleRows: Row[] = [
+      { id: "r1", state: "RUNNING", agent: "a", envelope: { payload } },
+    ];
+    const r = render(<Harness rows={sampleRows} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+
+    const input = r.getByRole("combobox", { name: "Add custom property path" });
+    fireEvent.focus(input);
+    expect(within(r.getByRole("listbox", { name: "Discovered property paths" })).getAllByRole("option")).toHaveLength(12);
+  });
+
+  test("filters suggestions and adds the keyboard-highlighted path", () => {
+    let latest: DisplayState | undefined;
+    const sampleRows: Row[] = [
+      {
+        id: "r1",
+        state: "RUNNING",
+        agent: "a",
+        envelope: { payload: { repo: "watt-mind/factory" } },
+        spec: { input: { model: "claude-sonnet" } },
+      },
+    ];
+    const r = render(<Harness onState={(s) => (latest = s)} rows={sampleRows} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+
+    const input = r.getByRole("combobox", { name: "Add custom property path" });
+    act(() => {
+      changeInput(input as HTMLInputElement, "model");
+    });
+    const options = within(r.getByRole("listbox", { name: "Discovered property paths" })).getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toContain("spec.input.model");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(latest?.customColumns).toEqual(["spec.input.model"]);
+    expect(r.getByRole("button", { name: "spec.input.model" })).toBeTruthy();
+  });
+
+  test("adds an undiscovered free-text path on Enter and explains the empty column", () => {
     let latest: DisplayState | undefined;
     const sampleRows: Row[] = [
       { id: "r1", state: "RUNNING", agent: "a", envelope: { payload: { repo: "watt-mind/factory" } } },
@@ -123,11 +187,17 @@ describe("DisplayOptions panel", () => {
     const r = render(<Harness onState={(s) => (latest = s)} rows={sampleRows} />);
     fireEvent.click(r.getByRole("button", { name: /display/i }));
 
-    const chip = r.getByRole("button", { name: /\+ payload\.repo/i });
-    expect(chip).toBeTruthy();
-    fireEvent.click(chip);
+    const input = r.getByRole("combobox", { name: "Add custom property path" });
+    act(() => {
+      changeInput(input as HTMLInputElement, "payload.futureField");
+    });
+    expect(r.getByText("not seen in loaded items; the column will show — until a row has it")).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(latest?.customColumns).toContain("payload.repo");
+    expect(latest?.customColumns).toEqual(["payload.futureField"]);
+    const removeBtn = r.getByLabelText("Remove column payload.futureField");
+    fireEvent.click(removeBtn);
+    expect(latest?.customColumns).toEqual([]);
   });
 
   test("Escape closes the panel and releases the modal depth", () => {

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -6,7 +6,16 @@
  * via `useDisplayOptions` and passes it down, so the panel never touches
  * storage and the table never re-derives what the panel showed.
  */
-import { useEffect, useId, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { keyGuard, modal } from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
@@ -19,7 +28,11 @@ import {
   type DisplayConfig,
   type DisplayState,
 } from "../displayOptions";
-import { discoverPayloadFields } from "../schemaDiscovery";
+import {
+  discoverPayloadFields,
+  groupDiscoveredFields,
+  type DiscoveredField,
+} from "../schemaDiscovery";
 
 function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: string; children: ReactNode }) {
   return (
@@ -143,6 +156,179 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
 }
 
+/** SuggestInput interaction model with richer, non-selectable discovery groups. */
+function DiscoveredFieldSuggestInput({
+  value,
+  fields,
+  placeholder,
+  onChange,
+  onAdd,
+}: {
+  value: string;
+  fields: DiscoveredField[];
+  placeholder: string;
+  onChange: (value: string) => void;
+  onAdd: (path: string) => void;
+}) {
+  const listId = useId();
+  const listRef = useRef<HTMLUListElement>(null);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+
+  const filteredFields = useMemo(() => {
+    const query = value.trim().toLowerCase();
+    if (!query) return fields;
+    return fields.filter((field) => field.path.toLowerCase().includes(query));
+  }, [fields, value]);
+  const groups = useMemo(() => groupDiscoveredFields(filteredFields), [filteredFields]);
+  const selectableFields = useMemo(() => groups.flatMap((group) => group.fields), [groups]);
+  const indexedGroups = useMemo(() => {
+    let index = 0;
+    return groups.map((group) => ({
+      ...group,
+      fields: group.fields.map((field) => ({ field, index: index++ })),
+    }));
+  }, [groups]);
+  const show = open && selectableFields.length > 0;
+  const showNotSeenHint = value.trim().length > 0 && selectableFields.length === 0;
+
+  useEffect(() => {
+    setHighlight(0);
+  }, [selectableFields]);
+
+  useEffect(() => {
+    if (!show || !listRef.current) return;
+    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [highlight, show]);
+
+  const pick = (field: DiscoveredField) => {
+    onAdd(field.path);
+    setOpen(false);
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown" && selectableFields.length > 0) {
+      event.preventDefault();
+      setOpen(true);
+      if (show) setHighlight((index) => (index + 1) % selectableFields.length);
+      return;
+    }
+    if (event.key === "ArrowUp" && selectableFields.length > 0) {
+      event.preventDefault();
+      setOpen(true);
+      setHighlight((index) => (show ? (index - 1 + selectableFields.length) % selectableFields.length : selectableFields.length - 1));
+      return;
+    }
+    if (event.key === "Enter") {
+      const selected = show ? selectableFields[highlight] : undefined;
+      if (!selected && !value.trim()) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (selected) pick(selected);
+      else {
+        onAdd(value);
+        setOpen(false);
+      }
+      return;
+    }
+    if (event.key === "Escape" && show) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          role="combobox"
+          aria-label="Add custom property path"
+          aria-autocomplete="list"
+          aria-expanded={show}
+          aria-controls={show ? listId : undefined}
+          aria-activedescendant={show && selectableFields[highlight] ? `${listId}-option-${highlight}` : undefined}
+          value={value}
+          placeholder={placeholder}
+          spellCheck={false}
+          onChange={(event) => {
+            onChange(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          onKeyDown={onKeyDown}
+          className="mono min-w-0 flex-1 rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[11px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--border-strong)"
+        />
+        <button
+          type="button"
+          disabled={!value.trim()}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => {
+            onAdd(value);
+            setOpen(false);
+          }}
+          className="cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-3) hover:text-(--text) disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          + Add
+        </button>
+      </div>
+
+      {show && (
+        <ul
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label="Discovered property paths"
+          className="mt-1 max-h-60 w-full overflow-auto rounded-md border border-(--border-strong) bg-(--surface-1) p-1 text-[11px] shadow-xl outline-none"
+        >
+          {indexedGroups.map((group) => (
+            <li key={group.root} role="presentation">
+              <div className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+                {group.root}
+              </div>
+              <ul role="group" aria-label={`${group.root} fields`}>
+                {group.fields.map(({ field, index }) => (
+                  <li
+                    key={field.path}
+                    id={`${listId}-option-${index}`}
+                    role="option"
+                    aria-selected={index === highlight}
+                    aria-label={`${field.path}, ${field.sampleValue}, ${field.occurrenceCount} ${field.occurrenceCount === 1 ? "row" : "rows"}`}
+                    title={`${field.path} — sample: ${field.sampleValue} — ${field.occurrenceCount} rows`}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      pick(field);
+                    }}
+                    className={`cursor-pointer rounded px-2 py-1 select-none ${
+                      index === highlight
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+                    }`}
+                  >
+                    <div className="mono truncate">{field.path}</div>
+                    <div className="flex items-center justify-between gap-2 text-[10px] text-(--text-faint)">
+                      <span className="truncate">{field.sampleValue}</span>
+                      <span className="shrink-0">{field.occurrenceCount} {field.occurrenceCount === 1 ? "row" : "rows"}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showNotSeenHint && (
+        <div role="status" className="mt-1 text-[10px] text-(--text-faint)">
+          not seen in loaded items; the column will show — until a row has it
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function DisplayOptions<T>({
   config,
   state,
@@ -187,6 +373,8 @@ export function DisplayOptions<T>({
     modal.depth += 1;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      const openSuggestInput = rootRef.current?.querySelector('[aria-label="Add custom property path"][aria-expanded="true"]');
+      if (openSuggestInput && e.target === openSuggestInput) return;
       e.stopPropagation();
       setOpen(false);
       triggerRef.current?.focus();
@@ -221,6 +409,14 @@ export function DisplayOptions<T>({
     if (!open || !rows?.length) return [];
     return discoverPayloadFields(rows, state.customColumns);
   }, [open, rows, state.customColumns]);
+
+  const discoveredPlaceholder = useMemo(() => {
+    const examples = groupDiscoveredFields(discoveredFields)
+      .slice(0, 2)
+      .map((group) => group.fields[0]?.path)
+      .filter(Boolean);
+    return examples.length > 0 ? `e.g. ${examples.join(", ")}` : "Enter a property path";
+  }, [discoveredFields]);
 
   const handleAddCustom = (pathToAdd?: string) => {
     const target = (pathToAdd ?? customInput).trim();
@@ -418,52 +614,13 @@ export function DisplayOptions<T>({
             </div>
           )}
 
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              const formEl = e.currentTarget;
-              const inputEl = formEl.elements.namedItem("property") as HTMLInputElement | null;
-              const val = inputEl?.value || customInput;
-              handleAddCustom(val);
-            }}
-            className="flex items-center gap-1.5"
-          >
-            <input
-              name="property"
-              type="text"
-              value={customInput}
-              placeholder="e.g. payload.repo, spec.input.model"
-              aria-label="Add custom property path"
-              onChange={(e) => setCustomInput(e.target.value)}
-              className="flex-1 rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
-            />
-            <button
-              type="submit"
-              disabled={!customInput.trim()}
-              className="cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-3) hover:text-(--text) disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              + Add
-            </button>
-          </form>
-
-          {discoveredFields.length > 0 && (
-            <div className="mt-2.5">
-              <div className="text-[10px] text-(--text-faint)">Discovered in loaded items:</div>
-              <div className="mt-1 flex max-h-24 flex-wrap gap-1 overflow-y-auto">
-                {discoveredFields.slice(0, 10).map((field) => (
-                  <button
-                    key={field.path}
-                    type="button"
-                    title={`Value sample: ${field.sampleValue}`}
-                    onClick={() => handleAddCustom(field.path)}
-                    className="cursor-pointer rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:border-(--border-strong) hover:bg-(--surface-3) hover:text-(--text)"
-                  >
-                    + {field.path} <span className="text-(--text-faint)">({field.occurrenceCount})</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
+          <DiscoveredFieldSuggestInput
+            value={customInput}
+            fields={discoveredFields}
+            placeholder={discoveredPlaceholder}
+            onChange={setCustomInput}
+            onAdd={handleAddCustom}
+          />
 
           {(onExport || customized) && (
             <div className="mt-3 flex items-center justify-between border-t border-(--border) pt-2">

--- a/event-runtime/web/src/schemaDiscovery.test.ts
+++ b/event-runtime/web/src/schemaDiscovery.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { groupDiscoveredFields, type DiscoveredField } from "./schemaDiscovery";
+
+const field = (path: string): DiscoveredField => ({
+  path,
+  sampleValue: `${path}-sample`,
+  occurrenceCount: 1,
+});
+
+describe("groupDiscoveredFields", () => {
+  test("turns an ungrouped discovery list into stable root groups", () => {
+    const groups = groupDiscoveredFields([
+      field("payload.repo"),
+      field("spec.input.model"),
+      field("payload.owner"),
+      field("id"),
+      field("labels.priority"),
+    ]);
+
+    expect(groups.map((group) => group.root)).toEqual(["payload", "spec", "top-level", "labels"]);
+    expect(groups[0].fields.map((item) => item.path)).toEqual(["payload.repo", "payload.owner"]);
+    expect(groups[2].fields.map((item) => item.path)).toEqual(["id"]);
+  });
+});

--- a/event-runtime/web/src/schemaDiscovery.ts
+++ b/event-runtime/web/src/schemaDiscovery.ts
@@ -9,6 +9,26 @@ export interface DiscoveredField {
   occurrenceCount: number;
 }
 
+export interface DiscoveredFieldGroup {
+  root: string;
+  fields: DiscoveredField[];
+}
+
+/** Preserve discovery relevance order while collecting fields under their root object. */
+export function groupDiscoveredFields(fields: DiscoveredField[]): DiscoveredFieldGroup[] {
+  const groups = new Map<string, DiscoveredField[]>();
+
+  for (const field of fields) {
+    const separator = field.path.indexOf(".");
+    const root = separator === -1 ? "top-level" : field.path.slice(0, separator);
+    const group = groups.get(root);
+    if (group) group.push(field);
+    else groups.set(root, [field]);
+  }
+
+  return Array.from(groups, ([root, groupedFields]) => ({ root, fields: groupedFields }));
+}
+
 const MAX_SCAN_ROWS = 60;
 const MAX_SCAN_DEPTH = 3;
 


### PR DESCRIPTION
## Summary
- replace the capped discovery chips with a searchable, root-grouped custom-column combobox
- show sample values and occurrence counts for every discovered path while preserving free-text additions
- derive examples from loaded rows and add regression coverage for grouping, filtering, keyboard behavior, and the uncapped list

## Verification
- `bun test event-runtime/web` — 554 pass, 0 fail
- `cd event-runtime/web && bun run build` — TypeScript and Vite build pass

## UX critique
- required — NOT-ASSESSED: the critic could not drive the running UI because browser tools were unavailable; interaction behavior is covered by component tests

Fixes WM-304