### PR TITLE
fix(triage): route write-detail through Linear CLI (WM-343)

### DIFF
--- a/event-runtime/agents/triage-apply.json
+++ b/event-runtime/agents/triage-apply.json
@@ -31,8 +31,8 @@
     "write-detail": {
       "argv": [
         "bun",
-        "-e",
-        "import { gql } from './orchestrator/reaper.mjs'; const [identifier, rawDetail] = process.argv.slice(1); if (!identifier || !rawDetail) throw new Error('write-detail requires issueId and detail'); const found = await gql('query($id:String!){ issue(id:$id){ id description } }', { id: identifier }); const issue = found?.issue; if (!issue) throw new Error(`issue not found: ${identifier}`); const detail = rawDetail.trim(); const current = issue.description ?? ''; if (current.includes(detail)) { console.log(`${identifier} detail already present`); process.exit(0); } const separator = current.length === 0 || current.endsWith('\\n\\n') ? '' : current.endsWith('\\n') ? '\\n' : '\\n\\n'; const description = `${current}${separator}${detail}\\n`; const updated = await gql('mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }', { id: issue.id, in: { description } }); if (!updated?.issueUpdate?.success) throw new Error(`failed to append detail to ${identifier}`); console.log(`${identifier} detail appended`);",
+        "{factoryRoot}/tools/linear.mjs",
+        "detail",
         "{issueId}",
         "{detail}"
       ]
@@ -71,7 +71,9 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["linear:write"]
+    "services": [
+      "linear:write"
+    ]
   },
   "limits": {
     "timeout_seconds": 600,
@@ -79,7 +81,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/triage-apply.md": "sha256:e4d6bcb46316cd1d606d902b80a3ee77c43348b477b784c96a4d9fd9d250770b",
+    "agents/triage-apply.md": "sha256:88872839dbb90b8803b1ba0a64bd5bfdf83033c0f17311ffa2400ad2bae14639",
     "schemas/triage-apply.input.json": "sha256:012ae75d96534db28ea8c7c8856d247ee3fbe2e2bbec83bbf90e4e664d2011e1",
     "schemas/triage-applied.output.json": "sha256:5e4d4a2e59423a2aab88357521ff1e37889d50d658bee7278d599400f5dc3365"
   }

