### PR TITLE
feat(run): show causal follow-up events and chained runs

### DIFF
--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -69,6 +69,7 @@ export interface AdmittedEvent {
   occurredAt: string;
   receivedAt: string;
   correlationId: string | null;
+  causationId?: string | null;
   planFailures: number;
   lastPlanError: string | null;
   admittedAt: string;

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import { ApiError } from "../api";
 import { RunFull } from "./RunFull";
 import {
+  createEventFixture,
   createRunDetailFixture,
   createRunListItemFixture,
   renderWithClient,
@@ -219,6 +220,133 @@ describe("RunFull model rows (WM-221)", () => {
         expect(getByText("strong")).toBeTruthy();
         expect(getByText("default (CLI)")).toBeTruthy();
         expect(getByText("claude-opus-5[1m]")).toBeTruthy();
+      },
+    );
+  });
+});
+
+describe("RunFull causal follow-up events and chained runs (WM-420)", () => {
+  test("renders empty-state copy when no follow-up event was emitted", async () => {
+    const runId = "run_no_follow_ups";
+    const detail = createRunDetailFixture({
+      run: {
+        runId,
+        state: "COMPLETED",
+        spec: { agent: "merge-scan@1", adapter: "pi" },
+      } as RunDetail["run"],
+    });
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "COMPLETED" })],
+        }),
+        events: async () => ({
+          events: [
+            createEventFixture({
+              eventId: "unrelated-event-1",
+              causationId: "run_other",
+            }),
+          ],
+        }),
+      },
+      async () => {
+        const { getByText } = renderRunFull(runId);
+        await waitFor(() => getByText("Follow-up Events"));
+        expect(getByText("No follow-up event was emitted.")).toBeTruthy();
+      },
+    );
+  });
+
+  test("renders exact merge-scan → merge-escalate → merge-notify causal chain fixture", async () => {
+    const parentRunId = "run_74681439-530c-4301-bd9c-baa17d8b92d5";
+    const childRunId = "run_a07fde5a-ee51-46ae-9945-3b38cd87e180";
+    const eventId = "chain-run_74681439-530c-4301-bd9c-baa17d8b92d5";
+    const proposalId = "prop_escalate_7468";
+
+    const detail = createRunDetailFixture({
+      run: {
+        runId: parentRunId,
+        state: "COMPLETED",
+        spec: { agent: "merge-scan@1", adapter: "pi" },
+      } as RunDetail["run"],
+    });
+
+    const emittedEvent = createEventFixture({
+      source: "factory.chain",
+      eventId,
+      type: "factory.merge-escalate.requested",
+      subject: "merge-scan@1",
+      status: "planned",
+      causationId: parentRunId,
+      proposalId,
+      runId: childRunId,
+      envelope: { causationId: parentRunId },
+    });
+
+    const childRun = createRunListItemFixture({
+      runId: childRunId,
+      agent: "merge-notify@1",
+      state: "COMPLETED",
+      adapter: "pi",
+    });
+
+    let jumpedAgent = "";
+    let jumpedEvent = "";
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [
+            createRunListItemFixture({ runId: parentRunId, state: "COMPLETED" }),
+            childRun,
+          ],
+        }),
+        events: async () => ({
+          events: [emittedEvent],
+        }),
+      },
+      async () => {
+        const { getByText, getAllByText, getByTitle } = renderWithClient(
+          <RunFull
+            runId={parentRunId}
+            connected={true}
+            onBack={noop}
+            onJumpAgent={(ref) => {
+              jumpedAgent = ref;
+            }}
+            onJumpEvent={(source, id) => {
+              jumpedEvent = `${source}:${id}`;
+            }}
+          />,
+        );
+
+        await waitFor(() => getByText("Follow-up Events"));
+        // Event type and planning status
+        expect(getByText("factory.merge-escalate.requested")).toBeTruthy();
+        expect(getByText("planned")).toBeTruthy();
+
+        // Linked proposal
+        expect(getByTitle(proposalId)).toBeTruthy();
+
+        // Follow-up Run agent, state badge, and run link
+        expect(getByText("Follow-up Run")).toBeTruthy();
+        expect(getAllByText("COMPLETED").length).toBeGreaterThanOrEqual(1);
+        expect(getByText("merge-notify@1")).toBeTruthy();
+
+        const runLink = getByTitle(`Open run ${childRunId}`);
+        expect(runLink).toBeTruthy();
+        expect(runLink.getAttribute("href")).toContain(childRunId);
+
+        // Clicking agent jumps to agent
+        fireEvent.click(getByText("merge-notify@1"));
+        expect(jumpedAgent).toBe("merge-notify@1");
+
+        // Clicking event jumps to event
+        fireEvent.click(getByTitle(eventId));
+        expect(jumpedEvent).toBe(`factory.chain:${eventId}`);
       },
     );
   });

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { api, ApiError } from "../api";
 import { keyGuard, useNow } from "../hooks";
