### PR TITLE
feat(triage): add write-detail action (WM-331)

### DIFF
--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -28,6 +28,15 @@
         "Todo"
       ]
     },
+    "write-detail": {
+      "argv": [
+        "bun",
+        "-e",
+        "import { gql } from './orchestrator/reaper.mjs'; const [identifier, rawDetail] = process.argv.slice(1); if (!identifier || !rawDetail) throw new Error('write-detail requires issueId and detail'); const found = await gql('query($id:String!){ issue(id:$id){ id description } }', { id: identifier }); const issue = found?.issue; if (!issue) throw new Error(`issue not found: ${identifier}`); const detail = rawDetail.trim(); const current = issue.description ?? ''; if (current.includes(detail)) { console.log(`${identifier} detail already present`); process.exit(0); } const separator = current.length === 0 || current.endsWith('\\n\\n') ? '' : current.endsWith('\\n') ? '\\n' : '\\n\\n'; const description = `${current}${separator}${detail}\\n`; const updated = await gql('mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }', { id: issue.id, in: { description } }); if (!updated?.issueUpdate?.success) throw new Error(`failed to append detail to ${identifier}`); console.log(`${identifier} detail appended`);",
+        "{issueId}",
+        "{detail}"
+      ]
+    },
     "needs-detail": {
       "argv": [
         "bun",
@@ -62,9 +71,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:write"
-    ]
+    "services": ["linear:write"]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -72,8 +79,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/triage-apply.md": "sha256:4ff7a95e86abb5bbc82bdff3202090673a87347e256e40c03bd1d963b2499992",
-    "schemas/triage-apply.input.json": "sha256:db490430a3794775aa33263b12c8a91af1a8b5e5fcb532aa4e66a91788ff68a4",
+    "agents/triage-apply.md": "sha256:e4d6bcb46316cd1d606d902b80a3ee77c43348b477b784c96a4d9fd9d250770b",
+    "schemas/triage-apply.input.json": "sha256:012ae75d96534db28ea8c7c8856d247ee3fbe2e2bbec83bbf90e4e664d2011e1",
     "schemas/triage-applied.output.json": "sha256:5e4d4a2e59423a2aab88357521ff1e37889d50d658bee7278d599400f5dc3365"
   }
 }

--- a/event-runtime/agents/triage-apply.md
+++ b/event-runtime/agents/triage-apply.md
@@ -4,15 +4,22 @@ Not a prompt: this definition applies an **approved per-issue action list**
 via the deterministic actions adapter in item-list mode
 (`lib/adapters/actions.mjs`). No model runs.
 
-Registered actions — each resolves to one fixed `tools/linear.mjs` invocation:
+Registered actions — each resolves to one fixed, non-shell-interpolated argv:
 
-| action id | effect |
-| :--- | :--- |
+| action id           | effect                                                                                                                           |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------- |
 | `label-agent-ready` | `state {issueId} "Todo" --add ai:agent-ready` — the full make-dispatchable transition (the protocol's `Todo` + `ai:agent-ready`) |
-| `move-to-todo` | `state {issueId} "Todo"` |
-| `needs-detail` | `comment {issueId} "<reason>"` — tells the human exactly what is missing |
-| `mark-duplicate` | `comment {issueId} "<reason>"` — names the covering issue; the relation stays a human call |
-| `needs-human` | `comment {issueId} "<reason>"` |
+| `move-to-todo`      | `state {issueId} "Todo"`                                                                                                         |
+| `write-detail`      | read the current description, then append the approved missing sections from `detail`; no state or label change                  |
+| `needs-detail`      | `comment {issueId} "<reason>"` — tells the human exactly what is missing                                                         |
+| `mark-duplicate`    | `comment {issueId} "<reason>"` — names the covering issue; the relation stays a human call                                       |
+| `needs-human`       | `comment {issueId} "<reason>"`                                                                                                   |
+
+`write-detail` is intentionally separate from `label-agent-ready`. It
+preserves the description read immediately before the mutation and appends
+only the approved Markdown suffix. A later triage scan must make and justify
+the promotion decision independently; writing detail never changes state or
+labels.
 
 Every action is additive or a forward state move; nothing here closes,
 deletes, or reassigns an issue. An action ID outside this table refuses

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -13,10 +13,7 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": [
-      "linear:read",
-      "repo:read"
-    ]
+    "services": ["linear:read", "repo:read"]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -24,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:f78451d1e543ee57bc18c514770a9082af58052a27b0bcf5ee78409a3a67fa89",
+    "agents/triage-scan.md": "sha256:4331934a385d2fb711f6ab8572f9d7a0938e7bf82f3be776a39c60801bb54f4d",
     "schemas/triage-scan.input.json": "sha256:893c6ada3445fdcf2c5507319fe4933618ca6104298493b6339677ab2e295614",
