### PR TITLE
fix(adapters-pi): accept onUsage and return normalized usage in execute outcome

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -332,6 +332,7 @@ export async function execute({
   killGraceMs = KILL_GRACE_MS,
   env = {},
   onTrace,
+  onUsage,
   abortSignal,
   signal,
 }) {
@@ -377,6 +378,7 @@ export async function execute({
     let turnCount = 0;
     let costTotal = null;
     const usageTotals = {};
+    let observedModel = null;
     if (child.stdout) {
       const lines = createInterface({ input: child.stdout });
       lines.on("line", (line) => {
@@ -387,6 +389,11 @@ export async function execute({
           return; // not JSON — ignore
         }
         try {
+          if (parsed?.type === "message_end" && typeof parsed.message?.model === "string") {
+            observedModel = parsed.message.model;
+          } else if (typeof parsed?.model === "string") {
+            observedModel = parsed.model;
+          }
           for (const event of mapStreamEvent(parsed)) {
             if (event.kind === "tool_use") {
               lastTool = event.payload?.name ?? null;
@@ -459,9 +466,30 @@ export async function execute({
         costUSD: costTotal,
         usage: usageTotals,
       });
+
+      const normalized = {
+        model: observedModel ?? spec?.model ?? def?.model ?? null,
+        inputTokens: usageTotals.input ?? 0,
+        outputTokens: usageTotals.output ?? 0,
+        cacheCreationInputTokens: usageTotals.cacheWrite ?? 0,
+        cacheReadInputTokens: usageTotals.cacheRead ?? 0,
+        costUSD: typeof costTotal === "number" ? costTotal : 0,
+      };
+
+      try {
+        onUsage?.(normalized);
+      } catch {
+        // Usage is observability: a consumer failure must not change execution.
+      }
+
       // Same WM-127 rule as claude: a denial observed mid-run is evidence,
       // not a verdict — only surfaced to the worker when the run also failed.
-      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
+      resolve({
+        exitCode,
+        timedOut,
+        policyDenials: exitCode === 0 ? [] : policyDenials,
+        usage: normalized,
+      });
     });
   });
 }

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -521,7 +521,19 @@ process.stdin.on("end", () => {
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
 
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+      usage: {
+        model: "openai-codex/gpt-5.6-terra",
+        inputTokens: 15,
+        outputTokens: 25,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        costUSD: 0.001,
+      },
+    });
 
     // 1. Workspace confinement: cwd is workspaceDir
     expect(existsSync(recordFile)).toBe(true);
@@ -666,7 +678,9 @@ process.stdin.on("end", () => {
       },
       onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
     });
-    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.policyDenials).toEqual([]);
     expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "read")).toBe(true);
     expect(traceEvents.some((e) => e.kind === "tool_result" && e.payload.content === "hello world")).toBe(true);
 
@@ -674,6 +688,35 @@ process.stdin.on("end", () => {
     expect(usageEvent.payload.numTurns).toBe(2);
     expect(usageEvent.payload.costUSD).toBeCloseTo(0.0007, 6);
     expect(usageEvent.payload.usage.input).toBe(150);
+  });
+
+  test("delivers normalized usage to onUsage callback and returns usage in outcome (WM-260)", async () => {
+    let receivedUsage = null;
+    const outcome = await execute({
+      spec: { ...defaultSpec, model: "openai-codex/gpt-5.6-terra" },
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_tool_then_success",
+      },
+      onUsage: (usage) => {
+        receivedUsage = usage;
+      },
+    });
+
+    const expectedUsage = {
+      model: "openai-codex/gpt-5.6-terra",
+      inputTokens: 150,
+      outputTokens: 15,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      costUSD: 0.0007,
+    };
+
+    expect(receivedUsage).toEqual(expectedUsage);
+    expect(outcome.usage).toEqual(expectedUsage);
   });
 
   test("a tool_execution_end error that reads exactly like a permission denial is never classified as policy_denied (WM-127)", async () => {


### PR DESCRIPTION
## Summary
- accept `onUsage` callback in `adapters/pi.mjs` `execute()` and invoke it with normalized token counts
- return `usage: normalized` in resolved outcome object
- add unit test in `event-runtime/lib/adapters/pi.test.mjs` asserting onUsage delivery

## Verification
- `bun test event-runtime/lib/adapters/pi.test.mjs`

UX critique: skipped — adapter backend execution fix has no user-facing UI surface.

Fixes WM-260