### PR TITLE
sec(pi-adapter): always pass an explicit --tools allowlist (WM-336)

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -70,6 +70,32 @@ const TEXT_PREVIEW_CHARS = 4000;
 // native capability enforcement (OPS-515).
 export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write", "bash"];
 
+// The mutating counterpart, and the reason it exists (WM-336): until now
+// `--tools` was passed ONLY for `mutating: false`, so a mutating agent ran on
+// pi's implicit defaults. Measured against pi 0.84.1, that set was:
+//
+//   read bash edit write subagent web_search fetch_content get_search_content
+//   pi_claude_code_provider_web_search interactive_shell intercom vcc_recall
+//   ask_user
+//
+// The agent with the widest surface was therefore `dispatch@1` — the unattended
+// one that also inherits SSH_AUTH_SOCK and GITHUB_TOKEN/GH_TOKEN (WM-223).
+//
+// Be precise about what pinning this buys, because it is easy to overclaim:
+// `bash` is in the set, so egress and arbitrary subprocesses remain reachable
+// regardless. This is NOT a containment boundary — §14 still names the
+// workspace cwd and (once WM-313 lands) the sandbox as the real one. What it
+// buys is that the surface is DECLARED: it cannot widen silently when pi ships
+// a new default tool, and a globally installed pi extension cannot hand every
+// mutating agent a capability nobody reviewed (the reason WM-335 loads the
+// chrome-devtools extension per run rather than via `pi install`).
+//
+// `edit` is the repository-mutation tool and is the whole point of a mutating
+// agent. `subagent` is deliberately included: dispatch delegates focused work —
+// notably the UX critique (WM-335) — and the alternative is one context doing
+// everything, which is what long-run degradation looks like.
+export const MUTATING_TOOLS = ["read", "grep", "find", "ls", "write", "bash", "edit", "subagent"];
+
 export class CliNotFoundError extends Error {
   constructor(message) {
     super(message);
@@ -100,10 +126,26 @@ export function buildPiArgv({ def, model }) {
   if (typeof model === "string" && model !== "" && model !== "default") {
     args.push("--model", model);
   }
-  if (def?.mutating === false) {
-    args.push("--tools", READ_ONLY_TOOLS.join(","));
-  }
+  // Always allowlist (WM-336). Omitting `--tools` does not mean "no tools", it
+  // means "every tool pi currently ships" — a set that grows without review.
+  args.push("--tools", piTools(def).join(","));
   return args;
+}
+
+/**
+ * The tool allowlist for one definition: the base set for its mutability, plus
+ * any tools the definition explicitly declares.
+ *
+ * `def.tools` is additive on purpose. A definition that needs something unusual
+ * (WM-335's critic needs `chrome_devtools_*`) states it in the content-hashed
+ * definition, so widening a surface is a reviewable diff rather than an
+ * environment change. Order is stable and duplicates are dropped so the argv —
+ * and therefore the transcript — is deterministic.
+ */
+export function piTools(def) {
+  const base = def?.mutating === false ? READ_ONLY_TOOLS : MUTATING_TOOLS;
+  const extra = Array.isArray(def?.tools) ? def.tools : [];
+  return [...new Set([...base, ...extra])];
 }
 
 export const BASE_INHERITED_ENV = [

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -12,6 +12,8 @@ import {
   KILL_GRACE_MS,
   mapStreamEvent,
   PUSH_CREDENTIAL_ENV,
+  MUTATING_TOOLS,
+  piTools,
   READ_ONLY_TOOLS,
   resolvePiCommand,
   safeChildEnvironment,
@@ -126,8 +128,10 @@ describe("extractUsage", () => {
 });
 
 describe("buildPiArgv", () => {
-  test("prompt travels on stdin, not argv — base argv is -p --mode json", () => {
-    expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual(["-p", "--mode", "json"]);
+  test("prompt travels on stdin, not argv — base argv is -p --mode json plus the allowlist", () => {
+    expect(buildPiArgv({ def: { mutating: true }, model: null })).toEqual([
+      "-p", "--mode", "json", "--tools", MUTATING_TOOLS.join(","),
+    ]);
   });
 
   test("mutating: false → --tools read,grep,find,ls,write,bash (pi's own read-only pattern, not -r)", () => {
@@ -137,8 +141,42 @@ describe("buildPiArgv", () => {
     expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls,write,bash"]);
   });
 
-  test("mutating: true → no --tools restriction", () => {
-    expect(buildPiArgv({ def: { mutating: true }, model: null })).not.toContain("--tools");
+  test("mutating: true → an explicit allowlist, never pi's implicit defaults (WM-336)", () => {
+    // The regression this guards: omitting --tools handed mutating agents every
+    // tool pi ships, so the surface widened whenever pi did. dispatch@1 — which
+    // also holds push credentials — was the least constrained agent in the fleet.
+    const argv = buildPiArgv({ def: { mutating: true }, model: null });
+    expect(argv).toContain("--tools");
+    expect(argv[argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,edit,subagent");
+  });
+
+  test("mutating: true keeps edit and subagent — the tools that make it a dispatch agent", () => {
+    const tools = piTools({ mutating: true });
+    expect(tools).toContain("edit");
+    // dispatch delegates focused work, notably the UX critique (WM-335).
+    expect(tools).toContain("subagent");
+  });
+
+  test("undeclared tools are never passed, however plausible", () => {
+    const tools = piTools({ mutating: true });
+    for (const absent of ["web_search", "fetch_content", "interactive_shell", "chrome_devtools_load"]) {
+      expect(tools).not.toContain(absent);
+    }
+  });
+
+  test("a definition may declare extra tools; they are additive and deduplicated", () => {
+    const tools = piTools({ mutating: false, tools: ["chrome_devtools_load", "read"] });
+    expect(tools).toContain("chrome_devtools_load");
+    for (const base of READ_ONLY_TOOLS) expect(tools).toContain(base);
+    // "read" was already in the base set — declaring it again must not duplicate
+    // it, or the argv (and the transcript) stops being deterministic.
+    expect(tools.filter((t) => t === "read")).toHaveLength(1);
+  });
+
+  test("a missing or malformed tools field falls back to the base set rather than throwing", () => {
+    expect(piTools({ mutating: false })).toEqual(READ_ONLY_TOOLS);
+    expect(piTools({ mutating: false, tools: "read" })).toEqual(READ_ONLY_TOOLS);
+    expect(piTools(undefined)).toEqual(MUTATING_TOOLS);
   });
 
   test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {


### PR DESCRIPTION
Fixes WM-336

`--tools` was passed only when `mutating === false`, so mutating agents ran on pi's implicit defaults. Measured against pi 0.84.1 by asking a live run to enumerate its tools:

```
read bash edit write subagent web_search fetch_content get_search_content
pi_claude_code_provider_web_search interactive_shell intercom vcc_recall ask_user
```

That made `dispatch@1` — the unattended agent that also inherits `SSH_AUTH_SOCK` and `GITHUB_TOKEN`/`GH_TOKEN` (WM-223) — the *least* constrained agent in the fleet.

## What this does and does not buy

Deliberately understated in the code comment, because it is easy to overclaim: **`bash` remains in the set**, so egress and arbitrary subprocesses are still reachable. This is not a containment boundary — §14's workspace cwd and (once WM-313 lands) the sandbox are.

What it buys is that the surface is **declared**: it cannot widen silently when pi ships a new default tool, and a globally installed pi extension cannot hand every mutating agent a capability nobody reviewed. That last point is what makes WM-335 able to load chrome-devtools per run instead of via `pi install`.

## Changes

- `MUTATING_TOOLS` — `read, grep, find, ls, write, bash, edit, subagent`
- `piTools(def)` — base set plus `def.tools`, additive and deduplicated, so a definition needing something unusual (WM-335's critic needs `chrome_devtools_*`) declares it in the content-hashed definition
- `--tools` is now always passed

`subagent` is kept deliberately: dispatch delegates focused work, notably the UX critique.

## Verification

`bun test event-runtime/` — 1331 pass, 0 fail. `bun run format:check` clean. New tests cover the mutating allowlist, that undeclared tools are never passed, additive dedup, and malformed `tools` falling back rather than throwing.