### PR TITLE
fix(dispatch): a skipped UX critique reports verdict null (WM-346)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -34,7 +34,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/dispatch.md": "sha256:09fa0ce60dfe63c1a61f4d1cade28e347f22d24d4fc47a8e093e867e5c46ba93",
+    "agents/dispatch.md": "sha256:e3b7eebfe0b9741ea5ee8df7233e75a613463028ef08652d041934965b438ae4",
     "schemas/dispatch.input.json": "sha256:66898f48608fff53f07f2b59e9df9d41c15aae69615c2383c22d3978ca9807b2",
     "schemas/dispatch.output.json": "sha256:29b6677a5f13bb6ca38ba09c314290142987d1de32ecc7699e2e5460bcc8cbb8"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -43,7 +43,15 @@ steal a claim, never queue behind the holder.
    state transition, error/recovery path, responsive layout, authentication,
    payment, onboarding, or destructive action. It is skipped for isolated
    styling, copy-only/static content, icons/assets, and internal/admin-only
-   surfaces unless the ticket identifies UX risk.
+   surfaces unless the ticket identifies UX risk. A backend, infrastructure,
+   schema, or docs ticket has no user-facing surface and is skipped.
+
+   **A skipped critique reports `"status": "skipped"` with `"verdict": null`.**
+   There is no "not required" verdict and inventing one fails the output
+   contract, which discards the whole run after the work is already done — the
+   verdict enum is exactly `SHIP`, `FIX-FIRST`, `NOT-ASSESSED`, `BLOCKED`, or
+   `null`. `status` carries whether the gate applied; `verdict` carries what the
+   critic concluded, and a critic that never ran concluded nothing.
 
    Spawn the `factory-ux-critic` subagent after verification and before opening
    the PR. Its prompt must spell out `worktree: <absolute path>` plus the exact
@@ -135,6 +143,25 @@ report `outcome: "FAILED"`.
       "verdict": "SHIP",
       "evidence": ["http://127.0.0.1:7497/runs"],
       "rounds": 1,
+      "prReady": true
+    }
+  },
+  "evidence": { "commands": ["the commands this rests on"] }
+}
+```
+
+A ticket with no user-facing surface — backend, infra, schema, docs — reports
+the gate as skipped instead. This is the common case, so it gets its own
+example rather than being left to inference:
+
+```json
+{
+  "artifact": {
+    "uxCritique": {
+      "status": "skipped",
+      "verdict": null,
+      "evidence": [],
+      "rounds": 0,
       "prReady": true
     }
   },


### PR DESCRIPTION
Fixes WM-346

Since WM-335 made `uxCritique` required, **every backend, infra, schema or docs dispatch fails after doing its work**:

```
contract_violation: $.uxCritique.verdict: value not in enum
                    ["SHIP","FIX-FIRST","NOT-ASSESSED","BLOCKED",null]
```

The agent emitted `{"status": "skipped", "verdict": "NOT-REQUIRED", ...}`. It got `status` right and invented the verdict — because the brief never said what a skipped critique carries, and its only JSON example showed `"verdict": "SHIP"`. Given a required field, no stated value for its case, and an example of the opposite case, that is a reasonable guess.

## Why the brief and not the schema

The schema is coherent: `status` says whether the gate applied, `verdict` says what the critic concluded, and a critic that never ran concluded `null`. Adding a `NOT-REQUIRED` verdict would duplicate what `status: skipped` already expresses. So the fix is to stop making the agent infer it.

- names the verdict enum inline
- states the skipped rule explicitly, and that inventing a verdict fails the contract
- adds a **skipped** JSON example — the common case — instead of only a `SHIP` one
- says backend/infra/schema/docs tickets have no user-facing surface

## Why this mattered more than one failed run

The contract is validated *after* execution, so a wrong guess discards a run that already implemented and verified its ticket. It hit WM-344 and would hit every backend ticket in the queue — that is why the pool went idle with work available.

`agents/dispatch.json` re-pinned in the same commit (the definition hash covers the prompt).

## Verification

`bun test event-runtime/lib/registry.test.mjs` — 14 pass. `bun run format:check` clean.