### PR TITLE
fix(unblock): fetch recent label history (WM-275)

### DIFF
--- a/orchestrator/digest.mjs
+++ b/orchestrator/digest.mjs
@@ -55,7 +55,7 @@ const DIGEST_QUERY = `
       nodes {
         identifier title url
         state { name }
-        comments(first: 100) { nodes { createdAt body } }
+        comments(last: 100) { nodes { createdAt body } }
         history(last: 50) { nodes { createdAt addedLabelIds } }
       }
     }

--- a/orchestrator/digest.mjs
+++ b/orchestrator/digest.mjs
@@ -56,7 +56,7 @@ const DIGEST_QUERY = `
         identifier title url
         state { name }
         comments(first: 100) { nodes { createdAt body } }
-        history(first: 100) { nodes { createdAt addedLabelIds } }
+        history(last: 50) { nodes { createdAt addedLabelIds } }
       }
     }
   }`;

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -38,7 +38,7 @@ export const HELD_QUERY = `
       nodes {
         identifier
         state { name }
-        comments(first: 100) { nodes { createdAt } }
+        comments(last: 100) { nodes { createdAt } }
         history(last: 50) { nodes { createdAt addedLabelIds } }
       }
     }

--- a/orchestrator/reply-detection.mjs
+++ b/orchestrator/reply-detection.mjs
@@ -27,7 +27,7 @@ const LABEL_IDS_QUERY = `
 // Comments + label history for held tickets only. Kept out of the queue's main
 // issue query on purpose: this costs per-issue nested pagination, so it runs
 // as a second query and only when the cheap query shows a held ticket at all.
-const HELD_QUERY = `
+export const HELD_QUERY = `
   query($team: String!, $project: String!, $label: String!) {
     issues(first: 100, filter: {
       team: { key: { eq: $team } },
@@ -39,7 +39,7 @@ const HELD_QUERY = `
         identifier
         state { name }
         comments(first: 100) { nodes { createdAt } }
-        history(first: 100) { nodes { createdAt addedLabelIds } }
+        history(last: 50) { nodes { createdAt addedLabelIds } }
       }
     }
   }`;

--- a/orchestrator/reply-detection.test.mjs
+++ b/orchestrator/reply-detection.test.mjs
@@ -18,11 +18,13 @@ function issue({ id = "CLNT-1", state = "Blocked", adds = [], comments = [], add
 }
 
 describe("answeredIdentifiers", () => {
-  test("held-ticket queries request newest label history instead of truncating to oldest events", () => {
+  test("held-ticket queries request newest history and comments instead of truncating long timelines", () => {
     const digestSource = readFileSync(new URL("./digest.mjs", import.meta.url), "utf8");
     for (const querySource of [HELD_QUERY, digestSource]) {
       expect(querySource).toContain("history(last: 50)");
       expect(querySource).not.toContain("history(first:");
+      expect(querySource).toContain("comments(last: 100)");
+      expect(querySource).not.toContain("comments(first:");
     }
   });
 

--- a/orchestrator/reply-detection.test.mjs
+++ b/orchestrator/reply-detection.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { answeredIdentifiers, holdInfo, REPLY_GRACE_MS } from "./reply-detection.mjs";
+import { readFileSync } from "node:fs";
+import { answeredIdentifiers, HELD_QUERY, holdInfo, REPLY_GRACE_MS } from "./reply-detection.mjs";
 
 const LABEL_ID = "label-ai-blocked";
 const IDS = new Set([LABEL_ID]);
@@ -17,6 +18,21 @@ function issue({ id = "CLNT-1", state = "Blocked", adds = [], comments = [], add
 }
 
 describe("answeredIdentifiers", () => {
+  test("held-ticket queries request newest label history instead of truncating to oldest events", () => {
+    const digestSource = readFileSync(new URL("./digest.mjs", import.meta.url), "utf8");
+    for (const querySource of [HELD_QUERY, digestSource]) {
+      expect(querySource).toContain("history(last: 50)");
+      expect(querySource).not.toContain("history(first:");
+    }
+  });
+
+  test("a recent re-add in a long history keeps an older reply classified as unanswered", () => {
+    const oldAdds = Array.from({ length: 100 }, (_, i) => i * 60_000);
+    const recentAdd = 120 * 60_000;
+    const held = [issue({ adds: [...oldAdds, recentAdd], comments: [110 * 60_000] })];
+    expect(answeredIdentifiers(held, IDS)).toEqual(new Set());
+  });
+
   test("comment well after the label-add is answered", () => {
     const held = [issue({ adds: [0], comments: [-2000, 30 * 60_000] })];
     expect(answeredIdentifiers(held, IDS)).toEqual(new Set(["CLNT-1"]));


### PR DESCRIPTION
## Summary
- fetch the latest 50 label-history events for reply detection and blocked-ticket digests
- add a regression for long issue histories and guard both GraphQL query contracts

## Verification
- `bun test orchestrator/reply-detection.test.mjs` — 14 pass, 0 fail
- `bun build/emit.mjs --check` — generated files match

UX critique: skipped — backend/internal orchestration query with no user-facing flow

Fixes WM-275