### PR TITLE
fix(triage-scan): verify empty Linear reads

### DIFF
--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -13,7 +13,10 @@
   },
   "capabilities": {
     "filesystem": "workspace-only",
-    "services": ["linear:read", "repo:read"]
+    "services": [
+      "linear:read",
+      "repo:read"
+    ]
   },
   "limits": {
     "timeout_seconds": 900,
@@ -21,8 +24,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:4331934a385d2fb711f6ab8572f9d7a0938e7bf82f3be776a39c60801bb54f4d",
+    "agents/triage-scan.md": "sha256:8ab7c631223dcb48fd19425128dba4cccc454a3d81775d6e5d747c14fd2b33e0",
     "schemas/triage-scan.input.json": "sha256:893c6ada3445fdcf2c5507319fe4933618ca6104298493b6339677ab2e295614",
-    "schemas/triage-scan.output.json": "sha256:ceba80c94dcb5aa64201c63e0d0c322bcf9e57072349c07b898a24a19f7e1d77"
+    "schemas/triage-scan.output.json": "sha256:f262c7f418028b437829e8b5bd3343cdcd6ef8125f72dfc5f801aa492f850a7e"
   }
 }

--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -24,7 +24,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:8ab7c631223dcb48fd19425128dba4cccc454a3d81775d6e5d747c14fd2b33e0",
+    "agents/triage-scan.md": "sha256:2e8dbc7f99d7832f9bcf699b849797674a64590371c8ef829b71ccfb3fd828e3",
     "schemas/triage-scan.input.json": "sha256:893c6ada3445fdcf2c5507319fe4933618ca6104298493b6339677ab2e295614",
     "schemas/triage-scan.output.json": "sha256:f262c7f418028b437829e8b5bd3343cdcd6ef8125f72dfc5f801aa492f850a7e"
   }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -154,7 +154,10 @@ than emitting a best-effort malformed item.
 }
 ````
 
-Queue already clean, or nothing you can judge confidently → `recommendation:
-"NOOP"` with an empty `plan` and a summary saying so. That is a good outcome,
-not a failure. If Linear is unreachable, refuse:
+Use `recommendation: "NOOP"` with an empty `plan` **only** for a confirmed
+zero backlog that passed all three reads in "Empty reads must be confirmed."
+A non-empty read always uses `recommendation: "TRIAGE"` and contains exactly
+one valid item per issue. Lack of confidence is not a reason to omit an issue:
+encode it as `needs-detail` or `needs-human` with the missing fact or decision
+in `reason`. If Linear is unreachable, refuse:
 `{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -24,12 +24,46 @@ You never modify it, never run its build, never install anything. Write
 
 ## Method
 
-1. List the repo's open issues in `Triage` and `Todo`:
-   `factory linear issues --repo <name>` (or `bun "$FACTORY_ROOT/tools/linear.mjs"`).
-2. For each, judge whether an agent could pick it up **unambiguously**, using
-   `./repo` to check the claims: do the named files exist, is the described
-   behaviour actually still there, has it already been fixed on this SHA?
-3. Propose exactly one action per issue you touch — leave the rest alone.
+1. Resolve the repo's Linear team and project from
+   `$FACTORY_ROOT/config/repos.yaml`, then list **all** of that project's open
+   issues in `Triage` and `Todo` with paginated `factory linear raw` queries (or
+   `bun "$FACTORY_ROOT/tools/linear.mjs" raw`). Hard-code the state list as
+   `in:["Triage","Todo"]` in the GraphQL document: `linear.mjs raw` passes every
+   `--var` value as a string, so passing a JSON-looking array through `--var`
+   silently searches for one state with that literal name and can return a
+   false zero. The response is usable only when it contains an `issues.nodes`
+   array and complete `pageInfo`; follow `hasNextPage` until false, and fail
+   closed on a missing cursor, malformed response, non-zero command, or
+   interrupted pagination.
+2. Deduplicate the complete read by issue identifier and sort identifiers
+   lexically. Do not sample, truncate, or make a discretionary subset. For
+   every returned issue, judge whether an agent could pick it up
+   **unambiguously**, using `./repo` to check the claims: do the named files
+   exist, is the described behaviour actually still there, has it already
+   been fixed on this SHA?
+3. Emit exactly one action for every returned issue, in the same lexical order.
+   Set `evidence.issuesSeen` to that unique issue count and require
+   `artifact.plan.length` to equal it. This canonical ordering and complete
+   coverage are required so concurrent scans of the same Linear data and
+   `repoPin.sha` produce the same plan.
+
+### Empty reads must be confirmed
+
+Zero nodes from the first complete read is not evidence of an empty backlog.
+Immediately make structurally independent, uncached identifier-only queries:
+one filtered to `state.name = "Triage"` and one filtered to
+`state.name = "Todo"`, paginating each to completion. A second execution of the
+same combined query is not independent confirmation because it repeats the same
+filter or variable-encoding defect. Scalar `--var state=Triage` and
+`--var state=Todo` values are safe; JSON arrays in `--var` are not. Record the
+initial read and both confirmation reads in `evidence.commands`.
+
+Report `NOOP` for an empty backlog only when all three reads are successful,
+well-formed, complete, and both state-specific confirmations contain zero unique
+identifiers. If either confirmation fails, is malformed, or returns any issue,
+write only the refused result shown below with `reasonCode: "needs_human"`;
+never summarize the first read as "nothing to do" and never guess which read
+was right.
 
 ## Actions — the closed set
 
@@ -54,10 +88,13 @@ same issue in one scan.
 
 For a `write-detail` item:
 
-- Set `detail` to ready-to-append Markdown containing only missing `##
+- Set `detail` to ready-to-append Markdown containing one or more missing `##
 Acceptance criteria`, `## Owned Paths`, or `## Verification` sections.
