### PR TITLE
fix(ux-critic): give Pi critics scoped browser tools (WM-335)

### DIFF
--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -58,6 +58,18 @@ function splitFrontmatter(text) {
   return { fm, body: text.slice(m[0].length) };
 }
 
+/** Remove another harness's namespaced fields while preserving source bytes. */
+function withoutFrontmatterFields(text, fields) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return text;
+  const dropped = new Set(fields);
+  const kept = m[1].split("\n").filter((line) => {
+    const key = line.match(/^([\w-]+):/)?.[1];
+    return !dropped.has(key);
+  });
+  return `---\n${kept.join("\n")}\n---${text.slice(m[0].length)}`;
+}
+
 /** Render a harness-native Markdown agent without leaking another harness's model id. */
 function markdownAgent(agent, fields = {}) {
   const frontmatter = { name: agent.name, description: agent.description, ...fields };
@@ -99,12 +111,12 @@ const agentDefinitions = agents.map((file) => {
   if (!fm.description) throw new Error(`${rel(file)}: agents require a description`);
   if (name !== path.basename(file, ".md"))
     throw new Error(`${rel(file)}: agent name must match its filename (${name})`);
-  return { file, name, description: fm.description, body };
+  return { file, name, description: fm.description, fm, body };
 });
 
 // ------------------------------------------------- Claude Code (plugin) ------
-// Frontmatter passes through unchanged: shared/ already uses Claude's keys
-// (description / argument-hint / model), which are the most expressive set.
+// Shared frontmatter uses Claude's expressive keys by default. Pi-only fields
+// are stripped so one harness's tool names cannot alter Claude's allowlist.
 const CLAUDE = path.join(ROOT, "plugins", "core");
 for (const f of commands) emit(path.join(CLAUDE, "commands", path.basename(f)), read(f));
 for (const s of skillDirs)
@@ -114,7 +126,10 @@ for (const s of skillDirs)
 // second, stale specialist registered alongside the canonical one.
 if (!CHECK) rmSync(path.join(CLAUDE, "agents"), { recursive: true, force: true });
 for (const agent of agentDefinitions)
-  emit(path.join(CLAUDE, "agents", `${agent.name}.md`), read(agent.file));
+  emit(
+    path.join(CLAUDE, "agents", `${agent.name}.md`),
+    withoutFrontmatterFields(read(agent.file), ["pi-tools", "pi-extensions"]),
+  );
 
 // ------------------------------------------------------------- Codex ---------
 // Codex uses skills for reusable workflows. Factory's shared command bodies
@@ -170,14 +185,23 @@ for (const f of commands) {
 // ------------------------------------------------------------- Pi ------------
 // dist/pi/ — skills and prompts for the Pi coding agent.
 const PI = path.join(ROOT, "dist", "pi");
+const PI_DEFAULT_AGENT_TOOLS = "read, grep, find, ls, bash";
 if (!CHECK) rmSync(path.join(PI, "agents"), { recursive: true, force: true });
-for (const agent of agentDefinitions)
-  emit(path.join(PI, "agents", `${agent.name}.md`), markdownAgent(agent, {
-    tools: "read, grep, find, ls, bash",
+for (const agent of agentDefinitions) {
+  // Pi-specific declarations live in shared frontmatter so an exceptional
+  // agent's surface is reviewable at the source. Prefixing them avoids passing
+  // Pi tool names through to Claude Code, whose `tools` field has different
+  // names and semantics. Agents without a declaration retain the byte-identical
+  // historical allowlist.
+  const piFields = {
+    tools: agent.fm["pi-tools"] || PI_DEFAULT_AGENT_TOOLS,
     systemPromptMode: "replace",
     inheritProjectContext: true,
     inheritSkills: true,
-  }));
+  };
+  if (agent.fm["pi-extensions"]) piFields.extensions = agent.fm["pi-extensions"];
+  emit(path.join(PI, "agents", `${agent.name}.md`), markdownAgent(agent, piFields));
+}
 for (const s of skillDirs)
   for (const f of listFiles(path.join(SHARED, "skills", s)))
     emit(path.join(PI, "skills", s, path.relative(path.join(SHARED, "skills", s), f)), read(f));

--- a/dist/pi/agents/factory-ux-critic.md
+++ b/dist/pi/agents/factory-ux-critic.md
@@ -1,10 +1,11 @@
 ---
 name: "factory-ux-critic"
 description: "End-user perspective critic for materially changed user journeys. Spawn after verification passes and before opening the PR when a change introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action — mobile (simulator via argent), web (browser tools), or Electron (argent chromium). Requires the caller to pass `worktree: <absolute path>` and how to launch the app. It uses the running app the way a real user would and returns ranked findings plus a ship/fix-first/not-assessed/blocked verdict. It never edits code."
-tools: "read, grep, find, ls, bash"
+tools: "read, grep, find, ls, bash, chrome_devtools_load, chrome_devtools_list_pages, chrome_devtools_select_page, chrome_devtools_navigate, chrome_devtools_evaluate, chrome_devtools_screenshot"
 systemPromptMode: "replace"
 inheritProjectContext: true
 inheritSkills: true
+extensions: "npm:@narumitw/pi-chrome-devtools"
 ---
 
 You are a UX critic. You review a feature by **using it**, not by reading its code. Your value comes from your cold perspective: you were not part of the implementation, you don't know the compromises that were made, and you owe the solution nothing. Stay in that frame.

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -34,8 +34,8 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:ed2330097936e9f9aac39bf8705f5d691ab3db5cc7f2a20fa9c9ef86e4f0650d",
+    "agents/dispatch.md": "sha256:09fa0ce60dfe63c1a61f4d1cade28e347f22d24d4fc47a8e093e867e5c46ba93",
     "schemas/dispatch.input.json": "sha256:66898f48608fff53f07f2b59e9df9d41c15aae69615c2383c22d3978ca9807b2",
-    "schemas/dispatch.output.json": "sha256:56ea5a82df4bce92d5f22b60d173a03bbb9e139491abeff3c01a96524ef49a4d"
+    "schemas/dispatch.output.json": "sha256:29b6677a5f13bb6ca38ba09c314290142987d1de32ecc7699e2e5460bcc8cbb8"
   }
 }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -38,13 +38,48 @@ steal a claim, never queue behind the holder.
    `./repo`. Never proceed past failing output; never weaken a test to get
    green. The runtime re-runs the repo's declared verify command after you —
    your report is not the evidence, the output is.
