### PR TITLE
feat(event-runtime): auto-approve safe chain work (WM-357)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -1,6 +1,15 @@
 # Limits the dispatcher enforces. Changing these changes how much autonomy the
 # factory has, so they live in git and move by PR — not by editing a running box.
 
+chain_auto_approval:
+  # Only internally admitted chain events in this closed set may be approved
+  # unattended. Every other proposal remains watched by default.
+  allowed_event_types:
+    - factory.work.requested
+    - factory.triage.requested
+    - factory.triage-apply.requested
+    - factory.dispatch.requested
+
 concurrency:
   # Per-repo admission ceiling. Actual execution remains bounded by worker
   # availability, ticket claims, and Owned Paths collision checks.

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -279,6 +279,26 @@ validator, not a paragraph.
 
 ---
 
+### Chain auto-approval (WM-357)
+
+`config/policy.yaml` is the only allowlist for unattended chain proposals. Its
+closed set covers `factory.work.requested`, `factory.triage.requested`,
+`factory.triage-apply.requested`, and `factory.dispatch.requested`; missing or
+malformed policy means watched. The event must have been admitted with source
+`chain`, and the normal proposal, lifecycle, journal, budget, and worker gates
+remain in force.
+
+Dispatch is re-read immediately before approval: it must still be Todo,
+unassigned, `ai:agent-ready`, inside its lease cap, and disjoint from active
+Owned Paths. `ai:escalated`, security classification, and a ticket path that
+intersects the repo's `escalate_paths` leave the proposal open with a typed
+reason. Triage apply additionally revalidates its schema and closed action
+registry. Proposal/run-spec mismatches and expired proposals fail closed.
+
+`merge-apply` and `ship-apply` are not allowlistable by this path. In
+particular, their watched/human-only controls remain structurally unchanged;
+this policy does not implement autonomous merge work.
+
 ## 8. The §3 boundary, restated item by item
 
 Moved by this design — permitted only through §§2–7 above:

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -31,6 +31,8 @@ import { newWorkerId } from "./lib/ids.mjs";
 import { pruneArtifacts } from "./lib/artifacts.mjs";
 import { publishOutbox } from "./lib/outbox.mjs";
 import { autoApproveScheduled, emitDueTicks, scheduleView } from "./lib/schedules.mjs";
+import { autoApproveChains } from "./lib/auto-approval.mjs";
+import { worktreeDispatchAutoEligibility } from "./lib/planner.mjs";
 import { resolveChains } from "./lib/chain.mjs";
 import { notifyPending } from "./lib/notify.mjs";
 import { reconcileInbox } from "./lib/inbox.mjs";
@@ -135,7 +137,7 @@ async function withClient(fn) {
 // cannot hitch every 1s tick.
 export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
-export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "inbox", "notify", "outbox", "GC", "chains"];
+export const TICK_SUBSYSTEMS = ["tick emit", "plan", "auto-approve", "auto-approve-chains", "inbox", "notify", "outbox", "GC", "chains"];
 
 /**
  * One serve-loop pass (OPS-412). Each named subsystem is caught on its own
@@ -187,6 +189,17 @@ export async function tick({
     const auto = autoApproveScheduled(db, registry, approveProposal, { now, policyVersion: pv });
     for (const a of auto.approved) logLine(`schedule approved ${a.loop} → run ${a.runId} (actor: schedule)`);
     for (const err of auto.errors) logLine(`schedule approval error: ${err}`);
+  });
+
+  await runStep("auto-approve-chains", () => {
+    const auto = autoApproveChains(db, registry, {
+      now,
+      policyVersion: pv,
+      dispatchEligibility: worktreeDispatchAutoEligibility,
+      dispatch: db ? db : null,
+    });
+    for (const a of auto.approved) logLine(`chain proposal approved ${a.proposalId} → run ${a.runId} (actor: chain auto)`);
+    for (const e of auto.errors) logLine(`chain approval error: ${e.proposalId}:${e.reason}`);
   });
 
   await runStep("announce", () => {

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -26,12 +26,13 @@
  *
  *   Triage Chain (repository workspace with repoPin):
  *     COMPLETED triage-scan@1                             repository workspace, pinned sha
+ *     COMPLETED triage-apply@1                            chain auto-approved closed plan
  *
- *   Open proposals:
- *     - open approvable (`run`)
- *     - open human_needed (empty repos fails schema minItems)
- *     - open TTL-expired proposal
- *     - open triage-apply@1 from chain
+ *   Open watched proposals:
+ *     - direct operator approvable (`run`)
+ *     - merge-apply and ship-apply (human watched)
+ *     - human_needed (empty repos fails schema minItems)
+ *     - TTL-expired proposal
  *
  *   Admitted & anomaly events:
  *     - dead-lettered event (lastPlanError present)
@@ -93,12 +94,12 @@ async function projectNames() {
 /** repos[0] must stay the fake adapter's mode — the project name only trails it. */
 const tag = (mode, project) => (project ? [mode, project] : [mode]);
 