+import { hashPath, hashProject, withProject } from "../hash";
 import { setContextActions } from "../palette";
 import { RunTrace } from "../components/RunTrace";
 import {
@@ -9,11 +10,13 @@ import {
   CopyActions,
   Dialog,
   JumpLink,
+  Section,
   StateBadge,
   VerbError,
   copyLink,
   copyText,
   notify,
+  shortId,
 } from "../components/ui";
 import {
   RunDetailBlocks,
@@ -21,6 +24,7 @@ import {
   isCancellable,
 } from "../components/RunDetailBlocks";
 import { handleRunArtifactClick } from "./Runs";
+import type { RunListItem } from "../types";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -60,10 +64,28 @@ export function RunFull({
     queryFn: () => api.runs(),
     refetchInterval: 2000,
   });
+  const eventsQ = useQuery({
+    queryKey: ["events", "ALL"],
+    queryFn: () => api.events(),
+    refetchInterval: 2000,
+  });
   const listRow = useMemo(
     () => (listQ.data?.runs ?? []).find((r) => r.runId === runId) ?? null,
     [listQ.data, runId],
   );
+  const followUpEvents = useMemo(() => {
+    const events = eventsQ.data?.events ?? [];
+    return events.filter(
+      (e) => e.causationId === runId || (e.envelope as any)?.causationId === runId,
+    );
+  }, [eventsQ.data, runId]);
+  const runsById = useMemo(() => {
+    const map = new Map<string, RunListItem>();
+    for (const r of listQ.data?.runs ?? []) {
+      map.set(r.runId, r);
+    }
+    return map;
+  }, [listQ.data]);
 
   const d = detail.data;
   const attemptsExhausted = d
@@ -344,6 +366,101 @@ export function RunFull({
                 onRetry={() => retry.mutate({ id: d.run.runId, force: false })}
                 onForceRetry={() => setConfirm("force-retry")}
                 retryPending={retry.isPending}
+                afterLifecycle={
+                  <Section title="Follow-up Events" id="run-follow-up-events" card={followUpEvents.length === 0}>
+                    {followUpEvents.length === 0 ? (
+                      <div className="text-[12px] text-(--text-faint)">
+                        No follow-up event was emitted.
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {followUpEvents.map((e) => {
+                          const linkedRun = e.runId ? runsById.get(e.runId) : null;
+                          return (
+                            <div
+                              key={`${e.source}:${e.eventId}`}
+                              className="rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px]"
+                            >
+                              <div className="flex items-baseline justify-between gap-2">
+                                <span className="mono font-medium text-(--text) truncate" title={e.type}>
+                                  {e.type}
+                                </span>
+                                <span
+                                  className="mono shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase"
+                                  style={{
+                                    background: e.status === "planned" || e.status === "admitted" ? "var(--surface-2)" : "var(--surface-1)",
+                                    color: e.status === "dead_lettered" ? "var(--hue-err)" : "var(--text-dim)",
+                                  }}
+                                >
+                                  {e.status}
+                                </span>
+                              </div>
+
+                              <div className="mt-1.5 flex items-baseline justify-between gap-2 text-[11px] text-(--text-faint)">
+                                <span className="shrink-0">event</span>
+                                <JumpLink
+                                  onClick={() => onJumpEvent(e.source, e.eventId)}
+                                  title={e.eventId}
+                                  className="truncate"
+                                >
+                                  {shortId(e.eventId)}
+                                </JumpLink>
+                              </div>
+
+                              {e.proposalId && (
+                                <div className="mt-1 flex items-baseline justify-between gap-2 text-[11px] text-(--text-faint)">
+                                  <span className="shrink-0">proposal</span>
+                                  <JumpLink
+                                    href={`#/${withProject(hashPath("proposals", e.proposalId), hashProject(window.location.hash))}`}
+                                    title={e.proposalId}
+                                    className="truncate"
+                                  >
+                                    {shortId(e.proposalId)}
+                                  </JumpLink>
+                                </div>
+                              )}
+
+                              {e.runId && (
+                                <div className="mt-2 border-t border-(--border) pt-2">
+                                  <div className="flex items-center justify-between gap-2">
+                                    <span className="text-[11px] font-medium text-(--text-dim)">
+                                      Follow-up Run
+                                    </span>
+                                    {linkedRun?.state && (
+                                      <StateBadge state={linkedRun.state} />
+                                    )}
+                                  </div>
+                                  <div className="mt-1 flex items-baseline justify-between gap-2 text-[11px]">
+                                    <span className="text-(--text-faint)">agent</span>
+                                    <span className="text-(--text-dim) truncate">
+                                      {linkedRun?.agent ? (
+                                        <JumpLink onClick={() => onJumpAgent(linkedRun.agent)} title={linkedRun.agent}>
+                                          {linkedRun.agent}
+                                        </JumpLink>
+                                      ) : (
+                                        "—"
+                                      )}
+                                    </span>
+                                  </div>
+                                  <div className="mt-1 flex items-baseline justify-between gap-2 text-[11px]">
+                                    <span className="text-(--text-faint)">run</span>
+                                    <JumpLink
+                                      href={`#/${withProject(hashPath("run", e.runId), hashProject(window.location.hash))}`}
+                                      title={`Open run ${e.runId}`}
+                                      className="text-(--accent) truncate"
+                                    >
+                                      {shortId(e.runId)} →
+                                    </JumpLink>
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </Section>
+                }
                 verbError={
                   cancel.error ??
                   (confirm === "force-retry" ? null : retry.error)


### PR DESCRIPTION
Fixes WM-420

## Summary
- Display causal follow-up events emitted by a run (`causationId === run.runId` or `envelope.causationId === run.runId`) in the RunFull detail view sidebar.
- Show event type, event short ID (with jump link), planning status badge, proposal link, and follow-up run section with agent, terminal/current state badge, and navigation link to child run page.
- Render explicit empty-state notice "No follow-up event was emitted." when no causal follow-up events are present.
- Added regression unit tests covering the empty state and the exact merge-scan → merge-escalate → merge-notify causal chain fixture.