-4. **Never `sleep` to wait for anything.** Poll a condition with a real
+4. **Run the UX gate when required.** A critique is required when the change
+   introduces or materially changes a user-completable flow, interaction,
+   state transition, error/recovery path, responsive layout, authentication,
+   payment, onboarding, or destructive action. It is skipped for isolated
+   styling, copy-only/static content, icons/assets, and internal/admin-only
+   surfaces unless the ticket identifies UX risk.
+
+   Spawn the `factory-ux-critic` subagent after verification and before opening
+   the PR. Its prompt must spell out `worktree: <absolute path>` plus the exact
+   dev-server command and this worktree's port (or simulator/Electron target),
+   login route, ticket criteria, flow, and persona. The critic must use the
+   running app. A valid `SHIP` or `FIX-FIRST` report cites at least one observed
+   page URL or screenshot path; without browser evidence, treat it as
+   `NOT-ASSESSED`, never as approval.
+
+   Resolve in-scope `FIX-FIRST` findings and re-run the critic, for at most two
+   review rounds. A startup `BLOCKED - environment mismatch or unresponsive
+   shell` means the spawn prompt was defective: correct its path/launch details
+   and retry once without consuming a review round. If the retry blocks, or the
+   app cannot be driven, record that result rather than guessing.
+5. **Never `sleep` to wait for anything.** Poll a condition with a real
    command (`gh pr checks <PR> --watch --fail-fast` for CI); a fixed sleep
    wedges the run until the timeout kills it.
