### PR TITLE
fix(ps): reject zombie and recycled daemon PIDs (WM-277)

### DIFF
--- a/lib/ps.mjs
+++ b/lib/ps.mjs
@@ -311,16 +311,51 @@ export function categorizeProcess(proc, { worktrees = [], repos = [], home = osH
   return { kind: "other", proc };
 }
 
-/** Check if PID is alive */
-export function isPidAlive(pid) {
-  if (!pid || Number.isNaN(Number(pid))) return false;
+/** Read the POSIX process state and full command for a PID. */
+function inspectPidWithPs(pid) {
+  const result = spawnSync("ps", ["-o", "stat=", "-o", "command=", "-p", String(pid)], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  return String(result.stdout ?? "").trim() || null;
+}
+
+/** Check that a PID is alive, non-zombie, and still belongs to the expected daemon. */
+export function isPidAlive(
+  pid,
+  expectedCommand = null,
+  { inspectPid = inspectPidWithPs, kill = process.kill, platform = process.platform } = {},
+) {
+  const numericPid = Number(pid);
+  if (!Number.isInteger(numericPid) || numericPid <= 0) return false;
+
   try {
-    process.kill(Number(pid), 0);
-    return true;
+    kill(numericPid, 0);
+  } catch {
+    return false;
+  }
+
+  // Windows has no POSIX `ps`; signal 0 remains the best available check there.
+  if (platform === "win32") return true;
+
+  try {
+    const processInfo = inspectPid(numericPid);
+    const match = String(processInfo ?? "").trim().match(/^(\S+)\s+(.+)$/s);
+    if (!match) return false;
+
+    const [, state, command] = match;
+    if (state.toUpperCase().includes("Z") || command.toLowerCase().includes("<defunct>")) return false;
+    return expectedCommand ? command.includes(expectedCommand) : true;
   } catch {
     return false;
   }
 }
+
+const WORKTREE_DAEMON_SIGNATURES = {
+  serve: "event-runtime/cli.mjs serve",
+  worker: "event-runtime/cli.mjs work",
+  web: "event-runtime/web/serve.mjs",
+};
 
 /**
  * Scan worktrees across configured repos
@@ -402,7 +437,7 @@ export function scanWorktrees({
             if (existsSync(pidFile)) {
               try {
                 const p = Number(readFileSync(pidFile, "utf8").trim());
-                if (isPidAlive(p)) pids[s] = p;
+                if (isPidAlive(p, WORKTREE_DAEMON_SIGNATURES[s])) pids[s] = p;
               } catch {
                 // ignore
               }

--- a/orchestrator/ps.test.mjs
+++ b/orchestrator/ps.test.mjs
@@ -1,4 +1,6 @@
 import { test, expect, describe } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   parsePs,
@@ -8,6 +10,8 @@ import {
   extractAdapterOverride,
   extractWorktreePath,
   categorizeProcess,
+  isPidAlive,
+  scanWorktrees,
   collectFactoryPsSnapshot,
   formatFactoryPsReport,
 } from "../lib/ps.mjs";
@@ -164,6 +168,43 @@ describe("process categorization", () => {
 
     const helper = { pid: 401, ppid: 1, cpu: 0, mem: 0, etime: "10:00", command: "/Applications/Claude.app/Contents/Frameworks/Claude Helper" };
     expect(categorizeProcess(helper).kind).toBe("ignored");
+  });
+});
+
+describe("worktree daemon liveness", () => {
+  test("isPidAlive rejects zombie and defunct daemon processes", () => {
+    const inspectPid = () => "Z+   [bun] <defunct>";
+
+    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(false);
+  });
+
+  test("isPidAlive rejects a recycled PID whose command does not match the daemon", () => {
+    const inspectPid = () => "S+   unrelated-system-process --background";
+
+    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(false);
+  });
+
+  test("isPidAlive accepts a non-zombie process with the expected daemon signature", () => {
+    const inspectPid = () => "S+   bun event-runtime/cli.mjs work --adapter-override fake";
+
+    expect(isPidAlive(process.pid, "event-runtime/cli.mjs work", { inspectPid })).toBe(true);
+  });
+
+  test("scanWorktrees does not mark a worktree active when its PID was recycled", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "factory-ps-"));
+    const worktree = path.join(root, "factory", "WM-277");
+    const runDir = path.join(worktree, ".factory", "run");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(path.join(runDir, "worker.pid"), String(process.pid));
+
+    try {
+      const result = scanWorktrees({ worktreeRootFallback: root });
+      expect(result.worktrees).toHaveLength(1);
+      expect(result.worktrees[0].pids).toEqual({});
+      expect(result.worktrees[0].active).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- inspect POSIX daemon state and command identity after signal-0 liveness checks
- reject zombie, defunct, and recycled PID-file references
- validate worktree serve, worker, and web PID files against their expected command signatures
- add focused liveness and inactive-worktree regression coverage

## Verification
- `bun test orchestrator/ps.test.mjs` — 22 pass, 0 fail
- `bun build/emit.mjs --check` — generated files match

UX critique: skipped — backend/CLI process inspection change with no user-completable flow

Fixes WM-277