### PR TITLE
Fix SpecDiff long-line wrapping (WM-171)

### DIFF
--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -125,6 +125,7 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
           <div
             key={idx}
             data-diff-line
+            className="whitespace-pre"
             style={
               l.type === "del"
                 ? { color: "var(--hue-err)", background: "color-mix(in oklch, var(--hue-err) 8%, transparent)" }


### PR DESCRIPTION
## Summary
- preserve whitespace independently on every rendered spec-diff line
- keep long JSON values on one logical visual line with horizontal access through the existing overflow scroller

## Verification
- `cd event-runtime/web && bun test` — 578 passed, 0 failed

UX critique: skipped — isolated whitespace/wrapping style correction with no new interaction or flow.

Fixes WM-171