-5. **Push and open a PR** against the repo's base branch with
-   `Fixes <TICKET>` in the body. Post the structured `## Handoff` comment on
-   the ticket (PR link, verification command + one-line result, files
-   touched, risks), then move it to `In Review` + `ai:needs-review`, removing
+6. **Push and open a PR** against the repo's base branch with
+   `Fixes <TICKET>` in the body. For a required UX critique, create the PR as a
+   draft first. Run `gh pr ready <PR>` only after an evidence-backed `SHIP`
+   verdict (including a `FIX-FIRST` resolved to `SHIP`). Leave `FIX-FIRST`,
+   `NOT-ASSESSED`, and `BLOCKED` PRs in draft for review; skipped critiques may
+   open ready normally. Include `UX critique: <status>` in the PR body.
+
+   Post the structured `## Handoff` comment on the ticket before transitioning:
+
+   ```
+   ## Handoff
+   - PR: <url>
+   - Verification: `<exact command>` — pass, <one-line result>
+   - UX critique: required — SHIP | required — FIX-FIRST unresolved | required — NOT-ASSESSED, <reason> | blocked — <reason> | skipped — <reason>; evidence: <page URL or screenshot path, when required>
+   - Files: <n> changed, all within Owned Paths
+   - Risks: <reviewer focus, or "none known">
+   ```
+
+   Then move the ticket to `In Review` + `ai:needs-review`, removing
    `ai:in-progress`.
 
 **The paved road for pushing is `gh` over HTTPS.** Authenticate through the
@@ -94,7 +129,14 @@ report `outcome: "FAILED"`.
       "passed": true,
       "output": "the last lines of the verification run"
     },
