### PR TITLE
fix(event-runtime-web): preserve event facet query tokens (WM-269)

### DIFF
--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -521,6 +521,71 @@ describe("Events component harness: facet chips synchronization with FilterInput
     );
   });
 
+  test("replacing multiple Type facet tokens preserves the rest of the query", async () => {
+    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
+    const e2 = stubEvent("evt_2", "admitted", { type: "release.published", source: "github" });
+    const e3 = stubEvent("evt_3", "admitted", { type: "issue_comment.created", source: "gitlab" });
+
+    await withApi(
+      {
+        events: async () => ({ events: [e1, e2, e3] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole, getByLabelText } = renderEvents({});
+        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const filterInput = getByLabelText("Filter events") as HTMLInputElement;
+
+        act(() => {
+          changeInput(
+            filterInput,
+            "  type:pull_request.opened   source:github type:release.published",
+          );
+        });
+
+        const issueButton = Array.from(typeGroup.querySelectorAll("button")).find((button) =>
+          button.textContent?.includes("issue_comment.created"),
+        );
+        expect(issueButton).toBeTruthy();
+        fireEvent.click(issueButton!);
+
+        expect(filterInput.value).toBe("source:github type:issue_comment.created");
+      },
+    );
+  });
+
+  test("removing duplicate active Type facet tokens preserves the rest of the query", async () => {
+    const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
+    const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });
+
+    await withApi(
+      {
+        events: async () => ({ events: [e1, e2] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByRole, getByLabelText } = renderEvents({});
+        const typeGroup = await waitFor(() => getByRole("group", { name: "Event types" }));
+        const filterInput = getByLabelText("Filter events") as HTMLInputElement;
+
+        act(() => {
+          changeInput(
+            filterInput,
+            "  type:pull_request.opened   source:github type:pull_request.opened",
+          );
+        });
+
+        const pullRequestButton = Array.from(typeGroup.querySelectorAll("button")).find((button) =>
+          button.textContent?.includes("pull_request.opened"),
+        );
+        expect(pullRequestButton?.getAttribute("aria-pressed")).toBe("true");
+        fireEvent.click(pullRequestButton!);
+
+        expect(filterInput.value).toBe("source:github");
+      },
+    );
+  });
+
   test("typing type:<val> or source:<val> in FilterInput updates facet chips active state", async () => {
     const e1 = stubEvent("evt_1", "admitted", { type: "pull_request.opened", source: "github" });
     const e2 = stubEvent("evt_2", "admitted", { type: "issue_comment.created", source: "gitlab" });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -22,7 +22,7 @@ import { ScopeCaption } from "../components/ContextTabs";
 import type { AdmittedEvent, EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
-import { EVENT_FACETS, matchesFilterQuery, parseFilterQuery, removeFilterToken, type FilterToken } from "../filterQuery";
+import { EVENT_FACETS, matchesFilterQuery, parseFilterQuery, type FilterToken } from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import {
   Ago,
@@ -49,6 +49,20 @@ import {
   shortId,
 } from "../components/ui";
 
+function removeTokensFromQuery(filter: string, tokens: readonly FilterToken[]): string {
+  const ordered = [...tokens].sort((a, b) => a.start - b.start);
+  let cursor = 0;
+  let next = "";
+
+  for (const token of ordered) {
+    next += filter.slice(cursor, token.start);
+    cursor = token.end;
+  }
+  next += filter.slice(cursor);
+
+  return next.replace(/\s+/g, " ").trim();
+}
+
 function toggleFacetInQuery(filter: string, key: "type" | "source", value: string): string {
   const parsed = parseFilterQuery(filter, EVENT_FACETS);
   const existingTokens = parsed.tokens.filter(
@@ -60,23 +74,15 @@ function toggleFacetInQuery(filter: string, key: "type" | "source", value: strin
   );
 
   if (isAlreadyActive) {
-    let next = filter;
-    const matching = existingTokens
-      .filter((t) => t.value.toLowerCase() === value.toLowerCase())
-      .sort((a, b) => b.start - a.start);
-    for (const t of matching) {
-      next = removeFilterToken(next, t);
-    }
-    return next;
+    const matching = existingTokens.filter(
+      (t) => t.value.toLowerCase() === value.toLowerCase(),
+    );
+    return removeTokensFromQuery(filter, matching);
   }
 
-  let next = filter;
-  const toRemove = [...existingTokens].sort((a, b) => b.start - a.start);
-  for (const t of toRemove) {
-    next = removeFilterToken(next, t);
-  }
+  const next = removeTokensFromQuery(filter, existingTokens);
   const addition = `${key}:${value}`;
-  return next ? `${next} ${addition}`.replace(/\s+/g, " ").trim() : addition;
+  return next ? `${next} ${addition}` : addition;
 }
 
 function setFacetInQuery(filter: string, key: "type" | "source", value: string): string {
@@ -85,13 +91,9 @@ function setFacetInQuery(filter: string, key: "type" | "source", value: string):
     (t): t is Extract<FilterToken, { kind: "field" }> =>
       t.kind === "field" && t.key === key,
   );
-  let next = filter;
-  const toRemove = [...existingTokens].sort((a, b) => b.start - a.start);
-  for (const t of toRemove) {
-    next = removeFilterToken(next, t);
-  }
+  const next = removeTokensFromQuery(filter, existingTokens);
   const addition = `${key}:${value}`;
-  return next ? `${next} ${addition}`.replace(/\s+/g, " ").trim() : addition;
+  return next ? `${next} ${addition}` : addition;
 }
 
 const STATUS_TABS = ["all", "admitted", "planned", "noop", "human_needed", "dead_lettered"] as const;


### PR DESCRIPTION
## Summary
- remove all matching facet tokens against their original query offsets in one pass
- preserve unrelated filters while replacing or clearing repeated event facet tokens
- cover replacement and duplicate-removal regressions

## Verification
- `cd event-runtime/web && bun test src/views/Events.test.tsx` — 19 pass, 0 fail

UX critique: required — SHIP (2 rounds; rebuilt stale demo bundle after round 1)
Evidence: http://127.0.0.1:7511/events?uxcritique=wm269-rebuilt#/events

Fixes WM-269