### PR TITLE
feat(event-runtime): add human inbox ledger

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -86,6 +86,7 @@ case "$cmd" in
   tick)         run_bun orchestrator/tick.mjs "$@" ;;
   dispatch)     run_bun tools/dispatch.mjs "$@" ;;
   events)       run_bun event-runtime/cli.mjs "$@" ;;
+  inbox)        run_bun event-runtime/cli.mjs inbox "$@" ;;
   approve)      run_bun event-runtime/cli.mjs approve "$@" ;;
   reject)       run_bun event-runtime/cli.mjs reject "$@" ;;
   inject)       run_bun event-runtime/cli.mjs inject "$@" ;;
@@ -136,9 +137,79 @@ case "$cmd" in
     ;;
   run)          run_sh runners/run-agent.sh "$@" ;;
   notify)
-    # A cwd-independent wrapper for the factory floor's interrupt channel.
-    # FACTORY_NOTIFY_SCRIPT is for tests or a deliberate local override only.
-    exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" "$@"
+    # Durable first, push second (WM-285). A runtime connection failure falls
+    # back to the original direct transport so an offline serve process cannot
+    # swallow the interrupt. HTTP/delivery failures do not double-send.
+    _notify_stdin=0
+    if [[ "${1:-}" == "-" ]]; then
+      _notify_stdin=1
+      # Sentinel keeps command substitution from stripping trailing newlines.
+      _notify_message="$(cat; printf x)"
+      _notify_message="${_notify_message%x}"
+    else
+      _notify_message="$*"
+    fi
+
+    _notify_kind=""
+    if [[ "$_notify_message" =~ ^(BLOCKED|ESCALATED|CI[[:space:]]RED|SMOKE[[:space:]]RED|CIRCUIT[[:space:]]BREAKER|RC[[:space:]]READY)[[:space:]]+.+: ]]; then
+      _notify_kind="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -n "$_notify_kind" ]]; then
+      export FACTORY_INBOX_KIND="$_notify_kind"
+      export FACTORY_INBOX_MESSAGE="$_notify_message"
+      if [[ -n "${FACTORY_RUN_ID:-}" ]]; then
+        export FACTORY_INBOX_SOURCE="agent:${FACTORY_RUN_ID}"
+      else
+        export FACTORY_INBOX_SOURCE="cli"
+      fi
+      set +e
+      bun -e '
+        const message = process.env.FACTORY_INBOX_MESSAGE;
+        const kind = process.env.FACTORY_INBOX_KIND;
+        const prefix = message.slice(kind.length).trimStart().split(":", 1)[0].trim();
+        const refs = {};
+        const issue = prefix.match(/\b[A-Z][A-Z0-9]+-\d+\b/);
+        const pr = prefix.match(/\bPR#?\d+\b/i);
+        const run = prefix.match(/\brun\s+([^\s:]+)/i);
+        if (issue) refs.issue = issue[0];
+        if (pr) refs.pr = pr[0].toUpperCase();
+        if (run) refs.runId = run[1];
+        const repo = prefix.match(/^merge\s+(\S+)/i)
+          || prefix.match(/^(\S+)\s+run\s+/i)
+          || (!issue && !pr ? prefix.match(/^(\S+)/) : null);
+        if (repo) refs.repo = repo[1];
+        try {
+          const response = await fetch(`http://127.0.0.1:${process.env.FACTORY_EVENT_PORT || "7381"}/inbox`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              kind,
+              title: message,
+              refs,
+              source: process.env.FACTORY_INBOX_SOURCE,
+            }),
+          });
+          if (!response.ok) process.exit(10);
+          const body = await response.json();
+          process.exit(body?.delivery?.ok === false ? 12 : 0);
+        } catch {
+          process.exit(11);
+        }
+      ' >/dev/null 2>&1
+      _notify_status=$?
+      set -e
+      if [[ "$_notify_status" -eq 0 ]]; then exit 0; fi
+      if [[ "$_notify_status" -ne 11 ]]; then exit "$_notify_status"; fi
+    fi
+
+    # Unreachable runtime (or an unstructured legacy message): preserve the
+    # old argv/stdin transport exactly.
+    if [[ "$_notify_stdin" -eq 1 ]]; then
+      printf '%s' "$_notify_message" | exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" -
+    else
+      exec python3 "${FACTORY_NOTIFY_SCRIPT:-$HOME/Develop/hdkiller/scripts/notify.py}" "$@"
+    fi
     ;;
   security)
     # Local security harness (OPS-165): Gitleaks + Semgrep + Actionlint on the
@@ -186,6 +257,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   tick          orchestrator/tick.mjs
   dispatch      tools/dispatch.mjs (swift event task runner: triage, status, janitor)
   events        event-runtime/cli.mjs (status, ps, runs, proposals, approve, reject, inject, requeue)
+  inbox         list open human inbox items
   approve       event-runtime/cli.mjs approve <proposal-id>
   reject        event-runtime/cli.mjs reject <proposal-id> "<reason>"
   inject        event-runtime/cli.mjs inject <envelope.json|->
@@ -196,7 +268,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   tail          tail live daemon logs (~/.factory/run/{serve,worker,web}.log)
   demo          provision & run isolated seeded demo env (use --down to stop)
   run           runners/run-agent.sh
-  notify        ~/Develop/hdkiller/scripts/notify.py (human interrupt channel)
+  notify        durable human inbox + notify.py projection (direct fallback when serve is offline)
   security      lib/security-check.sh (gitleaks + semgrep + actionlint on cwd repo)
   emit          build/emit.mjs (--link --link-bin --link-repos when called bare)
 

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -21,7 +21,7 @@ sys.exit(int(os.environ.get("FACTORY_NOTIFY_TEST_EXIT", "0")))
   return notifier;
 }
 
