### PR TITLE
fix(metrics): correct Codex cumulative usage (WM-276)

### DIFF
--- a/lib/transcript.mjs
+++ b/lib/transcript.mjs
@@ -175,11 +175,11 @@ export function parseRun(file, text, mtimeMs = 0) {
       // Codex's input_tokens is the whole-turn total and INCLUDES the cached
       // part, unlike Claude's, where the three fields are disjoint. Subtract, or
       // the same tokens get counted twice and the cache ratio reads as perfect.
-      run.cacheRead += u.cached_input_tokens ?? 0;
-      run.cacheWrite += u.cache_write_input_tokens ?? 0;
-      run.in += Math.max(0, (u.input_tokens ?? 0) - (u.cached_input_tokens ?? 0));
-      run.out += (u.output_tokens ?? 0) + (u.reasoning_output_tokens ?? 0);
-      run.turns = run.turns || run.tools || 1;
+      run.cacheRead = u.cached_input_tokens ?? 0;
+      run.cacheWrite = u.cache_write_input_tokens ?? 0;
+      run.in = Math.max(0, (u.input_tokens ?? 0) - (u.cached_input_tokens ?? 0));
+      run.out = (u.output_tokens ?? 0) + (u.reasoning_output_tokens ?? 0);
+      run.turns++;
       run.ok = true;
       continue;
     }

--- a/lib/transcript.test.mjs
+++ b/lib/transcript.test.mjs
@@ -74,6 +74,18 @@ test("codex: token usage is recorded and input excludes the cached part", () => 
   expect(run.ok).toBe(true);
 });
 
+test("codex: cumulative usage snapshots replace prior turns", () => {
+  const run = parseRun("bj29-CLNT-276-x.jsonl", jsonl(
+    { type: "turn.completed", usage: { input_tokens: 100, cached_input_tokens: 60, cache_write_input_tokens: 10, output_tokens: 20, reasoning_output_tokens: 5 } },
+    { type: "turn.completed", usage: { input_tokens: 250, cached_input_tokens: 150, cache_write_input_tokens: 25, output_tokens: 50, reasoning_output_tokens: 15 } },
+  ));
+  expect(run.turns).toBe(2);
+  expect(run.in).toBe(100);
+  expect(run.cacheRead).toBe(150);
+  expect(run.cacheWrite).toBe(25);
+  expect(run.out).toBe(65);
+});
+
 test("codex: a non-zero exit code counts as an error", () => {
   const run = parseRun("bj29-CLNT-4-x.jsonl", jsonl(
     { type: "item.started", item: { type: "command_execution", command: "npm test" } },


### PR DESCRIPTION
## Summary
- increment Codex turn counts for every `turn.completed` event
- retain only the latest cumulative Codex token snapshot
- add a multi-turn regression test for turn and token metrics

## Verification
- `bun test lib/transcript.test.mjs`

UX critique: skipped — backend transcript metrics parser with no user-facing surface

Fixes WM-276