### PR TITLE
fix(web): require Overview rejection reasons (WM-186)

### DIFF
--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,12 +1,13 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Overview, groupJournalEntries, buildAnomalyRows } from "./Overview";
 import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
+import { changeInput } from "../test-render";
 import type { AdmittedEvent, JournalEntry, Proposal, RunListItem, StatusView } from "../types";
 
 afterEach(() => {
@@ -385,6 +386,57 @@ describe("Overview anomaly deck (WM-95)", () => {
       api.proposals = origProposals;
       api.outbox = origOutbox;
       api.journal = origJournal;
+    }
+  });
+
+  test("rejects an expired proposal only after collecting a non-empty reason", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    const origReject = api.reject;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    const rejectedCalls: { id: string; why?: string }[] = [];
+    api.reject = async (id: string, why?: string) => {
+      rejectedCalls.push({ id, why });
+      return { rejected: true };
+    };
+
+    try {
+      const view = renderOverview();
+      const reject = await waitFor(() => view.getByRole("button", { name: "Reject…" }));
+
+      expect(view.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      fireEvent.click(reject);
+
+      const confirm = view.getByRole("button", { name: "Reject proposal" }) as HTMLButtonElement;
+      const reasonInput = view.getByLabelText("Rejection reason") as HTMLInputElement;
+      expect(reasonInput.placeholder).toMatch(/Reason \(required/i);
+      expect(confirm.disabled).toBe(true);
+
+      await act(async () => changeInput(reasonInput, "   "));
+      fireEvent.click(confirm);
+      expect(rejectedCalls).toEqual([]);
+
+      await act(async () => changeInput(reasonInput, " No longer actionable "));
+      await waitFor(() => expect(confirm.disabled).toBe(false));
+      await act(async () => fireEvent.click(confirm));
+      await waitFor(() =>
+        expect(rejectedCalls).toEqual([
+          { id: stubProposal.id, why: "No longer actionable" },
+        ]),
+      );
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+      api.reject = origReject;
     }
   });
 

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -11,6 +11,7 @@ import {
   Ago,
   Button,
   Disclosure,
+  Dialog,
   EVENT_STATUS_HUES,
   STATE_HUES,
   humanSize,
@@ -508,6 +509,8 @@ export function Overview({
   const now = useNow();
   const queryClient = useQueryClient();
   const pollRequeue = useRequeuePoll(onJumpProposal);
+  const [rejectingProposalId, setRejectingProposalId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
   const status = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
   const outbox = useQuery({
     queryKey: ["outbox"],
@@ -543,14 +546,32 @@ export function Overview({
     onError: () => queryClient.invalidateQueries(),
   });
 
-  const dismiss = useMutation({
-    mutationFn: (proposalId: string) => api.reject(proposalId),
-    onSuccess: (_, proposalId) => {
+  const reject = useMutation({
+    mutationFn: ({ proposalId, why }: { proposalId: string; why: string }) => {
+      const trimmed = why.trim();
+      if (!trimmed) return Promise.reject(new Error("Rejection reason required"));
+      return api.reject(proposalId, trimmed);
+    },
+    onSuccess: (_, { proposalId }) => {
       queryClient.invalidateQueries();
-      notify(`Dismissed proposal ${proposalId}`, "ok");
+      notify(`Rejected proposal ${proposalId}`, "info");
+      setRejectingProposalId(null);
+      setRejectReason("");
     },
     onError: () => queryClient.invalidateQueries(),
   });
+
+  const closeReject = () => {
+    if (reject.isPending) return;
+    reject.reset();
+    setRejectingProposalId(null);
+    setRejectReason("");
+  };
+
+  const submitReject = () => {
+    if (!rejectingProposalId || !rejectReason.trim() || reject.isPending || !connected) return;
+    reject.mutate({ proposalId: rejectingProposalId, why: rejectReason });
+  };
 
   const s = status.data;
   const anomalies = s?.anomalies;
@@ -793,10 +814,14 @@ export function Overview({
                   </button>
                   {a.dismissProposalId && (
                     <Button
-                      disabled={!connected || dismiss.isPending}
-                      onClick={() => dismiss.mutate(a.dismissProposalId!)}
+                      disabled={!connected || reject.isPending}
+                      onClick={() => {
+                        reject.reset();
+                        setRejectingProposalId(a.dismissProposalId!);
+                        setRejectReason("");
+                      }}
                     >
-                      Dismiss
+                      Reject…
                     </Button>
                   )}
                   {a.requeue && (
@@ -1221,6 +1246,48 @@ export function Overview({
           </div>
         </Section>
       </div>
+
+      {rejectingProposalId && (
+        <Dialog title="Reject expired proposal?" onClose={closeReject}>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitReject();
+            }}
+          >
+            <p className="mb-3 text-[12px] text-(--text-dim)">
+              Rejections are audit records. Explain why this proposal should not run.
+            </p>
+            <label
+              htmlFor="overview-rejection-reason"
+              className="mb-1 block text-[11px] font-medium text-(--text-faint)"
+            >
+              Rejection reason
+            </label>
+            <input
+              id="overview-rejection-reason"
+              autoFocus
+              value={rejectReason}
+              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder="Reason (required — rejections are audit records)"
+              className="w-full rounded-md border border-(--border-strong) bg-(--surface-1) px-2.5 py-1.5 text-(--text) outline-none focus:border-(--accent)"
+            />
+            <VerbError error={reject.error} />
+            <div className="mt-4 flex justify-end gap-2">
+              <Button disabled={reject.isPending} onClick={closeReject}>
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                disabled={!rejectReason.trim() || reject.isPending || !connected}
+                onClick={submitReject}
+              >
+                {reject.isPending ? "Rejecting…" : "Reject proposal"}
+              </Button>
+            </div>
+          </form>
+        </Dialog>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace Overview's reason-less Dismiss action with an explicit Reject flow
- require and trim an audit reason before calling the reject API
- cover blank-reason gating, accessible labeling, and reason forwarding with a regression test

## Verification
- `cd event-runtime/web && bun test` — 572 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass

## UX critique
Required — NOT-ASSESSED: the UX critic could not launch its browser driver because the required CDP script was unavailable. The interaction is covered by DOM tests for required-reason gating and accessible labeling.

Fixes WM-186