--- a/event-runtime/agents/triage-apply.md
+++ b/event-runtime/agents/triage-apply.md
@@ -10,14 +10,15 @@ Registered actions — each resolves to one fixed, non-shell-interpolated argv:
 | :------------------ | :------------------------------------------------------------------------------------------------------------------------------- |
 | `label-agent-ready` | `state {issueId} "Todo" --add ai:agent-ready` — the full make-dispatchable transition (the protocol's `Todo` + `ai:agent-ready`) |
 | `move-to-todo`      | `state {issueId} "Todo"`                                                                                                         |
-| `write-detail`      | read the current description, then append the approved missing sections from `detail`; no state or label change                  |
+| `write-detail`      | `detail {issueId} "<detail>"` — idempotently append approved missing sections; no state or label change                          |
 | `needs-detail`      | `comment {issueId} "<reason>"` — tells the human exactly what is missing                                                         |
 | `mark-duplicate`    | `comment {issueId} "<reason>"` — names the covering issue; the relation stays a human call                                       |
 | `needs-human`       | `comment {issueId} "<reason>"`                                                                                                   |
 
-`write-detail` is intentionally separate from `label-agent-ready`. It
-preserves the description read immediately before the mutation and appends
-only the approved Markdown suffix. A later triage scan must make and justify
+`write-detail` is intentionally separate from `label-agent-ready`. It calls
+`tools/linear.mjs detail`, which preserves the description read immediately
+before the mutation and appends only the approved Markdown suffix. A later
+triage scan must make and justify
 the promotion decision independently; writing detail never changes state or
 labels.
 

--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -106,6 +106,11 @@ export function probeBytes(raw) {
 
 /** Substitute {field} placeholders across an argv template (item-list mode). */
 export function substituteArgv(argv, context) {
+  for (const element of argv) {
+    if (/\$\{[A-Za-z0-9_]+\}/.test(element)) {
+      throw new Error('argv template element contains "${", which collides with argv placeholder syntax');
+    }
+  }
   return argv.map((element) =>
     element.replace(/\{([A-Za-z0-9_]+)\}/g, (_, field) => {
       const value = context?.[field];

--- a/event-runtime/lib/adapters/actions.test.mjs
+++ b/event-runtime/lib/adapters/actions.test.mjs
@@ -10,8 +10,20 @@ import {
 import { mkdtempSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { appendIssueDetail } from "../../../tools/linear.mjs";
 
 const tmp = (p) => mkdtempSync(path.join(os.tmpdir(), p));
+
+describe("appendIssueDetail (WM-343)", () => {
+  test("appends the same detail only once", () => {
+    const first = appendIssueDetail("Existing description", "## Verification\n\nRun the exact command.");
+    const second = appendIssueDetail(first.description, "## Verification\n\nRun the exact command.");
+
+    expect(first.appended).toBe(true);
+    expect(second).toEqual({ description: first.description, appended: false });
+    expect(first.description.match(/## Verification/g)).toHaveLength(1);
+  });
+});
 
 describe("buildArgv (OPS-410)", () => {
   test("replaces {target} and {remote} in exec template", () => {
@@ -137,6 +149,12 @@ describe("substituteArgv", () => {
 
   test("throws on missing or non-primitive fields", () => {
     expect(() => substituteArgv(["echo", "{missing}"], {})).toThrow(/missing\/non-primitive/);
+  });
+
+  test("rejects JavaScript template interpolation that collides with argv placeholders", () => {
+    expect(() => substituteArgv(["bun", "-e", "console.log(`${identifier}`)"], {})).toThrow(
+      /contains "\$\{".*collides with argv placeholder syntax/,
+    );
   });
 });
 

--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -6,6 +6,7 @@
  *   bun tools/linear.mjs comments CLNT-616
  *   bun tools/linear.mjs claim CLNT-616 --agent claude
  *   bun tools/linear.mjs comment CLNT-616 "verified: 42 tests pass"
+ *   bun tools/linear.mjs detail CLNT-616 "## Acceptance criteria\n- [ ] ..."
  *   bun tools/linear.mjs labels CLNT-616 --add ai:needs-review --remove ai:in-progress
  *   bun tools/linear.mjs state CLNT-616 "In Review" --add ai:needs-review
  *   bun tools/linear.mjs file --team CLNT --title "..." --body "..." --type bug
@@ -164,6 +165,18 @@ export function formatComments(nodesOrIssue) {
   return nodes.map(formatComment).join("\n\n---\n\n");
 }
 
+/** Build an idempotent description update for the `detail` verb. */
+export function appendIssueDetail(currentDescription, rawDetail) {
+  const detail = String(rawDetail ?? "").trim();
+  if (!detail) throw new Error("detail must not be empty");
+
+  const current = currentDescription ?? "";
+  if (current.includes(detail)) return { description: current, appended: false };
+
+  const separator = current.length === 0 || current.endsWith("\n\n") ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+  return { description: `${current}${separator}${detail}\n`, appended: true };
+}
+
 // --------------------------------------------------------------- helpers ---
 const ISSUE_FIELDS = `id identifier title url description
   state{ id name type } assignee{ id name }
@@ -299,6 +312,22 @@ const VERBS = {
     await gql(`mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
       { in: { issueId: issue.id, body: stampRun(body) } });
     out({ ok: true, identifier: key }, `commented on ${key}`);
+  },
+
+  async detail() {
+    const key = positional[0];
+    const rawDetail = positional[1];
+    if (!key || !rawDetail) throw new Error(`usage: detail <ISSUE-ID> "<markdown>"`);
+    const issue = await issueByKey(key);
+    const { description, appended } = appendIssueDetail(issue.description, rawDetail);
+    if (!appended) {
+      out({ ok: true, identifier: key, appended: false }, `${key} detail already present`);
+      return;
+    }
+    const updated = await gql(`mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
+      { id: issue.id, in: { description } });
+    if (!updated?.issueUpdate?.success) throw new Error(`failed to append detail to ${key}`);
+    out({ ok: true, identifier: key, appended: true }, `${key} detail appended`);
   },
 
   async labels() {


### PR DESCRIPTION
## Summary
- add an idempotent `detail` verb to the factory Linear CLI
- route `write-detail` through the standard closed CLI action instead of an inline script
- reject JavaScript-style `${field}` interpolation collisions and add regression coverage
- update the triage-apply documentation pin

## Verification
- `bun test event-runtime/lib/adapters/actions.test.mjs && bun test && bun build/emit.mjs --check && bun run format:check`
- live `triage-apply@1` write-detail execution appended once and no-op’d on repeat

UX critique: skipped — internal deterministic adapter/CLI path; no user-completable UI flow

Fixes WM-343