### PR TITLE
fix(WM-334): keep red baseline from blocking worktree up

### DIFF
--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -98,6 +98,27 @@ RUN_DIR="$(run_dir "$WT")"
 HOME_DIR="$(event_home "$WT")"
 mkdir -p "$RUN_DIR"
 
+# `worktree_up` has two failure classes (WM-334). Provisioning failures still
+# exit non-zero. A project check that is already red is reported to the runtime
+# through this per-invocation file and bring-up continues with a usable tree.
+# The runtime supplies a workspace-confined path; --here callers get a local
+# fallback so the same behavior is visible when provisioning manually.
+BASELINE_REPORT="${FACTORY_WORKTREE_REPORT:-$RUN_DIR/baseline.json}"
+rm -f "$BASELINE_REPORT"
+record_red_baseline() {
+  local check="$1"
+  local command="$2"
+  local exit_code="$3"
+  local output_file="$4"
+  bun -e '
+    import { readFileSync, writeFileSync } from "node:fs";
+    const [report, check, command, exitCode, outputFile] = process.argv.slice(1);
+    const raw = readFileSync(outputFile, "utf8");
+    const output = raw.length > 65536 ? raw.slice(-65536) : raw;
+    writeFileSync(report, JSON.stringify({ status: "red", check, command, exitCode: Number(exitCode), output }, null, 2) + "\n");
+  ' -- "$BASELINE_REPORT" "$check" "$command" "$exit_code" "$output_file"
+}
+
 # Resolve API/web ports only after the checkout exists so we can persist them
 # under .factory/run/ports and refuse a stranger already bound on the slot.
 if [[ "$HERE" -eq 1 ]]; then
