### PR TITLE
ui(event-runtime-web): consolidate detail copy actions

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
+import { Button, clearToasts, CopyActions, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { changeInput, typeText } from "../test-render";
 
@@ -41,6 +41,62 @@ describe("shortId (WM-96)", () => {
   test("returns ids without a prefix unchanged", () => {
     expect(shortId("plainid-with-no-underscore")).toBe("plainid-with-no-underscore");
     expect(shortId("")).toBe("");
+  });
+});
+
+describe("CopyActions (WM-302)", () => {
+  test("renders icon-only actions with accessible labels and shortcut tooltips", () => {
+    const r = render(
+      <CopyActions
+        id="run_123"
+        idLabel="run id"
+        cli="bun event-runtime/cli.mjs inspect run_123"
+        cliLabel="CLI inspect command"
+      />,
+    );
+
+    const id = r.getByRole("button", { name: "Copy run id (c)" });
+    const cli = r.getByRole("button", { name: "Copy CLI inspect command (c i)" });
+    const link = r.getByRole("button", { name: "Copy link (c l)" });
+    expect(id.getAttribute("title")).toBe("Copy run id · c");
+    expect(cli.getAttribute("title")).toBe("Copy CLI inspect command · c i");
+    expect(link.getAttribute("title")).toBe("Copy link · c l");
+    expect(id.textContent).toBe("");
+    expect(cli.textContent).toBe("");
+    expect(link.textContent).toBe("");
+  });
+
+  test("omits the CLI action when no CLI value is provided", () => {
+    const r = render(<CopyActions id="event_123" idLabel="event id" />);
+
+    expect(r.getAllByRole("button")).toHaveLength(2);
+    expect(r.queryByRole("button", { name: /CLI/ })).toBeNull();
+  });
+
+  test("copies the id, CLI command, and current link through the shared handlers", () => {
+    const writes: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: (value: string) => writes.push(value) },
+    });
+    const r = render(
+      <CopyActions
+        id="run_123"
+        idLabel="run id"
+        cli="bun event-runtime/cli.mjs inspect run_123"
+        cliLabel="CLI inspect command"
+      />,
+    );
+
+    fireEvent.click(r.getByRole("button", { name: "Copy run id (c)" }));
+    fireEvent.click(r.getByRole("button", { name: "Copy CLI inspect command (c i)" }));
+    fireEvent.click(r.getByRole("button", { name: "Copy link (c l)" }));
+
+    expect(writes).toEqual([
+      "run_123",
+      "bun event-runtime/cli.mjs inspect run_123",
+      window.location.href,
+    ]);
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -102,6 +102,93 @@ export function copyLink() {
   copyText(window.location.href, "link");
 }
 
+type CopyActionButtonProps = {
+  label: string;
+  chord: string;
+  onClick: () => void;
+  children: ReactNode;
+};
+
+function CopyActionButton({ label, chord, onClick, children }: CopyActionButtonProps) {
+  return (
+    <button
+      type="button"
+      title={`${label} · ${chord}`}
+      aria-label={`${label} (${chord})`}
+      onClick={onClick}
+      className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-(--text-faint) transition-colors hover:text-(--text) focus-visible:text-(--text) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) focus-visible:ring-offset-1 focus-visible:ring-offset-(--surface-1)"
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Compact, accessible copy/share actions shared by every detail surface. */
+export function CopyActions({
+  id,
+  idLabel,
+  idChord = "c",
+  cli,
+  cliLabel = "CLI command",
+}: {
+  id: string;
+  idLabel: string;
+  idChord?: string;
+  cli?: string;
+  cliLabel?: string;
+}) {
+  return (
+    <div className="inline-flex items-center gap-1" role="group" aria-label="Copy actions">
+      <CopyActionButton label={`Copy ${idLabel}`} chord={idChord} onClick={() => copyText(id, idLabel)}>
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          aria-hidden="true"
+          className="size-3.5"
+        >
+          <path d="M5 2.5 4 11.5M10 2.5 9 11.5M2.5 5.5h9M2 8.5h9" />
+        </svg>
+      </CopyActionButton>
+      {cli !== undefined && (
+        <CopyActionButton label={`Copy ${cliLabel}`} chord="c i" onClick={() => copyText(cli, cliLabel)}>
+          <svg
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            className="size-3.5"
+          >
+            <polyline points="2.5,3.5 5.5,6.5 2.5,9.5" />
+            <line x1="7" y1="10" x2="11.5" y2="10" />
+          </svg>
+        </CopyActionButton>
+      )}
+      <CopyActionButton label="Copy link" chord="c l" onClick={copyLink}>
+        <svg
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className="size-3.5"
+        >
+          <path d="M5.2 9.8 4 11a2.1 2.1 0 0 1-3-3l2.1-2.1a2.1 2.1 0 0 1 3-.1" />
+          <path d="m8.8 4.2 1.2-1.2a2.1 2.1 0 1 1 3 3l-2.1 2.1a2.1 2.1 0 0 1-3 .1" />
+          <line x1="5" y1="9" x2="9" y2="5" />
+        </svg>
+      </CopyActionButton>
+    </div>
+  );
+}
+
 /**
  * One active token, as a dismissible chip (UX doc Proposal 4). The whole chip
  * is the remove target: a token is one word in the query box, so there is

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -253,13 +253,12 @@ describe("Agents copy chords and hints (WM-233)", () => {
     const agent = stubAgent("test-agent");
     await withAgents([agent], async () => {
       const r = renderAgents(agent.ref);
-      await r.findByText("copy:");
+      const refBtn = await r.findByRole("button", { name: "Copy agent ref (c)" });
 
-      // Verify utility hint badges
-      const refBtn = r.getByRole("button", { name: "ref" });
-      expect(refBtn.textContent).toContain("c");
-      const linkBtn = r.getByRole("button", { name: "link" });
-      expect(linkBtn.textContent).toContain("c l");
+      // Verify icon-action tooltips preserve shortcut discoverability.
+      expect(refBtn.getAttribute("title")).toBe("Copy agent ref · c");
+      const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+      expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies agent.ref
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -18,6 +18,7 @@ import type { AgentDef, AgentEventRoute } from "../types";
 import type { OperatorContext } from "../context";
 import {
   Button,
+  CopyActions,
   DetailPane,
   Disclosure,
   FilterInput,
@@ -439,26 +440,7 @@ export function Agents({
               {sel.ref}
             </span>
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.ref, "agent ref")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                ref <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.ref} idLabel="agent ref" />}
           close={<Button onClick={() => onSelectAgent(null)}>Close</Button>}
         >
 

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -710,13 +710,12 @@ describe("Events copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderEvents({ focusEvent: { source: "github", eventId } });
-        await r.findByText("copy:");
+        const idBtn = await r.findByRole("button", { name: "Copy event id (c)" });
 
-        // Verify utility hint badges
-        const idBtn = r.getByRole("button", { name: "id" });
-        expect(idBtn.textContent).toContain("c");
-        const linkBtn = r.getByRole("button", { name: "link" });
-        expect(linkBtn.textContent).toContain("c l");
+        // Verify icon-action tooltips preserve shortcut discoverability.
+        expect(idBtn.getAttribute("title")).toBe("Copy event id · c");
+        const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies eventId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -27,6 +27,7 @@ import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import {
   Ago,
   Button,
+  CopyActions,
   Dialog,
   Disclosure,
   EVENT_STATUS_HUES,
@@ -872,26 +873,7 @@ export function Events({
               </div>
             </>
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.eventId, "event id")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                id <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.eventId} idLabel="event id" />}
           close={<Button onClick={() => onSelectEvent(null)}>Close</Button>}
         >
 

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -23,6 +23,7 @@ import type { OperatorContext } from "../context";
 import {
   Ago,
   Button,
+  CopyActions,
   DECISION_HUES,
   DetailPane,
   JsonBlock,
@@ -488,24 +489,10 @@ export function Graph({
           title={selected.label}
           actions={<Button onClick={revealSelected}>Show on canvas</Button>}
           utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(selected.label, selected.kind === "agent" ? "agent ref" : "id")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                {selected.kind === "agent" ? "ref" : "id"} <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
+            <CopyActions
+              id={selected.label}
+              idLabel={selected.kind === "agent" ? "agent ref" : "id"}
+            />
           }
           close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
         >

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -236,13 +236,12 @@ describe("Projects copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderProjects("factory");
-        await r.findByText("copy:");
+        const pathBtn = await r.findByRole("button", { name: "Copy repo path (c p)" });
 
-        // Verify utility hint badges
-        const pathBtn = r.getByRole("button", { name: "path" });
-        expect(pathBtn.textContent).toContain("c p");
-        const linkBtn = r.getByRole("button", { name: "link" });
-        expect(linkBtn.textContent).toContain("c l");
+        // Verify icon-action tooltips preserve shortcut discoverability.
+        expect(pathBtn.getAttribute("title")).toBe("Copy repo path · c p");
+        const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies repo name
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -23,6 +23,7 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 import {
   Button,
+  CopyActions,
   DetailPane,
   Dialog,
   FilterInput,
@@ -467,26 +468,7 @@ export function Projects({
               </a>
             ) : null
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.path, "repo path")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                path <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c p</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.path} idLabel="repo path" idChord="c p" />}
           close={<Button onClick={() => onSelectRepo(null)}>Close</Button>}
         >
           <div className="space-y-4">

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -848,13 +848,12 @@ describe("Proposals copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderProposals({ focusProposalId: proposalId });
-        await r.findByText("copy:");
+        const idBtn = await r.findByRole("button", { name: "Copy proposal id (c)" });
 
-        // Verify utility hint badges
-        const idBtn = r.getByRole("button", { name: "id" });
-        expect(idBtn.textContent).toContain("c");
-        const linkBtn = r.getByRole("button", { name: "link" });
-        expect(linkBtn.textContent).toContain("c l");
+        // Verify icon-action tooltips preserve shortcut discoverability.
+        expect(idBtn.getAttribute("title")).toBe("Copy proposal id · c");
+        const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies proposalId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -27,6 +27,7 @@ import {
   Ago,
   BulkActionBar,
   Button,
+  CopyActions,
   Countdown,
   DECISION_HUES,
   Dialog,
@@ -952,26 +953,7 @@ export function Proposals({
               </div>
             ) : null
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.id, "proposal id")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                id <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.id} idLabel="proposal id" />}
           close={<Button onClick={() => onSelectProposal(null)}>Close</Button>}
         >
 

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -103,7 +103,7 @@ describe("RunFull cancel dialog (WM-144)", () => {
 });
 
 describe("RunFull header copy verbs and hints (WM-218)", () => {
-  test("renders trailing keyboard hints on ← Runs, Copy id, Copy CLI, Copy link", async () => {
+  test("renders shortcut tooltips on the back and copy icon actions", async () => {
     const runId = "run_header_hints";
     const detail = createRunDetailFixture({
       run: { runId, state: "RUNNING" } as RunDetail["run"],
@@ -122,15 +122,15 @@ describe("RunFull header copy verbs and hints (WM-218)", () => {
         expect(getByRole("button", { name: /← Runs/ }).textContent).toContain(
           "Esc",
         );
-        expect(getByRole("button", { name: /Copy id/ }).textContent).toContain(
-          "c",
+        expect(getByRole("button", { name: "Copy run id (c)" }).getAttribute("title")).toBe(
+          "Copy run id · c",
         );
-        expect(getByRole("button", { name: /Copy CLI/ }).textContent).toContain(
-          "c i",
+        expect(getByRole("button", { name: "Copy CLI inspect command (c i)" }).getAttribute("title")).toBe(
+          "Copy CLI inspect command · c i",
         );
-        expect(
-          getByRole("button", { name: /Copy link/ }).textContent,
-        ).toContain("c l");
+        expect(getByRole("button", { name: "Copy link (c l)" }).getAttribute("title")).toBe(
+          "Copy link · c l",
+        );
       },
     );
   });
@@ -161,7 +161,7 @@ describe("RunFull header copy verbs and hints (WM-218)", () => {
       },
       async () => {
         const { getByRole } = renderRunFull(runId);
-        await waitFor(() => getByRole("button", { name: /Copy id/ }));
+        await waitFor(() => getByRole("button", { name: "Copy run id (c)" }));
 
         // Single 'c' copies run ID
         document.body.dispatchEvent(

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -6,6 +6,7 @@ import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import {
   Button,
+  CopyActions,
   Dialog,
   JumpLink,
   StateBadge,
@@ -285,40 +286,12 @@ export function RunFull({
                 ))}
             </div>
           )}
-          <Button onClick={() => copyText(runId, "run id")}>
-            <span>Copy id</span>
-            <span
-              aria-hidden="true"
-              className="mono ml-1 text-(--text-faint) text-[10px]"
-            >
-              c
-            </span>
-          </Button>
-          <Button
-            onClick={() =>
-              copyText(
-                `bun event-runtime/cli.mjs inspect ${runId}`,
-                "CLI inspect command",
-              )
-            }
-          >
-            <span>Copy CLI</span>
-            <span
-              aria-hidden="true"
-              className="mono ml-1 text-(--text-faint) text-[10px]"
-            >
-              c i
-            </span>
-          </Button>
-          <Button onClick={copyLink}>
-            <span>Copy link</span>
-            <span
-              aria-hidden="true"
-              className="mono ml-1 text-(--text-faint) text-[10px]"
-            >
-              c l
-            </span>
-          </Button>
+          <CopyActions
+            id={runId}
+            idLabel="run id"
+            cli={`bun event-runtime/cli.mjs inspect ${runId}`}
+            cliLabel="CLI inspect command"
+          />
         </div>
       </header>
 

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -599,15 +599,14 @@ describe("Runs copy chords and hints (WM-233)", () => {
       },
       async () => {
         const r = renderRuns({ focusRunId: runId });
-        await r.findByText("copy:");
+        const idBtn = await r.findByRole("button", { name: "Copy run id (c)" });
 
-        // Verify utility hint badges
-        const idBtn = r.getByRole("button", { name: "id" });
-        expect(idBtn.textContent).toContain("c");
-        const cliBtn = r.getByRole("button", { name: "CLI" });
-        expect(cliBtn.textContent).toContain("c i");
-        const linkBtn = r.getByRole("button", { name: "link" });
-        expect(linkBtn.textContent).toContain("c l");
+        // Verify icon-action tooltips preserve shortcut discoverability.
+        expect(idBtn.getAttribute("title")).toBe("Copy run id · c");
+        const cliBtn = r.getByRole("button", { name: "Copy CLI inspect command (c i)" });
+        expect(cliBtn.getAttribute("title")).toBe("Copy CLI inspect command · c i");
+        const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies runId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -37,6 +37,7 @@ import type { RunListItem, RunState } from "../types";
 import {
   Ago,
   Button,
+  CopyActions,
   Dialog,
   FilterInput,
   ListPane,
@@ -874,28 +875,12 @@ export function Runs({
             </>
           }
           utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.runId, "run id")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                id <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={() => copyText(`bun event-runtime/cli.mjs inspect ${sel.runId}`, "CLI inspect command")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                CLI <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c i</span>
-              </button>
-              <span>·</span>
-              <button type="button" onClick={copyLink} className="cursor-pointer hover:text-(--text)">
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
+            <CopyActions
+              id={sel.runId}
+              idLabel="run id"
+              cli={`bun event-runtime/cli.mjs inspect ${sel.runId}`}
+              cliLabel="CLI inspect command"
+            />
           }
           close={<Button onClick={() => onSelectRun(null)}>Close</Button>}
         >

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -333,13 +333,12 @@ describe("Schedules copy chords and hints (WM-233)", () => {
       focusScheduleLoop: "loop-enabled-running",
     });
 
-    await r.findByText("copy:");
+    const loopBtn = await r.findByRole("button", { name: "Copy schedule loop (c)" });
 
-    // Verify utility hint badges
-    const loopBtn = r.getByRole("button", { name: "loop" });
-    expect(loopBtn.textContent).toContain("c");
-    const linkBtn = r.getByRole("button", { name: "link" });
-    expect(linkBtn.textContent).toContain("c l");
+    // Verify icon-action tooltips preserve shortcut discoverability.
+    expect(loopBtn.getAttribute("title")).toBe("Copy schedule loop · c");
+    const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+    expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
     // 1. Press 'c' -> copies loop
     fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -15,6 +15,7 @@ import { ScopeCaption } from "../components/ContextTabs";
 import {
   Ago,
   Button,
+  CopyActions,
   Countdown,
   DetailPane,
   Dialog,
@@ -465,26 +466,7 @@ export function Schedules({
               Run now… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">r</span>
             </Button>
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.loop, "schedule loop")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                loop <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.loop} idLabel="schedule loop" />}
           close={<Button onClick={() => onSelectSchedule(null)}>Close</Button>}
         >
           <div className="space-y-6">

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -266,13 +266,12 @@ describe("Workers copy chords and hints (WM-233)", () => {
       const r = renderWithClient(
         <Workers context={{ kind: "all" }} focusWorkerId="worker-copy-test" onSelectWorker={noop} />,
       );
-      await r.findByText("copy:");
+      const idBtn = await r.findByRole("button", { name: "Copy worker id (c)" });
 
-      // Verify utility hint badges
-      const idBtn = r.getByRole("button", { name: "id" });
-      expect(idBtn.textContent).toContain("c");
-      const linkBtn = r.getByRole("button", { name: "link" });
-      expect(linkBtn.textContent).toContain("c l");
+      // Verify icon-action tooltips preserve shortcut discoverability.
+      expect(idBtn.getAttribute("title")).toBe("Copy worker id · c");
+      const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
+      expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies workerId
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -30,6 +30,7 @@ import { ScopeCaption } from "../components/ContextTabs";
 import {
   Ago,
   Button,
+  CopyActions,
   DetailPane,
   FilterInput,
   JsonBlock,
@@ -797,26 +798,7 @@ export function Workers({
               </Button>
             ) : undefined
           }
-          utility={
-            <>
-              <span>copy:</span>
-              <button
-                type="button"
-                onClick={() => copyText(sel.workerId, "worker id")}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                id <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c</span>
-              </button>
-              <span>·</span>
-              <button
-                type="button"
-                onClick={copyLink}
-                className="cursor-pointer hover:text-(--text)"
-              >
-                link <span aria-hidden="true" className="mono ml-0.5 text-(--text-faint) text-[10px]">c l</span>
-              </button>
-            </>
-          }
+          utility={<CopyActions id={sel.workerId} idLabel="worker id" />}
           close={<Button onClick={() => onSelectWorker(null)}>Close</Button>}
         >
           {selHeartbeat.kind === "stale" && (


### PR DESCRIPTION
## Summary
- extract a shared `CopyActions` component with 14×14 hash, terminal, and link icons
- replace all nine duplicated detail-view copy strips while preserving labels, copy values, toasts, and shortcut chords
- add accessible names, native shortcut tooltips, visible focus rings, optional CLI rendering, and focused component/view coverage

## Verification
- `bun test event-runtime/web` — 582 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass

## UX critique
- required — NOT-ASSESSED: the UX critic had no browser/simulator driving tools; the worktree UI/API readiness checks passed and automated accessibility/interaction coverage is green

Fixes WM-302