-function envelope(id, repos, type = "factory.status-report.requested") {
+function envelope(id, repos, type = "factory.status-report.requested", source = "demo-seed") {
   return {
     schemaVersion: "factory.event/v1",
     eventId: `${prefix}-${id}`,
     type,
-    source: "demo-seed",
+    source,
     subject: "factory",
     occurredAt: new Date().toISOString(),
     correlationId: `${prefix}-${id}`,
@@ -149,11 +150,11 @@ async function until(what, fn, { timeoutMs = 30_000, everyMs = pollMs } = {}) {
   throw new Error(`timed out waiting for ${what}`);
 }
 
-async function openProposalFor(eventId, { agent } = {}) {
+async function proposalFor(eventId, { agent, status = "open" } = {}) {
   return until(`proposal for ${agent ?? eventId}`, async () => {
-    const { proposals } = await client.proposals();
+    const { proposals } = await client.proposals(status === "open" ? undefined : "all");
     return proposals.find((p) => {
-      if (p.status !== "open") return false;
+      if (status !== "all" && p.status !== status) return false;
       if (agent) return p.spec?.agent === agent || p.agent === agent;
       return (
         p.spec?.idempotencyKey?.includes(eventId) ||
@@ -163,6 +164,10 @@ async function openProposalFor(eventId, { agent } = {}) {
       );
     });
   });
+}
+
+async function openProposalFor(eventId, options = {}) {
+  return proposalFor(eventId, { ...options, status: "open" });
 }
 
 /** human_needed proposals carry no spec — match via their admitted event. */
@@ -338,18 +343,61 @@ await client.approve(triageScanProposal.id);
 await runTerminal(triageScanProposal.runId, "COMPLETED");
 log(`${triageScanProposal.runId} → COMPLETED (triage-scan@1, repository workspace)`);
 
-// Follow-up triage-apply proposal from chain
-const triageApplyProposal = await openProposalFor(triageEventId, { agent: "triage-apply@1" });
-log(`${triageApplyProposal.id} left open (triage-apply@1 chain recommendation)`);
+// Follow-up triage-apply run from chain: the closed plan is auto-approved.
+const triageApplyProposal = await proposalFor(triageEventId, { agent: "triage-apply@1", status: "all" });
+await runTerminal(triageApplyProposal.runId, "COMPLETED");
+log(`${triageApplyProposal.runId} → COMPLETED (triage-apply@1 chain auto-approved closed plan)`);
 
 // 7. Duplicate delivery suppression
 const dupOutcome = await client.replay(envelope("completed", tag("ok", projectA)));
 log(`duplicate admission test: duplicate=${dupOutcome.duplicate}`);
 
-// 8. Open proposals: approvable (`run`), human_needed, and TTL-expired
-await replay(envelope("open", tag("ok", projectA)));
+// 8. Open watched proposals: direct/operator, merge/ship, human_needed, and TTL-expired
+await replay(envelope("open", tag("ok", projectA), undefined, "operator"));
 const open = await openProposalFor(`${prefix}-open`);
-log(`${open.id} left open (approvable → instant COMPLETED)`);
+log(`${open.id} left open (direct operator approvable → instant COMPLETED)`);
+
+const fixtureSha = "a".repeat(40);
+const mergeEventId = `${prefix}-merge-watched`;
+await client.replay({
+  schemaVersion: "factory.event/v1",
+  eventId: mergeEventId,
+  type: "factory.merge-apply.requested",
+  source: "operator",
+  subject: primaryProject,
+  occurredAt: new Date().toISOString(),
+  correlationId: mergeEventId,
+  payload: {
+    repo: primaryProject,
+    github: "watt-mind/factory",
+    plan: [{ pr: 42, headSha: fixtureSha, ticket: "WM-400", action: "merge_pr" }],
+  },
+});
+const mergeWatched = await openProposalFor(mergeEventId, { agent: "merge-apply@1" });
+log(`${mergeWatched.id} left open (merge-apply@1 watched)`);
+
+const shipEventId = `${prefix}-ship-watched`;
+await client.replay({
+  schemaVersion: "factory.event/v1",
+  eventId: shipEventId,
+  type: "factory.ship-apply.requested",
+  source: "operator",
+  subject: primaryProject,
+  occurredAt: new Date().toISOString(),
+  correlationId: shipEventId,
+  payload: {
+    repo: primaryProject,
+    github: "watt-mind/factory",
+    base: "develop",
+    deployBranch: "main",
+    headSha: fixtureSha,
+    deployHeadSha: fixtureSha,
+    changelog: [{ sha: fixtureSha, subject: "fixture release", ticket: "WM-400" }],
+    plan: [{ action: "open_rc_pr" }],
+  },
+});
+const shipWatched = await openProposalFor(shipEventId, { agent: "ship-apply@1" });
+log(`${shipWatched.id} left open (ship-apply@1 human watched)`);
 
 await replay(envelope("human-needed", []));
 const human = await humanNeededProposal(`${prefix}-human-needed`);

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -155,13 +155,16 @@ async function proposalFor(eventId, { agent, status = "open" } = {}) {
     const { proposals } = await client.proposals(status === "open" ? undefined : "all");
     return proposals.find((p) => {
       if (status !== "all" && p.status !== status) return false;
-      if (agent) return p.spec?.agent === agent || p.agent === agent;
-      return (
+      const eventMatches =
         p.spec?.idempotencyKey?.includes(eventId) ||
         p.reason?.includes(eventId) ||
-        p.eventId?.includes(eventId) ||
-        (p.spec?.input && JSON.stringify(p.spec.input).includes(eventId))
-      );
+        p.eventId === eventId ||
+        (p.spec?.input && JSON.stringify(p.spec.input).includes(eventId));
+      if (agent) {
+        const agentMatches = p.spec?.agent === agent || p.agent === agent;
+        return agentMatches && eventMatches;
+      }
+      return eventMatches;
     });
   });
 }
@@ -343,10 +346,18 @@ await client.approve(triageScanProposal.id);
 await runTerminal(triageScanProposal.runId, "COMPLETED");
 log(`${triageScanProposal.runId} → COMPLETED (triage-scan@1, repository workspace)`);
 
-// Follow-up triage-apply run from chain: the closed plan is auto-approved.
-const triageApplyProposal = await proposalFor(triageEventId, { agent: "triage-apply@1", status: "all" });
+// Follow-up triage-apply run from this scan's exact causal edge. Matching only
+// by agent can reuse a terminal proposal from a prior seed while the fresh edge
+// has not even been emitted yet.
+const triageApplyEventId = `chain-${triageScanProposal.runId}`;
+const triageApplyProposal = await proposalFor(triageApplyEventId, {
+  agent: "triage-apply@1",
+  status: "all",
+});
 await runTerminal(triageApplyProposal.runId, "COMPLETED");
-log(`${triageApplyProposal.runId} → COMPLETED (triage-apply@1 chain auto-approved closed plan)`);
+log(
+  `${triageApplyProposal.runId} → COMPLETED (triage-apply@1 chain auto-approved closed plan; event ${triageApplyEventId})`,
+);
 
 // 7. Duplicate delivery suppression
 const dupOutcome = await client.replay(envelope("completed", tag("ok", projectA)));

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -12,6 +12,7 @@ const VERIFY = fileURLToPath(new URL("./verify.mjs", import.meta.url));
 const TRIAGE_SCAN_OUTPUT_SCHEMA = JSON.parse(
   readFileSync(fileURLToPath(new URL("../schemas/triage-scan.output.json", import.meta.url)), "utf8"),
 );
+const SEED_TIMEOUT_MS = 10_000;
 
 const redact = (text) => String(text ?? "")
   .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
@@ -24,6 +25,19 @@ function expectSuccess(label, result) {
     `stderr:\n${redact(result.stderr)}`,
   ].join("\n");
   expect(result.status, diagnostic).toBe(0);
+}
+
+async function waitForPublishedOutbox(port) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/status`);
+      const status = await response.json();
+      if (response.ok && status.anomalies?.unpublishedOutbox === 0) return;
+    } catch {}
+    await Bun.sleep(50);
+  }
+  expect.fail("seeded runtime did not publish its outbox within 5 seconds");
 }
 
 describe("triage-scan write-detail contract (WM-352)", () => {
@@ -144,14 +158,16 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     }
   });
 
-  test("initial seed succeeds and verify passes", () => {
+  test("initial seed succeeds and verify passes", async () => {
     const t0 = Date.now();
     const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t1", "--poll-ms", "40"], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
     expectSuccess("initial seed", seedRes);
-    expect(Date.now() - t0).toBeLessThan(8_000);
+    // The triage chain now waits for its auto-approved apply run to finish.
+    expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);
+    await waitForPublishedOutbox(port);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {
       encoding: "utf8",
@@ -173,14 +189,16 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     expect(output).toContain("duplicate prefix \"t1\"");
   }, 10_000);
 
-  test("re-seeding with a NEW prefix cleans up hang runs and allows verify to pass", () => {
+  test("re-seeding with a NEW prefix cleans up hang runs and allows verify to pass", async () => {
     const t0 = Date.now();
     const seedRes = spawnSync("bun", [SEED, "--port", port, "--prefix", "t2", "--poll-ms", "40"], {
       encoding: "utf8",
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
     expectSuccess("re-seed", seedRes);
-    expect(Date.now() - t0).toBeLessThan(8_000);
+    // The triage chain now waits for its auto-approved apply run to finish.
+    expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);
+    await waitForPublishedOutbox(port);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {
       encoding: "utf8",

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -91,6 +91,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   let port;
   let serveChild;
   let workerChild;
+  let initialTriageApplyRun;
 
   beforeAll(async () => {
     home = mkdtempSync(path.join(os.tmpdir(), "evrt-seed-test-"));
@@ -167,6 +168,10 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     expectSuccess("initial seed", seedRes);
     // The triage chain now waits for its auto-approved apply run to finish.
     expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);
+    initialTriageApplyRun = seedRes.stdout.match(
+      /^seed: (\S+) → COMPLETED \(triage-apply@1 chain auto-approved/m,
+    )?.[1];
+    expect(initialTriageApplyRun).toBeTruthy();
     await waitForPublishedOutbox(port);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {
@@ -196,8 +201,14 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
     });
     expectSuccess("re-seed", seedRes);
-    // The triage chain now waits for its auto-approved apply run to finish.
+    // A fresh prefix must follow the new scan's causal edge, never reuse the
+    // prior terminal triage-apply proposal while waiting for that edge.
     expect(Date.now() - t0).toBeLessThan(SEED_TIMEOUT_MS);
+    const reseedTriageApplyRun = seedRes.stdout.match(
+      /^seed: (\S+) → COMPLETED \(triage-apply@1 chain auto-approved/m,
+    )?.[1];
+    expect(reseedTriageApplyRun).toBeTruthy();
+    expect(reseedTriageApplyRun).not.toBe(initialTriageApplyRun);
     await waitForPublishedOutbox(port);
 
     const verifyRes = spawnSync("bun", [VERIFY, "--port", port], {

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -166,9 +166,11 @@ if (ciRerunRun) {
   check("ci-rerun@1 output contract is factory.command-result/v1", ciRerunView.run?.spec?.outputContract === "factory.command-result/v1");
 }
 
-// 7. Triage scenario (repository workspace with pinned repoPin)
+// 7. Triage scenario (repository workspace with pinned repoPin and auto-approved apply)
 const triageScanRun = completedRuns.find((r) => r.agent === "triage-scan@1");
+const triageApplyRun = completedRuns.find((r) => r.agent === "triage-apply@1" && r.eventSource === "chain");
 check("triage scenario: triage-scan@1 run present", Boolean(triageScanRun));
+check("triage scenario: chain triage-apply@1 run auto-approved and completed", Boolean(triageApplyRun));
 let triageScanView = null;
 if (triageScanRun) {
   triageScanView = await client.run(triageScanRun.runId);
@@ -231,6 +233,26 @@ check("≥1 open TTL-expired proposal (p.expired === true)", expiredProposals.le
 
 const { proposals: allProposals } = await client.proposals("all");
 check("GET /proposals?status=all returns proposal history", allProposals.length > openProposals.length);
+const autoApprovedTriageApply = allProposals.find(
+  (p) => p.agent === "triage-apply@1" && p.eventSource === "chain",
+);
+check(
+  "chain triage-apply proposal is approved by chain auto-approval",
+  autoApprovedTriageApply?.status === "approved" && autoApprovedTriageApply?.decided_by === "chain-auto-approval",
+  autoApprovedTriageApply ? `${autoApprovedTriageApply.status} by ${autoApprovedTriageApply.decided_by}` : "missing",
+);
+const operatorProposal = allProposals.find(
+  (p) => p.agent === "factory-status-report@1" && p.eventSource === "operator" && p.status === "open",
+);
+check("direct operator proposal remains open/watched", Boolean(operatorProposal));
+const mergeWatchedProposal = allProposals.find(
+  (p) => p.agent === "merge-apply@1" && p.eventSource === "operator" && p.status === "open",
+);
+check("merge-apply proposal remains open/watched", Boolean(mergeWatchedProposal));
+const shipWatchedProposal = allProposals.find(
+  (p) => p.agent === "ship-apply@1" && p.eventSource === "operator" && p.status === "open",
+);
+check("ship-apply proposal remains open/human watched", Boolean(shipWatchedProposal));
 
 // 9. Events verification
 const { events } = await client.events();

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -17,7 +17,7 @@ import path from "node:path";
 import { findArtifact, listArtifacts, pruneArtifacts, storeStats } from "./artifacts.mjs";
 import { API_HOST, DEFAULT_PORT, artifactsRoot, environmentName, runtimeHome, webhookSecret } from "./config.mjs";
 import { runUsage, usageSpend } from "./db.mjs";
-import { admitEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
+import { admitEvent, admitExternalEvent, githubWebhookSecret, translateGitHubEvent, verifyGitHubWebhook, verifyWebhook } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import {
   ackInboxItem,
@@ -652,7 +652,7 @@ export { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 function admit(db, registry, res, buffer, nowMs, onEvent) {
   const parsed = parseJson(buffer);
   if (parsed.error) return send(res, 422, { errors: [parsed.error] });
-  const outcome = admitEvent(db, registry, parsed.value, { now: nowMs });
+  const outcome = admitExternalEvent(db, registry, parsed.value, { now: nowMs });
   if (!outcome.admitted && !outcome.duplicate) return send(res, 422, { errors: outcome.errors });
   if (outcome.admitted) onEvent("admitted");
   return send(res, 200, {
@@ -830,7 +830,7 @@ export function createApi({
           if (translated.ignored) return send(res, 200, { admitted: false, ignored: true, reason: translated.reason });
           return send(res, 422, { errors: [translated.reason] });
         }
-        const outcome = admitEvent(db, registry, translated.envelope, { now: nowMs });
+        const outcome = admitExternalEvent(db, registry, translated.envelope, { now: nowMs });
         if (!outcome.admitted && !outcome.duplicate) return send(res, 422, { errors: outcome.errors });
         if (outcome.admitted) onEvent("admitted");
         return send(res, 200, {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -258,6 +258,58 @@ describe("webhook intake (§14)", () => {
     expect(none.events).toEqual([]);
   });
 
+  test("signed webhook and replay cannot forge reserved chain provenance", async () => {
+    const forged = envelope({
+      eventId: "forged-chain",
+      type: "factory.triage-apply.requested",
+      source: "chain",
+      causationId: "forged-parent-run",
+      payload: {
+        repo: "factory",
+        plan: [{ issueId: "WM-409", action: "label-agent-ready" }],
+      },
+    });
+    const body = JSON.stringify(forged);
+    const ts = String(Date.now());
+    const webhook = await fetch(s.url("/events"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-factory-timestamp": ts,
+        "x-factory-signature": sign(body, ts),
+      },
+      body,
+    });
+    expect(webhook.status).toBe(422);
+    expect((await webhook.json()).errors).toContain(
+      'source: reserved internal provenance "chain"',
+    );
+
+    const replay = await fetch(s.url("/replay"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    expect(replay.status).toBe(422);
+    expect((await replay.json()).errors).toContain(
+      'source: reserved internal provenance "chain"',
+    );
+
+    expect(
+      s.db.query(`SELECT COUNT(*) AS n FROM events WHERE event_id = ?`).get(
+        forged.eventId,
+      ).n,
+    ).toBe(0);
+    expect(planAdmittedEvents(s.db, registry, { policyVersion: PV })).toEqual({
+      planned: 1,
+      failed: 0,
+      deadLettered: 0,
+    });
+    expect(
+      s.db.query(`SELECT COUNT(*) AS n FROM runs WHERE state IN ('APPROVED', 'QUEUED')`).get().n,
+    ).toBe(0);
+  });
+
   test("envelope schema failure → 422 with errors, no admission", async () => {
     const body = JSON.stringify({ schemaVersion: "factory.event/v1", eventId: "bad" });
     const ts = String(Date.now());

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -1,0 +1,309 @@
+/**
+ * Narrow, git-owned approval policy for ordinary chain work.
+ *
+ * This is still the normal proposal path: each candidate is revalidated before
+ * approval and failures stay open with a typed reason for an operator.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { hashJson } from "./canonical.mjs";
+import { approveProposal } from "./proposals.mjs";
+import { getAgent, getEventType } from "./registry.mjs";
+import { reposRoot } from "./repos.mjs";
+import { validate } from "./schema.mjs";
+
+export const CHAIN_APPROVAL_SOURCE = "chain";
+export const CHAIN_APPROVAL_MODE_AUTO = "auto";
+export const CHAIN_APPROVAL_MODE_WATCHED = "watched";
+export const CHAIN_AUTO_APPROVAL_EVENT_TYPES = new Set([
+  "factory.work.requested",
+  "factory.triage.requested",
+  "factory.triage-apply.requested",
+  "factory.dispatch.requested",
+]);
+export const CHAIN_AUTO_APPROVAL_REASON = "auto_approved:chain-policy@1";
+export const CHAIN_AUTO_APPROVAL_ACTOR = "chain-auto-approval";
+const NEVER_AUTO_APPROVE = new Set([
+  "factory.merge-apply.requested",
+  "factory.ship-apply.requested",
+]);
+
+function policyPath(root = reposRoot()) {
+  return path.join(root, "config", "policy.yaml");
+}
+
+/** Missing or malformed policy is no approval, never an implicit default. */
+export function loadChainAutoApprovalPolicy({ root = reposRoot() } = {}) {
+  const file = policyPath(root);
+  if (!existsSync(file))
+    return { allowed: new Set(), reason: "policy_missing" };
+  try {
+    const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    const allowed = parsed?.chain_auto_approval?.allowed_event_types;
+    if (
+      !Array.isArray(allowed) ||
+      !allowed.every((value) => typeof value === "string")
+    ) {
+      return { allowed: new Set(), reason: "policy_invalid" };
+    }
+    if (
+      allowed.some(
+        (eventType) =>
+          NEVER_AUTO_APPROVE.has(eventType) ||
+          !CHAIN_AUTO_APPROVAL_EVENT_TYPES.has(eventType),
+      )
+    ) {
+      return { allowed: new Set(), reason: "policy_contains_forbidden_event" };
+    }
+    return { allowed: new Set(allowed), reason: null };
+  } catch {
+    return { allowed: new Set(), reason: "policy_invalid" };
+  }
+}
+
+/** Build the immutable approval policy embedded in a chain run spec. */
+export function buildChainApprovalPolicy(
+  eventType,
+  { source = "operator", policy = loadChainAutoApprovalPolicy() } = {},
+) {
+  if (source !== CHAIN_APPROVAL_SOURCE) return null;
+  if (policy.allowed.has(eventType)) {
+    return {
+      source: CHAIN_APPROVAL_SOURCE,
+      mode: CHAIN_APPROVAL_MODE_AUTO,
+      eventType,
+    };
+  }
+  return {
+    source: CHAIN_APPROVAL_SOURCE,
+    mode: CHAIN_APPROVAL_MODE_WATCHED,
+    eventType,
+    reason: policy.reason ?? "event_type_not_allowlisted",
+  };
+}
+
+export function stableChainApprovalPolicyForHash(policy) {
+  if (!policy) return null;
+  const { checkedAt, ...dispatchEvidence } = policy.dispatchEvidence ?? {};
+  return {
+    source: policy.source,
+    mode: policy.mode,
+    eventType: policy.eventType,
+    reason: policy.reason,
+    dispatchEvidenceHash: policy.dispatchEvidence
+      ? hashJson(dispatchEvidence)
+      : null,
+  };
+}
+
+function sameJson(left, right) {
+  return hashJson(left) === hashJson(right);
+}
+
+function hasSecurityOrEscalation(labels = []) {
+  return labels.some(
+    (label) =>
+      label === "ai:escalated" ||
+      label === "type:security" ||
+      /security/i.test(label),
+  );
+}
+
+function closedTriagePlan(def, input) {
+  if (!def?.actionRegistry || !input?.plan || !Array.isArray(input.plan))
+    return false;
+  return input.plan.every(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      typeof item.action === "string" &&
+      def.actionRegistry[item.action],
+  );
+}
+
+function proposalIntegrity(candidate, mapping, envelope) {
+  let proposalSpec;
+  let runSpec;
+  try {
+    proposalSpec = JSON.parse(candidate.proposal_spec_json);
+    runSpec = JSON.parse(candidate.run_spec_json);
+  } catch {
+    return "proposal_unparseable";
+  }
+  if (!sameJson(proposalSpec, runSpec)) return "proposal_run_spec_mismatch";
+  if (
+    hashJson(runSpec) !== candidate.run_spec_hash ||
+    candidate.proposal_spec_hash !== candidate.run_spec_hash
+  ) {
+    return "proposal_hash_mismatch";
+  }
+  if (proposalSpec.agent !== mapping.agent) return "proposal_agent_mismatch";
+  for (const [key, value] of Object.entries(envelope.payload ?? {})) {
+    if (!sameJson(proposalSpec.input?.[key], value))
+      return `proposal_input_mismatch:${key}`;
+  }
+  return null;
+}
+
+function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
+  if (typeof dispatchEligibility !== "function")
+    return "dispatch_recheck_unavailable";
+
+  let result;
+  try {
+    result = dispatchEligibility(envelope.payload, dispatch);
+  } catch {
+    return "dispatch_recheck_failed";
+  }
+
+  if (!result?.ok)
+    return `dispatch_ineligible:${result?.refusal?.reason ?? "unknown"}`;
+
+  const expectedEvidenceHash =
+    stableChainApprovalPolicyForHash(approvalPolicy)?.dispatchEvidenceHash;
+  if (!expectedEvidenceHash)
+    return "dispatch_ineligible:approval_policy_missing_evidence";
+  const { checkedAt, ...currentEvidence } = result.evidence ?? {};
+  if (expectedEvidenceHash !== hashJson(currentEvidence)) {
+    return "dispatch_ineligible:evidence_changed_since_plan";
+  }
+
+  const labels = result.evidence?.ticket?.labels ?? [];
+  if (hasSecurityOrEscalation(labels))
+    return "dispatch_ineligible:escalated_or_security";
+  if ((result.evidence?.escalatePathIntersections ?? []).length > 0)
+    return "dispatch_ineligible:escalate_paths_intersect";
+
+  return null;
+}
+
+function eligible(
+  candidate,
+  registry,
+  policy,
+  { dispatchEligibility, dispatch },
+) {
+  if (candidate.event_source !== CHAIN_APPROVAL_SOURCE)
+    return "event_source_not_chain";
+
+  let envelope;
+  try {
+    envelope = JSON.parse(candidate.envelope_json);
+  } catch {
+    return "event_unparseable";
+  }
+
+  let runSpec;
+  try {
+    runSpec = JSON.parse(candidate.run_spec_json);
+  } catch {
+    return "run_spec_unparseable";
+  }
+
+  const approvalPolicy = runSpec?.approvalPolicy;
+  if (!approvalPolicy) return "run_approval_policy_missing";
+  if (approvalPolicy.source !== CHAIN_APPROVAL_SOURCE)
+    return "run_approval_policy_source_unknown";
+  if (approvalPolicy.mode !== CHAIN_APPROVAL_MODE_AUTO)
+    return `run_approval_policy_${approvalPolicy.mode}`;
+
+  if (candidate.event_type !== approvalPolicy.eventType)
+    return "run_approval_policy_event_mismatch";
+  if (!policy.allowed.has(candidate.event_type))
+    return policy.reason ?? "policy_unknown";
+
+  const mapping = getEventType(registry, envelope.type);
+  if (!mapping || mapping.humanApprovalOnly) return "event_human_approval_only";
+  const integrityError = proposalIntegrity(candidate, mapping, envelope);
+  if (integrityError) return integrityError;
+
+  const def = getAgent(registry, mapping.agent);
+  if (!validate(def.inputSchema, envelope.payload).valid)
+    return "input_schema_invalid";
+  if (
+    envelope.type === "factory.triage-apply.requested" &&
+    !closedTriagePlan(def, envelope.payload)
+  ) {
+    return "triage_action_not_closed";
+  }
+  if (envelope.type === "factory.dispatch.requested") {
+    return dispatchSafe(
+      envelope,
+      approvalPolicy,
+      dispatchEligibility,
+      dispatch,
+    );
+  }
+  return null;
+}
+
+function noteOpenReason(db, id, reason) {
+  db.query(
+    `UPDATE proposals SET reason = ? WHERE id = ? AND status = 'open'`,
+  ).run(`auto_approval_ineligible:${reason}`, id);
+}
+
+/**
+ * Recheck and approve the currently open, eligible chain proposals once.
+ * A second pass finds no approved proposal and therefore cannot double-approve.
+ */
+export function autoApproveChains(
+  db,
+  registry,
+  {
+    now = Date.now(),
+    policyVersion = "unknown",
+    dispatchEligibility,
+    dispatch = {},
+    policy = loadChainAutoApprovalPolicy(),
+  } = {},
+) {
+  const approved = [];
+  const open = [];
+  const errors = [];
+  const rows = db
+    .query(
+      `SELECT p.id, p.event_source, p.event_id, p.spec_json AS proposal_spec_json, p.spec_hash AS proposal_spec_hash,
+            p.created_at, p.ttl_seconds, e.type AS event_type, e.envelope_json,
+            r.spec_json AS run_spec_json, r.spec_hash AS run_spec_hash
+       FROM proposals p
+       JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+       JOIN runs r ON r.run_id = p.run_id
+      WHERE p.status = 'open' AND p.decision = 'run' AND e.source = 'chain'
+      ORDER BY p.created_at, p.rowid`,
+    )
+    .all();
+
+  for (const row of rows) {
+    const age = now - Date.parse(row.created_at);
+    const reason =
+      age > row.ttl_seconds * 1000
+        ? "proposal_expired"
+        : eligible(row, registry, policy, { dispatchEligibility, dispatch });
+    if (reason) {
+      noteOpenReason(db, row.id, reason);
+      open.push({ proposalId: row.id, reason });
+      continue;
+    }
+    try {
+      const outcome = approveProposal(db, registry, row.id, {
+        actor: CHAIN_AUTO_APPROVAL_ACTOR,
+        reason: CHAIN_AUTO_APPROVAL_REASON,
+        now,
+        policyVersion,
+      });
+      if (outcome.approved)
+        approved.push({ proposalId: row.id, runId: outcome.runId });
+      else {
+        noteOpenReason(db, row.id, "replanned");
+        open.push({ proposalId: row.id, reason: "replanned" });
+      }
+    } catch (err) {
+      const message = String(err?.message ?? err);
+      noteOpenReason(db, row.id, "approval_error");
+      errors.push({ proposalId: row.id, reason: "approval_error", message });
+    }
+  }
+  return { approved, open, errors };
+}

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -7,6 +7,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { budgetExhausted } from "../../lib/spend.mjs";
 import { hashJson } from "./canonical.mjs";
 import { approveProposal } from "./proposals.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
@@ -95,6 +96,83 @@ export function stableChainApprovalPolicyForHash(policy) {
       ? hashJson(dispatchEvidence)
       : null,
   };
+}
+
+const ENVIRONMENT_FAILURE_REASONS = new Set([
+  "adapter_error",
+  "cli_not_found",
+  "unknown_adapter",
+]);
+
+function loadRuntimePolicy(root = reposRoot()) {
+  const file = policyPath(root);
+  if (!existsSync(file)) return null;
+  try {
+    const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shared unattended-work guard. It is evaluated immediately before every
+ * approval, so earlier approvals in the same bounded pass consume capacity.
+ */
+export function chainRuntimeGuard(
+  db,
+  {
+    root = reposRoot(),
+    runtimePolicy = loadRuntimePolicy(root),
+    budgetCheck = budgetExhausted,
+  } = {},
+) {
+  if (!runtimePolicy) return "runtime_policy_unavailable";
+
+  try {
+    if (budgetCheck(runtimePolicy)) return "budget_exhausted";
+  } catch {
+    return "budget_check_failed";
+  }
+
+  const workerCap = runtimePolicy?.workers?.max;
+  if (
+    typeof workerCap !== "number" ||
+    !Number.isInteger(workerCap) ||
+    workerCap < 1
+  ) {
+    return "worker_cap_policy_invalid";
+  }
+  const active = db
+    .query(
+      `SELECT COUNT(*) AS n FROM runs
+       WHERE state IN ('APPROVED','QUEUED','LEASED','RUNNING','VERIFYING')`,
+    )
+    .get().n;
+  if (active >= workerCap) return "worker_cap_full";
+
+  const threshold = runtimePolicy?.circuit_breaker?.consecutive_env_failures;
+  if (
+    typeof threshold !== "number" ||
+    !Number.isInteger(threshold) ||
+    threshold < 1
+  ) {
+    return "circuit_breaker_policy_invalid";
+  }
+  const recent = db
+    .query(
+      `SELECT reason_code FROM attempts
+       WHERE finished_at IS NOT NULL
+       ORDER BY rowid DESC LIMIT ?`,
+    )
+    .all(threshold);
+  const consecutive = recent.findIndex(
+    (attempt) => !ENVIRONMENT_FAILURE_REASONS.has(attempt.reason_code),
+  );
+  const failures = consecutive === -1 ? recent.length : consecutive;
+  if (failures >= threshold) return "circuit_breaker_tripped";
+
+  return null;
 }
 
 function sameJson(left, right) {
@@ -257,6 +335,8 @@ export function autoApproveChains(
     dispatchEligibility,
     dispatch = {},
     policy = loadChainAutoApprovalPolicy(),
+    runtimeGuard = chainRuntimeGuard,
+    runtimeGuardOptions = {},
   } = {},
 ) {
   const approved = [];
@@ -284,6 +364,17 @@ export function autoApproveChains(
     if (reason) {
       noteOpenReason(db, row.id, reason);
       open.push({ proposalId: row.id, reason });
+      continue;
+    }
+    let guardReason;
+    try {
+      guardReason = runtimeGuard(db, runtimeGuardOptions);
+    } catch {
+      guardReason = "runtime_guard_failed";
+    }
+    if (guardReason) {
+      noteOpenReason(db, row.id, guardReason);
+      open.push({ proposalId: row.id, reason: guardReason });
       continue;
     }
     try {

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   autoApproveChains,
+  chainRuntimeGuard,
   CHAIN_AUTO_APPROVAL_ACTOR,
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
   CHAIN_AUTO_APPROVAL_REASON,
@@ -141,6 +142,71 @@ describe("chain auto approval (WM-357)", () => {
       [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
     );
     expect(loaded.reason).toBeNull();
+  });
+
+  test("budget, worker cap, and circuit breaker each stop unattended approvals", () => {
+    const runtimePolicy = {
+      budget: { per_day_usd: 1 },
+      workers: { max: 1 },
+      circuit_breaker: { consecutive_env_failures: 2 },
+    };
+
+    const budgetDb = openDb(":memory:");
+    expect(
+      chainRuntimeGuard(budgetDb, {
+        runtimePolicy,
+        budgetCheck: () => "spent",
+      }),
+    ).toBe("budget_exhausted");
+
+    const capDb = openDb(":memory:");
+    const cap = seed(capDb, { id: "cap-active" });
+    capDb
+      .query(`UPDATE runs SET state = 'QUEUED' WHERE run_id = ?`)
+      .run(cap.runId);
+    expect(
+      chainRuntimeGuard(capDb, {
+        runtimePolicy,
+        budgetCheck: () => null,
+      }),
+    ).toBe("worker_cap_full");
+
+    const circuitDb = openDb(":memory:");
+    for (const id of ["env-1", "env-2"]) {
+      const failed = seed(circuitDb, { id });
+      circuitDb
+        .query(`UPDATE runs SET state = 'FAILED', attempts = 1 WHERE run_id = ?`)
+        .run(failed.runId);
+      circuitDb
+        .query(
+          `INSERT INTO attempts
+             (run_id, attempt, fencing_token, lease_owner, lease_expires_at,
+              finished_at, terminal_state, reason_code)
+           VALUES (?, 1, 1, 'test', ?, ?, 'FAILED', 'adapter_error')`,
+        )
+        .run(
+          failed.runId,
+          new Date(now).toISOString(),
+          new Date(now).toISOString(),
+        );
+    }
+    expect(
+      chainRuntimeGuard(circuitDb, {
+        runtimePolicy: { ...runtimePolicy, workers: { max: 3 } },
+        budgetCheck: () => null,
+      }),
+    ).toBe("circuit_breaker_tripped");
+
+    const guardedDb = openDb(":memory:");
+    const candidate = seed(guardedDb, { id: "guarded" });
+    const result = auto(guardedDb, {
+      runtimeGuard: () => "circuit_breaker_tripped",
+    });
+    expect(result.approved).toEqual([]);
+    expect(runState(guardedDb, candidate.runId)).toBe("PROPOSED");
+    expect(openProposals(guardedDb, {})[0].reason).toContain(
+      "circuit_breaker_tripped",
+    );
   });
 
   test("eligible chain work and triage proposals advance with an auditable actor and reason", () => {

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1,0 +1,350 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  autoApproveChains,
+  CHAIN_AUTO_APPROVAL_ACTOR,
+  CHAIN_AUTO_APPROVAL_EVENT_TYPES,
+  CHAIN_AUTO_APPROVAL_REASON,
+  loadChainAutoApprovalPolicy,
+} from "./auto-approval.mjs";
+import { canonicalJson, hashJson } from "./canonical.mjs";
+import { openDb } from "./db.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents } from "./planner.mjs";
+import { lifecycleOf, runState } from "./lifecycle.mjs";
+import { openProposals } from "./proposals.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const registry = loadRegistry();
+const now = Date.parse("2026-08-19T12:00:00.000Z");
+const policy = {
+  allowed: new Set(CHAIN_AUTO_APPROVAL_EVENT_TYPES),
+  reason: null,
+};
+
+function seed(
+  db,
+  {
+    id = "proposal-1",
+    runId = `run-${id}`,
+    type = "factory.work.requested",
+    source = "chain",
+    input = { repo: "factory" },
+    proposalSpec = null,
+    runSpec = null,
+    approvalPolicy = null,
+  } = {},
+) {
+  const mapping = registry.eventTypes[type];
+  const eventId = `event-${id}`;
+  const envelope = {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type,
+    source,
+    subject: input.ticket ?? input.repo,
+    occurredAt: new Date(now).toISOString(),
+    receivedAt: new Date(now).toISOString(),
+    correlationId: `corr-${id}`,
+    causationId: "parent-run",
+    payload: input,
+  };
+  const defaultApprovalPolicy =
+    approvalPolicy ??
+    (source === "chain"
+      ? {
+          source: "chain",
+          mode: CHAIN_AUTO_APPROVAL_EVENT_TYPES.has(type) ? "auto" : "watched",
+          eventType: type,
+          ...(CHAIN_AUTO_APPROVAL_EVENT_TYPES.has(type)
+            ? {
+                ...(type === "factory.dispatch.requested"
+                  ? {
+                      dispatchEvidence: {
+                        ticket: { labels: [] },
+                        escalatePathIntersections: [],
+                      },
+                    }
+                  : {}),
+              }
+            : { reason: "not_allowlisted" }),
+        }
+      : null);
+  const spec = {
+    schemaVersion: "factory.run-spec/v1",
+    runId,
+    agent: mapping.agent,
+    input,
+    ...(defaultApprovalPolicy ? { approvalPolicy: defaultApprovalPolicy } : {}),
+    ...(runSpec ?? {}),
+  };
+  const proposalJson = canonicalJson(proposalSpec ?? spec);
+  const runJson = canonicalJson(runSpec ?? spec);
+  const proposalHash = hashJson(proposalSpec ?? spec);
+  const runHash = hashJson(runSpec ?? spec);
+  const createdAt = new Date(now).toISOString();
+
+  db.query(
+    `INSERT INTO events
+       (source, event_id, type, subject, occurred_at, received_at, correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'planned', ?)`,
+  ).run(
+    source,
+    eventId,
+    type,
+    envelope.subject,
+    createdAt,
+    createdAt,
+    envelope.correlationId,
+    envelope.causationId,
+    canonicalJson(envelope),
+    hashJson(input),
+    createdAt,
+  );
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'PROPOSED', 0, ?, ?)`,
+  ).run(runId, `idem-${id}`, runJson, runHash, createdAt, createdAt);
+  db.query(
+    `INSERT INTO proposals
+       (id, event_source, event_id, run_id, decision, spec_json, spec_hash, idempotency_key, status, created_at, ttl_seconds)
+     VALUES (?, ?, ?, ?, 'run', ?, ?, ?, 'open', ?, 1800)`,
+  ).run(
+    id,
+    source,
+    eventId,
+    runId,
+    proposalJson,
+    proposalHash,
+    `idem-${id}`,
+    createdAt,
+  );
+  return { id, runId };
+}
+
+const dispatchOk = () => ({
+  ok: true,
+  evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+});
+const auto = (db, options = {}) =>
+  autoApproveChains(db, registry, {
+    now,
+    policy,
+    dispatchEligibility: dispatchOk,
+    ...options,
+  });
+
+describe("chain auto approval (WM-357)", () => {
+  test("git-owned policy is an explicit closed allowlist", () => {
+    const loaded = loadChainAutoApprovalPolicy();
+    expect([...loaded.allowed].sort()).toEqual(
+      [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
+    );
+    expect(loaded.reason).toBeNull();
+  });
+
+  test("eligible chain work and triage proposals advance with an auditable actor and reason", () => {
+    const db = openDb(":memory:");
+    const work = seed(db, { id: "work", type: "factory.work.requested" });
+    const triage = seed(db, { id: "triage", type: "factory.triage.requested" });
+
+    expect(
+      auto(db)
+        .approved.map((row) => row.runId)
+        .sort(),
+    ).toEqual([work.runId, triage.runId].sort());
+    for (const runId of [work.runId, triage.runId]) {
+      expect(runState(db, runId)).toBe("QUEUED");
+      const approved = lifecycleOf(db, runId).find(
+        (event) => event.to_state === "APPROVED",
+      );
+      expect(approved).toMatchObject({
+        actor: CHAIN_AUTO_APPROVAL_ACTOR,
+        reason: CHAIN_AUTO_APPROVAL_REASON,
+      });
+    }
+  });
+
+  test("the planner's bounded pass advances a newly planned chain proposal", () => {
+    const db = openDb(":memory:");
+    const synthetic = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
+    synthetic.agents.set("test-chain-work@1", {
+      ref: "test-chain-work@1",
+      output_contract: "factory.test/v1",
+      workspace: { type: "ephemeral" },
+      capabilities: { services: [] },
+      limits: { timeout_seconds: 60, attempts: 1 },
+      inputSchema: {
+        type: "object",
+        required: ["repo"],
+        additionalProperties: false,
+        properties: { repo: { type: "string" } },
+      },
+      mutating: false,
+    });
+    synthetic.eventTypes["factory.work.requested"] = {
+      ...synthetic.eventTypes["factory.work.requested"],
+      agent: "test-chain-work@1",
+    };
+    const event = admitEvent(
+      db,
+      synthetic,
+      {
+        schemaVersion: "factory.event/v1",
+        eventId: "chain-planner-pass",
+        type: "factory.work.requested",
+        source: "chain",
+        subject: "factory",
+        occurredAt: new Date(now).toISOString(),
+        correlationId: "chain-planner-pass",
+        causationId: "parent-run",
+        payload: { repo: "factory" },
+      },
+      { now },
+    );
+
+    expect(event.admitted).toBe(true);
+    planAdmittedEvents(db, synthetic, { now, policyVersion: "git:test" });
+    expect(openProposals(db, {})).toEqual([]);
+    expect(db.query(`SELECT state FROM runs`).get().state).toBe("QUEUED");
+  });
+
+  test("operator proposals and merge/ship proposals remain watched", () => {
+    const db = openDb(":memory:");
+    const manual = seed(db, { id: "manual", source: "operator" });
+    const merge = seed(db, {
+      id: "merge",
+      type: "factory.merge-apply.requested",
+    });
+    const ship = seed(db, { id: "ship", type: "factory.ship-apply.requested" });
+
+    const result = auto(db, {
+      policy: {
+        allowed: new Set([
+          "factory.merge-apply.requested",
+          "factory.ship-apply.requested",
+        ]),
+        reason: null,
+      },
+    });
+    expect(result.approved).toEqual([]);
+    expect(
+      openProposals(db, {})
+        .map((proposal) => proposal.id)
+        .sort(),
+    ).toEqual([manual.id, merge.id, ship.id].sort());
+    expect(
+      openProposals(db, {}).find((proposal) => proposal.id === merge.id).reason,
+    ).toContain("run_approval_policy_watched");
+  });
+
+  test("closed triage apply is approved, while unknown actions remain visible and watched", () => {
+    const db = openDb(":memory:");
+    const valid = seed(db, {
+      id: "triage-valid",
+      type: "factory.triage-apply.requested",
+      input: {
+        repo: "factory",
+        plan: [{ issueId: "WM-9", action: "label-agent-ready" }],
+      },
+    });
+    const invalid = seed(db, {
+      id: "triage-invalid",
+      type: "factory.triage-apply.requested",
+      input: {
+        repo: "factory",
+        plan: [{ issueId: "WM-10", action: "rm-everything" }],
+      },
+    });
+
+    expect(auto(db).approved.map((row) => row.runId)).toEqual([valid.runId]);
+    expect(runState(db, invalid.runId)).toBe("PROPOSED");
+    expect(
+      openProposals(db, {}).find((proposal) => proposal.id === invalid.id)
+        .reason,
+    ).toContain("input_schema_invalid");
+  });
+
+  test("dispatch rechecks escalated and path-sensitive tickets before approval", () => {
+    const db = openDb(":memory:");
+    const escalated = seed(db, {
+      id: "escalated",
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket: "WM-11" },
+      approvalPolicy: {
+        source: "chain",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: {
+          ticket: { labels: ["ai:agent-ready", "ai:escalated"] },
+          escalatePathIntersections: [],
+        },
+      },
+    });
+    const sensitive = seed(db, {
+      id: "sensitive",
+      type: "factory.dispatch.requested",
+      input: { repo: "factory", ticket: "WM-12" },
+      approvalPolicy: {
+        source: "chain",
+        mode: "auto",
+        eventType: "factory.dispatch.requested",
+        dispatchEvidence: {
+          ticket: { labels: ["ai:agent-ready"] },
+          escalatePathIntersections: ["src/auth/**"],
+        },
+      },
+    });
+    const dispatchEligibility = (payload) =>
+      payload.ticket === "WM-11"
+        ? {
+            ok: true,
+            evidence: {
+              ticket: { labels: ["ai:agent-ready", "ai:escalated"] },
+              escalatePathIntersections: [],
+            },
+          }
+        : {
+            ok: true,
+            evidence: {
+              ticket: { labels: ["ai:agent-ready"] },
+              escalatePathIntersections: ["src/auth/**"],
+            },
+          };
+
+    expect(auto(db, { dispatchEligibility }).approved).toEqual([]);
+    expect(runState(db, escalated.runId)).toBe("PROPOSED");
+    expect(runState(db, sensitive.runId)).toBe("PROPOSED");
+    const reasons = openProposals(db, {})
+      .map((proposal) => proposal.reason)
+      .join(" ");
+    expect(reasons).toContain("escalated_or_security");
+    expect(reasons).toContain("escalate_paths_intersect");
+  });
+
+  test("a tampered proposal fails closed and duplicate passes do not double-approve", () => {
+    const db = openDb(":memory:");
+    const safe = seed(db, { id: "safe" });
+    const tampered = seed(db, {
+      id: "tampered",
+      proposalSpec: {
+        schemaVersion: "factory.run-spec/v1",
+        runId: "run-tampered",
+        agent: "work-scan@1",
+        input: { repo: "other" },
+      },
+    });
+
+    expect(auto(db).approved.map((row) => row.runId)).toEqual([safe.runId]);
+    expect(auto(db).approved).toEqual([]);
+    expect(runState(db, tampered.runId)).toBe("PROPOSED");
+    expect(
+      openProposals(db, {}).find((proposal) => proposal.id === tampered.id)
+        .reason,
+    ).toContain("proposal_run_spec_mismatch");
+  });
+});

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -20,6 +20,15 @@ import { admitEvent } from "./intake.mjs";
 
 export const CHAIN_SOURCE = "chain";
 
