### PR TITLE
fix(web): open repo picker with ArrowDown (WM-189)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -257,8 +257,7 @@ describe("ContextTabs", () => {
     expect(window.location.hash).toBe("#/runs/run_abc");
   });
 
-  test("closed repo picker ignores ArrowDown and Enter (does not open a repo)", () => {
-    const opened: string[] = [];
+  test("native keyboard activation on the repo picker trigger opens the listbox", () => {
     const r = render(
       <ContextTabs
         repos={[repo("factory"), repo("client")]}
@@ -266,17 +265,44 @@ describe("ContextTabs", () => {
         openRepos={["factory"]}
         active={{ kind: "all" }}
         onSelect={() => {}}
-        onOpen={(name) => opened.push(name)}
+        onOpen={() => {}}
         onClose={() => {}}
       />,
     );
 
     const plus = r.getByRole("button", { name: "Open a repo tab" });
     plus.focus();
-    fireEvent.keyDown(plus, { key: "ArrowDown" });
-    fireEvent.keyDown(plus, { key: "Enter" });
-    expect(opened).toEqual([]);
-    expect(r.queryByRole("listbox")).toBeNull();
+    // Browsers synthesize a detail=0 click when Enter activates a native button.
+    // happy-dom does not synthesize that click from keyDown, so dispatch it directly.
+    fireEvent.click(plus, { detail: 0 });
+
+    expect(plus.getAttribute("aria-expanded")).toBe("true");
+    expect(r.getByRole("listbox", { name: "Factory repos" })).toBeDefined();
+  });
+
+  test("ArrowDown on the closed repo picker opens and focuses the listbox", () => {
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory"), repo("client")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "all" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const plus = r.getByRole("button", { name: "Open a repo tab" });
+    plus.focus();
+    const arrowDown = createEvent.keyDown(plus, { key: "ArrowDown" });
+    act(() => {
+      fireEvent(plus, arrowDown);
+    });
+
+    const listbox = r.getByRole("listbox", { name: "Factory repos" });
+    expect(arrowDown.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(listbox);
   });
 
   test("empty picker copy does not use registry or fleet jargon", () => {

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -262,6 +262,12 @@ export function ContextTabs({
     closePicker(true);
   };
 
+  const handlePickerTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey || e.key !== "ArrowDown") return;
+    e.preventDefault();
+    setPicker(true);
+  };
+
   const handlePickerKeyDown = (e: React.KeyboardEvent) => {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (e.key === "Tab") {
@@ -454,6 +460,7 @@ export function ContextTabs({
           title="Open a repo"
           className="rounded-md px-2 py-1 text-[14px] text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
           onClick={() => setPicker((open) => !open)}
+          onKeyDown={handlePickerTriggerKeyDown}
         >
           +
         </button>


### PR DESCRIPTION
## Summary
- model native Enter activation of the repo-picker button as the browser-synthesized click instead of a happy-dom keydown artifact
- open the collapsed repo picker with ArrowDown and transfer focus into its listbox
- add regression coverage for both activation paths

## Verification
- `cd event-runtime/web && bun test` — 572 pass, 0 fail
- UX critique: required — NOT-ASSESSED, critic browser tooling was unavailable to drive Enter/ArrowDown/listbox behavior

Fixes WM-189