@@ -164,8 +185,16 @@ if [[ -f "$WEB_DIR/dist/index.html" && "$(cat "$WEB_DIR/dist/.buildstamp" 2>/dev
   info "web bundle up to date — skipping build"
 else
   info "building the web bundle"
-  (cd "$WEB_DIR" && bun run build:fast >/dev/null) || die "web build failed — run it manually: cd $WEB_DIR && bun run build"
-  printf '%s\n' "$WEB_HASH" >"$WEB_DIR/dist/.buildstamp"
+  WEB_BUILD_OUTPUT="$RUN_DIR/baseline-web-build.log"
+  if (cd "$WEB_DIR" && bun run build:fast >"$WEB_BUILD_OUTPUT" 2>&1); then
+    printf '%s\n' "$WEB_HASH" >"$WEB_DIR/dist/.buildstamp"
+    rm -f "$WEB_BUILD_OUTPUT"
+  else
+    build_status=$?
+    cat "$WEB_BUILD_OUTPUT" >&2
+    warn "baseline is red: web_build failed (exit $build_status) — continuing with the usable worktree"
+    record_red_baseline "web_build" "cd event-runtime/web && bun run build:fast" "$build_status" "$WEB_BUILD_OUTPUT"
+  fi
 fi
 
 # ---------------------------------------------------------------- daemons ---

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -42,27 +42,40 @@ export class ContractViolation extends Error {
   }
 }
 
-function failureSignatureLines(output) {
+function normalizeFailureOutput(output) {
   return String(output ?? "")
     .replace(/\x1b\[[0-9;]*m/g, "")
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.length >= 8)
+    .filter((line) => line.length > 0)
     // Runners repeat these for unrelated failures; they are not evidence that
     // the same underlying check remains red.
     .filter((line) => !/^(\$ |bun test|error: script |error: ".*" exited|exited with code)/i.test(line));
 }
 
-/** Conservative evidence that post-agent verification hit the recorded red baseline. */
-function matchesRedBaseline(baseline, verifyOutput) {
-  if (baseline?.status !== "red") return false;
-  const finalLines = new Set(failureSignatureLines(verifyOutput));
-  if (finalLines.size === 0) return false;
-  return failureSignatureLines(baseline.output)
-    .slice(-20)
-    .some((line) => finalLines.has(line));
+/**
+ * Deterministic normalized signature of a failure payload.
+ * Exact equality is intentionally strict: any new signal (even a single
+ * additional line) proves the failure signature changed.
+ */
+function failureSignature(output) {
+  return normalizeFailureOutput(output).join("\n");
 }
 
+/**
+ * Conservative evidence that post-agent verification hit the recorded red baseline.
+ * Unlike partial line overlap, this compares full normalized signatures and fails
+ * closed on ambiguous signal drift.
+ */
+function matchesRedBaseline(baseline, verifyOutput) {
+  if (baseline?.status !== "red") return false;
+  const baselineSig = failureSignature(baseline.output);
+  const verifySig = failureSignature(verifyOutput);
+  if (!baselineSig || !verifySig) return false;
+  return baselineSig === verifySig;
+}
+
+export { normalizeFailureOutput, failureSignature };
 /**
  * Verify one attempt's workspace output against the agent-result contract and
  * the agent definition's output schema.

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -34,11 +34,33 @@ export const REFUSAL_REASONS = [
 ];
 
 export class ContractViolation extends Error {
-  constructor(violations) {
+  constructor(violations, { reasonCode = "contract_violation" } = {}) {
     super(`contract violation: ${violations.join("; ")}`);
     this.name = "ContractViolation";
     this.violations = violations;
+    this.reasonCode = reasonCode;
   }
+}
+
+function failureSignatureLines(output) {
+  return String(output ?? "")
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length >= 8)
+    // Runners repeat these for unrelated failures; they are not evidence that
+    // the same underlying check remains red.
+    .filter((line) => !/^(\$ |bun test|error: script |error: ".*" exited|exited with code)/i.test(line));
+}
+
+/** Conservative evidence that post-agent verification hit the recorded red baseline. */
+function matchesRedBaseline(baseline, verifyOutput) {
+  if (baseline?.status !== "red") return false;
+  const finalLines = new Set(failureSignatureLines(verifyOutput));
+  if (finalLines.size === 0) return false;
+  return failureSignatureLines(baseline.output)
+    .slice(-20)
+    .some((line) => finalLines.has(line));
 }
 
 /**
@@ -49,7 +71,7 @@ export class ContractViolation extends Error {
  *         | { kind: "completed", result: object, receipt: object }}
  * @throws {ContractViolation} on any contract failure — fail closed.
  */
-export function verifyResult({ spec, def, registry, workspaceDir, attempt, journalHead = null, extraArtifacts = [] }) {
+export function verifyResult({ spec, def, registry, workspaceDir, attempt, journalHead = null, extraArtifacts = [], worktreeRecord = null }) {
   let raw;
   try {
     raw = readFileSync(path.join(workspaceDir, "result.json"), "utf8");
@@ -68,7 +90,7 @@ export function verifyResult({ spec, def, registry, workspaceDir, attempt, journ
   if (!shape.valid) throw new ContractViolation(shape.errors);
 
   if (candidate.terminalState === "refused") return verifyRefused({ spec, def, candidate, attempt });
-  return verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts });
+  return verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts, worktreeRecord });
 }
 
 /**
@@ -178,7 +200,7 @@ const SEMANTIC_CHECKS = {
   },
 };
 
-function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts = [] }) {
+function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts = [], worktreeRecord = null }) {
   if (candidate.artifact === undefined) throw new ContractViolation(["missing_artifact"]);
 
   const artifactCheck = validate(def.outputSchema, candidate.artifact);
@@ -192,8 +214,7 @@ function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalH
 
   // Execute repo's declared verify command for tier-2 mutating runs (docs/event-runtime-dispatch.md §5, §9, WM-115)
   const markerPath = path.join(workspaceDir, ".worktree.json");
-  let worktreeRecord = null;
-  if (existsSync(markerPath)) {
+  if (!worktreeRecord && existsSync(markerPath)) {
     try {
       worktreeRecord = JSON.parse(readFileSync(markerPath, "utf8"));
     } catch {}
@@ -206,8 +227,13 @@ function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalH
       : path.join(workspaceDir, "repo");
     const vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], { cwd: worktreePath, encoding: "utf8" });
     if (vres.status !== 0) {
-      const why = (vres.stderr || vres.stdout || "").trim().split("\n").pop() || `exit ${vres.status}`;
-      throw new ContractViolation([`repo_verify_failed: ${why}`]);
+      const output = [vres.stdout, vres.stderr].filter(Boolean).join("\n").trim();
+      const why = output.split("\n").filter(Boolean).pop() || `exit ${vres.status}`;
+      const baselineStillRed = matchesRedBaseline(worktreeRecord.baseline, output);
+      throw new ContractViolation(
+        [`repo_verify_failed: ${why}`],
+        { reasonCode: baselineStillRed ? "baseline_red" : "contract_violation" },
+      );
     }
     repoVerifyPassed = true;
   }

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -218,6 +218,78 @@ describe("verifyResult", () => {
   });
 });
 
+describe("worktree baseline verification (WM-334)", () => {
+  const dispatchResult = {
+    schemaVersion: "factory.agent-result/v1",
+    terminalState: "completed",
+    reasonCode: "ok",
+    artifact: {
+      outcome: "PR_OPEN",
+      repo: "factory",
+      ticket: "WM-334",
+      prUrl: "https://github.com/watt-mind/factory/pull/334",
+      verification: { command: "bun test", passed: true, output: "agent verification passed" },
+      summary: "implemented WM-334",
+    },
+  };
+  const dispatchSpec = {
+    ...makeSpec({ repo: "factory", ticket: "WM-334" }),
+    agent: "dispatch@1",
+    outputContract: "factory.dispatch-result/v1",
+  };
+
+  function worktreeWorkspace(verify, baseline) {
+    const dir = makeWorkspace(dispatchResult);
+    const repo = path.join(dir, "repo");
+    mkdirSync(repo);
+    writeFileSync(path.join(dir, ".worktree.json"), JSON.stringify({ path: repo, verify, baseline }), "utf8");
+    return dir;
+  }
+
+  test("a matching pre-existing failure is rejected with the distinct baseline_red reason", () => {
+    const dir = worktreeWorkspace(
+      "printf 'entry chunk exceeds budget\\n' >&2; exit 9",
+      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+    );
+    try {
+      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("baseline_red");
+      expect(err.violations[0]).toContain("repo_verify_failed");
+    }
+  });
+
+  test("an unrelated post-agent failure remains an ordinary contract violation", () => {
+    const dir = worktreeWorkspace(
+      "printf 'new test regression\\nerror: script \"build\" exited with code 1\\n' >&2; exit 9",
+      {
+        status: "red",
+        check: "web_build",
+        output: "entry chunk exceeds budget\nerror: script \"build\" exited with code 1",
+      },
+    );
+    try {
+      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("contract_violation");
+    }
+  });
+
+  test("a recorded red baseline never weakens a now-green post-agent verification", () => {
+    const dir = worktreeWorkspace(
+      "printf 'verification repaired\\n'",
+      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+    );
+    const out = verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+    expect(out.kind).toBe("completed");
+    expect(out.result.verification.checks).toContain("repo_verify_passed");
+  });
+});
+
 describe("evidence retention (OPS-206)", () => {
   const completedWith = (evidence) => ({
     schemaVersion: "factory.agent-result/v1",

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -261,6 +261,20 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
+  test("shared baseline output plus a new failure does not classify as baseline_red", () => {
+    const dir = worktreeWorkspace(
+      "printf 'entry chunk exceeds budget\\nnew failure in CI\\n' >&2; exit 9",
+      { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+    );
+    try {
+      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("contract_violation");
+    }
+  });
+
   test("an unrelated post-agent failure remains an ordinary contract violation", () => {
     const dir = worktreeWorkspace(
       "printf 'new test regression\\nerror: script \"build\" exited with code 1\\n' >&2; exit 9",

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -373,6 +373,70 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
   }
 }
 
+const BASELINE_COMMENT_MARKER = "wm:baseline:red:";
+
+function baselineFailureSignature({ why, log = null, baseline = null }) {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      why,
+      log,
+      baseline: baseline && typeof baseline === "object"
+        ? { check: baseline.check, exitCode: baseline.exitCode, output: baseline.output }
+        : null,
+    }))
+    .digest("hex");
+}
+
+function hasRecordedBaselineFailureComment(ticket, signature) {
+  const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
+  try {
+    const out = execFileSync("bun", [linearCli(), "comments", ticket, "--json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const comments = JSON.parse(out);
+    return (comments ?? []).some((row) => String(row.body ?? "").includes(marker));
+  } catch {
+    return false;
+  }
+}
+
+function defaultBlockBaselineTicket({ repo, ticket, why, log = null, baseline = null, fetchTicket }) {
+  try {
+    let cur = null;
+    if (typeof fetchTicket === "function") {
+      cur = fetchTicket(ticket);
+    } else {
+      const out = execFileSync("bun", [linearCli(), "get", ticket, "--json"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      cur = JSON.parse(out);
+    }
+    if (!cur || cur.state?.name !== "In Progress") return false;
+    if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
+
+    const signature = baselineFailureSignature({ why, log, baseline });
+    execFileSync("bun", [linearCli(), "state", ticket, "Blocked", "--unassign", "--add", "ai:blocked", "--remove", "ai:in-progress"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    if (!hasRecordedBaselineFailureComment(ticket, signature)) {
+      const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
+      const body = `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}\n\n
+<!-- ${marker} -->`;
+      execFileSync("bun", [linearCli(), "comment", ticket, body], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Active executions by runId for cooperative cancellation. */
 const ACTIVE_EXECUTIONS = new Map();
 
@@ -425,6 +489,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
   const isAliveFn = dispatchOpts?.isAlive ?? defaultIsAlive;
   const claimTicketFn = dispatchOpts?.claimTicket ?? (dispatchOpts?.fetchTicket ? (() => ({ ok: true })) : defaultClaimTicket);
   const unclaimTicketFn = dispatchOpts?.unclaimTicket ?? ((args) => defaultUnclaimTicket({ ...args, fetchTicket: dispatchOpts?.fetchTicket }));
+  const blockTicketFn = dispatchOpts?.blockBaselineTicket ?? ((args) => defaultBlockBaselineTicket({ ...args, fetchTicket: dispatchOpts?.fetchTicket }));
 
   const nowFn = typeof now === "function" ? now : () => (now ?? Date.now());
 
@@ -737,7 +802,19 @@ export async function executeClaimed(db, registry, adapters, claim, {
       const reasonCode = err.reasonCode === "baseline_red" ? "baseline_red" : "contract_violation";
       const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
       if (ticketClaimed) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: failureReason, log: null }); } catch {}
+        if (reasonCode === "baseline_red") {
+          try {
+            blockTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              why: failureReason,
+              log: null,
+              baseline: worktreeRecord?.baseline,
+            });
+          } catch {}
+        } else {
+          try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: failureReason, log: null }); } catch {}
+        }
       }
       // Invalid output is a typed contract failure and emits no completion
       // event (§15) — no results row, no outbox row. A matching pre-existing

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -394,6 +394,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let workspaceDir = null;
   let checkoutPath = null;
   let checkoutBaseline = null;
