### PR TITLE
fix(worktrees): reclaim pidless bun install locks

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -177,14 +177,18 @@ test("old holder cleanup preserves a new holder before pid publication", () => {
   }
 });
 
-test("locked_bun_install cleans up held lock on SIGTERM and exits 143", async () => {
-  const testDir = createTempProject();
-  const lockDir = makeTestLockDir("test-sigterm-trap");
-  const mockBinDir = mkdtempSync(path.join(tmpdir(), "mock-bun-"));
-  const readyFile = path.join(mockBinDir, "ready.txt");
+test("locked_bun_install composes prior INT/TERM/EXIT traps on interruption", async () => {
+  for (const { trapName, exitCode } of [
+    { trapName: "INT", exitCode: 130 },
+    { trapName: "TERM", exitCode: 143 },
+  ]) {
+    const testDir = createTempProject();
+    const lockDir = makeTestLockDir(`test-${trapName.toLowerCase()}-trap`);
+    const mockBinDir = mkdtempSync(path.join(tmpdir(), "mock-bun-"));
+    const readyFile = path.join(mockBinDir, "ready.txt");
 
-  const mockBun = path.join(mockBinDir, "bun");
-  writeFileSync(mockBun, `#!/usr/bin/env bash
+    const mockBun = path.join(mockBinDir, "bun");
+    writeFileSync(mockBun, `#!/usr/bin/env bash
 if [[ "$1" == "install" ]]; then
   touch "${readyFile}"
   sleep 1
@@ -193,35 +197,48 @@ fi
 exec bun "$@"
 `, { mode: 0o755 });
 
-  try {
-    const proc = Bun.spawn([
-      "bash",
-      "-c",
-      `source "${COMMON}"\nlocked_bun_install "${testDir}"`,
-    ], {
-      stdout: "pipe",
-      stderr: "pipe",
-      env: {
-        ...process.env,
-        PATH: `${mockBinDir}${path.delimiter}${process.env.PATH}`,
-        FACTORY_LOCK_DIR: lockDir,
-      },
-    });
+    try {
+      const proc = Bun.spawn([
+        "bash",
+        "-c",
+        `source "${COMMON}"
+trap 'echo PRIOR_EXIT_TRIGGERED' EXIT
+trap 'echo PRIOR_${trapName}_TRIGGERED' ${trapName}
+(
+  for _ in {1..200}; do
+    if [[ -e "${readyFile}" ]]; then
+      kill -${trapName} "$$"
+      exit 0
+    fi
+    sleep 0.01
+  done
+  echo "timed out waiting for mock bun" >&2
+) &
+locked_bun_install "${testDir}"`,
+      ], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          PATH: `${mockBinDir}${path.delimiter}${process.env.PATH}`,
+          FACTORY_LOCK_DIR: lockDir,
+        },
+      });
+      const stdoutPromise = new Response(proc.stdout).text();
+      const stderrPromise = new Response(proc.stderr).text();
 
-    for (let i = 0; i < 50; i++) {
-      if (existsSync(readyFile)) break;
-      await Bun.sleep(10);
+      const [status, stdout, stderr] = await Promise.all([proc.exited, stdoutPromise, stderrPromise]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`PRIOR_${trapName}_TRIGGERED`);
+      expect(stdout).toContain("PRIOR_EXIT_TRIGGERED");
+      expect(status).toBe(exitCode);
+      expect(existsSync(readyFile)).toBe(true);
+      expect(existsSync(lockDir)).toBe(false);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+      rmSync(lockDir, { recursive: true, force: true });
+      rmSync(mockBinDir, { recursive: true, force: true });
     }
-
-    expect(existsSync(lockDir)).toBe(true);
-    proc.kill("SIGTERM");
-    const exitCode = await proc.exited;
-    expect([143, 1, 0]).toContain(exitCode);
-    expect(existsSync(lockDir)).toBe(false);
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-    rmSync(lockDir, { recursive: true, force: true });
-    rmSync(mockBinDir, { recursive: true, force: true });
   }
 });
 

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -157,20 +157,20 @@ test("locked_bun_install restores prior EXIT/INT/TERM traps upon clean return", 
   }
 });
 
-test("release_bun_install_lock only deletes lock owned by current process or pid-less", () => {
-  const lockDir = makeTestLockDir("test-release-ownership");
+test("old holder cleanup preserves a new holder before pid publication", () => {
+  const lockDir = makeTestLockDir("test-release-generation");
   mkdirSync(lockDir, { recursive: true });
-  writeFileSync(path.join(lockDir, "pid"), "12345");
 
   try {
-    // Attempt release with non-matching owner PID -> should NOT remove lock
-    const rNonMatch = sh(`release_bun_install_lock "${lockDir}" "99999"`);
-    expect(rNonMatch.status).toBe(0);
+    const oldCleanup = sh(`release_bun_install_lock "${lockDir}" "12345"`);
+    expect(oldCleanup.status).toBe(0);
     expect(existsSync(lockDir)).toBe(true);
 
-    // Release with matching owner PID -> removes lock
-    const rMatch = sh(`release_bun_install_lock "${lockDir}" "12345"`);
-    expect(rMatch.status).toBe(0);
+    writeFileSync(path.join(lockDir, "pid"), "67890");
+    expect(existsSync(lockDir)).toBe(true);
+
+    const newCleanup = sh(`release_bun_install_lock "${lockDir}" "67890"`);
+    expect(newCleanup.status).toBe(0);
     expect(existsSync(lockDir)).toBe(false);
   } finally {
     rmSync(lockDir, { recursive: true, force: true });

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -67,6 +67,25 @@ test("locked_bun_install reclaims stale lock with dead PID and succeeds", () => 
   }
 });
 
+test("locked_bun_install reclaims a stale pid-less lock directory", () => {
+  const testDir = createTempProject();
+  const lockDir = makeTestLockDir("test-pidless-lock");
+  mkdirSync(lockDir, { recursive: true });
+
+  try {
+    const r = sh(`locked_bun_install "${testDir}"`, {
+      FACTORY_LOCK_DIR: lockDir,
+      FACTORY_LOCK_STALE_AFTER: "0",
+      FACTORY_LOCK_MAX_WAIT: "2",
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
 test("locked_bun_install preserves live locks and times out when lock held", () => {
   const testDir = createTempProject();
   const lockDir = makeTestLockDir("test-live-lock");

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -135,6 +135,152 @@ test("concurrent locked_bun_install invocations serialize without colliding", as
   }
 });
 
+test("locked_bun_install restores prior EXIT/INT/TERM traps upon clean return", () => {
+  const testDir = createTempProject();
+  const lockDir = makeTestLockDir("test-trap-restore");
+  try {
+    const script = `
+      trap 'echo CUSTOM_EXIT_TRIGGERED' EXIT
+      trap 'echo CUSTOM_INT_TRIGGERED' INT
+      trap 'echo CUSTOM_TERM_TRIGGERED' TERM
+      locked_bun_install "${testDir}"
+      echo "INSTALL_COMPLETED"
+    `;
+    const r = sh(script, { FACTORY_LOCK_DIR: lockDir });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("INSTALL_COMPLETED");
+    expect(r.stdout).toContain("CUSTOM_EXIT_TRIGGERED");
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+test("release_bun_install_lock only deletes lock owned by current process or pid-less", () => {
+  const lockDir = makeTestLockDir("test-release-ownership");
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(path.join(lockDir, "pid"), "12345");
+
+  try {
+    // Attempt release with non-matching owner PID -> should NOT remove lock
+    const rNonMatch = sh(`release_bun_install_lock "${lockDir}" "99999"`);
+    expect(rNonMatch.status).toBe(0);
+    expect(existsSync(lockDir)).toBe(true);
+
+    // Release with matching owner PID -> removes lock
+    const rMatch = sh(`release_bun_install_lock "${lockDir}" "12345"`);
+    expect(rMatch.status).toBe(0);
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+test("locked_bun_install cleans up held lock on SIGTERM and exits 143", async () => {
+  const testDir = createTempProject();
+  const lockDir = makeTestLockDir("test-sigterm-trap");
+  const mockBinDir = mkdtempSync(path.join(tmpdir(), "mock-bun-"));
+  const readyFile = path.join(mockBinDir, "ready.txt");
+
+  const mockBun = path.join(mockBinDir, "bun");
+  writeFileSync(mockBun, `#!/usr/bin/env bash
+if [[ "$1" == "install" ]]; then
+  touch "${readyFile}"
+  sleep 1
+  exit 0
+fi
+exec bun "$@"
+`, { mode: 0o755 });
+
+  try {
+    const proc = Bun.spawn([
+      "bash",
+      "-c",
+      `source "${COMMON}"\nlocked_bun_install "${testDir}"`,
+    ], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: `${mockBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_LOCK_DIR: lockDir,
+      },
+    });
+
+    for (let i = 0; i < 50; i++) {
+      if (existsSync(readyFile)) break;
+      await Bun.sleep(10);
+    }
+
+    expect(existsSync(lockDir)).toBe(true);
+    proc.kill("SIGTERM");
+    const exitCode = await proc.exited;
+    expect([143, 1, 0]).toContain(exitCode);
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+    rmSync(mockBinDir, { recursive: true, force: true });
+  }
+});
+
+test("multiple contenders race to reclaim a stale pid-less lock and all succeed", async () => {
+  const testDirs = [createTempProject(), createTempProject(), createTempProject(), createTempProject()];
+  const lockDir = makeTestLockDir("test-pidless-race");
+  mkdirSync(lockDir, { recursive: true });
+
+  try {
+    const runContender = (dir) =>
+      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          FACTORY_LOCK_DIR: lockDir,
+          FACTORY_LOCK_STALE_AFTER: "0",
+          FACTORY_LOCK_MAX_WAIT: "10",
+        },
+      }).exited;
+
+    const results = await Promise.all(testDirs.map(runContender));
+    for (const code of results) {
+      expect(code).toBe(0);
+    }
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    for (const d of testDirs) rmSync(d, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+test("high concurrency race of 8 parallel locked_bun_install processes serializes cleanly", async () => {
+  const testDirs = Array.from({ length: 8 }, () => createTempProject());
+  const lockDir = makeTestLockDir("test-high-conc-lock");
+
+  try {
+    const runContender = (dir) =>
+      Bun.spawn(["bash", "-c", `source "${COMMON}"\nlocked_bun_install "${dir}"`], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          FACTORY_LOCK_DIR: lockDir,
+          FACTORY_LOCK_MAX_WAIT: "30",
+        },
+      }).exited;
+
+    const results = await Promise.all(testDirs.map(runContender));
+    for (const code of results) {
+      expect(code).toBe(0);
+    }
+    expect(existsSync(lockDir)).toBe(false);
+  } finally {
+    for (const d of testDirs) rmSync(d, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
 test("worktree-up --checkout-only creates checkout without daemons and worktree-down removes it", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-root-"));
   const ticketId = makeTestTicket("TEST");

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -320,6 +320,14 @@ release_bun_install_lock() { # <lock-dir> <owner-pid>
   fi
 }
 
+# Invoke the action from Bash's shell-escaped `trap -p` output.
+run_bun_install_trap() { # <trap-definition>
+  local definition="$1"
+  [[ -n "$definition" ]] || return 0
+  eval "set -- ${definition#trap -- }"
+  eval "$1"
+}
+
 # File-locked bun install with retry on SQLITE_BUSY (OPS-322).
 # Prevents concurrent worktree bring-ups from racing on bun's global cache DB.
 locked_bun_install() { # <dir>
@@ -387,9 +395,12 @@ locked_bun_install() { # <dir>
   previous_exit_trap=$(trap -p EXIT || true)
   previous_int_trap=$(trap -p INT || true)
   previous_term_trap=$(trap -p TERM || true)
-  trap 'release_bun_install_lock "$lock_dir" "$$"' EXIT
-  trap 'release_bun_install_lock "$lock_dir" "$$"; exit 130' INT
-  trap 'release_bun_install_lock "$lock_dir" "$$"; exit 143' TERM
+  local exit_handler
+  printf -v exit_handler 'code=$?; release_bun_install_lock %q %q; trap - EXIT; run_bun_install_trap %q; exit "$code"' \
+    "$lock_dir" "$$" "$previous_exit_trap"
+  trap "$exit_handler" EXIT
+  trap 'release_bun_install_lock "$lock_dir" "$$"; trap - EXIT INT; [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"; run_bun_install_trap "$previous_int_trap"; exit 130' INT
+  trap 'release_bun_install_lock "$lock_dir" "$$"; trap - EXIT TERM; [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"; run_bun_install_trap "$previous_term_trap"; exit 143' TERM
 
   local attempt=1 max_attempts=5 out="" code=0
   while [[ $attempt -le $max_attempts ]]; do

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -309,13 +309,13 @@ web_build_hash() { # <web-dir>
   ) | shasum | cut -d' ' -f1
 }
 
-# Remove a bun-install lock only when it still belongs to this process. The
-# pid-less case covers a signal arriving after mkdir but before the pid rename.
+# Remove a bun-install lock only when its published owner is this process.
+# A pid-less directory may be a new holder's pre-publication generation.
 release_bun_install_lock() { # <lock-dir> <owner-pid>
   local lock_dir="$1" owner_pid="$2" holder=""
   [[ -d "$lock_dir" ]] || return 0
   holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
-  if [[ -z "$holder" || "$holder" == "$owner_pid" ]]; then
+  if [[ "$holder" == "$owner_pid" ]]; then
     rm -rf "$lock_dir" 2>/dev/null || true
   fi
 }

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -309,69 +309,109 @@ web_build_hash() { # <web-dir>
   ) | shasum | cut -d' ' -f1
 }
 
+# Remove a bun-install lock only when it still belongs to this process. The
+# pid-less case covers a signal arriving after mkdir but before the pid rename.
+release_bun_install_lock() { # <lock-dir> <owner-pid>
+  local lock_dir="$1" owner_pid="$2" holder=""
+  [[ -d "$lock_dir" ]] || return 0
+  holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  if [[ -z "$holder" || "$holder" == "$owner_pid" ]]; then
+    rm -rf "$lock_dir" 2>/dev/null || true
+  fi
+}
+
 # File-locked bun install with retry on SQLITE_BUSY (OPS-322).
 # Prevents concurrent worktree bring-ups from racing on bun's global cache DB.
 locked_bun_install() { # <dir>
   local target_dir="$1"
   local lock_dir="${FACTORY_LOCK_DIR:-$HOME/.factory/locks/bun-install.lock}"
   local max_wait="${FACTORY_LOCK_MAX_WAIT:-120}"
+  local stale_after="${FACTORY_LOCK_STALE_AFTER:-2}"
   local start_time
   start_time=$(date +%s)
 
+  [[ "$max_wait" =~ ^[0-9]+$ ]] || die "FACTORY_LOCK_MAX_WAIT must be numeric (got '$max_wait')"
+  [[ "$stale_after" =~ ^[0-9]+$ ]] || die "FACTORY_LOCK_STALE_AFTER must be numeric (got '$stale_after')"
   mkdir -p "$(dirname "$lock_dir")"
 
   while ! mkdir "$lock_dir" 2>/dev/null; do
-    if [[ -f "$lock_dir/pid" ]]; then
-      local holder
-      holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
-      if [[ -n "$holder" ]] && ! kill -0 "$holder" 2>/dev/null; then
-        local stale_candidate="${lock_dir}.stale.$$.$RANDOM"
-        if mv "$lock_dir" "$stale_candidate" 2>/dev/null; then
-          local stale_holder
-          stale_holder=$(cat "$stale_candidate/pid" 2>/dev/null || true)
-          if [[ -n "$stale_holder" ]] && kill -0 "$stale_holder" 2>/dev/null; then
-            mv "$stale_candidate" "$lock_dir" 2>/dev/null || rm -rf "$stale_candidate"
-          else
-            rm -rf "$stale_candidate"
-          fi
-          continue
-        fi
+    local holder="" now lock_mtime=0 lock_age=0 reclaim=0
+    holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+    now=$(date +%s)
+
+    if [[ "$holder" =~ ^[0-9]+$ ]]; then
+      if ! kill -0 "$holder" 2>/dev/null; then
+        reclaim=1
+      fi
+    else
+      # A new holder needs a moment between mkdir and publishing its pid. Only
+      # reclaim a pid-less/malformed lock once that grace period has elapsed.
+      if stat -f '%m' "$lock_dir" >/dev/null 2>&1; then
+        lock_mtime=$(stat -f '%m' "$lock_dir" 2>/dev/null || printf '0')
+      else
+        lock_mtime=$(stat -c '%Y' "$lock_dir" 2>/dev/null || printf '0')
+      fi
+      [[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime=0
+      lock_age=$(( now - lock_mtime ))
+      if (( lock_age >= stale_after )); then
+        reclaim=1
       fi
     fi
-    local now
-    now=$(date +%s)
+
+    if [[ "$reclaim" -eq 1 ]]; then
+      local stale_candidate="${lock_dir}.stale.$$.$RANDOM"
+      if mv "$lock_dir" "$stale_candidate" 2>/dev/null; then
+        local stale_holder
+        stale_holder=$(cat "$stale_candidate/pid" 2>/dev/null || true)
+        if [[ "$stale_holder" =~ ^[0-9]+$ ]] && kill -0 "$stale_holder" 2>/dev/null; then
+          mv "$stale_candidate" "$lock_dir" 2>/dev/null || rm -rf "$stale_candidate"
+        else
+          rm -rf "$stale_candidate"
+        fi
+        continue
+      fi
+    fi
+
     if (( now - start_time >= max_wait )); then
       die "timed out waiting for bun install lock ($lock_dir)"
     fi
     sleep 0.1
   done
-  echo $$ > "$lock_dir/pid"
 
-  local attempt=1 max_attempts=5 out code=0
+  # Publish ownership atomically so contenders never observe a partially
+  # written pid file. Traps are restored before returning to the caller.
+  local pid_tmp="$lock_dir/pid.$$.$RANDOM"
+  printf '%s\n' "$$" > "$pid_tmp"
+  mv "$pid_tmp" "$lock_dir/pid"
+  local previous_exit_trap previous_int_trap previous_term_trap
+  previous_exit_trap=$(trap -p EXIT || true)
+  previous_int_trap=$(trap -p INT || true)
+  previous_term_trap=$(trap -p TERM || true)
+  trap 'release_bun_install_lock "$lock_dir" "$$"' EXIT
+  trap 'release_bun_install_lock "$lock_dir" "$$"; exit 130' INT
+  trap 'release_bun_install_lock "$lock_dir" "$$"; exit 143' TERM
+
+  local attempt=1 max_attempts=5 out="" code=0
   while [[ $attempt -le $max_attempts ]]; do
     out=$(cd "$target_dir" && bun install --frozen-lockfile 2>&1) && code=0 || code=$?
-    if [[ $code -eq 0 ]]; then
-      if [[ -f "$lock_dir/pid" ]] && [[ "$(cat "$lock_dir/pid" 2>/dev/null || true)" == "$$" ]]; then
-        rm -rf "$lock_dir" 2>/dev/null || true
-      fi
-      return 0
-    fi
+    [[ $code -eq 0 ]] && break
     if [[ "$out" =~ "SQLITE_BUSY" || "$out" =~ "database is locked" ]]; then
       warn "bun install in $target_dir hit SQLITE_BUSY (attempt $attempt/$max_attempts) — retrying"
       sleep $(( attempt ))
       attempt=$(( attempt + 1 ))
     else
-      if [[ -f "$lock_dir/pid" ]] && [[ "$(cat "$lock_dir/pid" 2>/dev/null || true)" == "$$" ]]; then
-        rm -rf "$lock_dir" 2>/dev/null || true
-      fi
-      printf '%s\n' "$out" >&2
-      return $code
+      break
     fi
   done
-  if [[ -f "$lock_dir/pid" ]] && [[ "$(cat "$lock_dir/pid" 2>/dev/null || true)" == "$$" ]]; then
-    rm -rf "$lock_dir" 2>/dev/null || true
+
+  release_bun_install_lock "$lock_dir" "$$"
+  trap - EXIT INT TERM
+  [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"
+  [[ -n "$previous_int_trap" ]] && eval "$previous_int_trap"
+  [[ -n "$previous_term_trap" ]] && eval "$previous_term_trap"
+  if [[ $code -ne 0 ]]; then
+    printf '%s\n' "$out" >&2
   fi
-  printf '%s\n' "$out" >&2
   return $code
 }
 


### PR DESCRIPTION
## Summary
- reclaim pid-less bun-install lock directories after a configurable grace period
- publish lock ownership atomically and clean holder-owned locks on EXIT, INT, and TERM
- cover pid-less lock recovery in the worktree checkout tests

## Verification
- `bun test bin/worktree-checkout.test.mjs`

UX critique: skipped — infrastructure-only shell lock handling has no user-facing surface.

Fixes WM-252