-    "summary": "one line an operator can act on"
+    "summary": "one line an operator can act on",
+    "uxCritique": {
+      "status": "required",
+      "verdict": "SHIP",
+      "evidence": ["http://127.0.0.1:7497/runs"],
+      "rounds": 1,
+      "prReady": true
+    }
   },
   "evidence": { "commands": ["the commands this rests on"] }
 }

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -126,6 +126,10 @@ export function buildPiArgv({ def, model }) {
   if (typeof model === "string" && model !== "" && model !== "default") {
     args.push("--model", model);
   }
+  // Extensions are definition-scoped and loaded explicitly for this process.
+  // Never `pi install` here: that writes global settings and would expose an
+  // extension's tools to unrelated agents (WM-335).
+  for (const extension of piExtensions(def)) args.push("-e", extension);
   // Always allowlist (WM-336). Omitting `--tools` does not mean "no tools", it
   // means "every tool pi currently ships" — a set that grows without review.
   args.push("--tools", piTools(def).join(","));
@@ -146,6 +150,19 @@ export function piTools(def) {
   const base = def?.mutating === false ? READ_ONLY_TOOLS : MUTATING_TOOLS;
   const extra = Array.isArray(def?.tools) ? def.tools : [];
   return [...new Set([...base, ...extra])];
+}
+
+/** Repeatable `-e` sources declared by this definition, normalized for argv. */
+export function piExtensions(def) {
+  if (!Array.isArray(def?.extensions)) return [];
+  return [
+    ...new Set(
+      def.extensions
+        .filter((extension) => typeof extension === "string")
+        .map((extension) => extension.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
 export const BASE_INHERITED_ENV = [

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -13,6 +13,7 @@ import {
   mapStreamEvent,
   PUSH_CREDENTIAL_ENV,
   MUTATING_TOOLS,
+  piExtensions,
   piTools,
   READ_ONLY_TOOLS,
   resolvePiCommand,
@@ -177,6 +178,33 @@ describe("buildPiArgv", () => {
     expect(piTools({ mutating: false })).toEqual(READ_ONLY_TOOLS);
     expect(piTools({ mutating: false, tools: "read" })).toEqual(READ_ONLY_TOOLS);
     expect(piTools(undefined)).toEqual(MUTATING_TOOLS);
+  });
+
+  test("declared extensions are loaded per run with repeatable -e flags (WM-335)", () => {
+    const argv = buildPiArgv({
+      def: {
+        mutating: false,
+        extensions: ["npm:@narumitw/pi-chrome-devtools", "./local-extension.ts"],
+      },
+      model: null,
+    });
+    expect(argv).toEqual([
+      "-p", "--mode", "json",
+      "-e", "npm:@narumitw/pi-chrome-devtools",
+      "-e", "./local-extension.ts",
+      "--tools", READ_ONLY_TOOLS.join(","),
+    ]);
+  });
+
+  test("extensions are scoped to definitions that declare them and deduplicated", () => {
+    expect(piExtensions(undefined)).toEqual([]);
+    expect(piExtensions({})).toEqual([]);
+    expect(piExtensions({ extensions: "npm:@narumitw/pi-chrome-devtools" })).toEqual([]);
+    expect(piExtensions({ extensions: ["", "  ", "npm:a", "npm:a", "npm:b"] })).toEqual([
+      "npm:a",
+      "npm:b",
+    ]);
+    expect(buildPiArgv({ def: { mutating: false }, model: null })).not.toContain("-e");
   });
 
   test("planner-pinned model → --model verbatim; default sentinel, null, or absent → no flag (WM-135)", () => {

--- a/event-runtime/schemas/dispatch.output.json
+++ b/event-runtime/schemas/dispatch.output.json
@@ -68,6 +68,57 @@
       "type": "string",
       "minLength": 1,
       "description": "One line an operator can act on: what shipped, what blocked, or why nothing happened"
+    },
+    "uxCritique": {
+      "type": "object",
+      "description": "UX gate result when the run reached post-verification review. Required by the dispatch prompt for PR_OPEN; optional in the schema for backward-compatible terminal outcomes produced before the gate.",
+      "required": [
+        "status",
+        "verdict",
+        "evidence",
+        "rounds",
+        "prReady"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "enum": [
+            "required",
+            "skipped",
+            "blocked"
+          ]
+        },
+        "verdict": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "SHIP",
+            "FIX-FIRST",
+            "NOT-ASSESSED",
+            "BLOCKED",
+            null
+          ]
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Observed worktree page URLs or screenshot paths supporting a required verdict; empty only when skipped or unavailable"
+        },
+        "rounds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2
+        },
+        "prReady": {
+          "type": "boolean",
+          "description": "True only when the PR is non-draft; an evidence-backed SHIP or a skipped gate may be ready"
+        }
+      }
     }
   }
 }

--- a/shared/agents/factory-ux-critic.md
+++ b/shared/agents/factory-ux-critic.md
@@ -2,6 +2,8 @@
 name: factory-ux-critic
 model: sonnet
 disallowedTools: Write, Edit, NotebookEdit
+pi-tools: read, grep, find, ls, bash, chrome_devtools_load, chrome_devtools_list_pages, chrome_devtools_select_page, chrome_devtools_navigate, chrome_devtools_evaluate, chrome_devtools_screenshot
+pi-extensions: npm:@narumitw/pi-chrome-devtools
 description: End-user perspective critic for materially changed user journeys. Spawn after verification passes and before opening the PR when a change introduces or materially changes a user-completable flow, interaction, state transition, error/recovery path, responsive layout, authentication, payment, onboarding, or destructive action — mobile (simulator via argent), web (browser tools), or Electron (argent chromium). Requires the caller to pass `worktree: <absolute path>` and how to launch the app. It uses the running app the way a real user would and returns ranked findings plus a ship/fix-first/not-assessed/blocked verdict. It never edits code.
 ---
 


### PR DESCRIPTION
## Summary
- derive Pi subagent tool and extension declarations from shared agent frontmatter while preserving every other agent’s existing allowlist
- load event-runtime Pi extensions only from each definition via repeatable per-run `-e` flags
- require evidence-backed UX verdicts in dispatch and move only SHIP critiques from draft to ready

## Verification
- `bun test && bun build/emit.mjs --check` — 1,721 pass, 0 fail; 90 generated files match
- live critic capability smoke — SHIP after driving `http://127.0.0.1:7497/`, observing `factory · Overview` and dashboard navigation, and capturing a screenshot
- generated diff check — only `dist/pi/agents/factory-ux-critic.md` changed among Pi agents; other harness agent outputs remained byte-identical

UX critique: skipped — internal agent/runtime plumbing; the required real-browser capability smoke passed separately.

Fixes WM-335