### PR TITLE
fix(event-runtime-web): surface doctor anomalies (WM-268)

### DIFF
--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -787,6 +787,49 @@ describe("buildAnomalyRows (WM-205)", () => {
     expect(rows[6]!.text).toMatch(/4 queued runs and no live worker/);
   });
 
+  test("maps stopped and late schedules, piling proposals, and configuration warnings", () => {
+    const onNavigate = mock((_path: string) => {});
+    const anomalies: StatusView["anomalies"] = {
+      ...baseStatus().anomalies,
+      stoppedSchedules: [
+        {
+          loop: "nightly",
+          every: "1h",
+          lastSlot: "2026-08-16T08:00:00.000Z",
+          intervalsLate: 3,
+          error: null,
+        },
+        {
+          loop: "reaper",
+          every: "5m",
+          lastSlot: "2026-08-16T10:00:00.000Z",
+          intervalsLate: 0,
+          error: "tick failed",
+        },
+      ],
+      proposalsPilingUp: [{ loop: "reconcile-bj29", count: 4, threshold: 3 }],
+      configuration: ["policyVersion is unknown"],
+    };
+
+    const rows = buildAnomalyRows(anomalies, new Map(), { ...callbacks, onNavigate });
+
+    expect(rows.map((row) => [row.kind, row.text])).toEqual([
+      ["schedule", "stopped schedule nightly: 3 intervals late"],
+      ["schedule", "stopped schedule reaper: error: tick failed"],
+      [
+        "proposal",
+        "proposals piling up for schedule reconcile-bj29: 4 open proposals (threshold 3)",
+      ],
+      ["configuration", "configuration: policyVersion is unknown"],
+    ]);
+
+    rows[0]!.links[0]!.go();
+    rows[2]!.links[0]!.go();
+    expect(rows[0]!.links[0]!.label).toBe("View schedules");
+    expect(rows[2]!.links[0]!.label).toBe("View proposals");
+    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual(["schedules", "proposals"]);
+  });
+
   test("returns empty array for undefined anomalies", () => {
     expect(buildAnomalyRows(undefined, new Map(), callbacks)).toEqual([]);
   });

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -243,7 +243,9 @@ export type AnomalyKind =
   | "lease"
   | "outbox"
   | "capacity"
-  | "ambiguous";
+  | "ambiguous"
+  | "schedule"
+  | "configuration";
 
 export interface AnomalyRow {
   kind: AnomalyKind;
@@ -273,6 +275,28 @@ export function buildAnomalyRows(
 ): AnomalyRow[] {
   const rows: AnomalyRow[] = [];
   if (!anomalies) return rows;
+
+  for (const schedule of anomalies.stoppedSchedules ?? []) {
+    rows.push({
+      kind: "schedule",
+      text: `stopped schedule ${schedule.loop}: ${schedule.error ? `error: ${schedule.error}` : `${schedule.intervalsLate} intervals late`}`,
+      links: [{ label: "View schedules", go: () => callbacks.onNavigate("schedules") }],
+    });
+  }
+  for (const proposal of anomalies.proposalsPilingUp ?? []) {
+    rows.push({
+      kind: "proposal",
+      text: `proposals piling up for schedule ${proposal.loop}: ${proposal.count} open proposals (threshold ${proposal.threshold})`,
+      links: [{ label: "View proposals", go: () => callbacks.onNavigate("proposals") }],
+    });
+  }
+  for (const warning of anomalies.configuration ?? []) {
+    rows.push({
+      kind: "configuration",
+      text: `configuration: ${warning}`,
+      links: [],
+    });
+  }
 
   for (const id of anomalies.expiredOpenProposals) {
     rows.push({
@@ -361,6 +385,8 @@ function CategoryPill({ kind }: { kind: AnomalyKind }) {
     outbox: "outbox",
     capacity: "capacity",
     ambiguous: "ambiguous",
+    schedule: "schedule",
+    configuration: "configuration",
   };
   return (
     <span className="shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-(--text-dim)">


### PR DESCRIPTION
## Summary
- surface stopped and late schedules in the Overview Doctor anomaly deck
- surface piling proposals and configuration warnings
- link schedule and proposal anomalies to their actionable views
- add regression coverage for all three omitted status fields

## Verification
- `cd event-runtime/web && bun test src/views/Overview.test.tsx` — 26 passed

UX critique: required — SHIP; evidence: http://127.0.0.1:7551/#/overview

Fixes WM-268