### PR TITLE
fix(adapters): terminate detached process groups (WM-263)

### DIFF
--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -25,6 +25,21 @@ import { DEFAULT_MODEL } from "../registry.mjs";
 
 export const KILL_GRACE_MS = 30_000;
 
+/** Terminate a detached CLI and every subprocess it started (WM-263). */
+export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
 
@@ -302,6 +317,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     // Capture the CLI's structured output as a runtime artifact: the worker
@@ -365,15 +381,15 @@ export async function execute({
     let killTimer = null;
     const termTimer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
       killTimer.unref?.();
     }, timeoutMs);
 
     const onAbort = () => {
-      child.kill("SIGTERM");
+      killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
         killTimer.unref?.();
       }
     };

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -9,7 +9,6 @@ import {
   deriveAllowedTools,
   execute,
   isHarnessDenial,
-  killProcessGroup,
   KILL_GRACE_MS,
   mapStreamEvent,
   PROMPT_SUFFIX,
@@ -18,26 +17,6 @@ import {
   safeChildEnvironment,
   WRITE_TOOLS,
 } from "./claude.mjs";
-
-describe("killProcessGroup (WM-263)", () => {
-  test("signals the detached process group through its negative leader PID", () => {
-    const signals = [];
-    const child = { pid: 4321, kill: () => { throw new Error("parent-only fallback must not run"); } };
-
-    killProcessGroup(child, "SIGKILL", (pid, signal) => signals.push([pid, signal]));
-
-    expect(signals).toEqual([[-4321, "SIGKILL"]]);
-  });
-
-  test("falls back to the child when process-group signaling is unavailable", () => {
-    const signals = [];
-    const child = { pid: 4321, kill: (signal) => signals.push(signal) };
-
-    killProcessGroup(child, "SIGTERM", () => { throw new Error("no process group"); });
-
-    expect(signals).toEqual(["SIGTERM"]);
-  });
-});
 
 describe("isHarnessDenial (WM-127)", () => {
   test("matches the harness's own refusal shapes", () => {
@@ -406,6 +385,15 @@ if (behavior === "ignore_sigterm") {
   setInterval(() => {}, 10_000);
 }
 
+if (behavior === "spawn_long_lived_grandchild") {
+  const grandchild = Bun.spawn([process.execPath, "-e", "setInterval(() => {}, 10_000)"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  writeFileSync(process.env.FACTORY_TEST_GRANDCHILD_PID_FILE, String(grandchild.pid), "utf8");
+  setInterval(() => {}, 10_000);
+}
+
 if (behavior === "emit_bash_then_success") {
   process.stdout.write(
     JSON.stringify({
@@ -516,6 +504,41 @@ if (behavior === "emit_denial_then_recovery") {
     agent: "test-agent@1",
     input: { repos: ["bj29"] },
   };
+  const testProcessGroup = process.platform === "win32" ? test.skip : test;
+
+  async function waitForGrandchildPid(pidFile) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("stub did not report its grandchild PID");
+  }
+
+  function processExists(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return error?.code !== "ESRCH";
+    }
+  }
+
+  async function expectProcessExit(pid) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (!processExists(pid)) return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(processExists(pid)).toBe(false);
+  }
+
+  function killIfRunning(pid) {
+    if (!pid || !processExists(pid)) return;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The process exited between the existence check and cleanup.
+    }
+  }
 
   test("executes stub binary in workspaceDir, strips ANTHROPIC_API_KEY, captures .transcript.json and trace", async () => {
     const workspaceDir = ws();
@@ -600,21 +623,37 @@ if (behavior === "emit_denial_then_recovery") {
     expect(outcome.timedOut).toBe(false);
   });
 
-  test("timeout sends SIGTERM and returns timedOut: true", async () => {
+  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
     const workspaceDir = ws();
-    const outcome = await execute({
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    const ac = new AbortController();
+    const runPromise = execute({
       spec: defaultSpec,
       def: defaultDef,
       workspaceDir,
-      timeoutMs: 150,
+      timeoutMs: 6_000,
       killGraceMs: 5000,
+      abortSignal: ac.signal,
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
       },
     });
-    expect(outcome.timedOut).toBe(true);
-  });
+    let grandchildPid;
+
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(true);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
+  }, { timeout: 12_000 });
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
     const workspaceDir = ws();
@@ -632,8 +671,9 @@ if (behavior === "emit_denial_then_recovery") {
     expect(outcome.timedOut).toBe(true);
   });
 
-  test("abortSignal terminates child process promptly with timedOut: false", async () => {
+  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
     const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
     const ac = new AbortController();
     const runPromise = execute({
       spec: defaultSpec,
@@ -644,14 +684,24 @@ if (behavior === "emit_denial_then_recovery") {
       abortSignal: ac.signal,
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
       },
     });
+    let grandchildPid;
 
-    setTimeout(() => ac.abort(), 100);
-
-    const outcome = await runPromise;
-    expect(outcome.timedOut).toBe(false);
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      ac.abort();
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(false);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
   });
 
   test("pre-aborted abortSignal terminates child immediately", async () => {

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -9,6 +9,7 @@ import {
   deriveAllowedTools,
   execute,
   isHarnessDenial,
+  killProcessGroup,
   KILL_GRACE_MS,
   mapStreamEvent,
   PROMPT_SUFFIX,
@@ -17,6 +18,26 @@ import {
   safeChildEnvironment,
   WRITE_TOOLS,
 } from "./claude.mjs";
+
+describe("killProcessGroup (WM-263)", () => {
+  test("signals the detached process group through its negative leader PID", () => {
+    const signals = [];
+    const child = { pid: 4321, kill: () => { throw new Error("parent-only fallback must not run"); } };
+
+    killProcessGroup(child, "SIGKILL", (pid, signal) => signals.push([pid, signal]));
+
+    expect(signals).toEqual([[-4321, "SIGKILL"]]);
+  });
+
+  test("falls back to the child when process-group signaling is unavailable", () => {
+    const signals = [];
+    const child = { pid: 4321, kill: (signal) => signals.push(signal) };
+
+    killProcessGroup(child, "SIGTERM", () => { throw new Error("no process group"); });
+
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+});
 
 describe("isHarnessDenial (WM-127)", () => {
   test("matches the harness's own refusal shapes", () => {

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -49,6 +49,21 @@ export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
 
 export const KILL_GRACE_MS = 30_000;
 
+/** Terminate a detached CLI and every subprocess it started (WM-263). */
+export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
 
@@ -333,6 +348,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
     });
 
     child.stdin.on("error", () => {}); // a child that exits before reading stdin must not crash the worker
@@ -396,15 +412,15 @@ export async function execute({
     let killTimer = null;
     const termTimer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
       killTimer.unref?.();
     }, timeoutMs);
 
     const onAbort = () => {
-      child.kill("SIGTERM");
+      killProcessGroup(child, "SIGTERM");
       if (!killTimer) {
-        killTimer = setTimeout(() => child.kill("SIGKILL"), killGraceMs);
+        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
         killTimer.unref?.();
       }
     };

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -9,7 +9,6 @@ import {
   execute,
   extractUsage,
   isHarnessDenial,
-  killProcessGroup,
   KILL_GRACE_MS,
   mapStreamEvent,
   PUSH_CREDENTIAL_ENV,
@@ -20,26 +19,6 @@ import {
   resolvePiCommand,
   safeChildEnvironment,
 } from "./pi.mjs";
-
-describe("killProcessGroup (WM-263)", () => {
-  test("signals the detached process group through its negative leader PID", () => {
-    const signals = [];
-    const child = { pid: 8765, kill: () => { throw new Error("parent-only fallback must not run"); } };
-
-    killProcessGroup(child, "SIGTERM", (pid, signal) => signals.push([pid, signal]));
-
-    expect(signals).toEqual([[-8765, "SIGTERM"]]);
-  });
-
-  test("falls back to the child when process-group signaling is unavailable", () => {
-    const signals = [];
-    const child = { pid: 8765, kill: (signal) => signals.push(signal) };
-
-    killProcessGroup(child, "SIGKILL", () => { throw new Error("no process group"); });
-
-    expect(signals).toEqual(["SIGKILL"]);
-  });
-});
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {
@@ -401,6 +380,15 @@ process.stdin.on("end", () => {
     setInterval(() => {}, 10_000);
   }
 
+  if (behavior === "spawn_long_lived_grandchild") {
+    const grandchild = Bun.spawn([process.execPath, "-e", "setInterval(() => {}, 10_000)"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    writeFileSync(process.env.FACTORY_TEST_GRANDCHILD_PID_FILE, String(grandchild.pid), "utf8");
+    setInterval(() => {}, 10_000);
+  }
+
   if (behavior === "emit_tool_then_success") {
     process.stdout.write(JSON.stringify({
       type: "message_end",
@@ -468,6 +456,41 @@ process.stdin.on("end", () => {
     agent: "test-pi-agent@1",
     input: { repos: ["bj29"] },
   };
+  const testProcessGroup = process.platform === "win32" ? test.skip : test;
+
+  async function waitForGrandchildPid(pidFile) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("stub did not report its grandchild PID");
+  }
+
+  function processExists(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return error?.code !== "ESRCH";
+    }
+  }
+
+  async function expectProcessExit(pid) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (!processExists(pid)) return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(processExists(pid)).toBe(false);
+  }
+
+  function killIfRunning(pid) {
+    if (!pid || !processExists(pid)) return;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The process exited between the existence check and cleanup.
+    }
+  }
 
   test("executes stub binary in workspaceDir, strips API keys, pipes prompt on stdin, captures transcript + trace", async () => {
     const workspaceDir = ws();
@@ -541,20 +564,37 @@ process.stdin.on("end", () => {
     expect(outcome.timedOut).toBe(false);
   });
 
-  test("timeout sends SIGTERM and returns timedOut: true", async () => {
-    const outcome = await execute({
+  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    const ac = new AbortController();
+    const runPromise = execute({
       spec: defaultSpec,
       def: defaultDef,
-      workspaceDir: ws(),
-      timeoutMs: 150,
+      workspaceDir,
+      timeoutMs: 6_000,
       killGraceMs: 5000,
+      abortSignal: ac.signal,
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
       },
     });
-    expect(outcome.timedOut).toBe(true);
-  });
+    let grandchildPid;
+
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(true);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
+  }, { timeout: 12_000 });
 
   test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
     const outcome = await execute({
@@ -571,23 +611,37 @@ process.stdin.on("end", () => {
     expect(outcome.timedOut).toBe(true);
   });
 
-  test("abortSignal terminates child process promptly with timedOut: false", async () => {
+  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
     const ac = new AbortController();
     const runPromise = execute({
       spec: defaultSpec,
       def: defaultDef,
-      workspaceDir: ws(),
+      workspaceDir,
       timeoutMs: 10_000,
       killGraceMs: 500,
       abortSignal: ac.signal,
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_TEST_BEHAVIOR: "sleep_sigterm",
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
       },
     });
-    setTimeout(() => ac.abort(), 100);
-    const outcome = await runPromise;
-    expect(outcome.timedOut).toBe(false);
+    let grandchildPid;
+
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      ac.abort();
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(false);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
   });
 
   test("multiple assistant turns accumulate into one combined usage trace event", async () => {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -9,6 +9,7 @@ import {
   execute,
   extractUsage,
   isHarnessDenial,
+  killProcessGroup,
   KILL_GRACE_MS,
   mapStreamEvent,
   PUSH_CREDENTIAL_ENV,
@@ -19,6 +20,26 @@ import {
   resolvePiCommand,
   safeChildEnvironment,
 } from "./pi.mjs";
+
+describe("killProcessGroup (WM-263)", () => {
+  test("signals the detached process group through its negative leader PID", () => {
+    const signals = [];
+    const child = { pid: 8765, kill: () => { throw new Error("parent-only fallback must not run"); } };
+
+    killProcessGroup(child, "SIGTERM", (pid, signal) => signals.push([pid, signal]));
+
+    expect(signals).toEqual([[-8765, "SIGTERM"]]);
+  });
+
+  test("falls back to the child when process-group signaling is unavailable", () => {
+    const signals = [];
+    const child = { pid: 8765, kill: (signal) => signals.push(signal) };
+
+    killProcessGroup(child, "SIGKILL", () => { throw new Error("no process group"); });
+
+    expect(signals).toEqual(["SIGKILL"]);
+  });
+});
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {


### PR DESCRIPTION
## Summary
- spawn Claude and Pi CLI children as detached process-group leaders
- terminate complete process groups on timeout and abort, with a parent-only fallback
- replace mock-only kill assertions with POSIX adapter-level timeout and abort regressions that spawn a real long-lived grandchild and assert its PID exits
- make the regressions falsifiable: observed failure when restoring detached:false or parent-only kill

## Verification
- `bun test event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/pi.test.mjs` — 73 pass, 0 fail

UX critique: skipped — backend process lifecycle change with no user-facing surface

Fixes WM-263