### PR TITLE
fix(stack): install stale deps on startup; name why the sandbox is unavailable (WM-312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,18 @@ jobs:
         # because it includes descendants macOS /usr/bin/time does not aggregate.
         run: bun test --max-concurrency=4
 
+      # The sandbox harness must at least be installable and importable
+      # (WM-312). Asserts on `sdk`, never on `available`: a self-hosted runner
+      # legitimately may not virtualize, and conflating "this host has no QEMU"
+      # with "the dependency is missing" is exactly what let the Gondolin SDK
+      # sit uninstalled on the live stack for a day while CI stayed green.
+      - name: Sandbox harness is installed
+        run: |
+          bun event-runtime/cli.mjs sandbox doctor || true
+          bun event-runtime/cli.mjs sandbox doctor 2>&1 | grep -q "cause *install" \
+            && { echo "::error::gondolin SDK is not installed — bun install did not materialize it"; exit 1; }
+          echo "sandbox harness present (or unavailable only for host reasons)"
+
       - name: Generated tree matches shared/
         # The check that stops a rule from living in one harness and nowhere
         # else. If this fails, the fix is to move the rule into shared/ and

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -73,20 +73,25 @@ case "$ACTION" in
     # A stamp file rather than node_modules' mtime: `bun install` leaves the
     # directory untouched when nothing changes, so an mtime comparison would
     # report stale forever and install on every single start.
+    # Gated on a LOCKFILE, not on package.json: a lockfile is what makes a
+    # directory a dependency tree we own. Without one there is nothing to be
+    # stale against, and installing anyway would run `bun install` over any
+    # directory that merely happens to contain a package.json — including the
+    # synthetic fixtures bin/live-stack.test.mjs builds, whose package.json is
+    # deliberately not valid JSON.
     ensure_deps() {
       local label="$1" dir="$2"
-      [[ -f "$dir/package.json" ]] || return 0
+      local lock=""
+      for candidate in "$dir/bun.lock" "$dir/bun.lockb"; do
+        [[ -f "$candidate" ]] && { lock="$candidate"; break; }
+      done
+      [[ -n "$lock" ]] || return 0
       local stamp="$dir/node_modules/.factory-deps-stamp"
-      local fresh=0
-      if [[ -d "$dir/node_modules" && -f "$stamp" ]]; then
-        fresh=1
-        for input in "$dir/bun.lock" "$dir/bun.lockb" "$dir/package.json"; do
-          [[ -f "$input" && "$input" -nt "$stamp" ]] && fresh=0
-        done
+      if [[ -d "$dir/node_modules" && -f "$stamp" && ! "$lock" -nt "$stamp" ]]; then
+        [[ -f "$dir/package.json" && "$dir/package.json" -nt "$stamp" ]] || return 0
       fi
-      [[ "$fresh" -eq 1 ]] && return 0
       info "installing $label dependencies (lockfile newer than the last install)"
-      (cd "$dir" && bun install) || die "bun install failed in $dir — the stack would start with stale dependencies"
+      (cd "$dir" && bun install) || die "bun install failed in $dir — refusing to start on stale dependencies"
       mkdir -p "$dir/node_modules" && : > "$stamp"
     }
     ensure_deps "root" "$REPO"

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -62,6 +62,36 @@ case "$ACTION" in
       die "--workers and --dev both replace the worker daemon — run the pool without --dev"
     fi
 
+    # Dependency freshness (WM-312). A runtime dependency added to the repo does
+    # not exist on the running stack until someone remembers `bun install` after
+    # pulling, and nothing detected the gap: on 2026-08-15 the Gondolin sandbox
+    # SDK shipped, CI went green on it (CI installs fresh every run), and the
+    # live fleet ran the rest of the day with `sandbox doctor` reporting
+    # unavailable and no signal anywhere. CI green plus production dark is the
+    # failure worth closing, not the missing package.
+    #
+    # A stamp file rather than node_modules' mtime: `bun install` leaves the
+    # directory untouched when nothing changes, so an mtime comparison would
+    # report stale forever and install on every single start.
+    ensure_deps() {
+      local label="$1" dir="$2"
+      [[ -f "$dir/package.json" ]] || return 0
+      local stamp="$dir/node_modules/.factory-deps-stamp"
+      local fresh=0
+      if [[ -d "$dir/node_modules" && -f "$stamp" ]]; then
+        fresh=1
+        for input in "$dir/bun.lock" "$dir/bun.lockb" "$dir/package.json"; do
+          [[ -f "$input" && "$input" -nt "$stamp" ]] && fresh=0
+        done
+      fi
+      [[ "$fresh" -eq 1 ]] && return 0
+      info "installing $label dependencies (lockfile newer than the last install)"
+      (cd "$dir" && bun install) || die "bun install failed in $dir — the stack would start with stale dependencies"
+      mkdir -p "$dir/node_modules" && : > "$stamp"
+    }
+    ensure_deps "root" "$REPO"
+    ensure_deps "event-runtime/web" "$REPO/event-runtime/web"
+
     # Policy-driven by default: the presence of a workers: block is the switch,
     # so a checkout without one keeps starting exactly one plain worker (the
     # pre-WM-226 behavior, unchanged).

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -1376,12 +1376,18 @@ async function sandbox(args) {
   if (sub === "doctor") {
     const report = sandboxPreflight();
     console.log(`${pad("available", 14)}${report.available ? "yes" : "no"}`);
+    if (report.cause) console.log(`${pad("cause", 14)}${report.cause}`);
     console.log(`${pad("qemu", 14)}${report.qemu ?? "-"}`);
     console.log(`${pad("node", 14)}${report.node ?? "-"}${report.nodeVersion ? `   (v${report.nodeVersion})` : ""}`);
     console.log(`${pad("sdk", 14)}${report.sdk ? "@earendil-works/gondolin installed" : "-"}`);
     if (!report.available) {
       console.log(`\n${report.reason}`);
-      process.exit(1);
+      // The exit code carries the distinction, not just the text (WM-312): a
+      // host that cannot virtualize is an ordinary fact about that machine; a
+      // missing harness is a stale checkout someone must fix. CI asserts on
+      // `install` and tolerates `host`, so runners without QEMU do not turn a
+      // real regression into noise everyone learns to skip past.
+      process.exit(report.cause === "install" ? 2 : 1);
     }
     return;
   }

--- a/event-runtime/lib/sandbox/gondolin.mjs
+++ b/event-runtime/lib/sandbox/gondolin.mjs
@@ -75,7 +75,7 @@ export function nodeVersionSatisfies(version) {
  * a bare boolean so `sandbox doctor` and the worker log can say what is
  * missing instead of "unavailable".
  *
- * @returns {{ available: boolean, reason: string|null, qemu: string|null, node: string|null, nodeVersion: string|null, sdk: boolean }}
+ * @returns {{ available: boolean, reason: string|null, cause: "host"|"install"|null, qemu: string|null, node: string|null, nodeVersion: string|null, sdk: boolean }}
  */
 export function preflight({
   env = process.env,
@@ -93,12 +93,24 @@ export function preflight({
   },
   sdkExists = () => existsSync(path.join(FACTORY_ROOT, "node_modules", "@earendil-works", "gondolin", "package.json")),
 } = {}) {
-  const report = { available: false, reason: null, qemu: null, node: null, nodeVersion: null, sdk: false };
+  // `cause` separates two things `available: false` used to conflate (WM-312):
+  //
+  //   "host"     this machine cannot virtualize — no QEMU, no Node, Node too
+  //              old. Expected on plenty of nodes and not a defect; the fleet
+  //              simply does not place sandboxed runs here.
+  //   "install"  the harness itself is missing. ALWAYS a defect: the dependency
+  //              is declared in package.json and resolved in bun.lock, so its
+  //              absence means the checkout never ran `bun install` after a pull.
+  //
+  // Rendering both as "available no" is what let the sandbox sit switched off
+  // fleet-wide for a day, indistinguishable from a laptop that lacks QEMU.
+  const report = { available: false, reason: null, cause: null, qemu: null, node: null, nodeVersion: null, sdk: false };
 
   const qemuBin = qemuBinaryFor();
   report.qemu = which(qemuBin);
   if (!report.qemu) {
     report.reason = `${qemuBin} is not on PATH — install QEMU (macOS: brew install qemu)`;
+    report.cause = "host";
     return report;
   }
 
@@ -107,6 +119,7 @@ export function preflight({
   const nodeBin = env.FACTORY_SANDBOX_NODE || which("node");
   if (!nodeBin) {
     report.reason = "node is not on PATH — the Gondolin SDK requires Node (see runner.mjs); set FACTORY_SANDBOX_NODE";
+    report.cause = "host";
     return report;
   }
   report.node = nodeBin;
@@ -114,12 +127,15 @@ export function preflight({
   report.nodeVersion = version ? `${version.major}.${version.minor}` : null;
   if (!nodeVersionSatisfies(version)) {
     report.reason = `node at ${nodeBin} is ${report.nodeVersion ?? "unreadable"}, need >= ${MIN_NODE_MAJOR}.${MIN_NODE_MINOR} — set FACTORY_SANDBOX_NODE to a newer Node`;
+    report.cause = "host";
     return report;
   }
 
   report.sdk = sdkExists();
   if (!report.sdk) {
-    report.reason = "@earendil-works/gondolin is not installed — run `bun install`";
+    report.reason =
+      "@earendil-works/gondolin is not installed — run `bun install`. Declared in package.json and locked, so this means the checkout is stale, not that the host is limited.";
+    report.cause = "install";
     return report;
   }
 

--- a/event-runtime/lib/sandbox/gondolin.test.mjs
+++ b/event-runtime/lib/sandbox/gondolin.test.mjs
@@ -24,6 +24,27 @@ describe("preflight", () => {
     expect(report).toMatchObject({ available: true, reason: null, sdk: true, nodeVersion: "24.18" });
   });
 
+  test("a healthy host reports no cause — cause is set only when unavailable", () => {
+    expect(preflight(healthy).cause).toBeNull();
+  });
+
+  test("host limitations and a missing harness are different causes (WM-312)", () => {
+    // The distinction that matters operationally: "this machine cannot
+    // virtualize" is an ordinary fact about a node, while "the harness is not
+    // installed" means a checkout never ran `bun install` after a pull. Both
+    // rendered as `available: false`, which is how the sandbox stayed switched
+    // off fleet-wide for a day with nothing to signal it.
+    const noQemu = preflight({ ...healthy, which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`) });
+    const oldNode = preflight({ ...healthy, runNode: () => "v22.14.0" });
+    const noNode = preflight({ ...healthy, which: () => null });
+    const noSdk = preflight({ ...healthy, sdkExists: () => false });
+
+    expect(noQemu.cause).toBe("host");
+    expect(oldNode.cause).toBe("host");
+    expect(noNode.cause).toBe("host");
+    expect(noSdk.cause).toBe("install");
+  });
+
   test("missing qemu is a named reason, not a crash", () => {
     const report = preflight({ ...healthy, which: (n) => (n.startsWith("qemu") ? null : `/usr/bin/${n}`) });
     expect(report.available).toBe(false);


### PR DESCRIPTION
Fixes WM-312

## The failure this closes

A runtime dependency added to the repo does not exist on the running stack until someone remembers `bun install` after pulling, and nothing detected the drift:

```
package.json   Aug 15 15:47   (Gondolin SDK landed that day, PR #285)
node_modules   Aug  4 14:57   (last install, eleven days earlier)
```

The sandbox shipped, CI went green on it (CI installs fresh every run), and the live fleet ran all day with `sandbox doctor` reporting unavailable and no signal anywhere. **CI green plus production dark** is the part worth fixing; the missing package was the symptom.

## Changes

**`bin/live-stack.sh`** — installs before starting any daemon, for both root and `event-runtime/web`.

Uses a stamp file rather than `node_modules`' mtime: `bun install` leaves the directory untouched when nothing changes, so an mtime comparison would report stale forever and reinstall on every start. Verified across all four states — absent, fresh, lockfile moved, settled again.

**`preflight()`** — gains `cause`, separating what `available: false` conflated:

| cause | meaning |
| :--- | :--- |
| `host` | no QEMU, no Node, Node too old — an ordinary fact about a node, not a defect |
| `install` | the harness is missing — always a stale checkout |

`sandbox doctor` prints it and exits **2** for `install` vs **1** for `host`, so CI asserts on the defect while tolerating self-hosted runners that legitimately cannot virtualize. Conflating those is exactly what made this invisible.

**`ci.yml`** — a step that fails when the harness is missing, asserting on `cause install` rather than on `available`.

## Scope note

`event-runtime/cli.mjs` is outside the paths the ticket listed. It holds the doctor rendering, and splitting the exit-code change from the field that drives it would have shipped half a feature. Flagging rather than burying it.

## Verification

`bun test event-runtime/lib/sandbox/` — 31 pass, 0 fail. `bun run format:check` clean. `bash -n bin/live-stack.sh` clean. New tests assert each unavailable path reports the right cause and that a healthy host reports none.