### PR TITLE
feat(event-runtime-web): resolve overview anomalies (WM-326)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -29,12 +29,12 @@ import {
 } from "./inbox.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { MetricsQueryError, metricsBreakdownView, metricsView } from "./metrics.mjs";
-import { planEvent, requeueEvent } from "./planner.mjs";
+import { archiveDeadLetteredEvent, planEvent, requeueEvent } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, approveProposal, openProposals, rejectProposal } from "./proposals.mjs";
 import { resolveModel } from "./registry.mjs";
 import { loadRepos, RepoError, reposRoot, reposView } from "./repos.mjs";
 import { traceOf } from "./trace.mjs";
-import { cancelRun, retryRun } from "./worker.mjs";
+import { cancelRun, releaseStalledWorkerLease, retryRun } from "./worker.mjs";
 import { parseCadence, proposalsPilingUp, scheduleView } from "./schedules.mjs";
 import { notifyCommand, sendNotification } from "./notify.mjs";
 import { listWorkers, loadWorkerPolicy, satisfiesPlacement, stalledWorkers } from "./workers.mjs";
@@ -259,7 +259,7 @@ function statusView(db, registry, nowMs, { secret, githubSecret, policyVersion, 
     .query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`)
     .get().n;
   const deadLettered = db
-    .query(`SELECT source, event_id, last_plan_error FROM events WHERE status = 'dead_lettered'`)
+    .query(`SELECT source, event_id, last_plan_error FROM events WHERE status = 'dead_lettered' AND archived_at IS NULL`)
     .all()
     .map((row) => ({ source: row.source, eventId: row.event_id, lastError: row.last_plan_error }));
 
@@ -1199,15 +1199,39 @@ export function createApi({
         return send(res, 200, { outbox: outboxView(db, limit) });
       }
 
-      if (route === "POST /events/requeue") {
+      if (route === "POST /events/requeue" || route === "POST /events/archive") {
         const body = parseJson(await readBody(req)).value ?? {};
         if (!body.source || !body.eventId) return send(res, 422, { error: "source and eventId required" });
         try {
+          if (route === "POST /events/archive") {
+            return send(
+              res,
+              200,
+              archiveDeadLetteredEvent(db, { source: body.source, eventId: body.eventId }, { now: nowMs }),
+            );
+          }
           requeueEvent(db, { source: body.source, eventId: body.eventId }, { actor: ACTOR, now: nowMs });
           onEvent("requeued"); // plan again right away, like a fresh admission
           return send(res, 200, { requeued: true });
         } catch (err) {
           const status = String(err.message).startsWith("unknown event") ? 404 : 409;
+          return send(res, status, { error: err.message });
+        }
+      }
+
+      const workerRelease = url.pathname.match(/^\/workers\/([^/]+)\/release$/);
+      if (req.method === "POST" && workerRelease) {
+        const workerId = decodeURIComponent(workerRelease[1]);
+        const body = parseJson(await readBody(req)).value ?? {};
+        if (!body.runId) return send(res, 422, { error: "runId required" });
+        try {
+          return send(
+            res,
+            200,
+            releaseStalledWorkerLease(db, { workerId, runId: body.runId }, { actor: ACTOR, now: nowMs, policyVersion }),
+          );
+        } catch (err) {
+          const status = String(err.message).startsWith("unknown worker") ? 404 : 409;
           return send(res, status, { error: err.message });
         }
       }

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -671,6 +671,63 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
     }
   });
 
+  test("archives dead-lettered events and releases stalled worker leases from status anomalies (WM-326)", async () => {
+    const nowMs = 300_000;
+    const { db, server, port } = await makeServer({ now: () => nowMs });
+    const client = apiClient({ port });
+    try {
+      await client.replay(envelope({ eventId: "dead-archive" }));
+      db.query(
+        `UPDATE events SET status = 'dead_lettered', plan_failures = 3, last_plan_error = 'historical failure'
+         WHERE source = 'test' AND event_id = 'dead-archive'`,
+      ).run();
+
+      const spec = { timeoutSeconds: 60, maxAttempts: 2 };
+      db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES ('run-stalled', 'stalled-key', ?, 'sha256:stalled', 'LEASED', 1, ?, ?)`,
+      ).run(JSON.stringify(spec), new Date(0).toISOString(), new Date(0).toISOString());
+      db.query(
+        `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, lease_expires_at)
+         VALUES ('run-stalled', 1, 1, 'worker-stalled', ?)`,
+      ).run(new Date(nowMs + 60_000).toISOString());
+      registerWorker(db, { workerId: "worker-stalled", now: 0 });
+      heartbeat(db, "worker-stalled", { state: "busy", runId: "run-stalled", now: 0 });
+
+      const before = await client.status();
+      expect(before.anomalies.deadLettered.map((event) => event.eventId)).toEqual(["dead-archive"]);
+      expect(before.anomalies.stalledWorkers.map((worker) => worker.workerId)).toEqual(["worker-stalled"]);
+
+      expect(await client.archive("test", "dead-archive")).toEqual({ archived: true });
+      expect(await client.releaseWorker("worker-stalled", "run-stalled")).toEqual({
+        released: true,
+        runId: "run-stalled",
+      });
+
+      const after = await client.status();
+      expect(after.anomalies.deadLettered).toEqual([]);
+      expect(after.anomalies.stalledWorkers).toEqual([]);
+      expect(db.query(`SELECT status, archived_at FROM events WHERE event_id = 'dead-archive'`).get()).toEqual({
+        status: "dead_lettered",
+        archived_at: new Date(nowMs).toISOString(),
+      });
+      expect(db.query(`SELECT state FROM runs WHERE run_id = 'run-stalled'`).get().state).toBe("QUEUED");
+      expect(db.query(`SELECT state, current_run FROM workers WHERE worker_id = 'worker-stalled'`).get()).toEqual({
+        state: "stopped",
+        current_run: null,
+      });
+
+      // Archiving is retry-safe, while invalid targets fail closed.
+      expect(await client.archive("test", "dead-archive")).toEqual({ archived: true });
+      expect((await rejection(client.archive("test", "ghost"))).status).toBe(404);
+      await client.replay(envelope({ eventId: "active-event" }));
+      expect((await rejection(client.archive("test", "active-event"))).status).toBe(409);
+      expect((await rejection(client.releaseWorker("ghost", "run-stalled"))).status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
   test("requeueing a human_needed event supersedes its open proposal", async () => {
     const { db, server, port } = await makeServer();
     const client = apiClient({ port });

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -56,6 +56,10 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
     outbox: ({ limit = 50 } = {}) => call("GET", `/outbox?limit=${limit}`),
     requeue: (source, eventId) =>
       call("POST", "/events/requeue", { body: JSON.stringify({ source, eventId }) }),
+    archive: (source, eventId) =>
+      call("POST", "/events/archive", { body: JSON.stringify({ source, eventId }) }),
+    releaseWorker: (workerId, runId) =>
+      call("POST", `/workers/${encodeURIComponent(workerId)}/release`, { body: JSON.stringify({ runId }) }),
     agents: () => call("GET", "/agents"),
     workers: () => call("GET", "/workers"),
     schedules: () => call("GET", "/schedules"),

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -216,6 +216,23 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 5,
+    name: "archive_dead_lettered_events",
+    up(db) {
+      // A cold start can have several processes read user_version before one
+      // acquires the migration lock. Keep the additive step retry-safe when a
+      // waiter enters with that stale read after the first process committed.
+      const columns = db.query(`PRAGMA table_info(events)`).all().map((row) => row.name);
+      if (!columns.includes("archived_at")) {
+        db.exec(`ALTER TABLE events ADD COLUMN archived_at TEXT;`);
+      }
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_events_dead_letter_archive
+          ON events (status, archived_at);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -694,10 +694,33 @@ export function requeueEvent(db, { source, eventId }, { actor = "operator", now 
        WHERE event_source = ? AND event_id = ? AND status = 'open'`,
     ).run(new Date(now).toISOString(), actor, source, eventId);
     db.query(
-      `UPDATE events SET status = 'admitted', plan_failures = 0, last_plan_error = NULL
+      `UPDATE events
+       SET status = 'admitted', plan_failures = 0, last_plan_error = NULL, archived_at = NULL
        WHERE source = ? AND event_id = ?`,
     ).run(source, eventId);
     return { requeued: true };
+  });
+}
+
+/**
+ * Acknowledge a dead-letter without rewriting its historical status or error.
+ * The archive marker removes it from the active doctor deck while preserving
+ * the event in the ledger and allowing a later explicit requeue.
+ */
+export function archiveDeadLetteredEvent(db, { source, eventId }, { now = Date.now() } = {}) {
+  return txImmediate(db, () => {
+    const event = db
+      .query(`SELECT status, archived_at FROM events WHERE source = ? AND event_id = ?`)
+      .get(source, eventId);
+    if (!event) throw new Error(`unknown event (${source}, ${eventId})`);
+    if (event.status !== "dead_lettered") {
+      throw new Error(`archive applies to dead_lettered events, not ${event.status}`);
+    }
+    if (!event.archived_at) {
+      db.query(`UPDATE events SET archived_at = ? WHERE source = ? AND event_id = ?`)
+        .run(new Date(now).toISOString(), source, eventId);
+    }
+    return { archived: true };
   });
 }
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -27,7 +27,7 @@ import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
-import { satisfiesPlacement } from "./workers.mjs";
+import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
 import { createWorkspace, destroyWorkspace, PathViolation, safeJoin } from "./workspace.mjs";
 
 /**
@@ -1073,6 +1073,80 @@ export async function executeClaimed(db, registry, adapters, claim, {
       try { releaseWorkerLease({ repo: repoName, ticket: ticketId, owner, dir: leasesDir }); } catch {}
     }
   }
+}
+
+/**
+ * Explicit operator recovery for a worker that stopped heartbeating while it
+ * still owned a run. This mirrors the lease reaper's retry/exhaustion rules,
+ * but targets exactly the selected worker/run and records an operator reason.
+ */
+export function releaseStalledWorkerLease(
+  db,
+  { workerId, runId },
+  { now = () => Date.now(), policyVersion = "unknown", actor = "operator" } = {},
+) {
+  const currentNow = resolveNow(now);
+  return txImmediate(db, () => {
+    const worker = db.query(`SELECT state, current_run, last_seen FROM workers WHERE worker_id = ?`).get(workerId);
+    if (!worker) throw new Error(`unknown worker ${workerId}`);
+    const stale = worker.state !== "stopped" && currentNow - Date.parse(worker.last_seen) > HEARTBEAT_STALE_MS;
+    if (!stale || !worker.current_run) throw new Error(`worker ${workerId} is not stalled with an active run`);
+    if (runId && worker.current_run !== runId) {
+      throw new Error(`worker ${workerId} holds ${worker.current_run}, not ${runId}`);
+    }
+
+    const heldRunId = worker.current_run;
+    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(heldRunId);
+    if (!run) throw new Error(`worker ${workerId} references unknown run ${heldRunId}`);
+    if (!["LEASED", "RUNNING", "VERIFYING"].includes(run.state)) {
+      throw new Error(`run ${heldRunId} is ${run.state}, not actively leased`);
+    }
+    const attempt = db
+      .query(`SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`)
+      .get(heldRunId, run.attempts);
+    if (!attempt) throw new Error(`run ${heldRunId} has no current attempt`);
+    if (attempt.lease_owner && attempt.lease_owner !== workerId) {
+      throw new Error(`run ${heldRunId} is leased by ${attempt.lease_owner}, not ${workerId}`);
+    }
+
+    const spec = JSON.parse(run.spec_json);
+    const reason = "operator_release_stalled_worker";
+    db.query(`UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`)
+      .run(iso(currentNow - 1), heldRunId, run.attempts);
+    if (run.attempts < spec.maxAttempts) {
+      if (run.state === "VERIFYING") {
+        transition(db, {
+          runId: heldRunId, to: "FAILED", actor, reason,
+          attempt: run.attempts, policyVersion, now: currentNow,
+        });
+        transition(db, {
+          runId: heldRunId, to: "QUEUED", actor, reason: "retry_after_stalled_worker_release",
+          attempt: run.attempts, policyVersion, now: currentNow,
+        });
+      } else {
+        transition(db, {
+          runId: heldRunId, to: "QUEUED", actor, reason,
+          attempt: run.attempts, policyVersion, now: currentNow,
+        });
+      }
+    } else {
+      if (run.state === "LEASED") {
+        transition(db, {
+          runId: heldRunId, to: "RUNNING", actor, reason,
+          attempt: run.attempts, policyVersion, now: currentNow,
+        });
+      }
+      transition(db, {
+        runId: heldRunId, to: "FAILED", actor, reason,
+        attempt: run.attempts, policyVersion, now: currentNow,
+      });
+      finishAttempt(db, heldRunId, run.attempts, "FAILED", "stalled_worker_released", currentNow);
+    }
+    db.query(
+      `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,
+    ).run(iso(currentNow), workerId);
+    return { released: true, runId: heldRunId };
+  });
 }
 
 /**

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -102,6 +102,12 @@ export const api = {
   // Re-plan a dead_lettered or human_needed event (404 unknown, 409 wrong status).
   requeue: (source: string, eventId: string) =>
     call<{ requeued: boolean }>("POST", "/events/requeue", { source, eventId }),
+  // Preserve a dead letter in history while removing it from active anomalies.
+  archive: (source: string, eventId: string) =>
+    call<{ archived: boolean }>("POST", "/events/archive", { source, eventId }),
+  // Requeue/fail the run held by a stale worker and retire its registry row.
+  releaseWorker: (workerId: string, runId: string) =>
+    call<{ released: boolean; runId: string }>("POST", `/workers/${encodeURIComponent(workerId)}/release`, { runId }),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
   // Configured factory repositories (config/repos.yaml) — context tabs open from this list.

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -313,6 +313,8 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       outbox: [],
     })),
     requeue: mock(async (_source: string, _eventId: string) => ({ requeued: true })),
+    archive: mock(async (_source: string, _eventId: string) => ({ archived: true })),
+    releaseWorker: mock(async (_workerId: string, runId: string) => ({ released: true, runId })),
     agents: mock(async () => createAgentsFixture()),
     repos: mock(async (): Promise<{ repos: RepoItem[] }> => ({ repos: [] })),
     janitor: mock(async (name: string, apply = false): Promise<JanitorResult> => ({

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -465,6 +465,64 @@ describe("Overview anomaly deck (WM-95)", () => {
     }
   });
 
+  test("archives dead letters and releases stalled worker leases, removing both rows (WM-326)", async () => {
+    const mutableApi = api as typeof api & {
+      archive: (source: string, eventId: string) => Promise<{ archived: boolean }>;
+      releaseWorker: (workerId: string, runId: string) => Promise<{ released: boolean; runId: string }>;
+    };
+    const originals = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+      archive: mutableApi.archive,
+      releaseWorker: mutableApi.releaseWorker,
+    };
+    let deadLettered = true;
+    let stalled = true;
+    api.status = async () =>
+      baseStatus({
+        deadLettered: deadLettered
+          ? [{ source: "github", eventId: "dead-1", lastError: "historical failure" }]
+          : [],
+        stalledWorkers: stalled
+          ? [{ workerId: "worker-1", runId: "run-1", host: "lab", lastSeen: new Date(0).toISOString() }]
+          : [],
+      });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    mutableApi.archive = async (source, eventId) => {
+      expect({ source, eventId }).toEqual({ source: "github", eventId: "dead-1" });
+      deadLettered = false;
+      return { archived: true };
+    };
+    mutableApi.releaseWorker = async (workerId, runId) => {
+      expect({ workerId, runId }).toEqual({ workerId: "worker-1", runId: "run-1" });
+      stalled = false;
+      return { released: true, runId };
+    };
+
+    try {
+      const view = renderOverview();
+      await waitFor(() => view.getByRole("button", { name: "Archive" }));
+
+      view.getByRole("button", { name: "Archive" }).click();
+      await waitFor(() => expect(view.queryByText(/dead-lettered \(github, dead-1\)/)).toBeNull());
+
+      view.getByRole("button", { name: "Release lease" }).click();
+      await waitFor(() => view.getByText(/Doctor: All systems nominal/));
+      expect(view.queryByText(/stalled worker worker-1/)).toBeNull();
+    } finally {
+      api.status = originals.status;
+      api.proposals = originals.proposals;
+      api.outbox = originals.outbox;
+      api.journal = originals.journal;
+      mutableApi.archive = originals.archive;
+      mutableApi.releaseWorker = originals.releaseWorker;
+    }
+  });
+
   test("other anomaly kinds (stale leases, unpublished outbox) render unchanged", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
@@ -782,7 +840,9 @@ describe("buildAnomalyRows (WM-205)", () => {
     expect(rows[1]!.text).toMatch(/stale leases: 2/);
     expect(rows[2]!.text).toMatch(/unpublished outbox rows: 1/);
     expect(rows[3]!.requeue).toEqual({ source: "github", eventId: "e99" });
+    expect(rows[3]!.archive).toEqual({ source: "github", eventId: "e99" });
     expect(rows[4]!.text).toMatch(/stalled worker w1 still holds run r1/);
+    expect(rows[4]!.releaseWorker).toEqual({ workerId: "w1", runId: "r1" });
     expect(rows[5]!.text).toMatch(/ambiguous open proposals: 3/);
     expect(rows[6]!.text).toMatch(/4 queued runs and no live worker/);
   });

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -907,7 +907,7 @@ export function Overview({
               </div>
             ))}
           </div>
-          <VerbError error={resolveAnomaly.error ?? dismiss.error ?? requeue.error} />
+          <VerbError error={resolveAnomaly.error ?? reject.error ?? requeue.error} />
         </div>
       ) : (
         <div className="mb-5 flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -252,6 +252,8 @@ export interface AnomalyRow {
   text: string;
   links: { label: string; go: () => void }[];
   requeue?: { source: string; eventId: string };
+  archive?: { source: string; eventId: string };
+  releaseWorker?: { workerId: string; runId: string };
   dismissProposalId?: string;
   proposalId?: string;
   proposal?: Proposal;
@@ -333,6 +335,7 @@ export function buildAnomalyRows(
       text: `dead-lettered (${d.source}, ${d.eventId}): ${d.lastError ?? "unknown error"}`,
       links: [{ label: "View event", go: () => callbacks.onJumpEvents({ source: d.source, eventId: d.eventId }) }],
       requeue: { source: d.source, eventId: d.eventId },
+      archive: { source: d.source, eventId: d.eventId },
     });
   }
   for (const w of anomalies.stalledWorkers) {
@@ -343,6 +346,7 @@ export function buildAnomalyRows(
         { label: "View worker", go: () => callbacks.onNavigate("workers") },
         { label: "View run", go: () => callbacks.onJumpRun(w.runId) },
       ],
+      releaseWorker: { workerId: w.workerId, runId: w.runId },
     });
   }
   for (const a of anomalies.ambiguousOpenProposals) {
@@ -568,6 +572,22 @@ export function Overview({
       queryClient.invalidateQueries();
       notify(`Requeued event ${eventId}`, "ok");
       await pollRequeue(source, eventId);
+    },
+    onError: () => queryClient.invalidateQueries(),
+  });
+
+  const resolveAnomaly = useMutation({
+    mutationFn: (
+      target:
+        | { kind: "archive"; source: string; eventId: string }
+        | { kind: "release"; workerId: string; runId: string },
+    ) => {
+      if (target.kind === "archive") return api.archive(target.source, target.eventId).then(() => undefined);
+      return api.releaseWorker(target.workerId, target.runId).then(() => undefined);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      notify("Anomaly resolved", "ok");
     },
     onError: () => queryClient.invalidateQueries(),
   });
@@ -850,12 +870,28 @@ export function Overview({
                       Reject…
                     </Button>
                   )}
+                  {a.archive && (
+                    <Button
+                      disabled={!connected || resolveAnomaly.isPending}
+                      onClick={() => resolveAnomaly.mutate({ kind: "archive", ...a.archive! })}
+                    >
+                      Archive
+                    </Button>
+                  )}
                   {a.requeue && (
                     <Button
                       disabled={!connected || requeue.isPending}
                       onClick={() => requeue.mutate(a.requeue!)}
                     >
                       Requeue
+                    </Button>
+                  )}
+                  {a.releaseWorker && (
+                    <Button
+                      disabled={!connected || resolveAnomaly.isPending}
+                      onClick={() => resolveAnomaly.mutate({ kind: "release", ...a.releaseWorker! })}
+                    >
+                      Release lease
                     </Button>
                   )}
                   {a.links.map((l, idx) => (
@@ -871,7 +907,7 @@ export function Overview({
               </div>
             ))}
           </div>
-          <VerbError error={requeue.error} />
+          <VerbError error={resolveAnomaly.error ?? dismiss.error ?? requeue.error} />
         </div>
       ) : (
         <div className="mb-5 flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">


### PR DESCRIPTION
## Summary
- archive dead-lettered events without erasing their ledger history
- release stale worker leases under existing retry/exhaustion rules
- add Overview actions plus backend and UI regression coverage

## Verification
- `bun test && bun build/emit.mjs --check`
- `cd event-runtime/web && bun run build`

## UX critique
- required — NOT-ASSESSED: the UX critic had no browser/simulator tooling available; automated UI coverage verifies both actions remove their anomaly rows

Fixes WM-326