+/**
+ * The only chain-provenance admission path. The source is assigned here after
+ * the resolver has derived the edge; no envelope supplied by a caller can
+ * select it through the public API.
+ */
+export function admitChainEvent(db, registry, envelope, options = {}) {
+  return admitEvent(db, registry, { ...envelope, source: CHAIN_SOURCE }, options);
+}
+
 /** Resolve a "$.input.x" / "$.artifact.x.y" path against the chain context. */
 function resolvePath(expr, context) {
   if (typeof expr !== "string" || !expr.startsWith("$.")) return expr; // literal
@@ -173,7 +182,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
             causationId: row.run_id,
             payload: itemPayload,
           };
-          const admitted = admitEvent(db, registry, envelope, { now });
+          const admitted = admitChainEvent(db, registry, envelope, { now });
           if (admitted.admitted) outcome.emitted += 1;
           else if (admitted.duplicate) outcome.skipped += 1;
           else outcome.errors.push(`${eventId}: ${admitted.errors.join("; ")}`);
@@ -196,7 +205,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
             artifactHash,
           }),
         };
-        const admitted = admitEvent(db, registry, envelope, { now });
+        const admitted = admitChainEvent(db, registry, envelope, { now });
         if (admitted.admitted) outcome.emitted += 1;
         else if (admitted.duplicate) outcome.skipped += 1;
         else outcome.errors.push(`${eventId}: ${admitted.errors.join("; ")}`);

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -3,7 +3,7 @@ import { cpSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
-import { buildChainInput, resolveChains } from "./chain.mjs";
+import { admitChainEvent, buildChainInput, resolveChains } from "./chain.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
@@ -54,6 +54,20 @@ function harness() {
 
   return { db, adapters, workerOpts, runToCompletion };
 }
+
+describe("trusted chain admission", () => {
+  test("assigns immutable chain provenance instead of preserving caller source", () => {
+    const db = openDb(":memory:");
+    const outcome = admitChainEvent(db, registry, {
+      ...failedRunEnvelope({ eventId: "internal-chain-proof" }),
+      source: "operator",
+    });
+
+    expect(outcome.admitted).toBe(true);
+    expect(outcome.event.source).toBe("chain");
+    expect(JSON.parse(outcome.event.envelope_json).source).toBe("chain");
+  });
+});
 
 describe("buildChainInput", () => {
   const context = { input: { repo: "wm/x", runId: 7 }, artifact: { verdict: "FLAKE", nested: { a: 1 } } };

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -51,11 +51,15 @@ beforeAll(() => {
       `  - name: wt29\n    path: ${repoDir}\n    github: watt-mind/wt29\n    base: develop\n` +
       `    team: WM\n    project: Factory\n    max_in_flight: 1\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-      `    worktree_root: ${wtRoot}\n    verify: echo verified\n` +
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n    escalate_paths:\n      - src/auth/**\n` +
       `  - name: watched\n    path: ${repoDir}\n    team: OPS\n    project: Watched\n    report_only: true\n` +
-      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n    escalate_paths: []\n` +
       `  - name: uncapped\n    path: ${repoDir}\n    team: WM\n    project: Factory\n` +
-      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n`,
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n    escalate_paths: []\n` +
+      `  - name: missing-policy\n    path: ${repoDir}\n    team: WM\n    project: Factory\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n` +
+      `  - name: malformed-policy\n    path: ${repoDir}\n    team: WM\n    project: Factory\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n    worktree_root: ${wtRoot}\n    escalate_paths: src/auth/**\n`,
   );
   writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
 
@@ -173,6 +177,66 @@ describe("dispatch planner refusals (WM-108, dispatch doc §§2–5)", () => {
     expect(unlabelled.outcome).toMatchObject({ decision: "noop", reason: "ticket_not_agent_ready" });
   });
 
+  test("escalated and security tickets fail closed before dispatch", () => {
+    for (const label of ["ai:escalated", "type:security"]) {
+      const refusal = worktreeDispatchGate(
+        { repo: "wt29", ticket: "WM-500" },
+        openWorld({
+          fetchTicket: () =>
+            readyTicket({
+              labels: {
+                nodes: [{ name: "ai:agent-ready" }, { name: label }],
+              },
+            }),
+        }),
+      );
+      expect(refusal?.reason).toBe(
+        label === "ai:escalated" ? "ticket_escalated" : "ticket_security",
+      );
+    }
+  });
+
+  test("sensitive Owned Paths and unverifiable escalate_paths fail closed", () => {
+    const sensitive = worktreeDispatchGate(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        fetchTicket: () =>
+          readyTicket({
+            description: "## Owned Paths\n- src/auth/session.ts\n",
+          }),
+      }),
+    );
+    expect(sensitive).toEqual({
+      decision: "noop",
+      reason: "escalate_paths_intersect",
+    });
+
+    for (const repo of ["missing-policy", "malformed-policy"]) {
+      const refusal = worktreeDispatchGate(
+        { repo, ticket: "WM-500" },
+        openWorld(),
+      );
+      expect(refusal?.decision).toBe("human_needed");
+      expect(refusal?.reason).toContain("escalate_paths_unverifiable");
+    }
+  });
+
+  test("an exhausted or unreadable budget refuses before eligibility reads", () => {
+    let fetched = false;
+    const refusal = worktreeDispatchGate(
+      { repo: "wt29", ticket: "WM-500" },
+      openWorld({
+        fetchTicket: () => {
+          fetched = true;
+          return readyTicket();
+        },
+        budgetRefusal: () => "budget_exhausted",
+      }),
+    );
+    expect(refusal).toEqual({ decision: "noop", reason: "budget_exhausted" });
+    expect(fetched).toBe(false);
+  });
+
   test("vanished ticket → human_needed ticket_not_found", () => {
     const { outcome } = plan({ repo: "wt29", ticket: "WM-500" }, openWorld({ fetchTicket: () => null }));
     expect(outcome).toMatchObject({ decision: "human_needed", reason: "ticket_not_found" });
@@ -268,7 +332,10 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
 
     const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
     const summary = await runOnce(db, registry, { pi: dispatchFake }, {
-      workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+      workspacesRoot: workspaces,
+      owner: "w-test",
+      policyVersion: PV,
+      dispatch: openWorld(),
     });
 
     expect(summary.terminalState).toBe("COMPLETED");
@@ -285,6 +352,58 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     expect(result.artifact.verification.passed).toBe(true);
     expect(result.evidence.treeVisible).toBe(true);
     expect(JSON.parse(row.receipt_json).runId).toBe(approved.runId);
+  });
+
+  test("execution rechecks stale security eligibility before worktree and adapter", async () => {
+    const db = openDb(":memory:");
+    const workspaces = mkdtempSync(path.join(os.tmpdir(), "evrt-dispatch-ws-"));
+    fixtures.push(workspaces);
+    let labels = [{ name: "ai:agent-ready" }];
+    let adapterCalls = 0;
+    const world = openWorld({
+      fetchTicket: () => readyTicket({ labels: { nodes: labels } }),
+    });
+
+    admitEvent(
+      db,
+      registry,
+      dispatchEnvelope({ repo: "wt29", ticket: "WM-503" }, "d-stale-security"),
+    );
+    planAdmittedEvents(db, registry, { policyVersion: PV, dispatch: world });
+    const proposal = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "dispatch@1",
+    );
+    approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
+    labels = [{ name: "ai:agent-ready" }, { name: "type:security" }];
+
+    const summary = await runOnce(
+      db,
+      registry,
+      {
+        pi: {
+          async execute() {
+            adapterCalls += 1;
+            throw new Error("adapter must not execute");
+          },
+        },
+      },
+      {
+        workspacesRoot: workspaces,
+        owner: "w-test",
+        policyVersion: PV,
+        dispatch: world,
+      },
+    );
+
+    expect(summary).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "ticket_security",
+    });
+    expect(adapterCalls).toBe(0);
+    expect(calls()).not.toContain("up WM-503");
   });
 
   test("a failing run without retain still tears the worktree down (down-on-failure)", async () => {
@@ -305,7 +424,10 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     db.query(`UPDATE runs SET spec_json = ? WHERE run_id = ?`).run(JSON.stringify(spec), proposal.run_id);
 
     const summary = await runOnce(db, registry, { pi: crashing }, {
-      workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+      workspacesRoot: workspaces,
+      owner: "w-test",
+      policyVersion: PV,
+      dispatch: openWorld(),
     });
     expect(summary.terminalState).toBe("FAILED");
     expect(calls()).toContain("up WM-502");

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -197,6 +197,35 @@ export function translateGitHubEvent({ event, deliveryId, payload, repos, now = 
  *         | { admitted: false, duplicate: true, event: object }
  *         | { admitted: false, duplicate: false, errors: string[] }}
  */
+export const RESERVED_INTERNAL_SOURCES = new Set(["chain"]);
+
+/**
+ * Persist an envelope supplied by a public/operator boundary. Reserved runtime
+ * provenance is never caller-selectable: rejecting it before persistence keeps
+ * `events.source = "chain"` as durable proof that the chain resolver created
+ * the event, rather than untrusted envelope text.
+ */
+export function admitExternalEvent(db, registry, envelope, options = {}) {
+  if (
+    envelope &&
+    typeof envelope === "object" &&
+    !Array.isArray(envelope) &&
+    RESERVED_INTERNAL_SOURCES.has(envelope.source)
+  ) {
+    return {
+      admitted: false,
+      duplicate: false,
+      errors: [`source: reserved internal provenance "${envelope.source}"`],
+    };
+  }
+  return admitEvent(db, registry, envelope, options);
+}
+
+/**
+ * Trusted in-process persistence primitive. Public HTTP/replay boundaries must
+ * call admitExternalEvent; internal producers use narrow wrappers such as
+ * admitChainEvent instead of accepting a caller-selected source.
+ */
 export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
   if (envelope === null || typeof envelope !== "object" || Array.isArray(envelope)) {
     return { admitted: false, duplicate: false, errors: ["$: envelope must be an object"] };

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { openDb } from "./db.mjs";
-import { admitEvent, verifyWebhook } from "./intake.mjs";
+import { admitEvent, admitExternalEvent, verifyWebhook } from "./intake.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -129,6 +129,23 @@ describe("admitEvent", () => {
     expect(second).toEqual({ admitted: false, duplicate: true, event: first.event });
     const rows = db.query(`SELECT COUNT(*) AS n FROM events`).get();
     expect(rows.n).toBe(1);
+  });
+
+  test("external admission rejects reserved chain provenance before persistence", () => {
+    const db = openDb(":memory:");
+    const result = admitExternalEvent(
+      db,
+      registry,
+      envelope({ source: "chain", causationId: "forged-parent" }),
+      { now: NOW },
+    );
+
+    expect(result).toEqual({
+      admitted: false,
+      duplicate: false,
+      errors: ['source: reserved internal provenance "chain"'],
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
   });
 
   test("schema-invalid envelope returns errors and writes no row", () => {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -11,11 +11,9 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+
+import { effectiveOwnedPaths, parseOwnedPaths, pathsCollide } from "../../orchestrator/owned-paths.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
-// Imported as a library, never copied (docs/event-runtime-dispatch.md §4):
-// one collision oracle for both mutation paths, with its safety biases —
-// missing Owned Paths owns everything, ambiguous overlap errs to collision.
-import { effectiveOwnedPaths, pathsCollide } from "../../orchestrator/owned-paths.mjs";
 import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { artifactsRoot, DEAD_LETTER_AFTER, DEFAULT_PROPOSAL_TTL_SECONDS, FACTORY_ROOT } from "./config.mjs";
@@ -23,11 +21,12 @@ import { isBusyError, tx, txImmediate } from "./db.mjs";
 import { newProposalId, newRunId } from "./ids.mjs";
 import { createRun, idempotencyKeyForNewRun, resolveIdempotency } from "./lifecycle.mjs";
 import { getAgent, getEventType, resolveModel } from "./registry.mjs";
-import { getRepo, loadRepos, reposRoot } from "./repos.mjs";
 import { pinRepo } from "./repository.mjs";
+import { RepoError, getRepo, loadRepos, reposConfigPath, reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { loopInFlight } from "./schedules.mjs";
 import { resolveInputRef } from "./workspace.mjs";
+import { autoApproveChains, buildChainApprovalPolicy } from "./auto-approval.mjs";
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -67,7 +66,7 @@ export function repoNotAllowed(def, payload) {
  * Pure assembly of the §5.2 RunSpec from a registered mapping. No I/O, no
  * clock reads beyond the injected `now` — same inputs, same spec, always.
  */
-export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion, adapterOverride, now = Date.now() } = {}) {
+export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion, adapterOverride, now = Date.now(), approvalPolicy = null } = {}) {
   const def = getAgent(registry, mapping.agent);
   let payload = envelope.payload;
   if (def.workspace?.type === "repository" && payload?.repo) {
@@ -114,42 +113,28 @@ export function buildRunSpec(registry, envelope, mapping, { runId, policyVersion
       : {}),
     timeoutSeconds: def.limits.timeout_seconds,
     maxAttempts: def.limits.attempts,
+    ...(approvalPolicy ? { approvalPolicy } : {}),
     idempotencyKey,
     ...(placement ? { placement } : {}),
   };
 }
 
-/** policy.yaml's per-repo cap fallback, read from the same root as repos.yaml. */
+/** Default cap when neither repo nor policy config supplies one. */
 export const DEFAULT_MAX_IN_FLIGHT = 3;
 
-function policyMaxInFlight(root = reposRoot()) {
-  const file = path.join(root, "config", "policy.yaml");
-  if (!existsSync(file)) return DEFAULT_MAX_IN_FLIGHT;
-  try {
-    const n = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_in_flight_per_repo;
-    return typeof n === "number" && Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_IN_FLIGHT;
-  } catch {
-    return DEFAULT_MAX_IN_FLIGHT;
-  }
+function resolveNow(now) {
+  return typeof now === "function" ? now() : now;
 }
 
-/**
- * Plan-time Linear reads for the dispatch gate, through the factory's own
- * Linear surface (tools/linear.mjs — gql retries, backoff, and key loading
- * live there; a second client would be a second set of bugs). Synchronous
- * subprocesses because the planner is synchronous code; planEvent calls the
- * gate BEFORE its write transaction so these round trips never hold the
- * SQLite write lock. A transport failure throws — planAdmittedEvents turns
- * that into plan_failures with retry and eventual dead-letter (§13), which is
- * the right shape for a transient outage, unlike a one-shot refusal.
- */
-const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
+function linearCli() {
+  return path.join(FACTORY_ROOT, "tools", "linear.mjs");
+}
 
 function fetchTicketDefault(ticketId) {
   try {
-    return JSON.parse(
-      execFileSync("bun", [linearCli(), "get", ticketId, "--json"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    return JSON.parse(execFileSync("bun", [linearCli(), "get", ticketId, "--json"], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    }));
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
@@ -157,17 +142,14 @@ function fetchTicketDefault(ticketId) {
   }
 }
 
-// The same query shape tick.mjs uses for its in-flight set (dispatch doc §4).
 const IN_FLIGHT_QUERY =
   `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
 
 function fetchInFlightDefault(repoConfig) {
   try {
-    const out = execFileSync(
-      "bun",
-      [linearCli(), "raw", IN_FLIGHT_QUERY, "--var", `t=${repoConfig.team}`, "--var", `p=${repoConfig.project}`],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-    );
+    const out = execFileSync("bun", [linearCli(), "raw", IN_FLIGHT_QUERY, "--var", `t=${repoConfig.team}`, "--var", `p=${repoConfig.project}`], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    });
     return JSON.parse(out)?.issues?.nodes ?? [];
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
@@ -175,75 +157,139 @@ function fetchInFlightDefault(repoConfig) {
   }
 }
 
+function policyMaxInFlight(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return DEFAULT_MAX_IN_FLIGHT;
+  try {
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_in_flight_per_repo;
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : DEFAULT_MAX_IN_FLIGHT;
+  } catch {
+    return DEFAULT_MAX_IN_FLIGHT;
+  }
+}
+
+function loadRepoEscalatePaths(repoName, root = reposRoot()) {
+  const file = reposConfigPath(root);
+  if (!existsSync(file)) return [];
+  const entry = (Bun.YAML.parse(readFileSync(file, "utf8"))?.repos ?? []).find((row) => row?.name === repoName);
+  if (!entry) return [];
+  const escalate = entry.escalate_paths ?? entry.escalatePaths;
+  if (escalate === undefined || escalate === null) return [];
+  if (!Array.isArray(escalate)) throw new RepoError(`${file}: repo ${repoName} has invalid escalate_paths (must be an array)`);
+  return [...new Set(escalate.filter((item) => typeof item === "string").map((item) => item.trim()).filter(Boolean))];
+}
+
+function sortUnique(values) {
+  return [...new Set(values.filter((value) => typeof value === "string"))].sort();
+}
+
+function evidenceTicket(ticket, ticketId) {
+  const description = ticket?.description ?? "";
+  const parsed = parseOwnedPaths(description);
+  return {
+    id: ticketId,
+    state: ticket?.state?.name ?? null,
+    assigneeNull: !ticket?.assignee,
+    labels: sortUnique((ticket?.labels?.nodes ?? []).map((label) => label?.name).filter(Boolean)),
+    ownedPaths: effectiveOwnedPaths(description),
+    ownedPathsParsed: parsed.length > 0,
+    descriptionHash: hashJson(description),
+  };
+}
+
+function evidenceInFlight(issue) {
+  const description = issue.description ?? "";
+  const parsed = parseOwnedPaths(description);
+  return {
+    id: issue.identifier,
+    descriptionHash: hashJson(description),
+    ownedPaths: effectiveOwnedPaths(description),
+    ownedPathsParsed: parsed.length > 0,
+  };
+}
+
+function refusal(reason, evidence, decision = "noop") {
+  return { ok: false, refusal: { decision, reason }, evidence };
+}
+
 /**
- * The dispatch gate (docs/event-runtime-dispatch.md §§2–5, WM-108): may a
- * tier-2 mutating run for {repo, ticket} be PROPOSED right now? Checked
- * cheapest-first — repo config, then the shared lease ledger, then Linear.
- *
- * Refusal semantics follow the doc: durable config states an operator must
- * change (unknown repo, report_only, missing worktree scripts, missing
- * team/project, vanished ticket) are `human_needed` — visible in the inbox
- * and requeue-able after the fix. Transient world states (claimed ticket,
- * full cap, Owned Paths overlap) are typed NOOPs — a false refusal costs one
- * NOOP and the next request re-reads a fresh world; parking them as inbox
- * asks would train the operator to approve stale facts.
- *
- * This is the plan-time half of the doc's "checked twice" rule; the
- * execute-time re-check (claim lock file, lease write, cap and overlap under
- * the approval TTL) belongs to the executor and is NOT implemented here.
- *
- * @returns {null | { decision: "noop" | "human_needed", reason: string }}
+ * The shared dispatch proof used at plan time and immediately before a chain
+ * auto-approval. Its evidence captures every fact the latter needs to compare.
  */
-export function worktreeDispatchGate(payload, {
+export function worktreeDispatchAutoEligibility(payload, {
   fetchTicket = fetchTicketDefault,
   fetchInFlight = fetchInFlightDefault,
   countLeases = (repoName) => liveWorkerLeases(repoName).length,
   maxInFlightFallback,
+  now = Date.now(),
 } = {}) {
+  const evidence = {
+    checkedAt: new Date(resolveNow(now)).toISOString(),
+    repo: {},
+    checks: {},
+    ticket: null,
+    inFlight: [],
+    escalatePathIntersections: [],
+  };
   let repo;
   try {
     repo = getRepo(loadRepos(), payload?.repo);
   } catch (err) {
-    return { decision: "human_needed", reason: `repo_unknown: ${err.message}` };
+    evidence.checks.repo_found = false;
+    return refusal(`repo_unknown: ${err.message}`, evidence, "human_needed");
   }
-  // report_only repos are never tier-2 targets (dispatch doc §5): safe
-  // concurrency of one human, same refusal as tick.mjs.
-  if (repo.reportOnly) return { decision: "human_needed", reason: "repo_report_only" };
-  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) {
-    return { decision: "human_needed", reason: "no_worktree_scripts" };
-  }
-
-  // One budget for both paths (§3): the repo's cap against the dispatcher's
-  // own lease ledger — files under ~/.factory/worker-leases that count every
-  // live ticket worker, whichever coordinator started it.
   const cap = repo.maxInFlight ?? maxInFlightFallback ?? policyMaxInFlight();
-  if (countLeases(repo.name) >= cap) return { decision: "noop", reason: "capacity_full" };
+  const live = countLeases(repo.name);
+  evidence.repo = {
+    name: repo.name,
+    team: repo.team ?? null,
+    project: repo.project ?? null,
+    capLimit: cap,
+    capCurrent: live,
+    capSource: repo.maxInFlight === null || repo.maxInFlight === undefined ? "policy.yaml: max_in_flight_per_repo" : "repo.max_in_flight",
+  };
+  evidence.checks.repo_found = true;
+  if (repo.reportOnly) return refusal("repo_report_only", evidence, "human_needed");
+  evidence.checks.repo_is_dispatchable = true;
+  if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) return refusal("no_worktree_scripts", evidence, "human_needed");
+  evidence.checks.worktree_scripts_configured = true;
+  if (live >= cap) return refusal("capacity_full", evidence);
+  evidence.checks.cap_available = true;
 
-  // The Linear assignee stays the only ticket lock (§2). Stricter than
-  // tick.mjs on purpose — any assignee refuses; the asymmetry is recorded in
-  // the doc (§2, §9) and collapses when OPS-40 lands. Do not "fix" either
-  // side to match the other.
-  const ticket = fetchTicket(payload.ticket);
-  if (!ticket) return { decision: "human_needed", reason: "ticket_not_found" };
-  if (ticket.assignee) return { decision: "noop", reason: "ticket_assigned" };
-  if (ticket.state?.name !== "Todo") return { decision: "noop", reason: "ticket_not_todo" };
-  if (!(ticket.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready")) {
-    return { decision: "noop", reason: "ticket_not_agent_ready" };
-  }
+  const ticket = fetchTicket(payload?.ticket);
+  evidence.ticket = evidenceTicket(ticket, payload?.ticket);
+  if (!ticket) return refusal("ticket_not_found", evidence, "human_needed");
+  evidence.checks.ticket_found = true;
+  if (ticket.assignee) return refusal("ticket_assigned", evidence);
+  evidence.checks.ticket_unassigned = true;
+  if (ticket.state?.name !== "Todo") return refusal("ticket_not_todo", evidence);
+  evidence.checks.ticket_todo = true;
+  if (!evidence.ticket.labels.includes("ai:agent-ready")) return refusal("ticket_not_agent_ready", evidence);
+  evidence.checks.ticket_agent_ready = true;
+  if (!repo.team || !repo.project) return refusal("repo_unconfigured: team/project missing for the in-flight query", evidence, "human_needed");
+  evidence.checks.repo_team_project = true;
 
-  // One collision oracle (§4): the in-flight set is Linear's In Progress
-  // tickets for the repo's team/project, whichever path claimed them.
-  if (!repo.team || !repo.project) {
-    return { decision: "human_needed", reason: "repo_unconfigured: team/project missing for the in-flight query" };
-  }
   const inFlight = fetchInFlight(repo);
-  const busy = inFlight
-    .filter((i) => i.identifier !== payload.ticket)
-    .flatMap((i) => effectiveOwnedPaths(i.description ?? ""));
-  if (pathsCollide(effectiveOwnedPaths(ticket.description ?? ""), busy)) {
-    return { decision: "noop", reason: "owned_paths_overlap" };
+  evidence.inFlight = inFlight.filter((issue) => String(issue.identifier) !== String(payload?.ticket)).map(evidenceInFlight);
+  if (pathsCollide(evidence.ticket.ownedPaths, evidence.inFlight.flatMap((issue) => issue.ownedPaths))) {
+    evidence.checks.owned_paths_disjoint = false;
+    return refusal("owned_paths_overlap", evidence);
   }
-  return null;
+  evidence.checks.owned_paths_disjoint = true;
+  evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
+  evidence.escalatePathIntersections = evidence.repo.escalatePaths.filter((item) => pathsCollide(evidence.ticket.ownedPaths, [item]));
+  evidence.checks.escalate_paths = { configured: evidence.repo.escalatePaths.length > 0, intersect: evidence.escalatePathIntersections };
+  evidence.checks.owned_paths_parsed = evidence.ticket.ownedPathsParsed;
+  return { ok: true, evidence };
+}
+
+/**
+ * Plan-time dispatch refusal verdict. Existing callers retain the historical
+ * null-or-refusal contract while auto-approval consumes the richer proof.
+ */
+export function worktreeDispatchGate(payload, options = {}) {
+  const result = worktreeDispatchAutoEligibility(payload, options);
+  return result.ok ? null : result.refusal;
 }
 
 function insertProposal(db, { id, event, runId = null, decision, specJson = null, specHash = null, idempotencyKey = null, status, reason = null, at, ttlSeconds }) {
@@ -459,8 +505,30 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       eventId: event.event_id,
     });
     const runId = newRunId();
+
+    let approvalPolicy = null;
+    if (envelope.source === "chain") {
+      approvalPolicy = buildChainApprovalPolicy(envelope.type, { source: envelope.source });
+      if (approvalPolicy?.mode === "auto" && envelope.type === "factory.dispatch.requested") {
+        const result = worktreeDispatchAutoEligibility(pinnedEnvelope.payload, dispatch);
+        if (!result?.ok) {
+          return humanNeeded(db, event, `dispatch_eligibility_check_failed_at_plan: ${result?.refusal?.reason ?? "unknown"}`, at, ttlSeconds);
+        }
+        approvalPolicy = {
+          ...approvalPolicy,
+          dispatchEvidence: result.evidence,
+        };
+      }
+    }
+
     const spec = {
-      ...buildRunSpec(registry, pinnedEnvelope, mapping, { runId, policyVersion, adapterOverride, now }),
+      ...buildRunSpec(registry, pinnedEnvelope, mapping, {
+        runId,
+        policyVersion,
+        adapterOverride,
+        now,
+        approvalPolicy,
+      }),
       idempotencyKey,
     };
     const specJson = canonicalJson(spec);
@@ -564,5 +632,15 @@ export function planAdmittedEvents(db, registry, opts = {}) {
       }
     }
   }
+  // A bounded pass over open chain proposals: successful decisions leave the
+  // candidate set, while every failed proof remains open with a typed reason.
+  // This stays after planning so no approval happens inside a planner write
+  // transaction or before the proposal has a persisted immutable RunSpec.
+  autoApproveChains(db, registry, {
+    now: opts.now ?? Date.now(),
+    policyVersion: opts.policyVersion ?? "unknown",
+    dispatchEligibility: worktreeDispatchAutoEligibility,
+    dispatch: opts.dispatch ?? {},
+  });
   return { planned, failed, deadLettered };
 }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -13,6 +13,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { effectiveOwnedPaths, parseOwnedPaths, pathsCollide } from "../../orchestrator/owned-paths.mjs";
+import { budgetExhausted } from "../../lib/spend.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { findArtifact, pinRunArtifact } from "./artifacts.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
@@ -170,13 +171,52 @@ function policyMaxInFlight(root = reposRoot()) {
 
 function loadRepoEscalatePaths(repoName, root = reposRoot()) {
   const file = reposConfigPath(root);
-  if (!existsSync(file)) return [];
-  const entry = (Bun.YAML.parse(readFileSync(file, "utf8"))?.repos ?? []).find((row) => row?.name === repoName);
-  if (!entry) return [];
+  if (!existsSync(file)) {
+    throw new RepoError(`${file}: cannot verify escalate_paths because repos.yaml is missing`);
+  }
+  let parsed;
+  try {
+    parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    throw new RepoError(`${file}: cannot verify escalate_paths: ${err.message}`);
+  }
+  const entry = (parsed?.repos ?? []).find((row) => row?.name === repoName);
+  if (!entry) {
+    throw new RepoError(`${file}: cannot verify escalate_paths for unknown repo ${repoName}`);
+  }
   const escalate = entry.escalate_paths ?? entry.escalatePaths;
-  if (escalate === undefined || escalate === null) return [];
-  if (!Array.isArray(escalate)) throw new RepoError(`${file}: repo ${repoName} has invalid escalate_paths (must be an array)`);
-  return [...new Set(escalate.filter((item) => typeof item === "string").map((item) => item.trim()).filter(Boolean))];
+  if (!Array.isArray(escalate)) {
+    throw new RepoError(
+      `${file}: repo ${repoName} must declare escalate_paths as an array (use [] only when deliberately empty)`,
+    );
+  }
+  if (
+    !escalate.every(
+      (item) => typeof item === "string" && item.trim().length > 0,
+    )
+  ) {
+    throw new RepoError(
+      `${file}: repo ${repoName} has invalid escalate_paths (every glob must be a non-empty string)`,
+    );
+  }
+  return [...new Set(escalate.map((item) => item.trim()))];
+}
+
+function loadRuntimePolicy(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return null;
+  try {
+    const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultBudgetRefusal() {
+  const policy = loadRuntimePolicy();
+  if (!policy) return "budget_policy_unavailable";
+  return budgetExhausted(policy) ? "budget_exhausted" : null;
 }
 
 function sortUnique(values) {
@@ -221,6 +261,7 @@ export function worktreeDispatchAutoEligibility(payload, {
   fetchInFlight = fetchInFlightDefault,
   countLeases = (repoName) => liveWorkerLeases(repoName).length,
   maxInFlightFallback,
+  budgetRefusal = defaultBudgetRefusal,
   now = Date.now(),
 } = {}) {
   const evidence = {
@@ -231,6 +272,15 @@ export function worktreeDispatchAutoEligibility(payload, {
     inFlight: [],
     escalatePathIntersections: [],
   };
+  let budgetReason;
+  try {
+    budgetReason = budgetRefusal();
+  } catch {
+    budgetReason = "budget_check_failed";
+  }
+  if (budgetReason) return refusal(budgetReason, evidence);
+  evidence.checks.budget_available = true;
+
   let repo;
   try {
     repo = getRepo(loadRepos(), payload?.repo);
@@ -266,6 +316,17 @@ export function worktreeDispatchAutoEligibility(payload, {
   evidence.checks.ticket_todo = true;
   if (!evidence.ticket.labels.includes("ai:agent-ready")) return refusal("ticket_not_agent_ready", evidence);
   evidence.checks.ticket_agent_ready = true;
+  if (evidence.ticket.labels.includes("ai:escalated")) {
+    return refusal("ticket_escalated", evidence);
+  }
+  evidence.checks.ticket_not_escalated = true;
+  if (
+    evidence.ticket.labels.includes("type:security") ||
+    evidence.ticket.labels.some((label) => /security/i.test(label))
+  ) {
+    return refusal("ticket_security", evidence);
+  }
+  evidence.checks.ticket_not_security = true;
   if (!repo.team || !repo.project) return refusal("repo_unconfigured: team/project missing for the in-flight query", evidence, "human_needed");
   evidence.checks.repo_team_project = true;
 
@@ -276,9 +337,23 @@ export function worktreeDispatchAutoEligibility(payload, {
     return refusal("owned_paths_overlap", evidence);
   }
   evidence.checks.owned_paths_disjoint = true;
-  evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
-  evidence.escalatePathIntersections = evidence.repo.escalatePaths.filter((item) => pathsCollide(evidence.ticket.ownedPaths, [item]));
-  evidence.checks.escalate_paths = { configured: evidence.repo.escalatePaths.length > 0, intersect: evidence.escalatePathIntersections };
+  try {
+    evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
+  } catch (err) {
+    evidence.checks.escalate_paths = { verified: false };
+    return refusal(`escalate_paths_unverifiable: ${err.message}`, evidence, "human_needed");
+  }
+  evidence.escalatePathIntersections = evidence.repo.escalatePaths.filter(
+    (item) => pathsCollide(evidence.ticket.ownedPaths, [item]),
+  );
+  evidence.checks.escalate_paths = {
+    verified: true,
+    configured: evidence.repo.escalatePaths.length > 0,
+    intersect: evidence.escalatePathIntersections,
+  };
+  if (evidence.escalatePathIntersections.length > 0) {
+    return refusal("escalate_paths_intersect", evidence);
+  }
   evidence.checks.owned_paths_parsed = evidence.ticket.ownedPathsParsed;
   return { ok: true, evidence };
 }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -272,15 +272,6 @@ export function worktreeDispatchAutoEligibility(payload, {
     inFlight: [],
     escalatePathIntersections: [],
   };
-  let budgetReason;
-  try {
-    budgetReason = budgetRefusal();
-  } catch {
-    budgetReason = "budget_check_failed";
-  }
-  if (budgetReason) return refusal(budgetReason, evidence);
-  evidence.checks.budget_available = true;
-
   let repo;
   try {
     repo = getRepo(loadRepos(), payload?.repo);
@@ -303,6 +294,16 @@ export function worktreeDispatchAutoEligibility(payload, {
   evidence.checks.repo_is_dispatchable = true;
   if (!repo.worktreeUp || !repo.worktreeDown || !repo.worktreeRoot) return refusal("no_worktree_scripts", evidence, "human_needed");
   evidence.checks.worktree_scripts_configured = true;
+
+  let budgetReason;
+  try {
+    budgetReason = budgetRefusal();
+  } catch {
+    budgetReason = "budget_check_failed";
+  }
+  if (budgetReason) return refusal(budgetReason, evidence);
+  evidence.checks.budget_available = true;
+
   if (live >= cap) return refusal("capacity_full", evidence);
   evidence.checks.cap_available = true;
 

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -99,7 +99,7 @@ function approveRun(db, proposal, envelope, { actor, now, policyVersion, reason 
  * @returns {{ approved: true, runId: string }
  *         | { approved: false, replanned: true, proposal: object }}
  */
-export function approveProposal(db, registry, id, { actor, now = Date.now(), policyVersion = "unknown", adapterOverride } = {}) {
+export function approveProposal(db, registry, id, { actor, now = Date.now(), policyVersion = "unknown", adapterOverride, reason } = {}) {
   return tx(db, () => {
     const proposal = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!proposal) throw new Error(`unknown proposal ${id}`);
@@ -122,7 +122,7 @@ export function approveProposal(db, registry, id, { actor, now = Date.now(), pol
       throw err;
     }
     if (!isExpired(proposal, now)) {
-      return approveRun(db, proposal, envelope, { actor, now, policyVersion, reason: "approved" });
+      return approveRun(db, proposal, envelope, { actor, now, policyVersion, reason: reason ?? "approved" });
     }
 
     // Expired: re-plan against current registry state, reusing the runId.

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1009,17 +1009,18 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     );
 
     mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+    writeFileSync(path.join(factoryRoot, "config", "policy.yaml"), "{}\n");
     writeFileSync(
       path.join(factoryRoot, "config", "repos.yaml"),
       `repos:\n` +
         `  - name: wt-worker\n    path: ${repoDir}\n    github: watt-mind/wt-worker\n    base: develop\n` +
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-        `    worktree_root: ${wtRoot}\n    verify: echo repo_verified\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo repo_verified\n    escalate_paths: []\n` +
         `  - name: wt-failing-verify\n    path: ${repoDir}\n    github: watt-mind/wt-failing-verify\n    base: develop\n` +
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-        `    worktree_root: ${wtRoot}\n    verify: exit 42\n`,
+        `    worktree_root: ${wtRoot}\n    verify: exit 42\n    escalate_paths: []\n`,
     );
     previousReposRoot = process.env.FACTORY_REPOS_ROOT;
     process.env.FACTORY_REPOS_ROOT = factoryRoot;

--- a/event-runtime/loop.test.mjs
+++ b/event-runtime/loop.test.mjs
@@ -63,7 +63,7 @@ beforeAll(() => {
       `  - name: wt29\n    path: ${repoDir}\n    github: watt-mind/wt29\n    base: develop\n` +
       `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-      `    worktree_root: ${wtRoot}\n    verify: echo verified\n`,
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n    escalate_paths: []\n`,
   );
   writeFileSync(path.join(root, "config", "policy.yaml"), `concurrency:\n  max_in_flight_per_repo: 2\n`);
 
@@ -149,7 +149,10 @@ async function dispatchTo(outcome, eventId, ticket) {
   expect(proposal).toBeTruthy();
   const approved = approveProposal(db, registry, proposal.id, { actor: "operator", policyVersion: PV });
   const summary = await runOnce(db, registry, { pi: dispatchFake(outcome) }, {
-    workspacesRoot: workspaces, owner: "w-test", policyVersion: PV,
+    workspacesRoot: workspaces,
+    owner: "w-test",
+    policyVersion: PV,
+    dispatch: openWorld,
   });
   expect(summary.terminalState).toBe("COMPLETED");
   return { db, planAll, runId: approved.runId };

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -70,17 +70,18 @@ beforeAll(() => {
     );
   }
 
+  writeFileSync(path.join(root, "config", "policy.yaml"), "{}\n");
   writeFileSync(
     path.join(root, "config", "repos.yaml"),
     `repos:\n` +
       `  - name: wm29\n    path: ${wm29}\n    github: watt-mind/wm29\n    base: develop\n` +
       `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-      `    worktree_root: ${wtRoot}\n    verify: echo verified\n` +
+      `    worktree_root: ${wtRoot}\n    verify: echo verified\n    escalate_paths: []\n` +
       `  - name: clean\n    path: ${clean}\n    github: watt-mind/clean\n    base: develop\n` +
       `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
-      `    worktree_root: ${wtRoot}\n`,
+      `    worktree_root: ${wtRoot}\n    escalate_paths: []\n`,
   );
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
   process.env.FACTORY_REPOS_ROOT = root;


### PR DESCRIPTION
## Summary
- reserve `source: chain` for the trusted in-process edge resolver and reject forged webhook/replay provenance
- fail closed on escalated/security/sensitive dispatches and unverifiable `escalate_paths`, including execution-time rechecks before worktree/adapter use
- recheck budget, worker cap, and circuit breaker before each chain auto-approval
- require demo re-seeds to follow the exact fresh triage-scan causal edge

## Verification
- `bun test event-runtime/demo/seed.test.mjs`
- `bun test event-runtime/lib/auto-approval.test.mjs event-runtime/lib/proposals.test.mjs event-runtime/lib/dispatch.test.mjs event-runtime/loop.test.mjs event-runtime/lib/api.test.mjs && bun run format:check`
- `bun test event-runtime/lib/api.test.mjs event-runtime/lib/intake.test.mjs event-runtime/lib/chain.test.mjs event-runtime/lib/auto-approval.test.mjs`

UX critique: skipped — internal event-runtime authorization policy and demo fixture with no user-completable UI change.

Fixes WM-357
Fixes WM-400
Fixes WM-409
Fixes WM-410
