### PR TITLE
feat(event-runtime): add metrics query layer

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -20,6 +20,7 @@ import { runUsage, usageSpend } from "./db.mjs";
 import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
+import { MetricsQueryError, metricsBreakdownView, metricsView } from "./metrics.mjs";
 import { planEvent, requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { resolveModel } from "./registry.mjs";
@@ -838,6 +839,35 @@ export function createApi({
             secret, githubSecret, policyVersion, env, getStoreStats, workerPolicy, workerRunDir,
           }),
         });
+      }
+
+      if (route === "GET /metrics") {
+        try {
+          return send(res, 200, metricsView(db, {
+            now: nowMs,
+            window: url.searchParams.get("window") ?? "24h",
+            bucket: url.searchParams.get("bucket") ?? "1h",
+            series: url.searchParams.get("series"),
+          }));
+        } catch (err) {
+          if (err instanceof MetricsQueryError) return send(res, 422, err.body);
+          throw err;
+        }
+      }
+
+      if (route === "GET /metrics/breakdown") {
+        try {
+          return send(res, 200, metricsBreakdownView(db, {
+            now: nowMs,
+            window: url.searchParams.get("window") ?? "24h",
+            by: url.searchParams.get("by"),
+            metric: url.searchParams.get("metric"),
+            limit: url.searchParams.get("limit"),
+          }));
+        } catch (err) {
+          if (err instanceof MetricsQueryError) return send(res, 422, err.body);
+          throw err;
+        }
       }
 
       if (route === "GET /events") {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1015,6 +1015,52 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
   });
 });
 
