### PR TITLE
fix(event-runtime-web): preserve project scope when unpinning run (WM-271)

### DIFF
--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -257,6 +257,29 @@ describe("ContextTabs", () => {
     expect(selected).toEqual([{ kind: "inflight" }]);
   });
 
+  test("unpinning the active run preserves the project-scoped hash", () => {
+    window.location.hash = "#/runs?project=factory";
+    const r = render(
+      <ContextTabs
+        repos={[repo("factory")]}
+        reposError={false}
+        openRepos={["factory"]}
+        active={{ kind: "repo", name: "factory" }}
+        onSelect={() => {}}
+        onOpen={() => {}}
+        onClose={() => {}}
+        pinnedRuns={["run_abc"]}
+      />,
+    );
+
+    // App navigation uses replaceState, which does not emit hashchange; unpinRun
+    // must read the live hash rather than relying on its last rendered state.
+    window.history.replaceState(null, "", "#/runs/run_abc?project=factory");
+    fireEvent.click(r.getByRole("button", { name: "Close run_abc" }));
+
+    expect(window.location.hash).toBe("#/runs?project=factory");
+  });
+
   test("Enter on All and Space on a pinned run activate those tabs", () => {
     const selected: OperatorContext[] = [];
     const r = render(

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { OperatorContext } from "../context";
 import { INFLIGHT, toggleInflight } from "../context";
+import { hashProject, withProject } from "../hash";
 import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
 
@@ -127,8 +128,8 @@ export function ContextTabs({
       setInternalPinned(next);
       savePinnedRuns(next);
     }
-    if (activeRunId === runId && typeof window !== "undefined") {
-      window.location.hash = "#/runs";
+    if (typeof window !== "undefined" && getHashRunId() === runId) {
+      window.location.hash = `#/${withProject("runs", hashProject(window.location.hash))}`;
     }
   };
 


### PR DESCRIPTION
## Summary
- preserve the active project query when closing the active pinned run
- read the live hash so replaceState-driven run navigation cannot leave unpin behavior stale
- add a regression test covering the scoped transition

## Verification
- `cd event-runtime/web && bun test src/components/ContextTabs.test.tsx` — 26 pass, 0 fail

UX critique: required — SHIP after 2 rounds; evidence: http://127.0.0.1:7485/#/runs?project=bj29

Fixes WM-271