-  Preserve everything already written; do not restate or revise an existing
-  section.
+  Combine all repository-derivable missing sections for that issue into this
+  one item, in the canonical order shown above. A common item therefore contains
+  both Owned Paths and Verification. Preserve everything already written; do
+  not restate or revise an existing section, put prose before the first
+  heading, or use any other level-two heading.
 - When authoring Owned Paths, set `ownedPaths` to the same paths used in
   `detail`. Every entry must name a concrete regular file that exists in
   `./repo` at `repoPin.sha`. Reject globs (`*`, `?`, bracket/brace patterns),
@@ -79,6 +116,17 @@ Acceptance criteria`, `## Owned Paths`, or `## Verification` sections.
 The schema rejects globbed entries in `ownedPaths`, but schema validation is
 only the last guard: you must still prove each entry is an existing regular
 file and each verification target exists.
+
+### Validate the complete plan before writing it
+
+The runtime validates the plan as one artifact: **one malformed item rejects the
+entire result and discards every valid item with it.** Before writing
+`result.json`, check every item against the closed action set and its field
+rules, check that multi-section `detail` values use only the three exact
+headings above, check lexical ordering and unique identifiers, and check
+`plan.length === evidence.issuesSeen`. If a proposed action cannot be encoded
+validly, replace it with a valid `needs-detail` or `needs-human` decision rather
+than emitting a best-effort malformed item.
 
 ## Output
 

--- a/event-runtime/schemas/triage-scan.output.json
+++ b/event-runtime/schemas/triage-scan.output.json
@@ -28,8 +28,8 @@
           "detail": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^## (Acceptance criteria|Owned Paths|Verification)",
-            "description": "For write-detail only: additive Markdown containing only missing template sections"
+            "pattern": "^\\s*## (Acceptance criteria|Owned Paths|Verification)",
+            "description": "For write-detail only: additive Markdown containing one or more missing template sections; multiple allowed headings may appear in one detail"
           },
           "ownedPaths": {
             "type": "array",


### PR DESCRIPTION
## Summary
- fail closed on malformed or incomplete paginated Linear reads
- confirm a zero result with independent per-state queries and document raw variable encoding
- canonicalize complete scan coverage and validate every plan item before output
- allow multi-section write-detail Markdown and re-pin the agent definition

## Verification
- `bun test && bun build/emit.mjs --check && bun run format:check`
- 1,727 tests pass; generated files and Prettier are clean
- two concurrent live Factory scans both validated and covered the same 60 issues in lexical order (56 Triage + 4 Todo)

UX critique: skipped — internal read-only agent prompt/schema; no user-facing flow

Fixes WM-344