+  let worktreeRecord = null;
   const repoName = spec.input?.repoPin?.repo ?? spec.input?.repo ?? null;
   const ticketId = spec.input?.ticket ?? null;
   const isWorktree = spec.workspace?.type === "worktree";
@@ -591,6 +592,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     workspaceDir = created.dir;
     checkoutPath = created.checkout?.path ?? null;
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
+    worktreeRecord = created.worktree ?? null;
     db.query(`UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`)
       .run(workspaceDir, runId, attempt);
 
@@ -727,14 +729,20 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     let verified;
     try {
-      verified = verifyResult({ spec, def, registry, workspaceDir, attempt, extraArtifacts: RUNTIME_ARTIFACTS });
+      verified = verifyResult({
+        spec, def, registry, workspaceDir, attempt, extraArtifacts: RUNTIME_ARTIFACTS, worktreeRecord,
+      });
     } catch (err) {
       if (!(err instanceof ContractViolation)) throw err;
+      const reasonCode = err.reasonCode === "baseline_red" ? "baseline_red" : "contract_violation";
+      const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
       if (ticketClaimed) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `contract_violation: ${err.violations.join(", ")}`, log: null }); } catch {}
+        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: failureReason, log: null }); } catch {}
       }
       // Invalid output is a typed contract failure and emits no completion
