### PR TITLE
fix(web): align stale worker footer status (WM-159)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -38,6 +38,7 @@ const STATUS: StatusView = {
 };
 
 const HEALTH = { ok: true, policyVersion: "test", env: ENV };
+let currentStatus = STATUS;
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {
@@ -64,10 +65,11 @@ function renderApp() {
 }
 
 beforeEach(() => {
+  currentStatus = STATUS;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.includes("/api/health")) return jsonResponse(HEALTH);
-    if (url.includes("/api/status")) return jsonResponse(STATUS);
+    if (url.includes("/api/status")) return jsonResponse(currentStatus);
     if (url.includes("/api/agents")) {
       return jsonResponse({
         agents: [],
@@ -159,6 +161,36 @@ describe("sidebar navigation accessibility", () => {
 });
 
 describe("bottom status bar", () => {
+  test("stale-only fleet agrees with the Workers badge instead of saying no workers (WM-159)", async () => {
+    currentStatus = {
+      ...STATUS,
+      workers: { busy: 0, stale: 1, live: 0 },
+    };
+    const utils = renderApp();
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+
+    await waitFor(() => {
+      expect(utils.sidebar.getByRole("button", { name: "Workers" }).textContent).toContain(
+        "1stale",
+      );
+      expect(statusBar.textContent).toContain("1 stale worker");
+    });
+    expect(statusBar.textContent).not.toContain("no workers");
+  });
+
+  test("empty registry still says no workers (WM-159)", async () => {
+    currentStatus = {
+      ...STATUS,
+      workers: { busy: 0, stale: 0, live: 0 },
+    };
+    const utils = renderApp();
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+
+    await waitFor(() => {
+      expect(statusBar.textContent).toContain("no workers");
+    });
+  });
+
   test("renders connection status, policy, workers, shortcuts, and theme switcher", async () => {
     const utils = renderApp();
     const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -711,9 +711,11 @@ export function App() {
                     }
                   >
                     ·{" "}
-                    {liveWorkers === 0
-                      ? "no workers"
-                      : `${liveWorkers} worker${liveWorkers === 1 ? "" : "s"}`}
+                    {staleWorkers > 0
+                      ? `${staleWorkers} stale worker${staleWorkers === 1 ? "" : "s"}`
+                      : liveWorkers === 0
+                        ? "no workers"
+                        : `${liveWorkers} worker${liveWorkers === 1 ? "" : "s"}`}
                   </span>
                 )}
               </span>


### PR DESCRIPTION
## Summary
- show the stale worker count in the global footer whenever stale workers exist
- preserve `no workers` for a truly empty registry
- cover stale-only/nav consistency and empty-registry behavior with regression tests

## Verification
- `cd event-runtime/web && bun test src/App.test.tsx` — 12 pass, 0 fail

## UX critique
- required — NOT-ASSESSED: critic browser/simulator tooling was unavailable, so the running footer/nav/tooltip could not be driven; regression coverage verifies the copy and badge consistency

Fixes WM-159