+describe("metrics query API (WM-281)", () => {
+  let s;
+  const metricsNow = Date.parse("2026-08-15T12:00:00.000Z");
+  beforeAll(async () => {
+    s = await makeServer({ now: () => metricsNow });
+    s.db.query(
+      `INSERT INTO lifecycle_events
+         (run_id, from_state, to_state, actor, attempt, at, record_hash)
+       VALUES ('metrics-run', 'VERIFYING', 'COMPLETED', 'test', 1,
+               '2026-08-15T11:30:00.000Z', 'metrics-hash')`,
+    ).run();
+  });
+  afterAll(() => s.close());
+
+  test("GET /metrics returns one shared aligned bucket axis", async () => {
+    const res = await fetch(s.url("/metrics?window=24h&bucket=1h&series=runs.outcomes,runs.started"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.buckets).toHaveLength(24);
+    expect(body.series["runs.outcomes"].COMPLETED.at(-1)).toBe(1);
+    expect(body.series["runs.started"].total).toHaveLength(body.buckets.length);
+  });
+
+  test("query validation returns 422 and advertises valid values", async () => {
+    const unknown = await fetch(s.url("/metrics?series=not.real"));
+    expect(unknown.status).toBe(422);
+    const unknownBody = await unknown.json();
+    expect(unknownBody.error).toBe("unknown_series");
+    expect(unknownBody.validSeries).toContain("runs.outcomes");
+
+    const oversized = await fetch(s.url("/metrics?window=30d&bucket=15m&series=runs.started"));
+    expect(oversized.status).toBe(422);
+    expect((await oversized.json()).error).toBe("too_many_buckets");
+  });
+
+  test("GET /metrics/breakdown validates dimensions and returns rows", async () => {
+    const invalid = await fetch(s.url("/metrics/breakdown?window=24h&by=nope&metric=runs"));
+    expect(invalid.status).toBe(422);
+    expect((await invalid.json()).validDimensions).toContain("edge");
+
+    const valid = await fetch(s.url("/metrics/breakdown?window=24h&by=agent&metric=runs"));
+    expect(valid.status).toBe(200);
+    expect((await valid.json()).rows).toEqual([]);
+  });
+});
+
 describe("Host and Origin header security confinement (OPS-408)", () => {
   let s;
   beforeAll(async () => {
@@ -1095,6 +1141,22 @@ describe("Host and Origin header security confinement (OPS-408)", () => {
     const res = await rawRequest({ host: "attacker.com", path: "/health" });
     expect(res.status).toBe(403);
     expect(res.json?.error).toBe("invalid_host");
+  });
+
+  test("new metrics routes inherit Host and Origin confinement", async () => {
+    const badHost = await rawRequest({
+      host: "attacker.com",
+      path: "/metrics?window=24h&bucket=1h&series=runs.outcomes",
+    });
+    expect(badHost.status).toBe(403);
+    expect(badHost.json?.error).toBe("invalid_host");
+
+    const badOrigin = await rawRequest({
+      path: "/metrics/breakdown?window=24h&by=agent&metric=runs",
+      headers: { origin: "http://evil.com" },
+    });
+    expect(badOrigin.status).toBe(403);
+    expect(badOrigin.json?.error).toBe("cross_origin_rejected");
   });
 
   test("rejects mutating request carrying a foreign Origin header", async () => {

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -178,6 +178,18 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 3,
+    name: "metrics_query_indexes",
+    up(db) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_lifecycle_at ON lifecycle_events (at);
+        CREATE INDEX IF NOT EXISTS idx_runs_created_at ON runs (created_at);
+        CREATE INDEX IF NOT EXISTS idx_events_admitted_at ON events (admitted_at);
+        CREATE INDEX IF NOT EXISTS idx_proposals_created_at ON proposals (created_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION = MIGRATIONS.length > 0 ? MIGRATIONS[MIGRATIONS.length - 1].version : 1;

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -122,6 +122,26 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
+  test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    for (const migration of MIGRATIONS.filter((entry) => entry.version <= 2)) migration.up(db);
+    setSchemaVersion(db, 2);
+    db.close();
+
+    const migrated = openDb(file);
+    expect(getSchemaVersion(migrated)).toBe(CURRENT_SCHEMA_VERSION);
+    const indexes = migrated
+      .query(`SELECT name FROM sqlite_master WHERE type = 'index'`)
+      .all()
+      .map((row) => row.name);
+    expect(indexes).toContain("idx_lifecycle_at");
+    expect(indexes).toContain("idx_runs_created_at");
+    expect(indexes).toContain("idx_events_admitted_at");
+    expect(indexes).toContain("idx_proposals_created_at");
+    migrated.close();
+  });
+
   test("an older/unversioned database (user_version 0) is migrated on open", () => {
     const file = freshFile();
     // Simulate an unversioned raw sqlite db

--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -1,0 +1,444 @@
+const DURATIONS_MS = Object.freeze({
+  "15m": 15 * 60_000,
+  "1h": 60 * 60_000,
+  "6h": 6 * 60 * 60_000,
+  "24h": 24 * 60 * 60_000,
+  "7d": 7 * 24 * 60 * 60_000,
+  "30d": 30 * 24 * 60 * 60_000,
+});
+
+export const VALID_METRIC_SERIES = Object.freeze([
+  "runs.outcomes",
+  "runs.started",
+  "latency.queue_wait",
+  "latency.execution",
+  "spend.cost",
+  "spend.tokens",
+  "proposals.decisions",
+  "proposals.time_to_decision",
+  "events.intake",
+  "attempts.retries",
+]);
+
+export const VALID_BREAKDOWN_DIMENSIONS = Object.freeze([
+  "agent",
+  "adapter",
+  "model",
+  "repo",
+  "source",
+  "reason_code",
+  "event_type",
+  "edge",
+]);
+
+export const VALID_BREAKDOWN_METRICS = Object.freeze([
+  "runs",
+  "failures",
+  "cost",
+  "tokens",
+  "p95_execution",
+]);
+
+export const MAX_METRIC_BUCKETS = 500;
+
+export class MetricsQueryError extends Error {
+  constructor(error, details = {}) {
+    super(error);
+    this.name = "MetricsQueryError";
+    this.body = { error, ...details };
+  }
+}
+
+function nowValue(now) {
+  return typeof now === "function" ? now() : (now ?? Date.now());
+}
+
+function duration(name, parameter) {
+  const value = DURATIONS_MS[name];
+  if (!value) {
+    throw new MetricsQueryError(`invalid_${parameter}`, {
+      [parameter]: name,
+      valid: Object.keys(DURATIONS_MS),
+    });
+  }
+  return value;
+}
+
+function timeRange({ now, window = "24h", bucket = "1h", withBuckets = true } = {}) {
+  const nowMs = nowValue(now);
+  const windowMs = duration(window, "window");
+  const bucketMs = withBuckets ? duration(bucket, "bucket") : null;
+  const bucketCount = withBuckets ? Math.ceil(windowMs / bucketMs) : null;
+  if (withBuckets && bucketCount > MAX_METRIC_BUCKETS) {
+    throw new MetricsQueryError("too_many_buckets", {
+      window,
+      bucket,
+      buckets: bucketCount,
+      maxBuckets: MAX_METRIC_BUCKETS,
+    });
+  }
+  const startMs = nowMs - windowMs;
+  return {
+    window,
+    bucket,
+    nowMs,
+    startMs,
+    endMs: nowMs,
+    startIso: new Date(startMs).toISOString(),
+    endIso: new Date(nowMs).toISOString(),
+    bucketMs,
+    bucketCount,
+    buckets: withBuckets
+      ? Array.from({ length: bucketCount }, (_, index) => new Date(startMs + index * bucketMs).toISOString())
+      : null,
+  };
+}
+
+function bucketIndex(at, range) {
+  const timestamp = Date.parse(at);
+  if (!Number.isFinite(timestamp) || timestamp < range.startMs || timestamp >= range.endMs) return -1;
+  const index = Math.floor((timestamp - range.startMs) / range.bucketMs);
+  return index >= 0 && index < range.bucketCount ? index : -1;
+}
+
+function zeroArray(range, value = 0) {
+  return Array.from({ length: range.bucketCount }, () => value);
+}
+
+function countSeries(rows, range, fixedKeys = []) {
+  const result = Object.fromEntries(fixedKeys.map((key) => [key, zeroArray(range)]));
+  for (const row of rows) {
+    const index = Number(row.bucket_index);
+    if (!Number.isInteger(index) || index < 0 || index >= range.bucketCount) continue;
+    const key = String(row.key ?? "unknown");
+    if (!result[key]) result[key] = zeroArray(range);
+    result[key][index] += Number(row.value ?? 0);
+  }
+  return result;
+}
+
+function sqliteMilliseconds(expression) {
+  return `(CAST(strftime('%s', ${expression}) AS INTEGER) * 1000 + ` +
+    `CAST(substr(strftime('%f', ${expression}), 4, 3) AS INTEGER))`;
+}
+
+function groupedCounts(db, range, { table, time, key, where = "1 = 1", value = "COUNT(*)", joins = "" }) {
+  return db.query(
+    `SELECT CAST((${sqliteMilliseconds(time)} - ?) / ? AS INTEGER) AS bucket_index,
+            ${key} AS key,
+            ${value} AS value
+     FROM ${table} ${joins}
+     WHERE ${time} >= ? AND ${time} < ? AND (${where})
+     GROUP BY bucket_index, key
+     ORDER BY bucket_index, key`,
+  ).all(range.startMs, range.bucketMs, range.startIso, range.endIso);
+}
+
+function percentile(sorted, fraction) {
+  if (sorted.length === 0) return null;
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+function percentileSeries(rows, range) {
+  const samples = Array.from({ length: range.bucketCount }, () => []);
+  for (const row of rows) {
+    const index = bucketIndex(row.bucket_at, range);
+    const start = Date.parse(row.started_at);
+    const finish = Date.parse(row.finished_at ?? row.bucket_at);
+    if (index < 0 || !Number.isFinite(start) || !Number.isFinite(finish) || finish < start) continue;
+    samples[index].push(finish - start);
+  }
+  const p50 = zeroArray(range, null);
+  const p95 = zeroArray(range, null);
+  for (let index = 0; index < samples.length; index += 1) {
+    if (samples[index].length < 5) continue;
+    samples[index].sort((a, b) => a - b);
+    p50[index] = percentile(samples[index], 0.5);
+    p95[index] = percentile(samples[index], 0.95);
+  }
+  return { p50, p95 };
+}
+
+function outcomes(db, range) {
+  const rows = groupedCounts(db, range, {
+    table: "lifecycle_events",
+    time: "at",
+    key: "to_state",
+    where: "to_state IN ('COMPLETED', 'FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')",
+  });
+  return countSeries(rows, range, ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"]);
+}
+
+function started(db, range) {
+  const rows = groupedCounts(db, range, {
+    table: "lifecycle_events",
+    time: "at",
+    key: "'total'",
+    where: "to_state = 'RUNNING'",
+  });
+  return countSeries(rows, range, ["total"]);
+}
+
+function queueWait(db, range) {
+  const rows = db.query(
+    `SELECT leased.at AS bucket_at,
+            (SELECT queued.at
+             FROM lifecycle_events queued
+             WHERE queued.run_id = leased.run_id
+               AND queued.to_state = 'QUEUED'
+               AND queued.seq < leased.seq
+               AND (
+                 queued.attempt = leased.attempt
+                 OR queued.attempt = leased.attempt - 1
+                 OR (leased.attempt = 1 AND queued.attempt IS NULL)
+               )
+             ORDER BY queued.seq DESC
+             LIMIT 1) AS started_at,
+            leased.at AS finished_at
+     FROM lifecycle_events leased
+     WHERE leased.to_state = 'LEASED' AND leased.at >= ? AND leased.at < ?`,
+  ).all(range.startIso, range.endIso);
+  return percentileSeries(rows, range);
+}
+
+function execution(db, range) {
+  const rows = db.query(
+    `SELECT finished_at AS bucket_at, started_at, finished_at
+     FROM attempts
+     WHERE started_at IS NOT NULL AND finished_at IS NOT NULL
+       AND finished_at >= ? AND finished_at < ?`,
+  ).all(range.startIso, range.endIso);
+  return percentileSeries(rows, range);
+}
+
+function spend(db, range, column) {
+  const rows = groupedCounts(db, range, {
+    table: "run_usage u",
+    joins: "JOIN runs r ON r.run_id = u.run_id",
+    time: "u.recorded_at",
+    key: "COALESCE(json_extract(r.spec_json, '$.agent'), 'unknown')",
+    value: column,
+  });
+  return countSeries(rows, range);
+}
+
+function proposalDecisions(db, range) {
+  const decidedMilliseconds = sqliteMilliseconds("decided_at");
+  const createdMilliseconds = sqliteMilliseconds("created_at");
+  const rows = db.query(
+    `WITH decisions AS (
+       SELECT status AS key, ${decidedMilliseconds} AS at_ms
+       FROM proposals
+       WHERE status IN ('approved', 'rejected', 'superseded', 'expired')
+         AND decided_at IS NOT NULL
+       UNION ALL
+       SELECT 'expired' AS key, ${createdMilliseconds} + ttl_seconds * 1000 AS at_ms
+       FROM proposals
+       WHERE status = 'open'
+         AND ${createdMilliseconds} + ttl_seconds * 1000 < ?
+     )
+     SELECT CAST((at_ms - ?) / ? AS INTEGER) AS bucket_index,
+            key,
+            COUNT(*) AS value
+     FROM decisions
+     WHERE at_ms >= ? AND at_ms < ?
+     GROUP BY bucket_index, key
+     ORDER BY bucket_index, key`,
+  ).all(range.endMs, range.startMs, range.bucketMs, range.startMs, range.endMs);
+  return countSeries(rows, range, ["approved", "rejected", "expired", "superseded"]);
+}
+
+function proposalDecisionTime(db, range) {
+  const rows = db.query(
+    `SELECT decided_at AS bucket_at, created_at AS started_at, decided_at AS finished_at
+     FROM proposals
+     WHERE decided_at IS NOT NULL AND decided_at >= ? AND decided_at < ?`,
+  ).all(range.startIso, range.endIso);
+  return percentileSeries(rows, range);
+}
+
+function intake(db, range) {
+  const rows = groupedCounts(db, range, {
+    table: "events",
+    time: "admitted_at",
+    key: "status",
+  });
+  return countSeries(rows, range, ["admitted", "planned", "noop", "human_needed", "dead_lettered"]);
+}
+
+function retries(db, range) {
+  const rows = groupedCounts(db, range, {
+    table: "attempts",
+    time: "started_at",
+    key: "'total'",
+    where: "attempt > 1 AND started_at IS NOT NULL",
+  });
+  return countSeries(rows, range, ["total"]);
+}
+
+const SERIES_QUERIES = {
+  "runs.outcomes": outcomes,
+  "runs.started": started,
+  "latency.queue_wait": queueWait,
+  "latency.execution": execution,
+  "spend.cost": (db, range) => spend(db, range, "COALESCE(SUM(u.cost_usd), 0)"),
+  "spend.tokens": (db, range) => spend(
+    db,
+    range,
+    "COALESCE(SUM(u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens), 0)",
+  ),
+  "proposals.decisions": proposalDecisions,
+  "proposals.time_to_decision": proposalDecisionTime,
+  "events.intake": intake,
+  "attempts.retries": retries,
+};
+
+/** Aligned, zero-filled time-series query used by GET /metrics. */
+export function metricsView(db, { now, window = "24h", bucket = "1h", series } = {}) {
+  const names = series == null || series === ""
+    ? [...VALID_METRIC_SERIES]
+    : (Array.isArray(series) ? series : String(series).split(",")).map((name) => name.trim()).filter(Boolean);
+  const unknown = names.filter((name) => !VALID_METRIC_SERIES.includes(name));
+  if (unknown.length > 0) {
+    throw new MetricsQueryError("unknown_series", { unknown, validSeries: VALID_METRIC_SERIES });
+  }
+  const range = timeRange({ now, window, bucket });
+  const output = {};
+  for (const name of [...new Set(names)]) output[name] = SERIES_QUERIES[name](db, range);
+  return { window, bucket, buckets: range.buckets, series: output };
+}
+
+function repoNames(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return [];
+  const names = [];
+  const add = (value) => {
+    if (typeof value === "string" && value !== "" && !names.includes(value)) names.push(value);
+  };
+  add(input.repoPin?.repo);
+  add(input.repo);
+  for (const entry of input.repos ?? []) add(typeof entry === "string" ? entry : entry?.name);
+  return names;
+}
+
+const RUN_FACTS_SELECT = `
+  SELECT r.run_id, r.spec_json, r.state, r.created_at, r.updated_at,
+         a.reason_code, e.source AS event_source, e.type AS event_type,
+         parent.spec_json AS parent_spec_json`;
+const RUN_FACTS_JOINS = `
+  LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+  LEFT JOIN proposals p ON p.rowid = (
+    SELECT p2.rowid FROM proposals p2 WHERE p2.run_id = r.run_id
+    ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1
+  )
+  LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+  LEFT JOIN runs parent ON parent.run_id = e.causation_id`;
+
+function factKeys(row, dimension) {
+  const spec = JSON.parse(row.spec_json || "{}");
+  if (dimension === "agent") return [spec.agent ?? "unknown"];
+  if (dimension === "adapter") return [spec.adapter ?? row.usage_adapter ?? "unknown"];
+  if (dimension === "model") return [row.usage_model ?? spec.model ?? "unknown"];
+  if (dimension === "repo") return repoNames(spec.input).length > 0 ? repoNames(spec.input) : ["unknown"];
+  if (dimension === "source") return [row.event_source ?? "unknown"];
+  if (dimension === "reason_code") return [row.reason_code ?? "unknown"];
+  if (dimension === "event_type") return [row.event_type ?? "unknown"];
+  if (dimension === "edge") {
+    if (!row.parent_spec_json || !row.event_type) return [];
+    const parent = JSON.parse(row.parent_spec_json);
+    return [`${parent.agent ?? "unknown"}→${row.event_type}`];
+  }
+  return [];
+}
+
+function breakdownFacts(db, metric, range) {
+  if (metric === "runs" || metric === "failures") {
+    const failures = metric === "failures"
+      ? "AND r.state IN ('FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')"
+      : "";
+    const time = metric === "failures" ? "r.updated_at" : "r.created_at";
+    return db.query(
+      `${RUN_FACTS_SELECT}, 1 AS value
+       FROM runs r ${RUN_FACTS_JOINS}
+       WHERE ${time} >= ? AND ${time} < ? ${failures}`,
+    ).all(range.startIso, range.endIso);
+  }
+  if (metric === "cost" || metric === "tokens") {
+    const value = metric === "cost"
+      ? "u.cost_usd"
+      : "u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens";
+    return db.query(
+      `${RUN_FACTS_SELECT}, u.adapter AS usage_adapter, u.model AS usage_model, ${value} AS value
+       FROM run_usage u
+       JOIN runs r ON r.run_id = u.run_id
+       LEFT JOIN attempts a ON a.run_id = u.run_id AND a.attempt = u.attempt
+       LEFT JOIN proposals p ON p.rowid = (
+         SELECT p2.rowid FROM proposals p2 WHERE p2.run_id = r.run_id
+         ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1
+       )
+       LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+       LEFT JOIN runs parent ON parent.run_id = e.causation_id
+       WHERE u.recorded_at >= ? AND u.recorded_at < ?`,
+    ).all(range.startIso, range.endIso);
+  }
+  return db.query(
+    `${RUN_FACTS_SELECT}, a.started_at, a.finished_at
+     FROM attempts a
+     JOIN runs r ON r.run_id = a.run_id
+     LEFT JOIN proposals p ON p.rowid = (
+       SELECT p2.rowid FROM proposals p2 WHERE p2.run_id = r.run_id
+       ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1
+     )
+     LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+     LEFT JOIN runs parent ON parent.run_id = e.causation_id
+     WHERE a.started_at IS NOT NULL AND a.finished_at IS NOT NULL
+       AND a.finished_at >= ? AND a.finished_at < ?`,
+  ).all(range.startIso, range.endIso);
+}
+
+/** Top-N operational dimensions used by GET /metrics/breakdown. */
+export function metricsBreakdownView(db, {
+  now,
+  window = "24h",
+  by,
+  metric,
+  limit,
+} = {}) {
+  if (!VALID_BREAKDOWN_DIMENSIONS.includes(by)) {
+    throw new MetricsQueryError("invalid_dimension", { by, validDimensions: VALID_BREAKDOWN_DIMENSIONS });
+  }
+  if (!VALID_BREAKDOWN_METRICS.includes(metric)) {
+    throw new MetricsQueryError("invalid_metric", { metric, validMetrics: VALID_BREAKDOWN_METRICS });
+  }
+  let actualLimit;
+  if (limit == null || limit === "") actualLimit = by === "event_type" || by === "edge" ? null : 10;
+  else {
+    actualLimit = Number(limit);
+    if (!Number.isInteger(actualLimit) || actualLimit < 1 || actualLimit > 500) {
+      throw new MetricsQueryError("invalid_limit", { limit, min: 1, max: 500 });
+    }
+  }
+  const range = timeRange({ now, window, withBuckets: false });
+  const facts = breakdownFacts(db, metric, range);
+  const grouped = new Map();
+  for (const fact of facts) {
+    for (const key of factKeys(fact, by)) {
+      if (metric === "p95_execution") {
+        const durationMs = Date.parse(fact.finished_at) - Date.parse(fact.started_at);
+        if (!Number.isFinite(durationMs) || durationMs < 0) continue;
+        const samples = grouped.get(key) ?? [];
+        samples.push(durationMs);
+        grouped.set(key, samples);
+      } else {
+        grouped.set(key, (grouped.get(key) ?? 0) + Number(fact.value ?? 0));
+      }
+    }
+  }
+  let rows = [...grouped.entries()].map(([key, value]) => {
+    if (metric !== "p95_execution") return { key, value };
+    value.sort((a, b) => a - b);
+    return { key, value: percentile(value, 0.95) };
+  });
+  rows.sort((a, b) => b.value - a.value || a.key.localeCompare(b.key));
+  if (actualLimit != null) rows = rows.slice(0, actualLimit);
+  return { window, by, metric, limit: actualLimit, rows };
+}

--- a/event-runtime/lib/metrics.test.mjs
+++ b/event-runtime/lib/metrics.test.mjs
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { openDb, recordRunUsage } from "./db.mjs";
+import {
+  MAX_METRIC_BUCKETS,
+  MetricsQueryError,
+  VALID_METRIC_SERIES,
+  metricsBreakdownView,
+  metricsView,
+} from "./metrics.mjs";
+
+const NOW = Date.parse("2026-08-15T12:00:00.000Z");
+const at = (millisecondsAgo) => new Date(NOW - millisecondsAgo).toISOString();
+
+function insertRun(db, id, {
+  agent = "agent-a@1",
+  adapter = "pi",
+  model = "openai/test",
+  input = { repo: "factory" },
+  state = "COMPLETED",
+  attempts = 1,
+  createdAt = at(30 * 60_000),
+  updatedAt = createdAt,
+} = {}) {
+  db.query(
+    `INSERT INTO runs
+       (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, 'hash', ?, ?, ?, ?)`,
+  ).run(id, `idem-${id}`, JSON.stringify({ agent, adapter, model, input }), state, attempts, createdAt, updatedAt);
+}
+
+let lifecycleSequence = 0;
+function insertLifecycle(db, runId, to, when, { from = null, attempt = null } = {}) {
+  lifecycleSequence += 1;
+  db.query(
+    `INSERT INTO lifecycle_events
+       (run_id, from_state, to_state, actor, attempt, at, record_hash)
+     VALUES (?, ?, ?, 'test', ?, ?, ?)`,
+  ).run(runId, from, to, attempt, when, `lifecycle-${lifecycleSequence}`);
+}
+
+function insertAttempt(db, runId, attempt, {
+  startedAt,
+  finishedAt,
+  terminalState = "COMPLETED",
+  reasonCode = null,
+} = {}) {
+  db.query(
+    `INSERT INTO attempts
+       (run_id, attempt, fencing_token, started_at, finished_at, terminal_state, reason_code)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(runId, attempt, attempt, startedAt ?? null, finishedAt ?? null, terminalState, reasonCode);
+}
+
+function insertEvent(db, id, {
+  type = "factory.test.requested",
+  source = "test",
+  status = "planned",
+  admittedAt = at(30 * 60_000),
+  causationId = null,
+} = {}) {
+  db.query(
+    `INSERT INTO events
+       (source, event_id, type, occurred_at, received_at, causation_id,
+        envelope_json, payload_hash, status, admitted_at)
+     VALUES (?, ?, ?, ?, ?, ?, '{}', ?, ?, ?)`,
+  ).run(source, id, type, admittedAt, admittedAt, causationId, `hash-${source}-${id}`, status, admittedAt);
+}
+
+function insertProposal(db, id, eventId, {
+  runId = null,
+  status = "approved",
+  source = "test",
+  createdAt = at(31 * 60_000),
+  decidedAt = at(30 * 60_000),
+  ttlSeconds = 3600,
+} = {}) {
+  db.query(
+    `INSERT INTO proposals
+       (id, event_source, event_id, run_id, decision, spec_json, spec_hash,
+        idempotency_key, status, created_at, ttl_seconds, decided_at)
+     VALUES (?, ?, ?, ?, 'run', '{}', 'hash', ?, ?, ?, ?, ?)`,
+  ).run(id, source, eventId, runId, `idem-proposal-${id}`, status, createdAt, ttlSeconds, decidedAt);
+}
+
+function seededSeriesDb() {
+  const db = openDb(":memory:");
+  insertLifecycle(db, "run-outcome", "RUNNING", at(40 * 60_000), { from: "LEASED", attempt: 1 });
+  insertLifecycle(db, "run-outcome", "COMPLETED", at(30 * 60_000), { from: "VERIFYING", attempt: 1 });
+
+  const executionDurations = [1000, 2000, 3000, 100_000, 200_000];
+  const queueDurations = [10_000, 20_000, 30_000, 40_000, 50_000];
+  executionDurations.forEach((duration, index) => {
+    const runId = index < 3 ? "multi-attempt" : `single-${index}`;
+    const attempt = index < 3 ? index + 1 : 1;
+    const finishedAt = at(20 * 60_000 + index * 1000);
+    insertAttempt(db, runId, attempt, {
+      startedAt: new Date(Date.parse(finishedAt) - duration).toISOString(),
+      finishedAt,
+    });
+    const leasedAt = at(10 * 60_000 + index * 1000);
+    insertLifecycle(db, runId, "QUEUED", new Date(Date.parse(leasedAt) - queueDurations[index]).toISOString(), {
+      from: index < 3 && index > 0 ? "FAILED" : "APPROVED",
+      attempt: index < 3 && index > 0 ? index : null,
+    });
+    insertLifecycle(db, runId, "LEASED", leasedAt, { from: "QUEUED", attempt });
+  });
+
+  insertRun(db, "spend-a", { agent: "agent-a@1" });
+  recordRunUsage(db, {
+    runId: "spend-a",
+    attempt: 1,
+    adapter: "pi",
+    model: "openai/test",
+    inputTokens: 10,
+    outputTokens: 20,
+    cacheCreationInputTokens: 30,
+    cacheReadInputTokens: 40,
+    costUSD: 1.25,
+    recordedAt: at(15 * 60_000),
+  });
+
+  const decisions = ["approved", "rejected", "superseded", "approved", "rejected"];
+  decisions.forEach((status, index) => {
+    const decidedAt = at(25 * 60_000 + index * 1000);
+    insertProposal(db, `decision-${index}`, `decision-event-${index}`, {
+      status,
+      createdAt: new Date(Date.parse(decidedAt) - (index + 1) * 1000).toISOString(),
+      decidedAt,
+    });
+  });
+  insertProposal(db, "expired", "expired-event", {
+    status: "open",
+    createdAt: at(2 * 60 * 60_000),
+    decidedAt: null,
+    ttlSeconds: 3600,
+  });
+
+  for (const status of ["admitted", "planned", "noop", "human_needed", "dead_lettered"]) {
+    insertEvent(db, `event-${status}`, { status });
+  }
+  return db;
+}
+
+describe("metrics time series (WM-281)", () => {
+  test("all allowlisted series share aligned buckets and preserve empty buckets", () => {
+    const db = seededSeriesDb();
+    const view = metricsView(db, {
+      now: NOW,
+      window: "24h",
+      bucket: "1h",
+      series: VALID_METRIC_SERIES.join(","),
+    });
+
+    expect(view.buckets).toHaveLength(24);
+    expect(Object.keys(view.series)).toEqual(VALID_METRIC_SERIES);
+    for (const values of Object.values(view.series)) {
+      for (const points of Object.values(values)) expect(points).toHaveLength(view.buckets.length);
+    }
+    expect(view.series["runs.outcomes"].COMPLETED.at(-1)).toBe(1);
+    expect(view.series["runs.outcomes"].COMPLETED[0]).toBe(0);
+    expect(view.series["runs.started"].total.at(-1)).toBe(1);
+    expect(view.series["latency.queue_wait"].p50.at(-1)).toBe(30_000);
+    expect(view.series["latency.queue_wait"].p95.at(-1)).toBe(50_000);
+    // Three samples belong to one run. Per-run first→last timing would leave
+    // fewer than five samples (and include retry queue gaps), so these values
+    // prove execution is measured independently per completed attempt.
+    expect(view.series["latency.execution"].p50.at(-1)).toBe(3000);
+    expect(view.series["latency.execution"].p95.at(-1)).toBe(200_000);
+    expect(view.series["spend.cost"]["agent-a@1"].at(-1)).toBe(1.25);
+    expect(view.series["spend.tokens"]["agent-a@1"].at(-1)).toBe(100);
+    expect(view.series["proposals.decisions"].approved.at(-1)).toBe(2);
+    expect(view.series["proposals.decisions"].expired.at(-1)).toBe(1);
+    expect(view.series["proposals.time_to_decision"].p50.at(-1)).toBe(3000);
+    expect(view.series["proposals.time_to_decision"].p95.at(-1)).toBe(5000);
+    expect(view.series["events.intake"].dead_lettered.at(-1)).toBe(1);
+    expect(view.series["attempts.retries"].total.at(-1)).toBe(2);
+    db.close();
+  });
+
+  test("in-flight intervals are excluded and sparse percentile buckets are null", () => {
+    const db = openDb(":memory:");
+    insertAttempt(db, "flight", 1, { startedAt: at(10_000), finishedAt: null });
+    insertAttempt(db, "finished", 1, { startedAt: at(20_000), finishedAt: at(10_000) });
+    const view = metricsView(db, { now: NOW, series: "latency.execution" });
+    expect(view.series["latency.execution"].p50.every((value) => value === null)).toBe(true);
+    expect(view.series["latency.execution"].p95.every((value) => value === null)).toBe(true);
+    db.close();
+  });
+
+  test("invalid series and oversized bucket combinations are typed 422 errors", () => {
+    const db = openDb(":memory:");
+    try {
+      metricsView(db, { now: NOW, series: "runs.nope" });
+      throw new Error("expected unknown series error");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MetricsQueryError);
+      expect(err.body.error).toBe("unknown_series");
+      expect(err.body.validSeries).toEqual(VALID_METRIC_SERIES);
+    }
+    try {
+      metricsView(db, { now: NOW, window: "30d", bucket: "15m", series: "runs.started" });
+      throw new Error("expected bucket cap error");
+    } catch (err) {
+      expect(err.body).toMatchObject({ error: "too_many_buckets", maxBuckets: MAX_METRIC_BUCKETS });
+    }
+    db.close();
+  });
+});
+
+function seededBreakdownDb() {
+  const db = openDb(":memory:");
+  insertRun(db, "parent", { agent: "recommender@1", adapter: "pi", input: { repo: "factory" } });
+  insertAttempt(db, "parent", 1, {
+    startedAt: at(35 * 60_000),
+    finishedAt: at(34 * 60_000),
+  });
+
+  for (let index = 0; index < 12; index += 1) {
+    const runId = `child-${index}`;
+    const eventId = `caused-${index}`;
+    const type = `factory.caused-${index}.requested`;
+    insertEvent(db, eventId, { source: "result", type, causationId: "parent" });
+    insertRun(db, runId, {
+      agent: "worker@1",
+      adapter: "claude",
+      model: "claude/test",
+      input: { repos: ["factory", { name: "bj29" }] },
+      state: index === 0 ? "FAILED" : "COMPLETED",
+      updatedAt: at(20 * 60_000),
+    });
+    insertProposal(db, `proposal-${index}`, eventId, { runId, source: "result" });
+    insertAttempt(db, runId, 1, {
+      startedAt: at(25 * 60_000),
+      finishedAt: at(24 * 60_000 - index * 1000),
+      terminalState: index === 0 ? "FAILED" : "COMPLETED",
+      reasonCode: index === 0 ? "adapter_error" : null,
+    });
+    recordRunUsage(db, {
+      runId,
+      attempt: 1,
+      adapter: "claude",
+      model: "claude/test",
+      inputTokens: index + 1,
+      costUSD: 0.1,
+      recordedAt: at(15 * 60_000),
+    });
+  }
+  // Multiple proposal-history rows for a run must not multiply an edge.
+  insertProposal(db, "proposal-0-history", "caused-0", {
+    runId: "child-0",
+    source: "result",
+    status: "superseded",
+    createdAt: at(29 * 60_000),
+  });
+  return db;
+}
+
+describe("metrics breakdowns (WM-281)", () => {
+  test("top-N dimensions and unbounded graph dimensions are computed server-side", () => {
+    const db = seededBreakdownDb();
+    expect(metricsBreakdownView(db, { now: NOW, by: "agent", metric: "runs" }).rows[0]).toEqual({
+      key: "worker@1",
+      value: 12,
+    });
+    expect(metricsBreakdownView(db, { now: NOW, by: "adapter", metric: "runs" }).rows[0]).toEqual({
+      key: "claude",
+      value: 12,
+    });
+    expect(metricsBreakdownView(db, { now: NOW, by: "reason_code", metric: "failures" }).rows).toEqual([
+      { key: "adapter_error", value: 1 },
+    ]);
+
+    const eventTypes = metricsBreakdownView(db, { now: NOW, by: "event_type", metric: "runs" });
+    expect(eventTypes.limit).toBeNull();
+    expect(eventTypes.rows).toHaveLength(13); // twelve event types plus the uncaused parent
+    const edges = metricsBreakdownView(db, { now: NOW, by: "edge", metric: "runs" });
+    expect(edges.limit).toBeNull();
+    expect(edges.rows).toHaveLength(12);
+    expect(edges.rows.find((row) => row.key === "recommender@1→factory.caused-0.requested")).toEqual({
+      key: "recommender@1→factory.caused-0.requested",
+      value: 1,
+    });
+
+    expect(metricsBreakdownView(db, { now: NOW, by: "model", metric: "tokens" }).rows[0]).toEqual({
+      key: "claude/test",
+      value: 78,
+    });
+    expect(metricsBreakdownView(db, { now: NOW, by: "repo", metric: "runs" }).rows).toContainEqual({
+      key: "bj29",
+      value: 12,
+    });
+    expect(metricsBreakdownView(db, { now: NOW, by: "source", metric: "cost" }).rows[0].key).toBe("result");
+    expect(metricsBreakdownView(db, { now: NOW, by: "agent", metric: "p95_execution" }).rows[0].value).toBe(71_000);
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add aligned, zero-filled time-series queries for runtime outcomes, latency, spend, proposal, intake, and retry metrics
- add top-N and graph breakdown queries across agent, adapter, model, repo, source, reason, event type, and causation edge
- add the v3 timestamp index migration and seeded API/database regression coverage

## Verification
- `bun test event-runtime/lib` — 663 pass, 0 fail
- live-database backup migration check — schema v3 with all four metrics indexes

## UX critique
- skipped — backend query-layer only; no user-completable flow or UI changed

Fixes WM-281