### PR TITLE
fix(planner): coalesce chain repeat triggers (WM-319)

### DIFF
--- a/event-runtime/lib/lifecycle.mjs
+++ b/event-runtime/lib/lifecycle.mjs
@@ -104,17 +104,46 @@ export function lifecycleOf(db, runId) {
   return db.query(`SELECT * FROM lifecycle_events WHERE run_id = ? ORDER BY seq`).all(runId);
 }
 
+const IDEMPOTENCY_TRIGGER_MARKER = ":trigger:";
+
+function idempotencyFamily(db, idempotencyKey) {
+  return db.query(
+    `SELECT run_id, idempotency_key, state, created_at, rowid
+       FROM runs
+      WHERE idempotency_key = ?
+         OR instr(idempotency_key, ? || ?) = 1
+      ORDER BY CASE WHEN state IN ('COMPLETED', 'REFUSED', 'TIMED_OUT', 'CANCELLED') THEN 1 ELSE 0 END,
+               created_at DESC, rowid DESC`,
+  ).all(idempotencyKey, idempotencyKey, IDEMPOTENCY_TRIGGER_MARKER);
+}
+
 /**
- * Resolve an existing run for an idempotency key and event correlation context (§5.4).
- * A duplicate delivery (same idempotencyKey and matching correlationId / causationId)
- * resolves to the existing run. A repeat trigger (different correlationId / eventId)
- * with identical inputHash is NOT falsely suppressed and returns null.
+ * Produce the concrete UNIQUE key for a new run in an idempotency family.
+ * The first generation keeps the declared key. Later generations add the
+ * triggering event identity, allowing a fresh run after the prior generation
+ * is terminal without weakening the schema's per-run UNIQUE guarantee.
+ */
+export function idempotencyKeyForNewRun(db, { idempotencyKey, source, eventId }) {
+  if (idempotencyFamily(db, idempotencyKey).length === 0) return idempotencyKey;
+  return `${idempotencyKey}${IDEMPOTENCY_TRIGGER_MARKER}${hashJson({ source, eventId })}`;
+}
+
+/**
+ * Resolve an existing run for an idempotency family and event context (§5.4).
+ * Any non-terminal generation coalesces repeat triggers into that run. Once
+ * every generation is terminal, only a redelivery of the same correlation /
+ * causation resolves to the terminal run; a distinct trigger returns null so
+ * the planner can create a new generation with its own concrete UNIQUE key.
  */
 export function resolveIdempotency(db, { idempotencyKey, correlationId, causationId, eventId } = {}) {
   if (!idempotencyKey) return null;
-  const run = db.query(`SELECT run_id, idempotency_key, state FROM runs WHERE idempotency_key = ?`).get(idempotencyKey);
-  if (!run) return null;
+  const family = idempotencyFamily(db, idempotencyKey);
+  if (family.length === 0) return null;
 
+  const active = family.find((run) => !TERMINAL_STATES.has(run.state));
+  if (active) return active;
+
+  const run = family[0];
   const correlation = correlationId ?? eventId ?? null;
   if (!correlation && !causationId) return run;
 
@@ -123,11 +152,7 @@ export function resolveIdempotency(db, { idempotencyKey, correlationId, causatio
     .get(run.run_id);
   if (!journal) return run;
 
-  if (correlation && journal.correlation_id && journal.correlation_id !== correlation) {
-    return null;
-  }
-  if (causationId && journal.causation_id && journal.causation_id !== causationId) {
-    return null;
-  }
+  if (correlation && journal.correlation_id !== correlation) return null;
+  if (causationId && journal.causation_id !== causationId) return null;
   return run;
 }

--- a/event-runtime/lib/lifecycle.test.mjs
+++ b/event-runtime/lib/lifecycle.test.mjs
@@ -72,26 +72,46 @@ describe("lifecycle", () => {
     expect(runState(db, runId)).toBe("QUEUED");
   });
 
-  test("resolveIdempotency: duplicate delivery matches existing run, distinct correlation returns null (OPS-419)", () => {
+  test("resolveIdempotency coalesces an active repeat trigger, then releases it after terminal completion", () => {
     const db = openDb(":memory:");
     createRun(db, {
-      runId: "run_remed_1",
-      idempotencyKey: "remed-key-1",
+      runId: "run_chain_1",
+      idempotencyKey: "chain-key-1",
       spec: {},
       specJson: "{}",
       specHash: "sha256:0",
       actor: "planner",
-      correlationId: "alert-001",
+      correlationId: "lineage-001",
+      causationId: "run_dispatch_1",
       policyVersion: "test",
     });
 
-    // Same key and matching correlationId -> resolves to existing run
-    const dup = resolveIdempotency(db, { idempotencyKey: "remed-key-1", correlationId: "alert-001" });
-    expect(dup?.run_id).toBe("run_remed_1");
+    // Same lineage and input, but a distinct chain causation: while the first
+    // run is active the repeat trigger coalesces into it.
+    const active = resolveIdempotency(db, {
+      idempotencyKey: "chain-key-1",
+      correlationId: "lineage-001",
+      causationId: "run_dispatch_2",
+    });
+    expect(active?.run_id).toBe("run_chain_1");
 
-    // Same key but distinct correlationId (repeat remediation) -> null (not falsely suppressed)
-    const distinct = resolveIdempotency(db, { idempotencyKey: "remed-key-1", correlationId: "alert-002" });
-    expect(distinct).toBeNull();
+    transition(db, { runId: "run_chain_1", to: "CANCELLED", actor: "test" });
+
+    // Once terminal, that distinct trigger is eligible to create a new run.
+    const afterTerminal = resolveIdempotency(db, {
+      idempotencyKey: "chain-key-1",
+      correlationId: "lineage-001",
+      causationId: "run_dispatch_2",
+    });
+    expect(afterTerminal).toBeNull();
+
+    // Redelivery of the original trigger still resolves to its terminal run.
+    const duplicate = resolveIdempotency(db, {
+      idempotencyKey: "chain-key-1",
+      correlationId: "lineage-001",
+      causationId: "run_dispatch_1",
+    });
+    expect(duplicate?.run_id).toBe("run_chain_1");
   });
 
   test("lifecycle timestamps are monotonic and distinct across states when clock advances", () => {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -21,7 +21,7 @@ import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS, FACTORY_ROOT } from "./config.mjs";
 import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
-import { createRun, resolveIdempotency } from "./lifecycle.mjs";
+import { createRun, idempotencyKeyForNewRun, resolveIdempotency } from "./lifecycle.mjs";
 import { getAgent, getEventType, resolveModel } from "./registry.mjs";
 import { getRepo, loadRepos, reposRoot } from "./repos.mjs";
 import { pinRepo } from "./repository.mjs";
@@ -260,6 +260,10 @@ function setEventStatus(db, event, status) {
   db.query(`UPDATE events SET status = ? WHERE source = ? AND event_id = ?`).run(status, event.source, event.event_id);
 }
 
+function isIdempotencyKeyCollision(err) {
+  return err?.code === "SQLITE_CONSTRAINT_UNIQUE" || /UNIQUE constraint failed: runs\.idempotency_key/.test(String(err?.message ?? err));
+}
+
 function humanNeeded(db, event, reason, at, ttlSeconds) {
   const proposal = insertProposal(db, {
     id: newProposalId(), event, decision: "human_needed", status: "open", reason, at, ttlSeconds,
@@ -446,17 +450,41 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       return { decision: "noop", proposal, runId: existingRun.run_id, reason: "duplicate_run" };
     }
 
+    // A terminal generation releases the family for another trigger. Keep the
+    // schema's concrete-key UNIQUE guarantee by deriving a generation key from
+    // the admitted event; resolveIdempotency still coalesces over the family.
+    idempotencyKey = idempotencyKeyForNewRun(db, {
+      idempotencyKey,
+      source: event.source,
+      eventId: event.event_id,
+    });
     const runId = newRunId();
-    const spec = buildRunSpec(registry, pinnedEnvelope, mapping, { runId, policyVersion, adapterOverride, now });
+    const spec = {
+      ...buildRunSpec(registry, pinnedEnvelope, mapping, { runId, policyVersion, adapterOverride, now }),
+      idempotencyKey,
+    };
     const specJson = canonicalJson(spec);
     const specHash = hashJson(spec);
-    createRun(db, {
-      runId, idempotencyKey, spec, specJson, specHash,
-      actor: "planner",
-      correlationId: envelope.correlationId ?? null,
-      causationId: envelope.causationId ?? null,
-      policyVersion, now,
-    });
+    try {
+      createRun(db, {
+        runId, idempotencyKey, spec, specJson, specHash,
+        actor: "planner",
+        correlationId: envelope.correlationId ?? null,
+        causationId: envelope.causationId ?? null,
+        policyVersion, now,
+      });
+    } catch (err) {
+      if (!isIdempotencyKeyCollision(err)) throw err;
+      const winner = resolveIdempotency(db, { idempotencyKey });
+      if (!winner) throw err;
+      const reason = `idempotency_collision:${winner.run_id}`;
+      const proposal = insertProposal(db, {
+        id: newProposalId(), event, runId: winner.run_id, decision: "noop",
+        idempotencyKey, status: "resolved", reason, at, ttlSeconds,
+      });
+      setEventStatus(db, event, "noop");
+      return { decision: "noop", proposal, runId: winner.run_id, reason };
+    }
     const proposal = insertProposal(db, {
       id: newProposalId(), event, runId, decision: "run",
       specJson, specHash, idempotencyKey, status: "open", at, ttlSeconds,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -7,7 +7,7 @@ import { hashJson } from "./canonical.mjs";
 import { DEAD_LETTER_AFTER } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
-import { createRun, lifecycleOf, runState } from "./lifecycle.mjs";
+import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
 import { buildRunSpec, idempotencyKeyFor, planAdmittedEvents, planEvent } from "./planner.mjs";
 import { loadRegistry } from "./registry.mjs";
 
@@ -186,6 +186,93 @@ describe("planEvent", () => {
     expect(second.reason).toBe("duplicate_run");
     expect(second.runId).toBe(first.runId);
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("chain repeat triggers coalesce while active and self-feed again after terminal completion (WM-319)", () => {
+    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    synthetic.eventTypes["test.chain.requested"] = {
+      agent: "test-chain@1",
+      adapter: "fake",
+      idempotencyScope: ["inputHash"],
+    };
+    synthetic.agents.set("test-chain@1", {
+      id: "test-chain",
+      version: 1,
+      ref: "test-chain@1",
+      output_contract: "factory.test/v1",
+      workspace: { type: "ephemeral" },
+      capabilities: { services: [] },
+      limits: { timeout_seconds: 60, attempts: 1 },
+      mutating: false,
+      inputSchema: { type: "object" },
+    });
+
+    const chainEvent = (eventId, causationId) => ({
+      eventId,
+      type: "test.chain.requested",
+      source: "chain",
+      subject: "factory",
+      correlationId: "lineage-001",
+      causationId,
+      payload: { repo: "factory" },
+    });
+    const db = openDb(":memory:");
+
+    const firstRef = admit(db, chainEvent("chain-dispatch-1", "run_dispatch_1"));
+    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+    expect(first.decision).toBe("run");
+
+    const concurrentRef = admit(db, chainEvent("chain-dispatch-2", "run_dispatch_2"));
+    const concurrent = planEvent(db, synthetic, concurrentRef, { now: NOW + 1000, policyVersion: "git:test" });
+    expect(concurrent).toMatchObject({ decision: "noop", reason: "duplicate_run", runId: first.runId });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    const nextCycleRef = admit(db, chainEvent("chain-dispatch-3", "run_dispatch_3"));
+    const nextCycle = planEvent(db, synthetic, nextCycleRef, { now: NOW + 2000, policyVersion: "git:test" });
+    expect(nextCycle.decision).toBe("run");
+    expect(nextCycle.runId).not.toBe(first.runId);
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+
+    const coalescedAgainRef = admit(db, chainEvent("chain-dispatch-4", "run_dispatch_4"));
+    const coalescedAgain = planEvent(db, synthetic, coalescedAgainRef, { now: NOW + 3000, policyVersion: "git:test" });
+    expect(coalescedAgain).toMatchObject({ decision: "noop", reason: "duplicate_run", runId: nextCycle.runId });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: nextCycle.runId, to, actor: "test" });
+    }
+
+    // Even if a concrete generation key collides after resolution (for
+    // example, two planners racing around a terminal generation), the raw
+    // SQLite error is converted to a typed noop naming the winning run.
+    const collisionEventId = "chain-collision";
+    const collisionKey = `${first.proposal.idempotency_key}:trigger:${hashJson({ source: "chain", eventId: collisionEventId })}`;
+    createRun(db, {
+      runId: "run_collision_winner",
+      idempotencyKey: collisionKey,
+      spec: {},
+      specJson: "{}",
+      specHash: "sha256:0",
+      actor: "planner",
+      correlationId: "lineage-001",
+      causationId: "run_dispatch_old",
+      policyVersion: "git:test",
+      now: NOW + 4000,
+    });
+    transition(db, { runId: "run_collision_winner", to: "CANCELLED", actor: "test", now: NOW + 4000 });
+
+    const collisionRef = admit(db, chainEvent(collisionEventId, "run_dispatch_5"));
+    const collision = planEvent(db, synthetic, collisionRef, { now: NOW + 5000, policyVersion: "git:test" });
+    expect(collision).toMatchObject({
+      decision: "noop",
+      reason: "idempotency_collision:run_collision_winner",
+      runId: "run_collision_winner",
+    });
+    expect(db.query(`SELECT status FROM events WHERE event_id = ?`).get(collisionEventId).status).toBe("noop");
   });
 
   test("unregistered event type → human_needed", () => {


### PR DESCRIPTION
## Summary
- coalesce identical idempotency-family triggers while any generation is non-terminal
- derive event-scoped concrete keys so terminal generations can self-feed a new run without weakening the UNIQUE constraint
- convert residual UNIQUE collisions into typed noops naming the winning run
- cover the real same-correlation/different-causation chain shape across multiple cycles

## Verification
- `bun test && bun build/emit.mjs --check && bun run format:check`
- Pass: 1,647 tests; 90 generated files match; Prettier check passed (existing stale-floor warning for bj29 only).

## Operations
The seven live parked events were not replayed from this isolated ticket worktree: it does not hold the live runtime database, and production requeue before this fix merges would dead-letter them again. Requeue them after deployment.

UX critique: skipped — internal planner/lifecycle behavior with no user-completable UI flow.

Fixes WM-319