-function runNotify({ args, stdin = "", exitCode = "0" }) {
+function runNotify({ args, stdin = "", exitCode = "0", env = {} }) {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-notify-"));
   const argsFile = path.join(dir, "args");
   const stdinFile = path.join(dir, "stdin");
@@ -38,12 +38,14 @@ function runNotify({ args, stdin = "", exitCode = "0" }) {
       FACTORY_NOTIFY_TEST_ARGS: argsFile,
       FACTORY_NOTIFY_TEST_STDIN: stdinFile,
       FACTORY_NOTIFY_TEST_EXIT: exitCode,
+      FACTORY_EVENT_PORT: "1", // deterministic unreachable-runtime fallback
+      ...env,
     },
   });
   return {
     status: result.exitCode,
-    args: readFileSync(argsFile, "utf8"),
-    stdin: readFileSync(stdinFile, "utf8"),
+    args: existsSync(argsFile) ? readFileSync(argsFile, "utf8") : null,
+    stdin: existsSync(stdinFile) ? readFileSync(stdinFile, "utf8") : null,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -67,6 +69,56 @@ test("factory notify preserves stdin mode and the notifier exit code", () => {
     expect(result.stdin).toBe("CI RED LAB-176: test failure\n");
   } finally {
     result.cleanup();
+  }
+});
+
+test("factory notify posts a structured inbox item when serve is reachable", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "factory-inbox-server-"));
+  const requestFile = path.join(dir, "request.json");
+  const serverScript = path.join(dir, "server.py");
+  const port = 31000 + (process.pid % 10000);
+  writeFileSync(serverScript, `
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        with open(${JSON.stringify(requestFile)}, "w") as f:
+            f.write(self.rfile.read(length).decode())
+        body = json.dumps({"delivery": {"ok": True}}).encode()
+        self.send_response(201)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *_): pass
+server = HTTPServer(("127.0.0.1", ${port}), Handler)
+print("ready", flush=True)
+server.handle_request()
+`);
+  const server = Bun.spawn({ cmd: ["python3", serverScript], stdout: "pipe", stderr: "pipe" });
+  const reader = server.stdout.getReader();
+  await reader.read();
+
+  const result = runNotify({
+    args: ["BLOCKED", "WM-1:", "choose policy"],
+    env: { FACTORY_EVENT_PORT: String(port), FACTORY_RUN_ID: "run_test" },
+  });
+  try {
+    expect(result.status).toBe(0);
+    expect(result.args).toBeNull();
+    const body = JSON.parse(readFileSync(requestFile, "utf8"));
+    expect(body).toEqual({
+      kind: "BLOCKED",
+      title: "BLOCKED WM-1: choose policy",
+      refs: { issue: "WM-1" },
+      source: "agent:run_test",
+    });
+  } finally {
+    server.kill();
+    await server.exited;
+    result.cleanup();
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -33,6 +33,7 @@ import { publishOutbox } from "./lib/outbox.mjs";
 import { autoApproveScheduled, emitDueTicks, scheduleView } from "./lib/schedules.mjs";
 import { resolveChains } from "./lib/chain.mjs";
 import { notifyPending } from "./lib/notify.mjs";
+import { reconcileInbox } from "./lib/inbox.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { loadRegistry, updatePins } from "./lib/registry.mjs";
 import { approveProposal } from "./lib/proposals.mjs";
@@ -78,6 +79,7 @@ usage: bun event-runtime/cli.mjs <command>
   ps [state]                     running event processes/runs (default: RUNNING or LEASED)
   runs [state]                   runs (optionally filtered by state)
   proposals                      open proposals with TTL age
+  inbox                          open items waiting on the human
   agents                         registered agent definitions and event routing
   workers                        worker processes: host, labels, state, heartbeat
   schedule                       recurring loops: cadence, approval, last fire, next due
@@ -133,7 +135,7 @@ async function withClient(fn) {
 // cannot hitch every 1s tick.
 export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
-export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "notify", "outbox", "GC", "chains"];
+export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "inbox", "notify", "outbox", "GC", "chains"];
 
 /**
  * One serve-loop pass (OPS-412). Each named subsystem is caught on its own
@@ -190,6 +192,12 @@ export async function tick({
   await runStep("announce", () => {
     announceProposals();
     announceTransitions();
+  });
+
+  // Referent state is authoritative: acknowledged or untouched items both
+  // resolve automatically once the proposal/event no longer needs a human.
+  await runStep("inbox", () => {
+    reconcileInbox(db, { now });
   });
 
   // Push channel for states awaiting a human (WM-65): human_needed parks and
@@ -1092,6 +1100,7 @@ export async function status(client) {
   }
   console.log(countLine("events", s.events, ["admitted", "planned", "noop", "human_needed", "dead_lettered"]));
   console.log(countLine("proposals", s.proposals, ["open", "expired"]));
+  if (s.inbox) console.log(countLine("inbox", s.inbox, ["open", "acked"]));
   const states = Object.keys(s.runs.byState);
   console.log(states.length ? countLine("runs", s.runs.byState, states) : `${pad("runs", 11)}none`);
   const spend = s.runs?.spend;
@@ -1176,6 +1185,24 @@ async function proposals(client) {
     );
   }
   console.log(`\napprove with: bun event-runtime/cli.mjs approve <id>`);
+}
+
+async function inbox(client) {
+  const res = await fetch(`http://${client.host}:${client.port}/inbox?status=open`);
+  const body = await res.json();
+  if (!res.ok) {
+    const err = new Error(body?.error ?? `HTTP ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+  if (body.items.length === 0) {
+    console.log("no open inbox items");
+    return;
+  }
+  console.log(`${pad("ID", 44)}${pad("KIND", 18)}${pad("SEVERITY", 11)}${pad("CREATED", 26)}TITLE`);
+  for (const item of body.items) {
+    console.log(`${pad(item.id, 44)}${pad(item.kind, 18)}${pad(item.severity, 11)}${pad(item.createdAt, 26)}${item.title}`);
+  }
 }
 
 async function inspect(client, runId) {
@@ -1447,6 +1474,9 @@ async function main() {
 
     case "proposals":
       return withClient(proposals);
+
+    case "inbox":
+      return withClient(inbox);
 
     case "agents":
       return withClient(agents);

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -19,6 +19,14 @@ import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, we
 import { runUsage, usageSpend } from "./db.mjs";
 import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
+import {
+  ackInboxItem,
+  createInboxItem,
+  deliverInboxItem,
+  inboxCounts,
+  listInboxItems,
+  resolveInboxItem,
+} from "./inbox.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { planEvent, requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
@@ -27,6 +35,7 @@ import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
 import { cancelRun, retryRun } from "./worker.mjs";
 import { parseCadence, proposalsPilingUp, scheduleView } from "./schedules.mjs";
+import { notifyCommand, sendNotification } from "./notify.mjs";
 import { listWorkers, loadWorkerPolicy, satisfiesPlacement, stalledWorkers } from "./workers.mjs";
 
 /**
@@ -289,6 +298,7 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
   return {
     events: eventCounts(db),
     proposals: { open: open.length, expired: expiredOpen.length },
+    inbox: inboxCounts(db),
     runs,
     workers: {
       live: fleet.capacity.live,
@@ -724,6 +734,9 @@ export function createApi({
   // Host-side janitor spawn (OPS-301). Tests inject a fake; production
   // shells out to orchestrator/janitor.mjs --json, never --force.
   janitor = spawnFactoryJanitor,
+  inboxSend = sendNotification,
+  inboxCommand = notifyCommand(),
+  inboxWebUrl = process.env.FACTORY_WEB_URL,
 } = {}) {
   const ACTOR = "operator"; // one local operator in the MVP (§14)
   const STORE_STATS_TTL_MS = 10_000;
@@ -829,6 +842,62 @@ export function createApi({
       if (route === "POST /replay") {
         const raw = await readBody(req);
         return admit(db, registry, res, raw, nowMs, onEvent);
+      }
+
+      if (route === "POST /inbox") {
+        const parsed = parseJson(await readBody(req));
+        if (parsed.error) return send(res, 422, { error: parsed.error });
+        try {
+          const item = createInboxItem(db, parsed.value, { now: nowMs });
+          // Item first, projection second: even a failed transport leaves a
+          // queryable row and records the delivery error on it.
+          const delivery = await deliverInboxItem(db, item.id, {
+            command: inboxCommand,
+            send: inboxSend,
+            webUrl: inboxWebUrl,
+            now: nowMs,
+          });
+          return send(res, 201, { item: delivery.item, delivery: {
+            ok: delivery.ok,
+            exitCode: delivery.exitCode,
+            error: delivery.error,
+          } });
+        } catch (err) {
+          return send(res, 422, { error: err.message });
+        }
+      }
+
+      if (route === "GET /inbox") {
+        const status = url.searchParams.get("status") ?? "open";
+        try {
+          return send(res, 200, { items: listInboxItems(db, { status }) });
+        } catch (err) {
+          return send(res, 422, { error: err.message });
+        }
+      }
+
+      const inboxVerb = url.pathname.match(/^\/inbox\/([^/]+)\/(ack|resolve)$/);
+      if (req.method === "POST" && inboxVerb) {
+        const id = decodeURIComponent(inboxVerb[1]);
+        const verb = inboxVerb[2];
+        const raw = await readBody(req);
+        const parsed = raw.length === 0 ? { value: {} } : parseJson(raw);
+        if (parsed.error) return send(res, 422, { error: parsed.error });
+        if (!parsed.value || typeof parsed.value !== "object" || Array.isArray(parsed.value)) {
+          return send(res, 422, { error: "body must be an object" });
+        }
+        if (parsed.value.reason !== undefined && typeof parsed.value.reason !== "string") {
+          return send(res, 422, { error: "reason must be a string" });
+        }
+        try {
+          const item = verb === "ack"
+            ? ackInboxItem(db, id, { now: nowMs })
+            : resolveInboxItem(db, id, { now: nowMs, resolvedBy: "operator" });
+          return send(res, 200, { item });
+        } catch (err) {
+          const status = String(err.message).startsWith("unknown inbox item") ? 404 : 409;
+          return send(res, status, { error: err.message });
+        }
       }
 
       if (route === "GET /status") {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -89,6 +89,81 @@ describe("repoNamesFromInput (OPS-356)", () => {
   });
 });
 
+describe("human inbox API (WM-285)", () => {
+  test("POST writes before a failed delivery, rejects unknown kinds, and GET/ack/resolve filter rows", async () => {
+    const delivered = [];
+    const s = await makeServer({
+      now: () => 1000,
+      inboxWebUrl: "http://127.0.0.1:7382",
+      inboxSend: async (_command, message) => {
+        delivered.push(message);
+        return { ok: false, exitCode: 9, error: "telegram unavailable" };
+      },
+    });
+    try {
+      const unknown = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ kind: "claimed", title: "routine" }),
+      });
+      expect(unknown.status).toBe(422);
+      expect((await unknown.json()).error).toContain("unknown inbox kind");
+
+      const created = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "BLOCKED",
+          title: "BLOCKED WM-1: choose a policy",
+          refs: { issue: "WM-1" },
+          source: "agent:run_1",
+        }),
+      });
+      expect(created.status).toBe(201);
+      const body = await created.json();
+      expect(body.delivery).toEqual({ ok: false, exitCode: 9, error: "telegram unavailable" });
+      expect(body.item.refs).toEqual({ issue: "WM-1" });
+      expect(body.item.delivery.telegram.error).toBe("telegram unavailable");
+      expect(delivered[0]).toEndWith(`/#/inbox/${body.item.id}`);
+
+      let listed = await (await fetch(s.url("/inbox?status=open"))).json();
+      expect(listed.items.map((item) => item.id)).toEqual([body.item.id]);
+
+      const acked = await fetch(s.url(`/inbox/${body.item.id}/ack`), { method: "POST", body: "{}" });
+      expect(acked.status).toBe(200);
+      listed = await (await fetch(s.url("/inbox?status=acked"))).json();
+      expect(listed.items).toHaveLength(1);
+
+      const resolved = await fetch(s.url(`/inbox/${body.item.id}/resolve`), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reason: "handled" }),
+      });
+      expect(resolved.status).toBe(200);
+      expect((await resolved.json()).item.resolvedBy).toBe("operator");
+      expect((await (await fetch(s.url("/inbox?status=resolved"))).json()).items).toHaveLength(1);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("inbox routes inherit loopback Host and Origin confinement", async () => {
+    const s = await makeServer({ inboxSend: async () => ({ ok: true, exitCode: 0, error: null }) });
+    try {
+      const res = await fetch(s.url("/inbox"), {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "https://evil.example" },
+        body: JSON.stringify({ kind: "BLOCKED", title: "BLOCKED WM-1: q" }),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe("cross_origin_rejected");
+      expect(s.db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(0);
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("webhook intake (§14)", () => {
   let s;
   beforeAll(async () => {
@@ -1705,10 +1780,12 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
       expect(res.status).toBe(200);
       const status = await res.json();
 
-      // Top-level StatusView keys match
+      // Top-level StatusView keys match. The inbox field is introduced by
+      // WM-285; its web type/view lands separately with WM-286.
       const statusViewBlock = extractInterfaceBlock(typesSrc, "StatusView");
-      const expectedStatusKeys = extractDirectProperties(statusViewBlock).sort();
+      const expectedStatusKeys = [...extractDirectProperties(statusViewBlock), "inbox"].sort();
       expect(Object.keys(status).sort()).toEqual(expectedStatusKeys);
+      expect(status.inbox).toEqual({ open: 0, acked: 0, byKind: {} });
 
       // StatusView.env matches EnvIdentity
       const envIdentityBlock = extractInterfaceBlock(typesSrc, "EnvIdentity");

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -178,6 +178,32 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 3,
+    name: "human_inbox_ledger",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS inbox_items (
+          id            TEXT PRIMARY KEY,
+          kind          TEXT NOT NULL,
+          severity      TEXT NOT NULL DEFAULT 'normal',
+          title         TEXT NOT NULL,
+          body          TEXT,
+          refs_json     TEXT NOT NULL DEFAULT '{}',
+          source        TEXT NOT NULL,
+          created_at    TEXT NOT NULL,
+          acked_at      TEXT,
+          resolved_at   TEXT,
+          resolved_by   TEXT,
+          delivery_json TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_inbox_items_status
+          ON inbox_items (resolved_at, acked_at, created_at);
+        CREATE INDEX IF NOT EXISTS idx_inbox_items_kind
+          ON inbox_items (kind, resolved_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION = MIGRATIONS.length > 0 ? MIGRATIONS[MIGRATIONS.length - 1].version : 1;
@@ -194,6 +220,7 @@ export const CORE_TABLES = [
   "counters",
   "attempt_trace",
   "run_usage",
+  "inbox_items",
 ];
 
 /** Read current database schema version from PRAGMA user_version. */

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -135,6 +135,25 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
+  test("the inbox migration upgrades an existing v2 database and advances user_version", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    migrateDb(db, { targetVersion: 2 });
+    expect(getSchemaVersion(db)).toBe(2);
+    expect(db.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'").get()).toBeNull();
+    db.close();
+
+    const upgraded = openDb(file);
+    expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(upgraded.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'inbox_items'").get()?.name).toBe("inbox_items");
+    const columns = upgraded.query("PRAGMA table_info(inbox_items)").all().map((row) => row.name);
+    expect(columns).toEqual([
+      "id", "kind", "severity", "title", "body", "refs_json", "source",
+      "created_at", "acked_at", "resolved_at", "resolved_by", "delivery_json",
+    ]);
+    upgraded.close();
+  });
+
   test("a database at a newer user_version refuses to open loudly with a clear message", () => {
     const file = freshFile();
     const db = openDb(file);

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1,0 +1,238 @@
+/**
+ * Durable human inbox ledger (WM-285).
+ *
+ * An inbox row is written before its Telegram projection is attempted. The
+ * ledger therefore remains authoritative even when the transport is absent or
+ * broken, while notify_log continues to provide runtime-notification dedup.
+ */
+import { randomUUID } from "node:crypto";
+
+export const INBOX_KINDS = Object.freeze([
+  "BLOCKED",
+  "ESCALATED",
+  "CI RED",
+  "SMOKE RED",
+  "CIRCUIT BREAKER",
+  "RC READY",
+  "human_needed",
+  "decision_needed",
+  "proposal_expired",
+]);
+
+const KIND_SET = new Set(INBOX_KINDS);
+const STATUSES = new Set(["open", "acked", "resolved", "all"]);
+const REF_KEYS = new Set([
+  "runId",
+  "proposalId",
+  "eventSource",
+  "eventId",
+  "issue",
+  "pr",
+  "repo",
+]);
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value, name) {
+  if (value === undefined || value === null) return null;
+  return requiredString(value, name);
+}
+
+function normalizeRefs(refs) {
+  if (refs === undefined || refs === null) return {};
+  if (typeof refs !== "object" || Array.isArray(refs)) throw new Error("refs must be an object");
+  const normalized = {};
+  for (const [key, value] of Object.entries(refs)) {
+    if (!REF_KEYS.has(key)) throw new Error(`unknown inbox ref ${key}`);
+    if (value === undefined || value === null) continue;
+    normalized[key] = requiredString(value, `refs.${key}`);
+  }
+  return normalized;
+}
+
+function parseObject(value) {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function itemView(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    kind: row.kind,
+    severity: row.severity,
+    title: row.title,
+    body: row.body ?? null,
+    refs: parseObject(row.refs_json),
+    source: row.source,
+    createdAt: row.created_at,
+    ackedAt: row.acked_at ?? null,
+    resolvedAt: row.resolved_at ?? null,
+    resolvedBy: row.resolved_by ?? null,
+    delivery: parseObject(row.delivery_json),
+  };
+}
+
+export function getInboxItem(db, id) {
+  return itemView(db.query("SELECT * FROM inbox_items WHERE id = ?").get(id));
+}
+
+export function createInboxItem(db, input, {
+  id = `inbox_${randomUUID()}`,
+  now = Date.now(),
+} = {}) {
+  const kind = requiredString(input?.kind, "kind");
+  if (!KIND_SET.has(kind)) throw new Error(`unknown inbox kind: ${kind}`);
+  const title = requiredString(input?.title, "title");
+  const body = optionalString(input?.body, "body");
+  const severity = optionalString(input?.severity, "severity") ?? "normal";
+  const source = optionalString(input?.source, "source") ?? "cli";
+  if (source !== "cli" && source !== "serve:notify" && !/^agent:.+/.test(source)) {
+    throw new Error(`unknown inbox source: ${source}`);
+  }
+  const refs = normalizeRefs(input?.refs);
+  const createdAt = new Date(now).toISOString();
+
+  db.query(
+    `INSERT INTO inbox_items
+       (id, kind, severity, title, body, refs_json, source, created_at, delivery_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}')`,
+  ).run(id, kind, severity, title, body, JSON.stringify(refs), source, createdAt);
+  return getInboxItem(db, id);
+}
+
+export function listInboxItems(db, { status = "open" } = {}) {
+  if (!STATUSES.has(status)) throw new Error(`unknown inbox status: ${status}`);
+  const where = {
+    open: "resolved_at IS NULL AND acked_at IS NULL",
+    acked: "resolved_at IS NULL AND acked_at IS NOT NULL",
+    resolved: "resolved_at IS NOT NULL",
+    all: "1 = 1",
+  }[status];
+  return db
+    .query(`SELECT * FROM inbox_items WHERE ${where} ORDER BY created_at DESC, rowid DESC`)
+    .all()
+    .map(itemView);
+}
+
+export function ackInboxItem(db, id, { now = Date.now() } = {}) {
+  const row = db.query("SELECT resolved_at FROM inbox_items WHERE id = ?").get(id);
+  if (!row) throw new Error(`unknown inbox item ${id}`);
+  if (row.resolved_at) throw new Error(`inbox item ${id} is already resolved`);
+  db.query("UPDATE inbox_items SET acked_at = COALESCE(acked_at, ?) WHERE id = ?")
+    .run(new Date(now).toISOString(), id);
+  return getInboxItem(db, id);
+}
+
+export function resolveInboxItem(db, id, {
+  now = Date.now(),
+  resolvedBy = "operator",
+} = {}) {
+  requiredString(resolvedBy, "resolvedBy");
+  if (resolvedBy !== "operator" && !resolvedBy.startsWith("auto:")) {
+    throw new Error(`invalid inbox resolver: ${resolvedBy}`);
+  }
+  const row = db.query("SELECT id FROM inbox_items WHERE id = ?").get(id);
+  if (!row) throw new Error(`unknown inbox item ${id}`);
+  db.query(
+    `UPDATE inbox_items
+     SET resolved_at = COALESCE(resolved_at, ?), resolved_by = COALESCE(resolved_by, ?)
+     WHERE id = ?`,
+  ).run(new Date(now).toISOString(), resolvedBy, id);
+  return getInboxItem(db, id);
+}
+
+export function inboxCounts(db) {
+  const totals = db.query(
+    `SELECT
+       SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NULL THEN 1 ELSE 0 END) AS open,
+       SUM(CASE WHEN resolved_at IS NULL AND acked_at IS NOT NULL THEN 1 ELSE 0 END) AS acked
+     FROM inbox_items`,
+  ).get();
+  const byKind = {};
+  for (const row of db.query(
+    `SELECT kind, COUNT(*) AS n FROM inbox_items
+     WHERE resolved_at IS NULL GROUP BY kind ORDER BY kind`,
+  ).all()) {
+    byKind[row.kind] = row.n;
+  }
+  return { open: Number(totals.open ?? 0), acked: Number(totals.acked ?? 0), byKind };
+}
+
+function telegramMessage(item, webUrl) {
+  const content = item.body ? `${item.title}\n${item.body}` : item.title;
+  if (!webUrl) return content;
+  return `${content}\n${String(webUrl).replace(/\/$/, "")}/#/inbox/${encodeURIComponent(item.id)}`;
+}
+
+/** Attempt the Telegram projection and persist its outcome on the existing row. */
+export async function deliverInboxItem(db, id, {
+  command,
+  send,
+  webUrl = process.env.FACTORY_WEB_URL,
+  now = Date.now(),
+} = {}) {
+  const item = getInboxItem(db, id);
+  if (!item) throw new Error(`unknown inbox item ${id}`);
+  if (typeof send !== "function") throw new Error("inbox delivery transport is required");
+  let outcome;
+  try {
+    outcome = await send(command, telegramMessage(item, webUrl));
+  } catch (err) {
+    outcome = { ok: false, exitCode: null, error: err.message };
+  }
+  const delivery = {
+    ...item.delivery,
+    telegram: {
+      sent_at: new Date(now).toISOString(),
+      exit_code: outcome.exitCode ?? null,
+      error: outcome.error ?? null,
+    },
+  };
+  db.query("UPDATE inbox_items SET delivery_json = ? WHERE id = ?")
+    .run(JSON.stringify(delivery), id);
+  return {
+    ok: outcome.ok === true,
+    exitCode: outcome.exitCode ?? null,
+    error: outcome.error ?? null,
+    item: getInboxItem(db, id),
+  };
+}
+
+/** Resolve runtime-owned asks when their authoritative referent stops waiting. */
+export function reconcileInbox(db, { now = Date.now() } = {}) {
+  const resolved = [];
+  const rows = db.query(
+    `SELECT id, kind, refs_json FROM inbox_items
+     WHERE resolved_at IS NULL
+       AND kind IN ('decision_needed', 'proposal_expired', 'human_needed')
+     ORDER BY created_at, rowid`,
+  ).all();
+  for (const row of rows) {
+    const refs = parseObject(row.refs_json);
+    let resolvedBy = null;
+    if (row.kind === "decision_needed" || row.kind === "proposal_expired") {
+      if (!refs.proposalId) continue;
+      const proposal = db.query("SELECT status FROM proposals WHERE id = ?").get(refs.proposalId);
+      if (proposal && proposal.status !== "open") resolvedBy = "auto:proposal_decided";
+    } else if (refs.eventSource && refs.eventId) {
+      const event = db.query("SELECT status FROM events WHERE source = ? AND event_id = ?")
+        .get(refs.eventSource, refs.eventId);
+      if (event && event.status !== "human_needed") resolvedBy = "auto:event_requeued";
+    }
+    if (!resolvedBy) continue;
+    resolveInboxItem(db, row.id, { now, resolvedBy });
+    resolved.push({ id: row.id, resolvedBy });
+  }
+  return resolved;
+}

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { openDb } from "./db.mjs";
+import {
+  INBOX_KINDS,
+  ackInboxItem,
+  createInboxItem,
+  deliverInboxItem,
+  getInboxItem,
+  inboxCounts,
+  listInboxItems,
+  reconcileInbox,
+  resolveInboxItem,
+} from "./inbox.mjs";
+
+function insertEvent(db, { source = "test", eventId, status = "human_needed" }) {
+  const at = new Date().toISOString();
+  db.query(
+    `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at)
+     VALUES (?, ?, 'test.event', ?, ?, '{}', 'sha256:x', ?, ?)`,
+  ).run(source, eventId, at, at, status, at);
+}
+
+function insertProposal(db, { id, status = "open" }) {
+  const at = new Date().toISOString();
+  db.query(
+    `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+     VALUES (?, 'test', 'evt', 'run', ?, ?, 1800)`,
+  ).run(id, status, at);
+}
+
+describe("human inbox ledger (WM-285)", () => {
+  test("kind is closed and rows expose parsed refs/delivery", () => {
+    const db = openDb(":memory:");
+    expect(INBOX_KINDS).toContain("BLOCKED");
+    expect(INBOX_KINDS).toContain("proposal_expired");
+    expect(() => createInboxItem(db, { kind: "routine_progress", title: "claimed" })).toThrow("unknown inbox kind");
+
+    const item = createInboxItem(db, {
+      kind: "BLOCKED",
+      severity: "high",
+      title: "BLOCKED WM-1: choose",
+      refs: { issue: "WM-1", runId: "run_1" },
+      source: "agent:run_1",
+    }, { now: 1000, id: "inbox_test" });
+    expect(item).toMatchObject({
+      id: "inbox_test",
+      kind: "BLOCKED",
+      severity: "high",
+      refs: { issue: "WM-1", runId: "run_1" },
+      delivery: {},
+      createdAt: new Date(1000).toISOString(),
+    });
+    expect(listInboxItems(db, { status: "open" })).toHaveLength(1);
+  });
+
+  test("delivery records failure without deleting the item and appends a configured deep link", async () => {
+    const db = openDb(":memory:");
+    const item = createInboxItem(db, { kind: "CI RED", title: "CI RED PR-4: tests", source: "cli" }, { id: "inbox_delivery" });
+    let message;
+    const outcome = await deliverInboxItem(db, item.id, {
+      command: "/stub",
+      webUrl: "http://127.0.0.1:7382/",
+      send: async (_command, sent) => {
+        message = sent;
+        return { ok: false, exitCode: 7, error: "notifier exited 7" };
+      },
+    });
+    expect(outcome.ok).toBe(false);
+    expect(message).toBe("CI RED PR-4: tests\nhttp://127.0.0.1:7382/#/inbox/inbox_delivery");
+    expect(listInboxItems(db, { status: "all" })[0].delivery.telegram).toMatchObject({
+      exit_code: 7,
+      error: "notifier exited 7",
+    });
+  });
+
+  test("ack, resolve, filters, and counts distinguish open from acknowledged", () => {
+    const db = openDb(":memory:");
+    createInboxItem(db, { kind: "BLOCKED", title: "one" }, { id: "one", now: 1000 });
+    createInboxItem(db, { kind: "ESCALATED", title: "two" }, { id: "two", now: 2000 });
+    expect(ackInboxItem(db, "one", { now: 3000 }).ackedAt).toBe(new Date(3000).toISOString());
+    expect(resolveInboxItem(db, "two", { now: 4000, resolvedBy: "operator" }).resolvedBy).toBe("operator");
+    expect(listInboxItems(db, { status: "open" }).map((i) => i.id)).toEqual([]);
+    expect(listInboxItems(db, { status: "acked" }).map((i) => i.id)).toEqual(["one"]);
+    expect(listInboxItems(db, { status: "resolved" }).map((i) => i.id)).toEqual(["two"]);
+    expect(inboxCounts(db)).toEqual({ open: 0, acked: 1, byKind: { BLOCKED: 1 } });
+  });
+
+  test("runtime-owned referents auto-resolve after leaving their waiting state", () => {
+    const db = openDb(":memory:");
+    insertProposal(db, { id: "prop-1" });
+    insertEvent(db, { eventId: "evt-1" });
+    createInboxItem(db, {
+      kind: "decision_needed",
+      title: "decision",
+      refs: { proposalId: "prop-1" },
+      source: "serve:notify",
+    }, { id: "decision" });
+    createInboxItem(db, {
+      kind: "human_needed",
+      title: "human",
+      refs: { eventSource: "test", eventId: "evt-1" },
+      source: "serve:notify",
+    }, { id: "human" });
+
+    expect(reconcileInbox(db)).toEqual([]);
+    db.query("UPDATE proposals SET status = 'approved' WHERE id = 'prop-1'").run();
+    db.query("UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-1'").run();
+    const resolved = reconcileInbox(db, { now: 5000 });
+    expect(resolved).toEqual([
+      { id: "decision", resolvedBy: "auto:proposal_decided" },
+      { id: "human", resolvedBy: "auto:event_requeued" },
+    ]);
+  });
+
+  test("the serve tick runs auto-resolution as an isolated inbox subsystem", async () => {
+    const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
+    const db = openDb(":memory:");
+    insertProposal(db, { id: "prop-tick", status: "approved" });
+    createInboxItem(db, {
+      kind: "decision_needed",
+      title: "decision",
+      refs: { proposalId: "prop-tick" },
+      source: "serve:notify",
+    }, { id: "tick-item" });
+    const noop = () => {};
+    await tick({
+      db,
+      now: 9000,
+      lastPrune: 9000,
+      subsystems: {
+        "tick emit": noop,
+        plan: noop,
+        "auto-approve": noop,
+        announce: noop,
+        notify: noop,
+        reap: noop,
+        "announce-after": noop,
+        outbox: noop,
+        GC: noop,
+        chains: noop,
+      },
+    });
+    expect(TICK_SUBSYSTEMS).toContain("inbox");
+    expect(getInboxItem(db, "tick-item").resolvedBy).toBe("auto:proposal_decided");
+  });
+});

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -23,6 +23,8 @@
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import path from "node:path";
+import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
+import { txImmediate } from "./db.mjs";
 
 export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hdkiller", "scripts", "notify.py")}`;
 
@@ -48,18 +50,24 @@ export function notifyCommand(env = process.env) {
  */
 export function ensureNotifyLog(db) {
   db.exec(`CREATE TABLE IF NOT EXISTS notify_log (
-    kind      TEXT NOT NULL,
-    target    TEXT NOT NULL,
-    message   TEXT NOT NULL,
-    sent_at   TEXT NOT NULL,
-    exit_code INTEGER,
-    error     TEXT,
+    kind          TEXT NOT NULL,
+    target        TEXT NOT NULL,
+    message       TEXT NOT NULL,
+    sent_at       TEXT NOT NULL,
+    exit_code     INTEGER,
+    error         TEXT,
+    inbox_item_id TEXT,
     PRIMARY KEY (kind, target)
   );`);
+  const columns = new Set(db.query("PRAGMA table_info(notify_log)").all().map((row) => row.name));
+  if (!columns.has("inbox_item_id")) db.exec("ALTER TABLE notify_log ADD COLUMN inbox_item_id TEXT;");
 }
 
 const KIND_HUMAN_NEEDED = "human_needed";
-const KIND_PROPOSAL_TTL = "proposal_ttl";
+// Keep the legacy notify_log kind for upgrade-safe dedup while the inbox uses
+// the closed-set name from WM-285.
+const DEDUP_PROPOSAL_TTL = "proposal_ttl";
+const KIND_DECISION_NEEDED = "decision_needed";
 const KIND_PROPOSAL_EXPIRED = "proposal_expired";
 
 function alreadyNotified(db, kind, target) {
@@ -80,7 +88,7 @@ function alreadyNotified(db, kind, target) {
  * and never appears here. Scheduled auto-approved proposals are decided
  * within a tick of creation, so they never age into either threshold.
  *
- * @returns {Array<{ kind: string, target: string, message: string }>}
+ * @returns {Array<{ kind: string, dedupKind?: string, target: string, title: string, refs: object, source: string }>}
  */
 export function pendingNotifications(db, { now = Date.now() } = {}) {
   ensureNotifyLog(db);
@@ -104,7 +112,9 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
     pending.push({
       kind: KIND_HUMAN_NEEDED,
       target,
-      message: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
+      title: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
+      refs: { eventSource: e.source, eventId: e.eventId },
+      source: "serve:notify",
     });
   }
 
@@ -122,15 +132,20 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
         pending.push({
           kind: KIND_PROPOSAL_EXPIRED,
           target: p.id,
-          message: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
+          title: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
+          refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+          source: "serve:notify",
         });
       }
-    } else if (!alreadyNotified(db, KIND_PROPOSAL_TTL, p.id)) {
+    } else if (!alreadyNotified(db, DEDUP_PROPOSAL_TTL, p.id)) {
       const minutesLeft = Math.max(1, Math.ceil((ttlMs - ageMs) / 60_000));
       pending.push({
-        kind: KIND_PROPOSAL_TTL,
+        kind: KIND_DECISION_NEEDED,
+        dedupKind: DEDUP_PROPOSAL_TTL,
         target: p.id,
-        message: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
+        title: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
+        refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+        source: "serve:notify",
       });
     }
   }
@@ -188,8 +203,8 @@ export function sendNotification(command, message, { timeoutMs = NOTIFY_TIMEOUT_
  * far as the tick is concerned; `deliveries` is only there so tests (and
  * curious callers) can await the actual outcomes.
  *
- * With the feature disabled (the default) this returns before touching the
- * database or spawning anything.
+ * The ledger is always populated. `enabled` gates only the Telegram
+ * projection, so turning pushes off never makes human work invisible.
  *
  * @returns {{ sent: Array<{kind, target, message}>, deliveries: Promise<Array> }}
  */
@@ -199,28 +214,43 @@ export function notifyPending(db, {
   command = notifyCommand(),
   log = () => {},
   send = sendNotification,
+  webUrl = process.env.FACTORY_WEB_URL,
 } = {}) {
-  if (!enabled) return { sent: [], deliveries: Promise.resolve([]) };
-
   const pending = pendingNotifications(db, { now });
   const at = new Date(now).toISOString();
   const deliveries = [];
+  const sent = [];
   for (const n of pending) {
-    db.query(`INSERT OR IGNORE INTO notify_log (kind, target, message, sent_at) VALUES (?, ?, ?, ?)`)
-      .run(n.kind, n.target, n.message, at);
-    log(`notify ${n.kind} ${n.target}: ${n.message}`);
+    const dedupKind = n.dedupKind ?? n.kind;
+    const created = txImmediate(db, () => {
+      // Recheck inside the write transaction so two tick triggers cannot both
+      // create a row for one referent.
+      if (alreadyNotified(db, dedupKind, n.target)) return null;
+      const item = createInboxItem(db, n, { now });
+      db.query(
+        `INSERT INTO notify_log (kind, target, message, sent_at, inbox_item_id)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).run(dedupKind, n.target, n.title, at, item.id);
+      return item;
+    });
+    if (!created) continue;
+    const notification = { ...n, message: n.title, inboxItemId: created.id };
+    log(`inbox ${n.kind} ${n.target}: ${n.title}`);
+    if (!enabled) continue;
+    sent.push(notification);
+    log(`notify ${n.kind} ${n.target}: ${n.title}`);
     deliveries.push(
-      send(command, n.message).then((outcome) => {
+      deliverInboxItem(db, created.id, { command, send, webUrl, now }).then((outcome) => {
         try {
           db.query(`UPDATE notify_log SET exit_code = ?, error = ? WHERE kind = ? AND target = ?`)
-            .run(outcome.exitCode, outcome.error, n.kind, n.target);
+            .run(outcome.exitCode, outcome.error, dedupKind, n.target);
         } catch {
           // db already closed (shutdown mid-delivery) — the log line below is the record
         }
         if (!outcome.ok) log(`notify ${n.kind} ${n.target} failed: ${outcome.error}`);
-        return { ...n, ...outcome };
+        return { ...notification, ...outcome };
       }),
     );
   }
-  return { sent: pending, deliveries: Promise.all(deliveries) };
+  return { sent, deliveries: Promise.all(deliveries) };
 }

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -57,7 +57,7 @@ describe("notify (WM-65)", () => {
     expect(notifyCommand({ FACTORY_EVENT_NOTIFY_CMD: "/x/stub" })).toBe("/x/stub");
   });
 
-  test("disabled (the default): no notifier is ever spawned, nothing is queried or marked", () => {
+  test("disabled (the default): inbox remains durable while the Telegram projection stays off", () => {
     const db = openDb(":memory:");
     insertEvent(db, { eventId: "evt-1", status: "human_needed" });
     insertProposal(db, { id: "prop-hn-1", eventId: "evt-1", decision: "human_needed", reason: "repo_unknown" });
@@ -65,9 +65,13 @@ describe("notify (WM-65)", () => {
     const out = notifyPending(db, { enabled: false, send: (cmd, msg) => (spawned.push(msg), Promise.resolve({ ok: true, exitCode: 0, error: null })) });
     expect(out.sent).toEqual([]);
     expect(spawned).toEqual([]);
-    // No dedup ledger was even created — the disabled path touches nothing.
-    const tables = db.query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'notify_log'`).all();
-    expect(tables).toEqual([]);
+    const item = db.query("SELECT kind, delivery_json FROM inbox_items").get();
+    expect(item.kind).toBe("human_needed");
+    expect(JSON.parse(item.delivery_json)).toEqual({});
+    expect(db.query("SELECT COUNT(*) AS n FROM notify_log").get().n).toBe(1);
+    // The next tick dedups the ledger item even though no projection ran.
+    expect(notifyPending(db, { enabled: false }).sent).toEqual([]);
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
   });
 
   test("a human_needed park pushes exactly once — with event type, id, and reason — and never again, across restarts", async () => {
@@ -79,11 +83,24 @@ describe("notify (WM-65)", () => {
     insertEvent(db, { eventId: "evt-park", type: "linear.ticket.agent_ready", status: "human_needed" });
     insertProposal(db, { id: "prop-park", eventId: "evt-park", decision: "human_needed", reason: "repo_report_only" });
 
-    const first = notifyPending(db, { enabled: true, command: stub.bin });
+    const first = notifyPending(db, {
+      enabled: true,
+      command: stub.bin,
+      webUrl: "http://127.0.0.1:7382",
+    });
     expect(first.sent).toHaveLength(1);
     expect(first.sent[0].message).toBe("BLOCKED linear.ticket.agent_ready evt-park: repo_report_only");
     await first.deliveries;
-    expect(stub.pushes()).toEqual(["BLOCKED linear.ticket.agent_ready evt-park: repo_report_only"]);
+    expect(stub.pushes()).toEqual([
+      "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
+      `http://127.0.0.1:7382/#/inbox/${first.sent[0].inboxItemId}`,
+    ]);
+    const item = db.query("SELECT kind, refs_json, source, delivery_json FROM inbox_items").get();
+    expect(item.kind).toBe("human_needed");
+    expect(JSON.parse(item.refs_json)).toEqual({ eventSource: "test", eventId: "evt-park" });
+    expect(item.source).toBe("serve:notify");
+    expect(JSON.parse(item.delivery_json).telegram.error).toBeNull();
+    expect(db.query("SELECT inbox_item_id FROM notify_log").get().inbox_item_id).toBe(first.sent[0].inboxItemId);
 
     // Same serve process, next tick: nothing new.
     const second = notifyPending(db, { enabled: true, command: stub.bin });
@@ -95,7 +112,7 @@ describe("notify (WM-65)", () => {
     const afterRestart = notifyPending(db, { enabled: true, command: stub.bin });
     expect(afterRestart.sent).toEqual([]);
     await afterRestart.deliveries;
-    expect(stub.pushes()).toHaveLength(1);
+    expect(stub.pushes()).toHaveLength(2);
     db.close();
   });
 
@@ -156,9 +173,11 @@ describe("notify (WM-65)", () => {
     const results = await out.deliveries;
     expect(results[0].ok).toBe(false);
     expect(results[0].exitCode).toBe(3);
-    const row = db.query(`SELECT exit_code, error FROM notify_log WHERE kind = 'human_needed'`).get();
+    const row = db.query(`SELECT exit_code, error, inbox_item_id FROM notify_log WHERE kind = 'human_needed'`).get();
     expect(row.exit_code).toBe(3);
     expect(row.error).toContain("exited 3");
+    const inbox = db.query("SELECT delivery_json FROM inbox_items WHERE id = ?").get(row.inbox_item_id);
+    expect(JSON.parse(inbox.delivery_json).telegram.error).toContain("exited 3");
     expect(logs.some((l) => l.includes("notify human_needed test/evt-f failed: notifier exited 3"))).toBe(true);
 
     // Failed delivery does NOT retry: once means once.


### PR DESCRIPTION
## Summary
- add the durable `inbox_items` ledger, closed kinds, delivery metadata, acknowledgement/resolution, auto-resolution, and status counts
- route runtime notifications and `factory notify` through the inbox while preserving dedup and offline direct-delivery fallback
- add loopback API and CLI inbox surfaces plus Telegram deep links

## Verification
- `bun test event-runtime/lib bin` — pass, 732 tests / 3207 assertions

## UX critique
Skipped — internal control-plane API/CLI surface; the user-facing web inbox is tracked separately in WM-286.

## Follow-up
- WM-306 tracks the out-of-scope web `StatusView` type update.

Fixes WM-285