### PR TITLE
Improve SpecDiff bottom-fade contrast (WM-172)

### DIFF
--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -142,7 +142,7 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
       {linesBelow > 0 && (
         <>
           <div
-            className="pointer-events-none sticky bottom-0 -mt-8 h-8 bg-linear-to-t from-(--surface-0) to-transparent"
+            className="pointer-events-none sticky bottom-0 -mt-8 h-8 bg-linear-to-t from-(--surface-3) to-transparent"
             aria-hidden
           />
           <div className="sticky bottom-0 bg-(--surface-0) px-3 pb-2 pt-0.5 text-center text-[10px] text-(--text-faint)">


### PR DESCRIPTION
## Summary

- derive the SpecDiff overflow fade from `--surface-3` instead of the matching `--surface-0` background
- preserve the existing fade dimensions and transparent transition so diff content readability is unchanged

## Verification

- `cd event-runtime/web && bun test` — 579 passed, 0 failed

UX critique: skipped — isolated styling refinement with no new or materially changed interaction or flow.

Fixes WM-172