-      // event (§15) — no results row, no outbox row.
+      // event (§15) — no results row, no outbox row. A matching pre-existing
+      // red baseline is equally non-admissible, but is named separately and
+      // not retried as though the agent caused an ordinary contract failure.
       const res = txImmediate(db, () => {
         const currentNow = nowFn();
         if (!assertCurrentToken(db, runId, fencingToken)) {
@@ -743,11 +751,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
         }
         transition(db, {
           runId, to: "FAILED", expectFrom: "VERIFYING",
-          actor: owner, reason: `contract_violation: ${err.violations.join(", ")}`,
+          actor: owner, reason: failureReason,
           attempt, policyVersion, now: currentNow,
         });
-        finishAttempt(db, runId, attempt, "FAILED", "contract_violation", currentNow, attemptUsage);
-        if (attempt < spec.maxAttempts) {
+        finishAttempt(db, runId, attempt, "FAILED", reasonCode, currentNow, attemptUsage);
+        if (reasonCode !== "baseline_red" && attempt < spec.maxAttempts) {
           transition(db, {
             runId, to: "QUEUED", expectFrom: "FAILED",
             actor: owner, reason: "retry", attempt, policyVersion, now: nowFn(),
@@ -757,7 +765,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
       });
       destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "FAILED", reasonCode: "contract_violation" };
+      return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
 
     if (verified.kind === "refused") {
@@ -906,13 +914,16 @@ export async function executeClaimed(db, registry, adapters, claim, {
     // lib/adapters/pi.mjs's CliNotFoundError) before ever spawning a child.
     // No `requeue`: retrying on the same worker just fails the same way.
     const isCliNotFound = err?.code === "cli_not_found";
-    const reasonCode = isCliNotFound ? "cli_not_found" : "adapter_error";
-    const journalReason = isCliNotFound
-      ? `cli_not_found: ${err.message}`
-      : `adapter_error: ${err?.message ?? String(err)}`;
+    const isWorkspaceProvisioning = err?.code === "workspace_provisioning_error";
+    const reasonCode = isCliNotFound
+      ? "cli_not_found"
+      : isWorkspaceProvisioning
+        ? "workspace_provisioning_error"
+        : "adapter_error";
+    const journalReason = `${reasonCode}: ${err?.message ?? String(err)}`;
     let res;
     try {
-      res = failTerminal("FAILED", journalReason, reasonCode, { requeue: !isCliNotFound });
+      res = failTerminal("FAILED", journalReason, reasonCode, { requeue: !isCliNotFound && !isWorkspaceProvisioning });
     } catch {
       // if failTerminal could not transition, continue
     }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
@@ -1007,6 +1007,14 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       path.join(repoDir, "bin", "worktree-down.sh"),
       `#!/bin/bash\nset -e\necho "down $1" >> "${callsLog}"\nrm -rf "${wtRoot}/$1"\n`,
     );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-red-baseline.sh"),
+      `#!/bin/bash\nset -e\necho "up-red $1" >> "${callsLog}"\nmkdir -p "${wtRoot}/$1"\nprintf '%s\\n' '{"status":"red","check":"web_build","command":"bun run build:fast","exitCode":1,"output":"entry chunk exceeds budget"}' > "$FACTORY_WORKTREE_REPORT"\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-broken.sh"),
+      `#!/bin/bash\necho "dependency install failed" >&2\nexit 12\n`,
+    );
 
     mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
     writeFileSync(
@@ -1019,7 +1027,15 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         `  - name: wt-failing-verify\n    path: ${repoDir}\n    github: watt-mind/wt-failing-verify\n    base: develop\n` +
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-        `    worktree_root: ${wtRoot}\n    verify: exit 42\n`,
+        `    worktree_root: ${wtRoot}\n    verify: exit 42\n` +
+        `  - name: wt-baseline-red\n    path: ${repoDir}\n    github: watt-mind/wt-baseline-red\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up-red-baseline.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: printf 'entry chunk exceeds budget\\n' >&2; exit 9\n` +
+        `  - name: wt-broken-up\n    path: ${repoDir}\n    github: watt-mind/wt-broken-up\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up-broken.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo never\n`,
     );
     previousReposRoot = process.env.FACTORY_REPOS_ROOT;
     process.env.FACTORY_REPOS_ROOT = factoryRoot;
@@ -1277,6 +1293,64 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("contract_violation");
+  });
+
+  test("a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-locks-"));
+    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-leases-"));
+    let executionInput = null;
+    const observingAdapter = {
+      async execute({ spec, workspaceDir }) {
+        executionInput = JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8"));
+        return dispatchFakeAdapter.execute({ spec, workspaceDir });
+      },
+    };
+
+    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-baseline-red", ticket: "WM-731" } }));
+    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
+      dispatch: {
+        locksDir: lockDir,
+        leasesDir: leaseDir,
+        fetchTicket: () => ({ identifier: "WM-731", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+      },
+    }));
+
+    expect(executionInput).toMatchObject({
+      repo: "wt-baseline-red",
+      ticket: "WM-731",
+      baseline: { status: "red", check: "web_build", output: "entry chunk exceeds budget" },
+    });
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("baseline_red");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("baseline_red");
+  });
+
+  test("worktree provisioning failure is not misclassified as adapter_error and never reaches execution", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-provision-locks-"));
+    let executed = false;
+    const observingAdapter = { async execute() { executed = true; return { exitCode: 0, timedOut: false }; } };
+
+    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-broken-up", ticket: "WM-732" } }));
+    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
+      dispatch: {
+        locksDir: lockDir,
+        fetchTicket: () => ({ identifier: "WM-732", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+      },
+    }));
+
+    expect(executed).toBe(false);
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("workspace_provisioning_error");
+    expect(summary.error).toContain("dependency install failed");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("workspace_provisioning_error");
   });
 
   test("rollback Linear ticket state to Todo on crash, timeout, and contract violation", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1382,16 +1382,22 @@ describe("execute-side dispatch hardening (WM-115)", () => {
 
 
     const currentBranch = (spawnSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).stdout || "").trim();
+    // GitHub Actions checks out a PR merge ref detached from its source branch.
+    // Give worktree-up a verified origin ref to that checked-out commit, rather
+    // than accidentally constructing the invalid origin/HEAD ref.
+    const detachedBaseBranch = currentBranch === "HEAD" ? `wm334-test-${ticket}-${process.pid}` : null;
+    if (detachedBaseBranch) {
+      const head = (spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout || "").trim();
+      execFileSync("git", ["-C", repoRoot, "update-ref", `refs/remotes/origin/${detachedBaseBranch}`, head]);
+    }
     const hasRemoteBranch = (branch) => branch && branch !== "HEAD" && spawnSync(
       "git",
       ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/remotes/origin/${branch}`],
     ).status === 0;
-    const baseBranch = [process.env.GITHUB_BASE_REF, currentBranch, "develop"].find(hasRemoteBranch);
+    const baseBranch = [currentBranch, detachedBaseBranch, process.env.GITHUB_BASE_REF, "develop"].find(hasRemoteBranch);
     expect(baseBranch).toBeDefined();
     expect(baseBranch).not.toBe("HEAD");
-    if (hasRemoteBranch(process.env.GITHUB_BASE_REF)) {
-      expect(baseBranch).toBe(process.env.GITHUB_BASE_REF);
-    }
+    expect(hasRemoteBranch(baseBranch)).toBe(true);
     const realBun = (spawnSync("bash", ["-c", "command -v bun"], { encoding: "utf8", env: { ...process.env } }).stdout || "").trim() || "bun";
 
     mkdirSync(stubDir, { recursive: true });
@@ -1638,6 +1644,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       });
       expect(comments[0].body).toContain(`<!-- ${marker} -->`);
     } finally {
+      if (detachedBaseBranch) {
+        spawnSync("git", ["-C", repoRoot, "update-ref", "-d", `refs/remotes/origin/${detachedBaseBranch}`]);
+      }
       for (const child of keepAliveProcesses) {
         try {
           child.kill();

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1381,7 +1381,17 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const seedRuntimeState = () => {};
 
 
-    const baseBranch = (spawnSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).stdout || "").trim() || "develop";
+    const currentBranch = (spawnSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).stdout || "").trim();
+    const hasRemoteBranch = (branch) => branch && branch !== "HEAD" && spawnSync(
+      "git",
+      ["-C", repoRoot, "show-ref", "--verify", "--quiet", `refs/remotes/origin/${branch}`],
+    ).status === 0;
+    const baseBranch = [process.env.GITHUB_BASE_REF, currentBranch, "develop"].find(hasRemoteBranch);
+    expect(baseBranch).toBeDefined();
+    expect(baseBranch).not.toBe("HEAD");
+    if (hasRemoteBranch(process.env.GITHUB_BASE_REF)) {
+      expect(baseBranch).toBe(process.env.GITHUB_BASE_REF);
+    }
     const realBun = (spawnSync("bash", ["-c", "command -v bun"], { encoding: "utf8", env: { ...process.env } }).stdout || "").trim() || "bun";
 
     mkdirSync(stubDir, { recursive: true });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -1032,6 +1033,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up-red-baseline.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n    verify: printf 'entry chunk exceeds budget\\n' >&2; exit 9\n` +
+        `  - name: wm-baseline-real\n    path: ${repoDir}\n    github: watt-mind/wm-baseline-real\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo repo_verified\n` +
         `  - name: wt-broken-up\n    path: ${repoDir}\n    github: watt-mind/wt-broken-up\n    base: develop\n` +
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up-broken.sh\n    worktree_down: bin/worktree-down.sh\n` +
@@ -1300,6 +1305,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-locks-"));
     const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-baseline-leases-"));
     let executionInput = null;
+    const unclaimCalls = [];
+    const blockCalls = [];
     const observingAdapter = {
       async execute({ spec, workspaceDir }) {
         executionInput = JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8"));
@@ -1316,6 +1323,14 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
+        unclaimTicket: (payload) => {
+          unclaimCalls.push(payload);
+          return false;
+        },
+        blockBaselineTicket: (payload) => {
+          blockCalls.push(payload);
+          return true;
+        },
       },
     }));
 
@@ -1326,7 +1341,310 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     });
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("baseline_red");
+    expect(blockCalls).toHaveLength(1);
+    expect(unclaimCalls).toHaveLength(0);
     expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("baseline_red");
+  });
+
+  test("worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments", { timeout: 45_000 }, async () => {
+    const repoRoot = process.cwd();
+    const repoName = "wm-baseline-real";
+    const ticket = `WM-${732000000 + Math.floor(Math.random() * 1_000_000)}`;
+    const apiPort = "7408";
+    const apiPortNumber = Number(apiPort);
+    const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "wm334-real-"));
+    const stubDir = path.join(tmpRoot, "stub");
+    const linearStateDir = path.join(tmpRoot, "linear-state");
+    const worktreeRoot = path.join(tmpRoot, "worktrees");
+    const reposFile = path.join(tmpRoot, "config", "repos.yaml");
+
+    const write = (p, c) => {
+      mkdirSync(path.dirname(p), { recursive: true });
+      writeFileSync(p, c, "utf8");
+    };
+
+    const baselineFailureSignature = ({ why, log = null, baseline }) =>
+      createHash("sha256")
+        .update(JSON.stringify({
+          why,
+          log,
+          baseline: baseline && typeof baseline === "object"
+            ? { check: baseline.check, exitCode: baseline.exitCode, output: baseline.output }
+            : null,
+        }))
+        .digest("hex");
+
+    const baselineFailureMarker = (payload) => `wm:baseline:red:${baselineFailureSignature(payload)}`;
+    const keepAliveProcesses = [];
+
+    const expectedHome = path.join(worktreeRoot, ticket, ".factory", "event-runtime");
+    const seedRuntimeState = () => {};
+
+
+    const baseBranch = (spawnSync("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).stdout || "").trim() || "develop";
+    const realBun = (spawnSync("bash", ["-c", "command -v bun"], { encoding: "utf8", env: { ...process.env } }).stdout || "").trim() || "bun";
+
+    mkdirSync(stubDir, { recursive: true });
+    mkdirSync(linearStateDir, { recursive: true });
+
+    const bunStubLines = [
+      "#!/usr/bin/env node",
+      "const fs = require(\"fs\");",
+      "const path = require(\"path\");",
+      "const { spawnSync } = require(\"child_process\");",
+      `const stateDir = process.env.WM334_LINEAR_STATE_DIR || ${JSON.stringify(linearStateDir)}`,
+      `const realBun = process.env.WM334_REAL_BUN || ${JSON.stringify(realBun)}`,
+      "const args = process.argv.slice(2);",
+      "const logPath = process.env.WM334_BUN_LOG || null;",
+      "if (logPath) {\n  try {\n    fs.appendFileSync(logPath, `CALL ${args.join(' ')}\\n`);\n  } catch {}\n}",
+      "",
+      "function commentsPath(ticket) {",
+      "  return path.join(stateDir, ticket + \".comments.json\");",
+      "}",
+      "function readComments(ticket) {",
+      "  try {",
+      "    return JSON.parse(fs.readFileSync(commentsPath(ticket), \"utf8\"));",
+      "  } catch {",
+      "    return [];",
+      "  }",
+      "}",
+      "function writeComments(ticket, rows) {",
+      "  fs.writeFileSync(commentsPath(ticket), JSON.stringify(rows), \"utf8\");",
+      "}",
+      "",
+      "if (args[0]?.endsWith(\"tools/linear.mjs\")) {",
+      "  const verb = args[1];",
+      "  if (verb === \"comments\") {",
+      "    const ticket = args[2];",
+      "    console.log(JSON.stringify(readComments(ticket)));",
+      "    process.exit(0);",
+      "  }",
+      "  if (verb === \"comment\") {",
+      "    const ticket = args[2];",
+      "    const body = args.slice(3).join(\" \");",
+      "    const rows = readComments(ticket);",
+      "    rows.push({ body });",
+      "    writeComments(ticket, rows);",
+      "    process.exit(0);",
+      "  }",
+      "  if (verb === \"state\") {",
+      "    console.log(\"ok\");",
+      "    process.exit(0);",
+      "  }",
+      "  if (verb === \"claim\") {",
+      "    console.log(\"ok\");",
+      "    process.exit(0);",
+      "  }",
+      "  if (verb === \"get\") {",
+      "    console.log(JSON.stringify({ identifier: args[2], state: { name: \"In Progress\" }, assignee: { name: \"agent\" }, labels: { nodes: [{ name: \"ai:in-progress\" }] } }));",
+      "    process.exit(0);",
+      "  }",
+      "  console.log(\"[]\");",
+      "  process.exit(0);",
+      "}",
+      "if (args[0] === \"-e\" || args[0] === \"--eval\") {",
+      "  const result = spawnSync(realBun, args, {",
+      "    stdio: \"inherit\",",
+      "    env: process.env,",
+      "  });",
+      "  process.exit(result.status ?? 0);",
+      "}",
+      "if (args.includes(\"install\")) {",
+      "  process.exit(0);",
+      "}",
+      "if (args[0] === \"run\" && args[1] === \"build:fast\") {",
+      "  console.log(\"entry chunk exceeds budget\");",
+      "  process.exit(1);",
+      "}",
+      "const result = spawnSync(realBun, args, {",
+      "  stdio: \"inherit\",",
+      "  env: process.env,",
+      "});",
+      "process.exit(result.status ?? 0);",
+    ];
+    write(path.join(stubDir, "bun"), bunStubLines.join("\n") + "\n");
+
+    const expectedHomeJson = JSON.stringify(expectedHome);
+    const curlStubLines = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `expected_home=${expectedHomeJson}`,
+      'if [[ "$*" == *"/health"* ]]; then',
+      '  printf "%s\\n" "{\\\"env\\\":{\\\"home\\\":\\\"$expected_home\\\",\\\"adapter\\\":\\\"fake\\\"}}"',
+      "  exit 0",
+      "fi",
+      "exit 0",
+    ];
+    write(path.join(stubDir, "curl"), curlStubLines.join("\n") + "\n");
+
+    for (const filePath of [path.join(stubDir, "bun"), path.join(stubDir, "curl")]) {
+      execFileSync("chmod", ["+x", filePath]);
+    }
+
+    write(
+      reposFile,
+      `repos:\n` +
+        `  - name: ${repoName}\n` +
+        `    path: ${repoRoot}\n` +
+        `    github: watt-mind/${repoName}\n` +
+        `    base: ${baseBranch}\n` +
+        `    team: WM\n` +
+        `    project: Factory\n` +
+        `    max_in_flight: 1\n` +
+        `    worktree_up: bin/worktree-up.sh\n` +
+        `    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${worktreeRoot}\n` +
+        `    verify: printf 'entry chunk exceeds budget\\n' \\n  >&2; exit 1\n`,
+    );
+    mkdirSync(path.join(tmpRoot, "config"), { recursive: true });
+    write(path.join(tmpRoot, "config", "policy.yaml"),
+      [
+        "models:",
+        "  fake:",
+        "    strong: default",
+        "    standard: default",
+        "    light: default",
+        "  pi:",
+        "    strong: default",
+        "    standard: default",
+        "    light: default",
+      ].join("\n") + "\n",
+    );
+
+    const originalEnv = {
+      FACTORY_REPOS_ROOT: process.env.FACTORY_REPOS_ROOT,
+      FACTORY_SKIP_FETCH: process.env.FACTORY_SKIP_FETCH,
+      FACTORY_BASE_BRANCH: process.env.FACTORY_BASE_BRANCH,
+      FACTORY_WT_ROOT: process.env.FACTORY_WT_ROOT,
+      PATH: process.env.PATH,
+      WM334_LINEAR_STATE_DIR: process.env.WM334_LINEAR_STATE_DIR,
+      WM334_REAL_BUN: process.env.WM334_REAL_BUN,
+      WM334_BUN_LOG: process.env.WM334_BUN_LOG,
+    };
+    try {
+      process.env.FACTORY_REPOS_ROOT = tmpRoot;
+      process.env.FACTORY_SKIP_FETCH = "1";
+      process.env.FACTORY_BASE_BRANCH = baseBranch;
+      process.env.FACTORY_WT_ROOT = worktreeRoot;
+      process.env.PATH = `${path.join(stubDir)}:${process.env.PATH}`;
+      process.env.WM334_LINEAR_STATE_DIR = linearStateDir;
+      process.env.WM334_REAL_BUN = realBun;
+      process.env.WM334_BUN_LOG = path.join(tmpRoot, 'bun-calls.log');
+
+      const db = openDb(":memory:");
+      const lockDir = mkdtempSync(path.join(os.tmpdir(), "wm334-real-locks-"));
+      const leaseDir = mkdtempSync(path.join(os.tmpdir(), "wm334-real-leases-"));
+      const executionInputs = [];
+      const blockCalls = [];
+      const observedAdapter = {
+        async execute({ spec, workspaceDir }) {
+          executionInputs.push(JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8")));
+          const result = {
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "completed",
+            reasonCode: "ok",
+            artifact: {
+              outcome: "PR_OPEN",
+              repo: spec.input.repo,
+              ticket: spec.input.ticket,
+              prUrl: `https://github.com/watt-mind/${spec.input.repo}/pull/10`,
+              verification: {
+                command: "printf 'entry chunk exceeds budget\\n' > /dev/null; exit 1",
+                passed: true,
+                output: "agent verification passed",
+              },
+              summary: `implemented ${spec.input.ticket}`,
+            },
+            evidence: { commands: ["cd event-runtime/web && bun run build:fast"] },
+          };
+          writeFileSync(path.join(workspaceDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`, "utf8");
+          return { exitCode: 0, timedOut: false };
+        },
+      };
+
+      const blockTicket = ({ ticket, why, baseline, log = null }) => {
+        blockCalls.push({ ticket, why, baseline, log });
+        const marker = baselineFailureMarker({ why, baseline, log });
+        const commentsPath = path.join(linearStateDir, `${ticket}.comments.json`);
+        const existing = existsSync(commentsPath) ? JSON.parse(readFileSync(commentsPath, "utf8")) : [];
+        if (!existing.some((row) => String(row.body ?? "").includes(marker))) {
+          existing.push({ body: `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}\n\n<!-- ${marker} -->` });
+          writeFileSync(commentsPath, JSON.stringify(existing), "utf8");
+        }
+        return true;
+      };
+
+      const run = async () => {
+        seedRuntimeState();
+        const spec = queueRun(db, makeDispatchSpec({
+          input: { repo: repoName, ticket },
+          workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: false },
+        }));
+        return runOnce(db, registry, { fake: observedAdapter }, opts({
+          workspacesRoot: mkdtempSync(path.join(os.tmpdir(), `${repoName}-run-`)),
+          dispatch: {
+            locksDir: lockDir,
+            leasesDir: leaseDir,
+            fetchTicket: () => ({
+              identifier: ticket,
+              state: { name: "Todo" },
+              assignee: null,
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+            }),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+            blockBaselineTicket: blockTicket,
+          },
+        }));
+      };
+
+      const first = await run();
+      const second = await run();
+      if (first.reasonCode !== "baseline_red") {
+        console.log("first summary", first);
+      }
+
+      expect(first.terminalState).toBe("FAILED");
+      expect(first.reasonCode).toBe("baseline_red");
+      expect(second.terminalState).toBe("FAILED");
+      expect(second.reasonCode).toBe("baseline_red");
+      expect(executionInputs).toHaveLength(2);
+      expect(blockCalls).toHaveLength(2);
+      expect(executionInputs[0]).toMatchObject({
+        repo: repoName,
+        ticket,
+        baseline: { status: "red", check: "web_build", exitCode: 1 },
+      });
+      expect(String(executionInputs[0].baseline.output ?? "")).toContain("entry chunk exceeds budget");
+
+      const comments = JSON.parse(readFileSync(path.join(linearStateDir, `${ticket}.comments.json`), "utf8"));
+      expect(comments).toHaveLength(1);
+
+      const marker = baselineFailureMarker({
+        why: blockCalls[0].why,
+        baseline: blockCalls[0].baseline,
+        log: blockCalls[0].log,
+      });
+      expect(comments[0].body).toContain(`<!-- ${marker} -->`);
+    } finally {
+      for (const child of keepAliveProcesses) {
+        try {
+          child.kill();
+        } catch {
+        }
+      }
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+      if (!process.env.WM334_KEEP_TMP_ROOT) {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    }
   });
 
   test("worktree provisioning failure is not misclassified as adapter_error and never reaches execution", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1403,6 +1403,12 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     mkdirSync(stubDir, { recursive: true });
     mkdirSync(linearStateDir, { recursive: true });
 
+    const worktreeUp = path.join(stubDir, "worktree-up-no-seed.sh");
+    write(
+      worktreeUp,
+      `#!/usr/bin/env bash\nexec ${JSON.stringify(path.join(repoRoot, "bin", "worktree-up.sh"))} "$@" --no-seed\n`,
+    );
+
     const bunStubLines = [
       "#!/usr/bin/env node",
       "const fs = require(\"fs\");",
@@ -1493,7 +1499,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     ];
     write(path.join(stubDir, "curl"), curlStubLines.join("\n") + "\n");
 
-    for (const filePath of [path.join(stubDir, "bun"), path.join(stubDir, "curl")]) {
+    for (const filePath of [path.join(stubDir, "bun"), path.join(stubDir, "curl"), worktreeUp]) {
       execFileSync("chmod", ["+x", filePath]);
     }
 
@@ -1507,7 +1513,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         `    team: WM\n` +
         `    project: Factory\n` +
         `    max_in_flight: 1\n` +
-        `    worktree_up: bin/worktree-up.sh\n` +
+        `    worktree_up: ${worktreeUp}\n` +
         `    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${worktreeRoot}\n` +
         `    verify: printf 'entry chunk exceeds budget\\n' \\n  >&2; exit 1\n`,

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -31,6 +31,7 @@ export class WorktreeError extends Error {
   constructor(message) {
     super(message);
     this.name = "WorktreeError";
+    this.code = "workspace_provisioning_error";
   }
 }
 
@@ -109,12 +110,38 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
       `repo "${repoName}" declares no worktree lifecycle in config/repos.yaml (worktree_up/worktree_down/worktree_root) — the planner should have refused this`,
     );
   }
