### PR TITLE
fix(dispatch): handle child spawn errors (WM-239)

### DIFF
--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -35,6 +35,26 @@ import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export const DISPATCH_FAILURE_THRESHOLD = 3;
 
+/**
+ * A failed spawn emits `error` asynchronously and is commonly followed by
+ * `close`. Observe both without allowing the same child to settle twice.
+ */
+export function observeChildTermination(child, onTermination) {
+  let settled = false;
+  const settle = async (outcome) => {
+    if (settled) return;
+    settled = true;
+    await onTermination(outcome);
+  };
+
+  child.on("error", async (error) => {
+    await settle({ error, code: null });
+  });
+  child.on("close", async (code) => {
+    await settle({ error: null, code });
+  });
+}
+
 export function isDispatchFailureComment(body) {
   if (!body || typeof body !== "string") return false;
   return /Dispatch (run )?failed/i.test(body.trim());
@@ -511,8 +531,6 @@ async function runTicket(t) {
     void emitFactoryEvent("factory.ticket.dispatched",
       { repo: repo.name, ticket: t.identifier, harness: HARNESS, worktree: wt },
       { eventId: `dispatch:${t.identifier}:${stamp}`, subject: t.identifier });
-    child.on("close", () => children.delete(child));
-
     let buf = "";
     let recorded = false;
     let turnCount = 0;
@@ -589,18 +607,28 @@ async function runTicket(t) {
       for (const line of lines) processLine(line);
     });
     child.stderr.on("data", (d) => out.write(d));
-    child.on("close", async (code) => {
-      // The final "result" line isn't guaranteed a trailing newline, so
-      // whatever is still in `buf` when the process exits needs a look too —
-      // otherwise a clean exit with no trailing "\n" silently reports nothing.
-      if (buf.trim()) processLine(buf);
-      // If the child never emitted a parseable result (crash, bad spawn,
-      // killed by the timeout), record it as a failure explicitly. Silence
-      // here previously showed up as "0 ok, 0 failed" — indistinguishable
-      // from an empty run.
-      if (!recorded) {
-        console.log(`${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(`no result (exit ${code})`)}`);
-        results.push({ id: t.identifier, ok: false, log, why: `no result emitted (exit ${code})` });
+    observeChildTermination(child, async ({ error, code }) => {
+      children.delete(child);
+      if (error) {
+        const detail = `${error.code ? `${error.code}: ` : ""}${error.message || error}`;
+        const why = `agent spawn failed (${detail})`;
+        console.log(`${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(why)}`);
+        out.write(`[dispatcher] ${why}\n`);
+        results.push({ id: t.identifier, ok: false, log, why });
+        recorded = true;
+        noteEnvFailure("agent spawn");
+      } else {
+        // The final "result" line isn't guaranteed a trailing newline, so
+        // whatever is still in `buf` when the process exits needs a look too —
+        // otherwise a clean exit with no trailing "\n" silently reports nothing.
+        if (buf.trim()) processLine(buf);
+        // If the child never emitted a parseable result (crash or killed by the
+        // timeout), record it as a failure explicitly. Silence here previously
+        // showed up as "0 ok, 0 failed" — indistinguishable from an empty run.
+        if (!recorded) {
+          console.log(`${c.dim(clock())} ${tag} ${c.red("FAILED")} ${c.dim(`no result (exit ${code})`)}`);
+          results.push({ id: t.identifier, ok: false, log, why: `no result emitted (exit ${code})` });
+        }
       }
       out.end();
       // A failed run must not keep its claim (unclaim() checks the ticket

--- a/orchestrator/tick.test.mjs
+++ b/orchestrator/tick.test.mjs
@@ -22,7 +22,9 @@ function withLock(content, run) {
 describe("observeChildTermination", () => {
   test("handles an asynchronous spawn error and settles only once", async () => {
     const child = new EventEmitter();
-    const spawnError = Object.assign(new Error("spawn agent ENOENT"), { code: "ENOENT" });
+    const spawnError = Object.assign(new Error("spawn agent ENOENT"), {
+      code: "ENOENT",
+    });
     const outcomes = [];
 
     observeChildTermination(child, async (outcome) => {

--- a/orchestrator/tick.test.mjs
+++ b/orchestrator/tick.test.mjs
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import { observeChildTermination } from "./tick.mjs";
+
+describe("observeChildTermination", () => {
+  test("handles an asynchronous spawn error and settles only once", async () => {
+    const child = new EventEmitter();
+    const spawnError = Object.assign(new Error("spawn agent ENOENT"), { code: "ENOENT" });
+    const outcomes = [];
+
+    observeChildTermination(child, async (outcome) => {
+      outcomes.push(outcome);
+    });
+
+    expect(() => child.emit("error", spawnError)).not.toThrow();
+    await Promise.resolve();
+    child.emit("close", -2);
+    await Promise.resolve();
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toEqual({ error: spawnError, code: null });
+  });
+
+  test("handles a real failed spawn without an uncaught exception", async () => {
+    const child = spawn("/definitely-not-a-factory-agent-binary", []);
+    const outcome = await new Promise((resolve) => {
+      observeChildTermination(child, resolve);
+    });
+
+    expect(outcome.code).toBeNull();
+    expect(outcome.error?.code).toBe("ENOENT");
+  });
+
+  test("settles normal child closure without an error", async () => {
+    const child = new EventEmitter();
+    const outcomes = [];
+
+    observeChildTermination(child, async (outcome) => {
+      outcomes.push(outcome);
+    });
+
+    child.emit("close", 0);
+    await Promise.resolve();
+
+    expect(outcomes).toEqual([{ error: null, code: 0 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- settle spawned child `error` and `close` events through a one-shot lifecycle observer
- record and log agent spawn failures before removing child tracking, releasing the worker lease, and unclaiming
- add regression coverage for synthetic and real ENOENT spawn failures

## Verification
- `bun test && bun build/emit.mjs --check` — pass (1,649 tests; 90 generated files match)

## UX critique
- skipped — internal dispatcher process lifecycle only; no user-completable flow or interface change

Fixes WM-239