### PR TITLE
fix(event-runtime-web): show VERIFYING deadline clocks (WM-249)

### DIFF
--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -88,6 +88,16 @@ describe("RunDetailBlocks field tiering (WM-129)", () => {
     expect(done.queryByText("Deadlines")).toBeNull();
   });
 
+  test("shows active attempt and lease clocks while a run is VERIFYING (WM-249)", () => {
+    const verifying = renderBlocks(
+      createRunDetailFixture({ run: { state: "VERIFYING" } as RunDetail["run"] }),
+    );
+
+    expect(verifying.getByText("Deadlines")).toBeTruthy();
+    expect(verifying.getByTitle(/^timeout in /)).toBeTruthy();
+    expect(verifying.getByTitle(/^reaped in /)).toBeTruthy();
+  });
+
   test("attempt cards carry started/finished timestamps", () => {
     const r = renderBlocks(createRunDetailFixture({}));
     // Once in the Deadlines clock, once on the attempt card — the card row is the one this test owns.

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -22,11 +22,10 @@ export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OU
 export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && state !== "VERIFYING";
 
 /**
- * The two states `reapExpiredLeases` sweeps (lib/worker.mjs) — so exactly the
- * states where the current attempt is racing a deadline. A VERIFYING run has
- * already exited its agent and is never reaped, so it has no clock to show.
+ * The states `reapExpiredLeases` sweeps (lib/worker.mjs) — exactly the states
+ * where the current attempt is still racing its attempt and lease deadlines.
  */
-export const IN_FLIGHT: RunState[] = ["LEASED", "RUNNING"];
+export const IN_FLIGHT: RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
 
 /** `off`: no deadline running yet. `spent`: the deadline passed; the runtime has not caught up. */
 export type Clock = { kind: "off" } | { kind: "live"; leftMs: number } | { kind: "spent" };


### PR DESCRIPTION
## Summary
- include `VERIFYING` in the states that render active attempt deadlines
- cover both the budget and lease clocks with a component regression test

## Verification
- `cd event-runtime/web && bun test src/components/RunDetailBlocks.test.tsx`

UX critique: skipped — restores existing read-only deadline information for one additional state; no new flow, interaction, or layout.

Fixes WM-249