-  const up = spawnSync("/bin/bash", [repo.worktreeUp, ticket], { cwd: repo.path, encoding: "utf8" });
+  // Repo-owned bring-up may discover a red project baseline after the usable
+  // worktree already exists. It reports that condition out-of-band and still
+  // exits zero; a non-zero exit remains a provisioning failure.
+  const reportPath = path.join(workspaceDir, ".worktree-up.json");
+  const up = spawnSync("/bin/bash", [repo.worktreeUp, ticket], {
+    cwd: repo.path,
+    encoding: "utf8",
+    env: { ...process.env, FACTORY_WORKTREE_REPORT: reportPath },
+  });
   if (up.status !== 0) {
     const why = (up.stderr || up.stdout || "").trim().split("\n").pop() || `exit ${up.status}`;
     throw new WorktreeError(`worktree_up failed for ${repoName}/${ticket}: ${why}`);
   }
+
   const worktreePath = path.join(repo.worktreeRoot, ticket);
+  if (!existsSync(worktreePath)) {
+    throw new WorktreeError(`worktree_up reported success for ${repoName}/${ticket} but did not create ${worktreePath}`);
+  }
+
+  let baseline = null;
+  if (existsSync(reportPath)) {
+    try {
+      const report = JSON.parse(readFileSync(reportPath, "utf8"));
+      if (report?.status !== "red" || typeof report.check !== "string" || typeof report.output !== "string") {
+        throw new Error("expected status=red with string check and output");
+      }
+      baseline = report;
+    } catch (err) {
+      throw new WorktreeError(`worktree_up wrote an invalid baseline report for ${repoName}/${ticket}: ${err.message}`);
+    }
+  }
+
   symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
   const record = {
     repo: repoName,
@@ -123,8 +150,23 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
     repoPath: repo.path,
     down: repo.worktreeDown,
     verify: repo.verify,
+    ...(baseline ? { baseline } : {}),
   };
   writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+
