### PR TITLE
feat(event-runtime-web): add Overview keyboard navigation (WM-292)

### DIFF
--- a/event-runtime/web/src/components/ShortcutsDialog.test.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.test.tsx
@@ -34,6 +34,18 @@ describe("ShortcutsDialog", () => {
     expect(runTrace.textContent).toContain("copy CLI inspect command");
   });
 
+  test("documents Overview pipeline and anomaly shortcuts (WM-292)", () => {
+    const r = render(<ShortcutsDialog onClose={() => {}} />);
+    const overview = r.getByRole("region", { name: "Overview" });
+
+    expect(overview.textContent).toContain("1–5");
+    expect(overview.textContent).toContain("pipeline stage views");
+    expect(overview.textContent).toContain(".");
+    expect(overview.textContent).toContain("next anomaly");
+    expect(overview.textContent).toContain("r");
+    expect(overview.textContent).toContain("requeue focused dead-letter event");
+  });
+
   test("documents context chords under Navigation chords (g 0, g 1–9, g i)", () => {
     const r = render(<ShortcutsDialog onClose={() => {}} />);
 

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -33,6 +33,12 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "?", does: "this list" },
 ];
 
+const OVERVIEW_KEYS: { keys: string; does: string }[] = [
+  { keys: "1–5", does: "open pipeline stage views (Events, Proposals, queued, running, outcomes)" },
+  { keys: ".", does: "focus next anomaly" },
+  { keys: "r", does: "requeue focused dead-letter event" },
+];
+
 const CONTEXT_STRIP: { keys: string; does: string }[] = [
   { keys: "Tab", does: "focus context strip (single stop, roving tabindex)" },
   { keys: "← →", does: "move focus among All / repos / In flight tabs" },
@@ -91,6 +97,23 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
           </div>
           <div>
             {ACTIONS.map((r) => (
+              <div
+                key={`${r.keys}::${r.does}`}
+                className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"
+              >
+                <span className="mono text-(--text)">{r.keys}</span>
+                <span className="text-left sm:text-right text-(--text-faint)">{r.does}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section aria-label="Overview">
+          <div className="mb-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+            Overview
+          </div>
+          <div>
+            {OVERVIEW_KEYS.map((r) => (
               <div
                 key={`${r.keys}::${r.does}`}
                 className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-4 border-b border-(--border) py-1.5 last:border-0"

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -331,24 +331,23 @@ describe("Overview keyboard navigation (WM-292)", () => {
       const view = renderOverview();
       await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
 
+      const first = view.getByText("expired open proposal").closest('[tabindex="-1"]');
+      const second = view.getByText(/dead-lettered \(github, evt_dead\)/).closest('[tabindex="-1"]');
+      expect(first).toBeTruthy();
+      expect(second).toBeTruthy();
+
       fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(
-        view.getByRole("group", { name: "Anomaly 1 of 2" }),
-      );
+      expect(document.activeElement).toBe(first);
       fireEvent.keyDown(document.body, { key: "r" });
       expect(requeue).not.toHaveBeenCalled();
 
       fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(
-        view.getByRole("group", { name: "Anomaly 2 of 2" }),
-      );
+      expect(document.activeElement).toBe(second);
       fireEvent.keyDown(document.body, { key: "r" });
       await waitFor(() => expect(requeue).toHaveBeenCalledWith("github", "evt_dead"));
 
       fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(
-        view.getByRole("group", { name: "Anomaly 1 of 2" }),
-      );
+      expect(document.activeElement).toBe(first);
     } finally {
       restore();
     }

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,6 +1,6 @@
 import "../test-dom";
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Overview, groupJournalEntries, buildAnomalyRows } from "./Overview";
 import { shortId } from "../components/ui";
@@ -111,16 +111,26 @@ const stubProposal: Proposal = {
   repos: [],
 };
 
-function renderOverview(context: OperatorContext = { kind: "all" }) {
+type OverviewCallbacks = Partial<
+  Pick<
+    React.ComponentProps<typeof Overview>,
+    "onJumpRun" | "onJumpProposal" | "onJumpEvents" | "onJumpRuns" | "onNavigate"
+  >
+>;
+
+function renderOverview(
+  context: OperatorContext = { kind: "all" },
+  callbacks: OverviewCallbacks = {},
+) {
   return renderWithClient(
     <Overview
       connected={true}
       context={context}
-      onJumpRun={noop}
-      onJumpProposal={noop}
-      onJumpEvents={noop}
-      onJumpRuns={noop}
-      onNavigate={noop}
+      onJumpRun={callbacks.onJumpRun ?? noop}
+      onJumpProposal={callbacks.onJumpProposal ?? noop}
+      onJumpEvents={callbacks.onJumpEvents ?? noop}
+      onJumpRuns={callbacks.onJumpRuns ?? noop}
+      onNavigate={callbacks.onNavigate ?? noop}
       onJumpExpired={noop}
       onJumpGraph={noop}
       onInject={noop}
@@ -231,6 +241,116 @@ describe("Overview activity feed rendering (WM-100)", () => {
       api.proposals = origProposals;
       api.outbox = origOutbox;
       api.journal = origJournal;
+    }
+  });
+});
+
+describe("Overview keyboard navigation (WM-292)", () => {
+  function stubOverviewApis(status: StatusView) {
+    const restore = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+      requeue: api.requeue,
+    };
+    api.status = async () => status;
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    return () => {
+      api.status = restore.status;
+      api.proposals = restore.proposals;
+      api.outbox = restore.outbox;
+      api.journal = restore.journal;
+      api.requeue = restore.requeue;
+    };
+  }
+
+  test("1–5 jump to the corresponding pipeline views", async () => {
+    const restore = stubOverviewApis(baseStatus());
+    const onJumpEvents = mock(() => {});
+    const onJumpRuns = mock((_state?: string) => {});
+    const onNavigate = mock(() => {});
+
+    try {
+      renderOverview({ kind: "all" }, { onJumpEvents, onJumpRuns, onNavigate });
+
+      for (const key of ["1", "2", "3", "4", "5"]) {
+        fireEvent.keyDown(document.body, { key });
+      }
+
+      expect(onJumpEvents).toHaveBeenCalledTimes(1);
+      expect(onJumpEvents).toHaveBeenCalledWith({});
+      expect(onNavigate).toHaveBeenCalledWith("proposals");
+      expect(onJumpRuns.mock.calls.map((call) => call[0])).toEqual([
+        "QUEUED",
+        "RUNNING",
+        "COMPLETED",
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("stage shortcuts stand down for modifiers and typing targets", () => {
+    const restore = stubOverviewApis(baseStatus());
+    const onJumpEvents = mock(() => {});
+    const onNavigate = mock(() => {});
+
+    try {
+      const view = renderOverview({ kind: "all" }, { onJumpEvents, onNavigate });
+      fireEvent.keyDown(document.body, { key: "1", metaKey: true });
+      fireEvent.keyDown(document.body, { key: "2", ctrlKey: true });
+      const input = document.createElement("input");
+      view.container.append(input);
+      fireEvent.keyDown(input, { key: "1" });
+
+      expect(onJumpEvents).not.toHaveBeenCalled();
+      expect(onNavigate).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  test(". cycles anomaly focus and r requeues only a focused dead-letter event", async () => {
+    const restore = stubOverviewApis(
+      baseStatus({
+        expiredOpenProposals: ["prop_expired"],
+        deadLettered: [
+          { source: "github", eventId: "evt_dead", lastError: "planner failed" },
+        ],
+      }),
+    );
+    const requeue = mock(
+      (_source: string, _eventId: string) => new Promise<{ requeued: boolean }>(() => {}),
+    );
+    api.requeue = requeue;
+
+    try {
+      const view = renderOverview();
+      await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(
+        view.getByRole("group", { name: "Anomaly 1 of 2" }),
+      );
+      fireEvent.keyDown(document.body, { key: "r" });
+      expect(requeue).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(
+        view.getByRole("group", { name: "Anomaly 2 of 2" }),
+      );
+      fireEvent.keyDown(document.body, { key: "r" });
+      await waitFor(() => expect(requeue).toHaveBeenCalledWith("github", "evt_dead"));
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(
+        view.getByRole("group", { name: "Anomaly 1 of 2" }),
+      );
+    } finally {
+      restore();
     }
   });
 });

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -583,12 +583,11 @@ export function Overview({
     function onKey(e: KeyboardEvent) {
       if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey || goPrefixActive()) return;
 
-      const runState = ["QUEUED", "RUNNING", "COMPLETED"][Number(e.key) - 3];
-      if (e.key === "1" || e.key === "2" || runState) {
+      if ("12345".includes(e.key)) {
         e.preventDefault();
         if (e.key === "1") onJumpEvents({});
         else if (e.key === "2") onNavigate("proposals");
-        else onJumpRuns(runState);
+        else onJumpRuns(["QUEUED", "RUNNING", "COMPLETED"][+e.key - 3]);
         return;
       }
 
@@ -740,8 +739,6 @@ export function Overview({
                 ref={(node) => {
                   anomalyRowRefs.current[i] = node;
                 }}
-                role="group"
-                aria-label={`Anomaly ${i + 1} of ${anomalyRows.length}`}
                 tabIndex={-1}
                 className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0 focus-visible:outline-2 focus-visible:outline-(--accent)"
               >

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
-import { useNow, useRequeuePoll } from "../hooks";
+import { goPrefixActive } from "../goSequence";
+import { keyGuard, useNow, useRequeuePoll } from "../hooks";
 import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
@@ -576,6 +577,41 @@ export function Overview({
   }, [anomalies, proposalsById, onJumpProposal, onJumpRuns, onJumpEvents, onJumpRun, onNavigate, s, now]);
 
   const hasAnomalies = anomalyRows.length > 0;
+  const anomalyRowRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey || goPrefixActive()) return;
+
+      const runState = ["QUEUED", "RUNNING", "COMPLETED"][Number(e.key) - 3];
+      if (e.key === "1" || e.key === "2" || runState) {
+        e.preventDefault();
+        if (e.key === "1") onJumpEvents({});
+        else if (e.key === "2") onNavigate("proposals");
+        else onJumpRuns(runState);
+        return;
+      }
+
+      const focusedIndex = anomalyRowRefs.current.indexOf(
+        document.activeElement as HTMLDivElement,
+      );
+      if (e.key === "." && anomalyRows.length > 0) {
+        e.preventDefault();
+        anomalyRowRefs.current[(focusedIndex + 1) % anomalyRows.length]?.focus();
+        return;
+      }
+
+      if (e.key === "r") {
+        const focused = anomalyRows[focusedIndex];
+        if (!focused?.requeue || !connected || requeue.isPending) return;
+        e.preventDefault();
+        requeue.mutate(focused.requeue);
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [anomalyRows, connected, onJumpEvents, onJumpRuns, onNavigate, requeue]);
 
   const activeRunStates: RunState[] = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
   const terminalRunStates: RunState[] = ["COMPLETED", "FAILED", "REFUSED", "TIMED_OUT", "CANCELLED"];
@@ -701,7 +737,13 @@ export function Overview({
             {anomalyRows.map((a, i) => (
               <div
                 key={i}
-                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0"
+                ref={(node) => {
+                  anomalyRowRefs.current[i] = node;
+                }}
+                role="group"
+                aria-label={`Anomaly ${i + 1} of ${anomalyRows.length}`}
+                tabIndex={-1}
+                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3 border-b border-(--border) px-3 py-2 last:border-0 focus-visible:outline-2 focus-visible:outline-(--accent)"
               >
                 <div className="min-w-0 flex items-start sm:items-center gap-2">
                   <CategoryPill kind={a.kind} />


### PR DESCRIPTION
## Summary
- add guarded 1–5 keyboard jumps from Overview to Events, Proposals, and run-stage views
- cycle focus through anomaly rows with `.` and requeue a focused dead-letter event with `r`
- document Overview shortcuts and cover navigation, input/modifier guards, cycling, and requeue behavior

## Verification
- `bun test event-runtime/web/src/views/Overview.test.tsx event-runtime/web/src/components/ShortcutsDialog.test.tsx && bun build/emit.mjs --check`
- `cd event-runtime/web && bun run build`

UX critique: required — NOT-ASSESSED, browser automation was unavailable because the configured Chrome CDP script path was missing.

Fixes WM-292