### PR TITLE
feat(event-runtime-web): add run pinning and graph reveal shortcuts (WM-295)

### DIFF
--- a/event-runtime/web/src/components/ShortcutsDialog.test.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.test.tsx
@@ -69,6 +69,8 @@ describe("ShortcutsDialog", () => {
     expect(actions.textContent).toContain("copy CLI inspect command (Runs)");
     expect(actions.textContent).toContain("c p");
     expect(actions.textContent).toContain("copy repo path (Projects)");
+    expect(actions.textContent).toContain("pin / unpin selected run (Runs)");
+    expect(actions.textContent).toContain("reveal selected node on canvas (Graph)");
   });
 
   test("documents 'v' for display options and '1–N' for status tabs (WM-234)", () => {

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -27,6 +27,8 @@ const ACTIONS: { keys: string; does: string }[] = [
   { keys: "* n / Esc", does: "clear proposal selection" },
   { keys: "A / X", does: "approve / reject selected proposals" },
   { keys: "q", does: "requeue event (Events)" },
+  { keys: "p", does: "pin / unpin selected run (Runs)" },
+  { keys: "z / Enter", does: "reveal selected node on canvas (Graph)" },
   { keys: "c", does: "copy selected id / name / ref" },
   { keys: "c l", does: "copy link to clipboard" },
   { keys: "c i / c c", does: "copy CLI inspect command (Runs)" },

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { keyGuard, useNow } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
@@ -232,11 +232,33 @@ export function Graph({
 
   const pendingC = useRef<number>(0);
 
+  const revealSelected = useCallback(() => {
+    if (!focusNodeId || !flowRef.current) return;
+    const zoom = flowRef.current.getZoom();
+    flowRef.current.fitView({
+      nodes: [{ id: focusNodeId }],
+      padding: 0.45,
+      duration: 180,
+      minZoom: zoom,
+      maxZoom: zoom,
+    });
+  }, [focusNodeId]);
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key === "Escape") {
         onSelectNode(null);
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      const enterActivatesControl =
+        e.key === "Enter" &&
+        Boolean(target?.closest("button, a, [role=button], [role=link]")) &&
+        !target?.closest(".react-flow__node");
+      if ((e.key === "z" || (e.key === "Enter" && !enterActivatesControl)) && focusNodeId) {
+        e.preventDefault();
+        revealSelected();
         return;
       }
       if (e.key === "c" && focusNodeId) {
@@ -274,19 +296,7 @@ export function Graph({
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onSelectNode, focusNodeId, graph, positioned]);
-
-  const revealSelected = () => {
-    if (!focusNodeId || !flowRef.current) return;
-    const zoom = flowRef.current.getZoom();
-    flowRef.current.fitView({
-      nodes: [{ id: focusNodeId }],
-      padding: 0.45,
-      duration: 180,
-      minZoom: zoom,
-      maxZoom: zoom,
-    });
-  };
+  }, [onSelectNode, focusNodeId, graph, positioned, revealSelected]);
 
   // Initial view (WM-99): fit the largest connected component with a zoom
   // floor instead of squeezing every island on screen at label-illegible zoom.
@@ -492,7 +502,11 @@ export function Graph({
         <DetailPane
           widthClass="w-[420px]"
           title={selected.label}
-          actions={<Button onClick={revealSelected}>Show on canvas</Button>}
+          actions={
+            <Button onClick={revealSelected}>
+              Show on canvas <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
+            </Button>
+          }
           utility={
             <CopyActions
               id={selected.label}

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -16,6 +16,7 @@ import type { RunDetail } from "../types";
 afterEach(() => {
   cleanup();
   restoreApi();
+  sessionStorage.clear();
 });
 
 const noop = () => {};
@@ -104,6 +105,33 @@ describe("RunFull cancel dialog (WM-144)", () => {
 });
 
 describe("RunFull header copy verbs and hints (WM-218)", () => {
+  test("p toggles the run in the context strip and Open in tab shows its hint", async () => {
+    const runId = "run_full_pin_shortcut";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+    });
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "RUNNING" })],
+        }),
+      },
+      async () => {
+        const { getByRole } = renderRunFull(runId);
+        const openInTab = await waitFor(() => getByRole("button", { name: /Open in tab/ }));
+        expect(openInTab.querySelector('[aria-hidden="true"]')?.textContent).toBe("p");
+
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([runId]);
+
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([]);
+      },
+    );
+  });
+
   test("renders shortcut tooltips on the back and copy icon actions", async () => {
     const runId = "run_header_hints";
     const detail = createRunDetailFixture({

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -23,8 +23,7 @@ import {
   RunFailureBanner,
   isCancellable,
 } from "../components/RunDetailBlocks";
-import { handleRunArtifactClick } from "./Runs";
-import type { RunListItem } from "../types";
+import { handleRunArtifactClick, toggleRunPin } from "./Runs";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -134,6 +133,11 @@ export function RunFull({
         onBack();
         return;
       }
+      if (e.key === "p") {
+        e.preventDefault();
+        toggleRunPin(runId);
+        return;
+      }
       if (e.key === "x" && d && connected && isCancellable(d.run.state)) {
         e.preventDefault();
         setConfirm("cancel");
@@ -172,6 +176,7 @@ export function RunFull({
   useEffect(() => {
     const copy = [
       { label: "Back to Runs", hint: "Esc", run: onBack },
+      { label: "Open in tab", hint: "p", run: () => toggleRunPin(runId) },
       {
         label: `Copy ${runId}`,
         hint: "c",
@@ -308,6 +313,15 @@ export function RunFull({
                 ))}
             </div>
           )}
+          <Button onClick={() => toggleRunPin(runId)}>
+            <span>Open in tab</span>
+            <span
+              aria-hidden="true"
+              className="mono ml-1 text-(--text-faint) text-[10px]"
+            >
+              p
+            </span>
+          </Button>
           <CopyActions
             id={runId}
             idLabel="run id"

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -24,6 +24,7 @@ import {
   isCancellable,
 } from "../components/RunDetailBlocks";
 import { handleRunArtifactClick, toggleRunPin } from "./Runs";
+import type { RunListItem } from "../types";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -240,6 +240,30 @@ describe("Runs detail failure banner (WM-93)", () => {
 });
 
 describe("Runs component harness: selection & filter retention", () => {
+  test("p toggles the selected run in the context strip and the detail action shows its hint", async () => {
+    const runId = "run_pin_shortcut";
+    sessionStorage.clear();
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [stubListItem(runId, "RUNNING")] }),
+        run: async () => stubDetail(runId, "RUNNING", []),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole } = renderRuns({ focusRunId: runId });
+        const openInTab = await waitFor(() => getByRole("button", { name: /Open in tab/ }));
+        expect(openInTab.querySelector('[aria-hidden="true"]')?.textContent).toBe("p");
+
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([runId]);
+
+        fireEvent.keyDown(document.body, { key: "p" });
+        expect(JSON.parse(sessionStorage.getItem("factory.pinnedRuns") ?? "[]")).toEqual([]);
+      },
+    );
+  });
+
   test("clicking a row selects the run via onSelectRun", async () => {
     const onSelectRun = mock(() => {});
     const r1 = stubListItem("run_click_test", "RUNNING");

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -65,6 +65,17 @@ export const RUN_TABS: readonly RunTab[] = [
   "CANCELLED",
 ] as const;
 
+export function toggleRunPin(id: string) {
+  const pinned = readPinnedRuns();
+  if (pinned.includes(id)) {
+    savePinnedRuns(pinned.filter((runId) => runId !== id));
+    notify(`Unpinned ${id}`, "info");
+  } else {
+    savePinnedRuns([...pinned, id]);
+    notify(`Pinned ${id}`, "ok");
+  }
+}
+
 function isTypingTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
 }
@@ -497,6 +508,7 @@ export function Runs({
           pendingC.current = 0;
         }
       },
+      p: () => sel && toggleRunPin(sel.runId),
     },
   });
 
@@ -522,23 +534,13 @@ export function Runs({
   const d = detail.data;
   const attemptsExhausted = d ? d.run.attempts >= d.run.spec.maxAttempts : false;
 
-  const pinRun = (id: string) => {
-    const cur = readPinnedRuns();
-    if (!cur.includes(id)) {
-      savePinnedRuns([...cur, id]);
-      notify(`Pinned ${id}`, "ok");
-    } else {
-      notify("Already pinned", "info");
-    }
-  };
-
   // Offer the selection's verbs in the ⌘K palette (§5).
   useEffect(() => {
     if (!sel) {
       setContextActions([]);
     } else {
       const copy = [
-        { label: "Open in tab", run: () => pinRun(sel.runId) },
+        { label: "Open in tab", hint: "p", run: () => toggleRunPin(sel.runId) },
         { label: "Open full view", hint: "o", run: () => onOpenFull(sel.runId) },
         { label: "Copy run id", hint: "c", run: () => copyText(sel.runId, "run id") },
         {
@@ -870,7 +872,9 @@ export function Runs({
                 <Button onClick={() => onOpenFull(sel.runId)}>
                   Expand <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">o</span>
                 </Button>
-                <Button onClick={() => pinRun(sel.runId)}>Open in tab</Button>
+                <Button onClick={() => toggleRunPin(sel.runId)}>
+                  Open in tab <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">p</span>
+                </Button>
               </div>
             </>
           }


### PR DESCRIPTION
## Summary
- add `p` to pin or unpin the selected run from Runs and full Run views
- add `z` / `Enter` to reveal the selected Graph node without overriding focused controls
- expose shortcut hints and document both actions
- add regression coverage for run pinning and shortcut documentation

## Verification
- `bun test event-runtime/web/src/views/Runs.test.tsx event-runtime/web/src/views/RunFull.test.tsx event-runtime/web/src/components/ShortcutsDialog.test.tsx && bun build/emit.mjs --check`
- `cd event-runtime/web && bun run build`

UX critique: required — NOT-ASSESSED, browser tooling was unavailable to the critic; automated interaction tests and the production build pass.

Fixes WM-295