### PR TITLE
fix(event-runtime-web): rank event facets by frequency (WM-202)

### DIFF
--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -407,6 +407,38 @@ describe("Events component harness: facet chips grouping and visual distinction"
     );
   });
 
+  test("sorts Type and Source facet chips by frequency, then alphabetically", async () => {
+    const events = [
+      stubEvent("evt_1", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
+      stubEvent("evt_2", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
+      stubEvent("evt_3", "admitted", { type: "zeta.frequent", source: "zeta-source" }),
+      stubEvent("evt_4", "admitted", { type: "alpha.rare", source: "alpha-source" }),
+      stubEvent("evt_5", "admitted", { type: "beta.rare", source: "beta-source" }),
+    ];
+
+    await withApi(
+      {
+        events: async () => ({ events }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole } = renderEvents({});
+
+        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const typeLabels = Array.from(typeGroup.querySelectorAll("button > span:first-child")).map(
+          (span) => span.textContent,
+        );
+        expect(typeLabels).toEqual(["zeta.frequent", "alpha.rare", "beta.rare"]);
+
+        const sourceGroup = getByRole("group", { name: "Event sources" });
+        const sourceLabels = Array.from(sourceGroup.querySelectorAll("button > span:first-child")).map(
+          (span) => span.textContent,
+        );
+        expect(sourceLabels).toEqual(["zeta-source", "alpha-source", "beta-source"]);
+      },
+    );
+  });
+
   test("facet chip counts reflect the active tab scope", async () => {
     const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
     const e2 = stubEvent("evt_2", "admitted", { type: "pull_request.opened", source: "github" });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -220,9 +220,6 @@ export function Events({
     return scoped;
   }, [scoped, fetchAll, tab]);
 
-  const types = useMemo(() => [...new Set(tabScoped.map((e) => e.type))].sort(), [tabScoped]);
-  const sources = useMemo(() => [...new Set(tabScoped.map((e) => e.source))].sort(), [tabScoped]);
-
   const typeCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const e of tabScoped) {
@@ -238,6 +235,21 @@ export function Events({
     }
     return counts;
   }, [tabScoped]);
+
+  const types = useMemo(
+    () =>
+      Object.keys(typeCounts).sort(
+        (a, b) => (typeCounts[b] ?? 0) - (typeCounts[a] ?? 0) || a.localeCompare(b),
+      ),
+    [typeCounts],
+  );
+  const sources = useMemo(
+    () =>
+      Object.keys(sourceCounts).sort(
+        (a, b) => (sourceCounts[b] ?? 0) - (sourceCounts[a] ?? 0) || a.localeCompare(b),
+      ),
+    [sourceCounts],
+  );
 
   const parsed = useMemo(() => parseFilterQuery(filter, EVENT_FACETS), [filter]);
 


### PR DESCRIPTION
## Summary
- rank Type and Source facet chips by descending active-scope event count
- use alphabetical tie-breaking for deterministic ordering
- add regression coverage for both facet groups

## Verification
- `bun test event-runtime/web/src/views/Events.test.tsx && bun build/emit.mjs --check`

## UX critique
- required — NOT-ASSESSED: the critic could not launch its Chrome CDP helper; automated DOM regression coverage verifies ordering and the existing count typography remains unchanged

Fixes WM-202