-    "schemas/triage-scan.output.json": "sha256:27f7e5bbe5e109561f2a3f055dd7801ef263f6750b84936105e6d54070efba97"
+    "schemas/triage-scan.output.json": "sha256:ceba80c94dcb5aa64201c63e0d0c322bcf9e57072349c07b898a24a19f7e1d77"
   }
 }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -6,7 +6,12 @@ tree to read it against:
 ```json
 {
   "repo": "bj29",
-  "repoPin": { "repo": "bj29", "ref": "develop", "sha": "<40-hex>", "github": "owner/name" }
+  "repoPin": {
+    "repo": "bj29",
+    "ref": "develop",
+    "sha": "<40-hex>",
+    "github": "owner/name"
+  }
 }
 ```
 
@@ -28,19 +33,56 @@ You never modify it, never run its build, never install anything. Write
 
 ## Actions — the closed set
 
-| action | when |
-| :--- | :--- |
-| `label-agent-ready` | fully specified: acceptance criteria, owned paths, verification command |
-| `move-to-todo` | specified and ready to queue (usually alongside agent-ready) |
-| `needs-detail` | real work, but an agent would have to guess — say what is missing |
-| `mark-duplicate` | another open issue covers it; name that issue in `reason` |
-| `needs-human` | a decision only the operator can make |
+| action              | when                                                                                               |
+| :------------------ | :------------------------------------------------------------------------------------------------- |
+| `label-agent-ready` | fully specified: acceptance criteria, owned paths, verification command                            |
+| `move-to-todo`      | specified and ready to queue (usually alongside agent-ready)                                       |
+| `write-detail`      | missing template sections can be derived from this pinned checkout without making a product choice |
+| `needs-detail`      | real work, but an agent would have to guess — say what is missing                                  |
+| `mark-duplicate`    | another open issue covers it; name that issue in `reason`                                          |
+| `needs-human`       | a decision only the operator can make                                                              |
 
 Never invent an action id. Never propose changes to issues outside this repo.
 
+### `write-detail` is narrow
+
+Use `write-detail` only when all missing information is discoverable in the
+pinned checkout. It appends detail; it does **not** promote the issue. A later
+scan must independently decide whether the completed issue deserves
+`label-agent-ready`. Never emit `write-detail` and a promotion action for the
+same issue in one scan.
+
+For a `write-detail` item:
+
+- Set `detail` to ready-to-append Markdown containing only missing `##
+Acceptance criteria`, `## Owned Paths`, or `## Verification` sections.
+  Preserve everything already written; do not restate or revise an existing
+  section.
+- When authoring Owned Paths, set `ownedPaths` to the same paths used in
+  `detail`. Every entry must name a concrete regular file that exists in
+  `./repo` at `repoPin.sha`. Reject globs (`*`, `?`, bracket/brace patterns),
+  directories, generated guesses, and paths broader than the expected diff.
+  Prefer `needs-detail` over a broad path.
+- When authoring Verification, set `verificationCommand` to the exact command
+  used in `detail`. Validate it statically against `./repo`: every referenced
+  file and directory must exist, every package script must exist in the
+  applicable `package.json`, and every explicitly named script/target must be
+  real. Record those reads in `evidence.commands`. Do **not** execute the
+  command — this checkout is read-only and builds and installs are forbidden.
+- Author acceptance criteria only when each criterion follows from repository
+  evidence. If the issue presents incompatible options, asks what behavior is
+  wanted, or otherwise requires a product/architecture choice, emit
+  `needs-human` instead. Do not silently choose an option.
+- Do not use `write-detail` to split or complete a multi-item bundle. Emit
+  `needs-detail` and identify the split that is needed.
+
+The schema rejects globbed entries in `ownedPaths`, but schema validation is
+only the last guard: you must still prove each entry is an existing regular
+file and each verification target exists.
+
 ## Output
 
