### PR TITLE
fix(linear): parse valued flags correctly

### DIFF
--- a/tools/linear.mjs
+++ b/tools/linear.mjs
@@ -241,9 +241,28 @@ async function applyLabels(issue, add, remove) {
 }
 
 // ------------------------------------------------------------------ verbs ---
+const VALUE_FLAGS = new Set([
+  "add", "agent", "area", "body", "label", "project", "remove",
+  "source", "team", "title", "type", "var",
+]);
+
+/** Return command arguments that are not flags or values consumed by flags. */
+export function parsePositionalArgs(argv) {
+  const positional = [];
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      if (VALUE_FLAGS.has(arg.slice(2))) i += 1;
+      continue;
+    }
+    positional.push(arg);
+  }
+  return positional;
+}
+
 const argv = process.argv.slice(2);
 const verb = argv[0];
-const positional = argv.slice(1).filter((a) => !a.startsWith("--"));
+const positional = parsePositionalArgs(argv);
 const flag = (name, dflt = null) => {
   const i = argv.indexOf(`--${name}`);
   return i === -1 ? dflt : argv[i + 1];

--- a/tools/linear.test.mjs
+++ b/tools/linear.test.mjs
@@ -8,7 +8,7 @@
  * tickets a human curated — so it gets real tests.
  */
 import { test, expect } from "bun:test";
-import { resolveLabelIds, claimLabels, validateLabels, formatTicket, agentLabel, TYPE_LABELS, formatComment, formatComments } from "./linear.mjs";
+import { resolveLabelIds, claimLabels, validateLabels, formatTicket, agentLabel, TYPE_LABELS, formatComment, formatComments, parsePositionalArgs } from "./linear.mjs";
 
 const LABELS = [
   { id: "l-ready", name: "ai:agent-ready" },
@@ -168,6 +168,28 @@ test("formatComments accepts issue object containing comments nodes", () => {
   const text = formatComments(issue);
   expect(text).toContain("Charlie");
   expect(text).toContain("Testing issue comments wrapper");
+});
+
+// ------------------------------------------------------- argument parsing ---
+test("state label-only updates do not parse flag values as positional arguments", () => {
+  expect(parsePositionalArgs([
+    "state", "WM-250", "--add", "ai:needs-review", "--remove", "ai:in-progress",
+  ])).toEqual(["WM-250"]);
+});
+
+test("state and label updates preserve the explicit state positional argument", () => {
+  expect(parsePositionalArgs([
+    "state", "WM-250", "In Review", "--add", "ai:needs-review",
+  ])).toEqual(["WM-250", "In Review"]);
+});
+
+test("values for other flags are not treated as positional arguments", () => {
+  expect(parsePositionalArgs([
+    "claim", "WM-250", "--agent", "codex", "--json",
+  ])).toEqual(["WM-250"]);
+  expect(parsePositionalArgs([
+    "file", "--team", "WM", "--title", "A title", "--todo",
+  ])).toEqual([]);
 });
 
 // -------------------------------------------------------- label mutations ---


### PR DESCRIPTION
## Summary
- parse CLI positionals without retaining values consumed by flags
- cover label-only and combined state updates plus other valued flags

## Verification
- `bun test tools/linear.test.mjs`

UX critique: skipped — internal CLI parser change with no user-facing application flow.

Fixes WM-250