+  // The agent contract points it at input.json, so runtime-discovered context
+  // must be present there rather than hidden in an implementation marker.
+  // Keep the run spec immutable; this is workspace-local execution context.
+  if (baseline) {
+    const enrichedInput = {
+      ...input,
+      baseline: {
+        ...baseline,
+        guidance: `The ${baseline.check} check already fails at this commit. If your ticket is unrelated, do not fix it; if it is related, use this as the starting point.`,
+      },
+    };
+    writeFileSync(path.join(workspaceDir, "input.json"), `${canonicalJson(enrichedInput)}\n`, "utf8");
+  }
   return record;
 }
 

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -83,6 +83,14 @@ describe("worktree workspaces (WM-108)", () => {
       `#!/bin/bash\necho "template failed to build" >&2\nexit 7\n`,
     );
     writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-empty.sh"),
+      `#!/bin/bash\nexit 0\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-red-baseline.sh"),
+      `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\nprintf '%s\\n' '{"status":"red","check":"web_build","command":"bun run build:fast","exitCode":1,"output":"entry chunk exceeds budget"}' > "$FACTORY_WORKTREE_REPORT"\n`,
+    );
+    writeFileSync(
       path.join(repoDir, "bin", "worktree-down-refuse.sh"),
       `#!/bin/bash\necho "refusing: dirty tree" >&2\nexit 1\n`,
     );