-```json
+````json
 {
   "schemaVersion": "factory.agent-result/v1",
   "terminalState": "completed",
@@ -49,13 +91,20 @@ Never invent an action id. Never propose changes to issues outside this repo.
     "recommendation": "TRIAGE",
     "repo": "bj29",
     "plan": [
-      { "issueId": "CLNT-123", "action": "label-agent-ready", "reason": "one sentence of why" }
+      {
+        "issueId": "CLNT-123",
+        "action": "write-detail",
+        "reason": "the missing ownership and verification are derivable from the pinned checkout",
+        "detail": "## Owned Paths\n\n- `src/client.ts`\n\n## Verification\n\n```\nbun test src/client.test.ts\n```",
+        "ownedPaths": ["src/client.ts"],
+        "verificationCommand": "bun test src/client.test.ts"
+      }
     ],
     "summary": "one line an operator can act on"
   },
   "evidence": { "commands": ["the reads this rests on"], "issuesSeen": 7 }
 }
-```
+````
 
 Queue already clean, or nothing you can judge confidently → `recommendation:
 "NOOP"` with an empty `plan` and a summary saying so. That is a good outcome,

--- a/event-runtime/schemas/triage-apply.input.json
+++ b/event-runtime/schemas/triage-apply.input.json
@@ -24,12 +24,46 @@
             "description": "Linear issue identifier (e.g. WM-76)"
           },
           "action": {
-            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"],
+            "enum": [
+              "label-agent-ready",
+              "move-to-todo",
+              "write-detail",
+              "needs-detail",
+              "mark-duplicate",
+              "needs-human"
+            ],
             "description": "Triage action to apply to the issue"
           },
           "reason": {
             "type": "string",
             "description": "One-line justification for the action, kept for the audit trail"
+          },
+          "detail": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^## (Acceptance criteria|Owned Paths|Verification)",
+            "description": "For write-detail only: approved additive Markdown containing only missing template sections"
+          },
+          "ownedPaths": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Concrete existing files authored into Owned Paths; glob metacharacters are refused by schema",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[^*?\\[\\]{}\\r\\n]+$"
+            }
+          },
+          "verificationCommand": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact authored command whose referenced paths, targets, and package scripts exist in the pinned checkout"
+          },
+          "acceptanceCriteria": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "Only repository-derivable criteria authored into the missing Acceptance criteria section"
           }
         }
       }

--- a/event-runtime/schemas/triage-scan.output.json
+++ b/event-runtime/schemas/triage-scan.output.json
@@ -15,9 +15,43 @@
         "properties": {
           "issueId": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
           "action": {
-            "enum": ["label-agent-ready", "move-to-todo", "needs-detail", "mark-duplicate", "needs-human"]
+            "enum": [
+              "label-agent-ready",
+              "move-to-todo",
+              "write-detail",
+              "needs-detail",
+              "mark-duplicate",
+              "needs-human"
+            ]
           },
-          "reason": { "type": "string", "minLength": 1 }
+          "reason": { "type": "string", "minLength": 1 },
+          "detail": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^## (Acceptance criteria|Owned Paths|Verification)",
+            "description": "For write-detail only: additive Markdown containing only missing template sections"
+          },
+          "ownedPaths": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Concrete existing files authored into Owned Paths; glob metacharacters are refused by schema",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[^*?\\[\\]{}\\r\\n]+$"
+            }
+          },
+          "verificationCommand": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact authored command after every referenced path, target, and package script was found in the pinned checkout"
+          },
+          "acceptanceCriteria": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "Only repository-derivable criteria authored into the missing Acceptance criteria section"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- add a guarded `write-detail` triage-scan action for repository-derivable metadata
- append approved missing sections without changing issue state or labels
- reject globbed Owned Paths and require static verification-target checks

## Verification
- `bun test && bun build/emit.mjs --check && bun run format:check`
- 1719 tests passed; generated files and formatting checks passed

## UX critique
UX critique: skipped — internal agent contracts and deterministic Linear adapter; no user-completable UI flow changed.

Fixes WM-331