### PR TITLE
fix(event-runtime-web): remove visible focus ring from main landmark on view navigation (WM-325)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -330,3 +330,23 @@ describe("context strip fast jump chords (WM-235)", () => {
     expect(utils.container.textContent).toContain("i In flight");
   });
 });
+
+describe("view navigation landmark focus and announcement (WM-325)", () => {
+  test("main landmark receives focus without visual focus ring on view navigation", async () => {
+    const utils = renderApp();
+    const main = utils.getByRole("main");
+    expect(main.className).toContain("focus:outline-none");
+    expect(main.className).not.toContain("focus:ring");
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: "g" });
+      fireEvent.keyDown(document.body, { key: "r" });
+    });
+    expect(window.location.hash).toBe("#/runs");
+
+    await waitFor(() => {
+      expect(main.textContent).toContain("Runs view");
+    });
+  });
+});
+

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -511,7 +511,7 @@ export function App() {
       <main
         ref={mainRef}
         tabIndex={-1}
-        className="flex min-w-0 flex-1 flex-col focus:outline-none focus:ring-2 focus:ring-inset focus:ring-(--focus-ring)"
+        className="flex min-w-0 flex-1 flex-col focus:outline-none"
       >
         <div aria-live="polite" aria-atomic="true" className="sr-only">
           {viewAnnouncement}


### PR DESCRIPTION
## Summary
Remove visible focus ring styling from the `<main>` landmark element in `event-runtime/web/src/App.tsx`.

When switching views (e.g., clicking Runs or Projects), programmatic focus is transferred to `<main tabIndex={-1}>` for accessibility route announcements. With `focus:ring-2 focus:ring-inset focus:ring-(--focus-ring)`, this drew an unintended white/bright rectangle around the main viewport container. Retaining `focus:outline-none` keeps the live announcement working cleanly without visual highlight artifacts.

## Verification
- `bun test` in `event-runtime/web` passes (565 tests passing across 43 files).
- `bun run build` in `event-runtime/web` passes cleanly.

Fixes WM-325