### PR TITLE
feat(event-runtime): clone mirrors from GitHub fallback (WM-310)

### DIFF
--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -97,7 +97,7 @@ export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = 
     return { repo: repo.name, ref: ref ?? repo.base, sha, github: repo.github };
   } catch (err) {
     if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
-      return { repo: repo.name, ref: ref ?? repo.base, sha: "000000000000000000000000000000000000000", github: repo.github };
+      return { repo: repo.name, ref: ref ?? repo.base, sha: "0".repeat(40), github: repo.github };
     }
     throw err;
   }
@@ -116,7 +116,7 @@ export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "rep
   if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
     throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
   }
-  if (sha === "0000000000000000000000000000000000000000" || (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors)))) {
+  if (sha === "0".repeat(40) || (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors)))) {
     mkdirSync(target, { recursive: true });
     // The worker's integrity gate must be able to inspect every repository
     // workspace, including a CI/demo fallback with no local source checkout.

--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -45,18 +45,29 @@ export function mirrorPath(repoName, root = mirrorsRoot()) {
   return path.join(root, `${repoName}.git`);
 }
 
+/** Turn the configured owner/repo slug into a clone URL. Full URLs are
+ * accepted as-is so tests and self-hosted mirrors can remain network-free. */
+function githubRemote(github) {
+  if (!github) return null;
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(github)) return github;
+  return `https://github.com/${github.replace(/\.git$/, "")}.git`;
+}
+
 /**
- * Create the mirror if absent, otherwise fetch it. The source is the local
- * checkout's path (fast, offline-friendly); it is only ever *read*.
+ * Create the mirror if absent, otherwise fetch it. Prefer the local checkout
+ * (fast, offline-friendly), falling back to the configured GitHub remote.
  */
 export function syncMirror(repo, { root = mirrorsRoot() } = {}) {
   const mirror = mirrorPath(repo.name, root);
   if (!existsSync(mirror)) {
-    if (!existsSync(repo.path)) {
-      throw new RepositoryWorkspaceError(`repo ${repo.name}: no checkout at ${repo.path} to mirror from`);
+    const source = existsSync(repo.path) ? repo.path : githubRemote(repo.github);
+    if (!source) {
+      throw new RepositoryWorkspaceError(
+        `repo ${repo.name}: no checkout at ${repo.path} and no github remote configured to mirror from`,
+      );
     }
     mkdirSync(root, { recursive: true });
-    git(["clone", "--mirror", "--quiet", repo.path, mirror]);
+    git(["clone", "--mirror", "--quiet", source, mirror]);
   } else {
     git(["fetch", "--prune", "--quiet", "origin"], mirror);
   }
@@ -80,7 +91,7 @@ export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = 
     const { sha } = resolveRef(repo, ref ?? repo.base, { root: mirrors });
     return { repo: repo.name, ref: ref ?? repo.base, sha, github: repo.github };
   } catch (err) {
-    if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
+    if (!repo.github && !existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
       return { repo: repo.name, ref: ref ?? repo.base, sha: "0000000000000000000000000000000000000000", github: repo.github };
     }
     throw err;
@@ -100,7 +111,7 @@ export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "rep
   if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
     throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
   }
-  if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
+  if (!repo.github && !existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
     mkdirSync(target, { recursive: true });
     // The worker's integrity gate must be able to inspect every repository
     // workspace, including a CI/demo fallback with no local source checkout.

--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -34,7 +34,12 @@ export class RepositoryWorkspaceError extends Error {
 
 const git = (args, cwd) => {
   try {
-    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    }).trim();
   } catch (err) {
     const detail = err.stderr?.toString().trim() || err.message;
     throw new RepositoryWorkspaceError(`git ${args.slice(0, 2).join(" ")} failed: ${detail}`);
@@ -111,7 +116,7 @@ export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "rep
   if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
     throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
   }
-  if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
+  if (sha === "0000000000000000000000000000000000000000" || (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors)))) {
     mkdirSync(target, { recursive: true });
     // The worker's integrity gate must be able to inspect every repository
     // workspace, including a CI/demo fallback with no local source checkout.

--- a/event-runtime/lib/repository.mjs
+++ b/event-runtime/lib/repository.mjs
@@ -91,8 +91,8 @@ export function pinRepo(repoName, ref, { reposRoot, mirrors = mirrorsRoot() } = 
     const { sha } = resolveRef(repo, ref ?? repo.base, { root: mirrors });
     return { repo: repo.name, ref: ref ?? repo.base, sha, github: repo.github };
   } catch (err) {
-    if (!repo.github && !existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
-      return { repo: repo.name, ref: ref ?? repo.base, sha: "0000000000000000000000000000000000000000", github: repo.github };
+    if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
+      return { repo: repo.name, ref: ref ?? repo.base, sha: "000000000000000000000000000000000000000", github: repo.github };
     }
     throw err;
   }
@@ -111,7 +111,7 @@ export function materializeCheckout({ workspaceDir, repoName, sha, subdir = "rep
   if (!target.startsWith(path.resolve(workspaceDir) + path.sep)) {
     throw new RepositoryWorkspaceError(`checkout subdir "${subdir}" escapes the workspace`);
   }
-  if (!repo.github && !existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
+  if (!existsSync(repo.path) && !existsSync(mirrorPath(repo.name, mirrors))) {
     mkdirSync(target, { recursive: true });
     // The worker's integrity gate must be able to inspect every repository
     // workspace, including a CI/demo fallback with no local source checkout.

--- a/event-runtime/lib/repository.test.mjs
+++ b/event-runtime/lib/repository.test.mjs
@@ -47,13 +47,20 @@ function makeRepo() {
   return { dir, first, head: git(["rev-parse", "HEAD"], dir) };
 }
 
+function makeBareRemote(src) {
+  const remote = path.join(tmp("evrt-remote-"), "repo.git");
+  git(["clone", "--bare", "--quiet", src.dir, remote]);
+  return { path: remote, url: `file://${remote}` };
+}
+
 /** A repos.yaml pointing at it, so the loader is exercised for real too. */
-function makeFactoryRoot(repoPath, name = "testrepo") {
+function makeFactoryRoot(repoPath, name = "testrepo", github = `watt-mind/${name}`) {
   const root = tmp("evrt-factory-");
   mkdirSync(path.join(root, "config"), { recursive: true });
+  const githubLine = github ? `    github: ${github}\n` : "";
   writeFileSync(
     path.join(root, "config", "repos.yaml"),
-    `repos:\n  - name: ${name}\n    path: ${repoPath}\n    github: watt-mind/${name}\n    base: main\n    worktree_up: bin/worktree-up.sh\n    verify: echo ok\n`,
+    `repos:\n  - name: ${name}\n    path: ${repoPath}\n${githubLine}    base: main\n    worktree_up: bin/worktree-up.sh\n    verify: echo ok\n`,
   );
   return root;
 }
@@ -85,6 +92,58 @@ describe("repos.yaml is read, not owned", () => {
 });
 
 describe("mirror + pinned checkout", () => {
+  test("clones a missing mirror from the configured GitHub remote when the checkout is absent", () => {
+    const src = makeRepo();
+    const remote = makeBareRemote(src);
+    const mirrors = tmp("evrt-mirrors-");
+    const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
+    const repo = { name: "testrepo", path: missing, github: remote.url, base: "main" };
+
+    const mirror = syncMirror(repo, { root: mirrors });
+
+    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(src.head);
+    expect(git(["remote", "get-url", "origin"], mirror)).toBe(remote.url);
+  }, { timeout: GIT_MS });
+
+  test("prefers the local checkout when both local and remote sources exist", () => {
+    const local = makeRepo();
+    const remote = makeBareRemote(makeRepo());
+    const mirrors = tmp("evrt-mirrors-");
+    const repo = { name: "testrepo", path: local.dir, github: remote.url, base: "main" };
+
+    const mirror = syncMirror(repo, { root: mirrors });
+
+    expect(git(["remote", "get-url", "origin"], mirror)).toBe(local.dir);
+    expect(resolveRef(repo, "main", { root: mirrors }).sha).toBe(local.head);
+  }, { timeout: GIT_MS });
+
+  test("names both missing sources when neither checkout nor GitHub remote is available", () => {
+    const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
+    const repo = { name: "testrepo", path: missing, github: null, base: "main" };
+
+    expect(() => syncMirror(repo, { root: tmp("evrt-mirrors-") })).toThrow(
+      new RegExp(`no checkout at ${missing}.*no github remote`),
+    );
+  });
+
+  test("never rewrites an existing mirror's origin", () => {
+    const original = makeRepo();
+    const replacement = makeBareRemote(makeRepo());
+    const mirrors = tmp("evrt-mirrors-");
+    const mirror = mirrorPath("testrepo", mirrors);
+    git(["clone", "--mirror", "--quiet", original.dir, mirror]);
+    const repo = {
+      name: "testrepo",
+      path: path.join(tmp("evrt-missing-"), "does-not-exist"),
+      github: replacement.url,
+      base: "main",
+    };
+
+    syncMirror(repo, { root: mirrors });
+
+    expect(git(["remote", "get-url", "origin"], mirror)).toBe(original.dir);
+  }, { timeout: GIT_MS });
+
   test("mirrors on first use, fetches thereafter, and never writes to the source", () => {
     const src = makeRepo();
     const mirrors = tmp("evrt-mirrors-");
@@ -139,7 +198,7 @@ describe("mirror + pinned checkout", () => {
 
   test("fallback checkout is an empty Git repository for integrity checks", () => {
     const missing = path.join(tmp("evrt-missing-"), "does-not-exist");
-    const reposRoot = makeFactoryRoot(missing);
+    const reposRoot = makeFactoryRoot(missing, "testrepo", null);
     const workspaceDir = tmp("evrt-ws-");
     const checkout = materializeCheckout({
       workspaceDir, repoName: "testrepo", sha: "0".repeat(40), reposRoot,


### PR DESCRIPTION
## Summary
- prefer an existing local checkout when seeding tier-1 mirrors
- fall back to the configured GitHub remote when no checkout exists
- preserve source-free CI/demo fallbacks and existing mirror origins
- cover all source-selection cases with network-free git fixtures

## Verification
- `bun test event-runtime/lib/repository.test.mjs && bun test && bun run format:check`

UX critique: skipped — internal repository provisioning behavior with no user-completable UI flow.

Fixes WM-310