### PR TITLE
fix(event-runtime-web): close only top Dialog on Escape

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,8 +2,9 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, CopyActions, Countdown, DetailPane, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
+import { Button, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
+import { modal } from "../hooks";
 import { changeInput, typeText } from "../test-render";
 
 function stackOf(r: ReturnType<typeof render>): HTMLElement {
@@ -703,6 +704,38 @@ describe("SuggestInput popover (WM-79)", () => {
     expect(r.getByRole("listbox")).toBeTruthy();
     fireEvent.keyDown(input, { key: "Escape" });
     expect(r.queryByRole("listbox")).toBeNull();
+  });
+});
+
+describe("Dialog (WM-270)", () => {
+  test("Escape closes only the topmost stacked dialog", () => {
+    function StackedDialogs() {
+      const [parentOpen, setParentOpen] = useState(true);
+      const [confirmationOpen, setConfirmationOpen] = useState(true);
+      return (
+        <>
+          {parentOpen && (
+            <Dialog title="Parent dialog" onClose={() => setParentOpen(false)}>
+              Parent content
+            </Dialog>
+          )}
+          {confirmationOpen && (
+            <Dialog title="Confirmation dialog" onClose={() => setConfirmationOpen(false)}>
+              Confirmation content
+            </Dialog>
+          )}
+        </>
+      );
+    }
+
+    const r = render(<StackedDialogs />);
+    expect(modal.depth).toBe(2);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(r.queryByRole("dialog", { name: "Confirmation dialog" })).toBeNull();
+    expect(r.getByRole("dialog", { name: "Parent dialog" })).toBeTruthy();
+    expect(modal.depth).toBe(1);
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1429,8 +1429,9 @@ export function Dialog({
   onCloseRef.current = onClose;
   useEffect(() => {
     modal.depth += 1;
+    const depth = modal.depth;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCloseRef.current();
+      if (e.key === "Escape" && depth === modal.depth) onCloseRef.current();
       else if (e.key === "Tab" && panelRef.current) tabCycle(panelRef.current, e);
     };
     window.addEventListener("keydown", onKey);


### PR DESCRIPTION
## Summary
- capture each Dialog mount depth and ignore Escape outside the top layer
- add a regression test proving a stacked confirmation closes without dismissing its parent

## Verification
- `cd event-runtime/web && bun test src/components/ui.test.tsx` — 42 pass, 0 fail

UX critique: required — SHIP; evidence: http://127.0.0.1:7701/#/projects/factory

Fixes WM-270