### PR TITLE
fix(event-runtime-web): preserve trace durations when filtering

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -78,6 +78,32 @@ describe("RunTrace feed", () => {
   });
 });
 
+describe("RunTrace timing (WM-272)", () => {
+  test("filtered views use the next unfiltered entry for duration", async () => {
+    const start = Date.parse("2025-01-01T00:00:00.000Z");
+    const timedTrace: TraceEntry[] = [
+      { ...entry(1, "tool_use", { name: "Read" }), ts: new Date(start).toISOString() },
+      { ...entry(2, "assistant_text", { text: "hidden by the tools filter" }), ts: new Date(start + 200).toISOString() },
+      { ...entry(3, "tool_use", { name: "Write" }), ts: new Date(start + 50_000).toISOString() },
+      { ...entry(4, "tool_result", { content: "done" }), ts: new Date(start + 50_300).toISOString() },
+    ];
+    const r = renderWithClient(
+      <RunTrace runId="run_trace_timing" state="COMPLETED" variant="full" />,
+      {
+        apiMocks: {
+          trace: async () => ({ head: timedTrace[timedTrace.length - 1].seq, entries: timedTrace }),
+        },
+      },
+    );
+    await waitForChrome(r);
+
+    fireEvent.click(r.getByRole("tab", { name: /^Tools/ }));
+
+    expect(await r.findByText("200ms")).toBeTruthy();
+    expect(r.queryByText("50.0s")).toBeNull();
+  });
+});
+
 describe("RunTrace a11y (WM-143)", () => {
   test("locks live trace behavior across every RunState (WM-174)", () => {
     const expectedLiveness: Record<RunState, boolean> = {

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -591,19 +591,18 @@ export function RunTrace({
     }
   }, [allErrorEntries, activeErrorIdx, shown, full]);
 
-  // Waterfall timing calculations:
+  // Calculate each duration from adjacent entries in the complete trace so
+  // filtering cannot make a visible row span hidden work. Scale bars only
+  // against the rows currently shown.
   const { durations, maxDurationMs } = useMemo(() => {
     const map = new Map<number, number>();
-    let max = 0;
-    for (let i = 0; i < shown.length; i++) {
-      const dur = getEntryDuration(shown[i], shown[i + 1]);
-      if (dur != null) {
-        map.set(shown[i].seq, dur);
-        if (dur > max) max = dur;
-      }
+    for (let i = 0; i < entries.length; i++) {
+      const dur = getEntryDuration(entries[i], entries[i + 1]);
+      if (dur != null) map.set(entries[i].seq, dur);
     }
+    const max = shown.reduce((largest, entry) => Math.max(largest, map.get(entry.seq) ?? 0), 0);
     return { durations: map, maxDurationMs: max || 1000 };
-  }, [shown]);
+  }, [entries, shown]);
 
   // In-trace text search matches:
   const searchMatches = useMemo(() => {


### PR DESCRIPTION
## Summary
- calculate trace durations from adjacent entries in the complete unfiltered stream
- scale timing bars using only currently shown rows
- add a regression test for filtered views with hidden intervening entries

## Verification
- `cd event-runtime/web && bun test src/components/RunTrace.test.tsx` — 11 pass, 0 fail

UX critique: required — NOT-ASSESSED; live filters worked, but seeded data had no mixed-category tool trace to validate numerical timing. Evidence: http://127.0.0.1:7403/#/run/run_e30f374c-3063-44f5-b4df-f0f8fdb541fb

Fixes WM-272