### PR TITLE
fix(event-runtime-web): map multi-state tabs to full state sets in Runs display grouping (WM-327)

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { Runs } from "./Runs";
+import { Runs, statesForRunTab } from "./Runs";
 import {
   changeInput,
   createLifecycleEventFixture,
@@ -629,4 +629,34 @@ describe("Runs copy chords and hints (WM-233)", () => {
       },
     );
   });
+
+  test("statesForRunTab maps multi-state and single-state tabs to their full run state sets (WM-327)", () => {
+    expect(statesForRunTab("ALL")).toEqual([
+      "PROPOSED",
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+      "REFUSED",
+      "FAILED",
+      "TIMED_OUT",
+      "CANCELLED",
+    ]);
+    expect(statesForRunTab("ACTIVE")).toEqual([
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+    ]);
+    expect(statesForRunTab("FAILED")).toEqual([
+      "FAILED",
+      "TIMED_OUT",
+      "REFUSED",
+    ]);
+    expect(statesForRunTab("COMPLETED")).toEqual(["COMPLETED"]);
+    expect(statesForRunTab("CANCELLED")).toEqual(["CANCELLED"]);
+  });
 });
+

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -93,6 +93,20 @@ export function matchesRunTab(state: RunState, tab: RunTab): boolean {
   return true;
 }
 
+export function statesForRunTab(tab: RunTab): readonly string[] {
+  if (tab === "ALL") {
+    return [
+      "PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING",
+      "COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED",
+    ];
+  }
+  if (tab === "ACTIVE") return ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
+  if (tab === "FAILED") return ["FAILED", "TIMED_OUT", "REFUSED"];
+  if (tab === "COMPLETED") return ["COMPLETED"];
+  if (tab === "CANCELLED") return ["CANCELLED"];
+  return [];
+}
+
 export function tabForRunState(state: string): RunTab {
   if (["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(state)) return "ACTIVE";
   if (["FAILED", "TIMED_OUT", "REFUSED"].includes(state)) return "FAILED";
@@ -263,13 +277,12 @@ export function Runs({
   // empty groups" on the COMPLETED tab must not render ten 0-count bands the
   // tab itself already filtered out.
   const displayConfig = useMemo(
-    () =>
-      tab === "ALL"
-        ? RUNS_DISPLAY
-        : {
-            ...RUNS_DISPLAY,
-            groups: RUNS_DISPLAY.groups.map((g) => (g.key === "state" ? { ...g, order: [tab] } : g)),
-          },
+    () => ({
+      ...RUNS_DISPLAY,
+      groups: RUNS_DISPLAY.groups.map((g) =>
+        g.key === "state" ? { ...g, order: statesForRunTab(tab) } : g,
+      ),
+    }),
     [tab],
   );
   const [display, setDisplay] = useDisplayOptions(displayConfig);


### PR DESCRIPTION
## Summary
In `event-runtime/web/src/views/Runs.tsx`, `displayConfig` mapped the `state` group order to `[tab]` on single-tab views. For multi-state tabs like **Active** (`QUEUED`, `LEASED`, `RUNNING`, `VERIFYING`) and **Failed** (`FAILED`, `TIMED_OUT`, `REFUSED`), setting order to `[tab]` used the tab name as a state identifier (e.g. `'ACTIVE'`), breaking canonical section ordering and producing empty `ACTIVE (0)` sections when 'Show empty groups' was enabled.

Added `statesForRunTab(tab)` to provide the full valid state sets per tab for display grouping.

## Verification
- `bun test` in `event-runtime/web` passes (566 tests passing).
- `bun run build` in `event-runtime/web` builds cleanly.

Fixes WM-327