### PR TITLE
fix(web): align bulk approve summary fields (WM-178)

### DIFF
--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -623,11 +623,23 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
   test("bulk approve does not call api.approve until confirm", async () => {
     const p1 = stubProposal("prop_1", "open", {
       agent: "triage-scan",
-      spec: createRunSpecFixture("run_prop_1", { agent: "triage-scan", capabilities: ["read"], timeoutSeconds: 600 }),
+      spec: createRunSpecFixture("run_prop_1", {
+        agent: "triage-scan",
+        adapter: "claude",
+        capabilities: ["read"],
+        timeoutSeconds: 600,
+        maxAttempts: 4,
+      }),
     });
     const p2 = stubProposal("prop_2", "open", {
       agent: "security-scan",
-      spec: createRunSpecFixture("run_prop_2", { agent: "security-scan", capabilities: ["net"], timeoutSeconds: 120 }),
+      spec: createRunSpecFixture("run_prop_2", {
+        agent: "security-scan",
+        adapter: "codex",
+        capabilities: ["net"],
+        timeoutSeconds: 120,
+        maxAttempts: 2,
+      }),
     });
     const stale = stubProposal("prop_stale", "open", {
       decision: "run",
@@ -660,6 +672,9 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     expect(dialog.textContent).toMatch(/net/);
     expect(dialog.textContent).toMatch(/600s/);
     expect(dialog.textContent).toMatch(/120s/);
+    expect(dialog.querySelectorAll('span[title="adapter"]')).toHaveLength(2);
+    expect(dialog.querySelectorAll('span[title="attempts"]')).toHaveLength(2);
+    expect(dialog.querySelectorAll('span[title="ttl"]')).toHaveLength(2);
     expect(dialog.textContent).toContain("timeoutSeconds");
     expect(dialog.textContent).not.toMatch(/stale-agent/);
 

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1256,8 +1256,11 @@ export function Proposals({
               <div key={p.id} className="rounded-md border border-(--border) bg-(--surface-0) p-2.5">
                 <div className="mb-2 font-medium text-[12px]">{p.agent ?? p.id}</div>
                 <KV k="agent" v={p.spec?.agent} />
+                <KV k="adapter" v={p.spec?.adapter} />
                 <KV k="capabilities" v={p.spec?.capabilities.join(", ") || "none"} />
                 <KV k="timeout" v={`${p.spec?.timeoutSeconds}s`} />
+                <KV k="attempts" v={String(p.spec?.maxAttempts)} />
+                <KV k="ttl" v={<Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />} />
                 {p.spec && <JsonBlock value={p.spec} />}
               </div>
             ))}


### PR DESCRIPTION
## Summary
- show adapter, attempts, and TTL in every bulk-approve confirmation card
- align bulk approval summaries with the single-proposal confirmation
- assert the added labels for each selected proposal

## Verification
- `cd event-runtime/web && bun test` — 571 passed, 0 failed

## UX critique
- required — NOT-ASSESSED; browser/simulator driving tools were unavailable to the critic

Fixes WM-178