### PR TITLE
fix(workers-remote): expand remote probe variables

### DIFF
--- a/event-runtime/lib/workers-remote.mjs
+++ b/event-runtime/lib/workers-remote.mjs
@@ -180,7 +180,7 @@ export function probeRemoteNode(node, {
     `OS=$(uname -s 2>/dev/null || echo "unknown");`,
     `BUN_VER=$(bun --version 2>/dev/null || echo "not_found");`,
     `WORKER_PIDS=$(ps -axo pid,command 2>/dev/null | grep -E "bun.*event-runtime/cli\\.mjs work" | grep -v grep | awk '{print $1}' | tr '\\n' ',' | sed 's/,$//');`,
-    `echo "PROBE_RESULT:$$HEAD_SHA|$$BRANCH|$$DIRTY|$$ARCH|$$OS|$$BUN_VER|$$WORKER_PIDS"`,
+    `echo "PROBE_RESULT:$HEAD_SHA|$BRANCH|$DIRTY|$ARCH|$OS|$BUN_VER|$WORKER_PIDS"`,
   ].join(" ");
 
   const res = executeSsh(node, probeScript, { spawnFn, connectTimeout });
@@ -212,8 +212,10 @@ export function probeRemoteNode(node, {
 
   const [headSha, branch, dirtyCount, arch, osName, bunVer, pidsRaw] = match[1].trim().split("|");
   const pids = pidsRaw ? pidsRaw.split(",").map(Number).filter(Boolean) : [];
+  const parsedDirtyCount = Number(dirtyCount);
+  const normalizedDirtyCount = Number.isInteger(parsedDirtyCount) && parsedDirtyCount >= 0 ? parsedDirtyCount : 0;
   const isMissingDir = headSha === "missing_dir";
-  const isDirty = Number(dirtyCount) > 0;
+  const isDirty = normalizedDirtyCount > 0;
 
   let outdated = false;
   let skewStatus = "synced";
@@ -241,6 +243,7 @@ export function probeRemoteNode(node, {
       factoryRoot: node.factoryRoot,
       headSha: isMissingDir ? null : headSha,
       branch: isMissingDir ? null : branch,
+      dirtyCount: normalizedDirtyCount,
       dirty: isDirty,
       arch,
       os: osName,

--- a/event-runtime/lib/workers-remote.test.mjs
+++ b/event-runtime/lib/workers-remote.test.mjs
@@ -130,15 +130,23 @@ describe("remote probe and version skew", () => {
     adapters: ["claude"],
   };
 
-  test("probeRemoteNode detects synced remote worker", () => {
-    const mockSpawn = () => ({
-      exitCode: 0,
-      stdout: "PROBE_RESULT:abc12345|develop|0|arm64|Darwin|1.3.14|45001",
-      stderr: "",
-    });
+  test("probeRemoteNode expands remote probe variables and returns exact telemetry", () => {
+    const mockSpawn = (args) => {
+      const probeScript = args.at(-1);
+      expect(probeScript).toContain(
+        'echo "PROBE_RESULT:$HEAD_SHA|$BRANCH|$DIRTY|$ARCH|$OS|$BUN_VER|$WORKER_PIDS"',
+      );
+      expect(probeScript).not.toContain("$$HEAD_SHA");
+      return {
+        exitCode: 0,
+        stdout:
+          "PROBE_RESULT:0123456789abcdef0123456789abcdef01234567|feat/remote-probe|2|arm64|Darwin|1.3.14|501,777",
+        stderr: "",
+      };
+    };
 
     const result = probeRemoteNode(testNode, {
-      localTrunkSha: "abc12345",
+      localTrunkSha: "0123456789abcdef0123456789abcdef01234567",
       spawnFn: mockSpawn,
     });
 
@@ -146,8 +154,10 @@ describe("remote probe and version skew", () => {
     expect(result.outdated).toBe(false);
     expect(result.skewStatus).toBe("synced");
     expect(result.workerActive).toBe(true);
-    expect(result.workerPids).toEqual([45001]);
-    expect(result.details.headSha).toBe("abc12345");
+    expect(result.workerPids).toEqual([501, 777]);
+    expect(result.details.headSha).toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(result.details.branch).toBe("feat/remote-probe");
+    expect(result.details.dirtyCount).toBe(2);
   });
 
   test("probeRemoteNode detects outdated version skew", () => {


### PR DESCRIPTION
## Summary
- expand remote probe telemetry variables with single-dollar Bash syntax
- preserve and expose the parsed integer dirty count
- add regression coverage for generated probe syntax and exact SSH telemetry parsing

## Verification
- `bun test event-runtime/lib/workers-remote.test.mjs`

UX critique: skipped — backend-only SSH telemetry fix with no user-facing flow

Fixes WM-258