### PR TITLE
fix(web): count repo-hidden proposals (WM-177)

### DIFF
--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -773,6 +773,30 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     expect(r.getByText("Showing proposals that name repo-test.")).toBeTruthy();
   });
 
+  test("repo caption counts open proposals hidden because they do not name the repo", async () => {
+    const matching = stubProposal("prop_matching", "open", {
+      repos: ["repo-test"],
+      agent: "triage-scan",
+    });
+    const unscoped = stubProposal("prop_unscoped", "open", {
+      repos: [],
+      agent: "human-needed",
+    });
+    const otherRepo = stubProposal("prop_other", "open", {
+      repos: ["another-repo"],
+      agent: "review-scan",
+    });
+    api.proposals = async () => ({ proposals: [matching, unscoped, otherRepo] });
+
+    const r = renderProposals({ context: { kind: "repo", name: "repo-test" } });
+    await waitFor(() => expect(r.getByText("triage-scan")).toBeTruthy());
+    expect(r.queryByText("human-needed")).toBeNull();
+    expect(r.queryByText("review-scan")).toBeNull();
+    expect(
+      r.getByText("Showing proposals that name repo-test. 2 open proposals do not name this repo and are hidden."),
+    ).toBeTruthy();
+  });
+
   test("origin column title is the full eventId; reason column title is p.reason", async () => {
     const eventId = "evt_abc123_full_event_id";
     const reason = "Needs a very long planner reason for the truncated cell";

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -186,6 +186,15 @@ export function Proposals({
     () => rows.filter((p) => p.id === focusProposalId || matchesRepo(p.repos, context)),
     [rows, context, focusProposalId],
   );
+  const hiddenOpenRepoCount = useMemo(
+    () =>
+      context.kind === "repo"
+        ? (query.data?.proposals ?? []).filter(
+            (p) => p.status === "open" && p.id !== focusProposalId && !matchesRepo(p.repos, context),
+          ).length
+        : 0,
+    [context, query.data, focusProposalId],
+  );
 
   // Origin event type, resolved from the shared events cache (cheap: same
   // query key as the Events view's "all" tab).
@@ -619,6 +628,8 @@ export function Proposals({
         {context.kind === "repo" && (
           <p className="mb-3 text-[11px] text-(--text-faint)">
             {`Showing proposals that name ${context.name}.`}
+            {hiddenOpenRepoCount > 0 &&
+              ` ${hiddenOpenRepoCount} open proposal${hiddenOpenRepoCount === 1 ? "" : "s"} ${hiddenOpenRepoCount === 1 ? "does" : "do"} not name this repo and ${hiddenOpenRepoCount === 1 ? "is" : "are"} hidden.`}
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- count open proposals excluded by the active repo context
- append the excluded count to the persistent Proposals scope caption
- cover unscoped and other-repo proposals with a regression test

## Verification
- `cd event-runtime/web && bun test` — 579 pass, 0 fail

## UX critique
Skipped — informational caption-only change; no user-completable flow, interaction, or state transition changed.

Fixes WM-177