@@ -97,6 +105,12 @@ describe("worktree workspaces (WM-108)", () => {
         `  - name: broken-up\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up-broken.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n` +
+        `  - name: empty-up\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up-empty.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n` +
+        `  - name: red-baseline\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up-red-baseline.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: bun test\n` +
         `  - name: refusing-down\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down-refuse.sh\n` +
         `    worktree_root: ${wtRoot}\n` +
@@ -164,9 +178,42 @@ describe("worktree workspaces (WM-108)", () => {
     expect(existsSync(path.join(wtRoot, "WM-4"))).toBe(true);
   });
 
-  test("a failing worktree_up is a typed error carrying the script's last line", () => {
-    expect(() => make("broken-up", "WM-5", "run_wt5")).toThrow(WorktreeError);
-    expect(() => make("broken-up", "WM-5", "run_wt5")).toThrow(/template failed to build/);
+  test("a red baseline is recorded in the marker and agent input without aborting workspace creation", () => {
+    const { dir, worktree } = make("red-baseline", "WM-5", "run_wt5");
+    expect(worktree.baseline).toMatchObject({
+      status: "red",
+      check: "web_build",
+      exitCode: 1,
+      output: "entry chunk exceeds budget",
+    });
+    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).baseline).toEqual(worktree.baseline);
+    expect(JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8"))).toMatchObject({
+      repo: "red-baseline",
+      ticket: "WM-5",
+      baseline: {
+        status: "red",
+        check: "web_build",
+        output: "entry chunk exceeds budget",
+        guidance: expect.stringContaining("already fails at this commit"),
+      },
+    });
+    expect(existsSync(path.join(dir, "repo"))).toBe(true);
+    expect(destroyWorkspace(dir)).toBe(true);
+  });
+
+  test("a failing worktree_up is a typed provisioning error carrying the script's last line", () => {
+    try {
+      make("broken-up", "WM-8", "run_wt8");
+      throw new Error("expected WorktreeError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorktreeError);
+      expect(err.code).toBe("workspace_provisioning_error");
+      expect(err.message).toContain("template failed to build");
+    }
+  });
+
+  test("a zero-exit script that created no worktree is still a provisioning failure", () => {
+    expect(() => make("empty-up", "WM-9", "run_wt9")).toThrow(/did not create/);
   });
 
   test("a repo with no declared scripts fails typed, not with a crash mid-spawn", () => {


### PR DESCRIPTION
## Summary

- Make web bundle build failures non-fatal in : capture baseline failure output and continue with a usable worktree.
- Record red baseline details in  and surface guidance in agent input.
- Distinguish workspace provisioning failures from adapter errors in / via .
- Extend verification to classify pre-existing red baselines as  in .
- Add regression coverage in workspace/verify/worker tests for baseline-red dispatch behavior and provisioning failures.

## Verification

bun test v1.3.14 (0d9b296a)
[1m
legalease[0m[2m  CLNT / LegalEase[0m
  [33mCLNT-522[0m is Done but PR #203 is still OPEN — moving to In Review
[2m    Something failed[0m
Checking formatting...
All matched files use Prettier code style!

Fixes WM-334