### PR TITLE
WM-188: Assert Proposals Dismiss is absent

### DIFF
--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -698,8 +698,7 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     const r = renderProposals({ focusProposalId: "prop_1" });
     await waitFor(() => expect(r.getByRole("button", { name: /^Reject/ })).toBeTruthy());
 
-    const dismiss = r.queryByRole("button", { name: /^Dismiss$/ });
-    if (dismiss) fireEvent.click(dismiss);
+    expect(r.queryByRole("button", { name: /^Dismiss$/ })).toBeNull();
     expect(rejectedCalls).toEqual([]);
 
     fireEvent.click(r.getByRole("button", { name: /^Reject/ }));


### PR DESCRIPTION
## Summary
- replace the optional Dismiss click with an explicit absence assertion
- preserve reject-with-reason coverage unchanged

## Verification
- `cd event-runtime/web && bun test` — 579 pass, 0 fail

UX critique: skipped — test-only regression coverage; no user-facing flow changed

Fixes WM-188