### PR TITLE
fix(inject): humanize schema validation errors and remove raw regex patterns

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -503,11 +503,13 @@ describe("InjectDialog field errors wait until blur or submit (WM-78)", () => {
       await selectTemplate(r, /disk\.diagnose/i);
       const mount = r.getByLabelText("mount") as HTMLInputElement;
       expect(mount.value).toBe("");
-      expect(r.queryAllByText(/does not match pattern/i)).toHaveLength(0);
+      expect(r.queryAllByText(/expected format/i)).toHaveLength(0);
       act(() => {
         fireEvent.click(r.getByRole("button", { name: /inject/i }));
       });
-      expect(r.getAllByText(/does not match pattern/i).length).toBeGreaterThan(0);
+      expect(r.getAllByText(/expected format/i).length).toBeGreaterThan(0);
+      expect(r.queryAllByText(/does not match pattern/i)).toHaveLength(0);
+      expect(r.container.textContent).not.toMatch(/\^\/\[A-Za-z0-9/);
       expect(r.getByText(/does not validate/i)).toBeTruthy();
       expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
     }));
@@ -698,5 +700,67 @@ describe("InjectDialog last-used template (WM-81)", () => {
       } finally {
         api.replay = origReplay;
       }
+    }));
+});
+
+describe("InjectDialog Inject-anyway banner regex sanitization (WM-179)", () => {
+  test("Inject-anyway banner in Form tab does not expose raw regex patterns", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /disk\.diagnose/i);
+      const mount = r.getByLabelText("mount") as HTMLInputElement;
+      act(() => {
+        changeInput(mount, "invalid-mount-path");
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      const banner = r.container.textContent ?? "";
+      expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
+      expect(banner).toContain("does not validate against");
+      expect(banner).not.toMatch(/\^\/\[A-Za-z0-9/);
+      expect(banner).not.toContain("does not match pattern");
+      expect(banner).toMatch(/expected format/i);
+    }));
+
+  test("Inject-anyway banner in JSON tab does not expose raw regex patterns", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /ci\.run\.failed/i);
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /json/i }));
+      });
+      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const parsed = JSON.parse(textarea.value);
+      parsed.payload = { repo: "watt-mind/factory", runId: 123, logArtifact: "invalid-log-artifact" };
+      act(() => {
+        changeInput(textarea, JSON.stringify(parsed, null, 2));
+      });
+      act(() => {
+        fireEvent.click(r.getByRole("button", { name: /inject/i }));
+      });
+      const banner = r.container.textContent ?? "";
+      expect(r.getByRole("button", { name: /inject anyway/i })).toBeTruthy();
+      expect(banner).toContain("does not validate against");
+      expect(banner).not.toMatch(/\^\[0-9a-f\]\{64\}/);
+      expect(banner).not.toContain("does not match pattern");
+      expect(banner).toMatch(/expected format/i);
+    }));
+
+  test("JSON tab live validation warning does not expose raw regex patterns", () =>
+    withSchemaApi(async (r) => {
+      await selectTemplate(r, /ci\.run\.failed/i);
+      act(() => {
+        fireEvent.click(r.getByRole("tab", { name: /json/i }));
+      });
+      const textarea = r.getByLabelText(/event envelope json/i) as HTMLTextAreaElement;
+      const parsed = JSON.parse(textarea.value);
+      parsed.payload = { repo: "watt-mind/factory", runId: 123, logArtifact: "invalid-log-artifact" };
+      act(() => {
+        changeInput(textarea, JSON.stringify(parsed, null, 2));
+      });
+      const liveWarning = r.container.textContent ?? "";
+      expect(liveWarning).toContain("payload does not validate against the registered input schema");
+      expect(liveWarning).not.toMatch(/\^\[0-9a-f\]\{64\}/);
+      expect(liveWarning).not.toContain("does not match pattern");
+      expect(liveWarning).toMatch(/expected format/i);
     }));
 });

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -247,6 +247,29 @@ const inputCls =
 
 type EditorTab = "form" | "json";
 
+export function humanizeSchemaErrors(errs: string[], fields?: FieldSpec[] | null): string[] {
+  const byName = new Map((fields ?? []).map((f) => [f.name, f]));
+  return errs.map((err) => {
+    if (!/does not match pattern/.test(err)) return err;
+    const fielded = err.match(/^\$\.([A-Za-z0-9_$-]+)((?:[.[])[^:]*)?: (.*)$/);
+    if (fielded) {
+      const name = fielded[1];
+      const subpath = fielded[2] ?? "";
+      const message = fielded[3];
+      const spec = byName.get(name);
+      const example = !subpath && spec ? placeholderFor(name, spec.schema) : null;
+      const hint = example ? ` (e.g. ${example})` : "";
+      const humanizedMsg = message.replace(
+        /does not match pattern[\s\S]*$/,
+        `does not match expected format${hint}`,
+      );
+      return `$.${name}${subpath}: ${humanizedMsg}`;
+    }
+    return err.replace(/does not match pattern[\s\S]*$/, "does not match expected format");
+  });
+}
+
+
 /**
  * Inject dialog (webui spec §4.4, templates per OPS-214, confirm per OPS-230,
  * format OPS-361, 2-column sidebar OPS-363, schema-driven Form view WM-76,
@@ -691,7 +714,9 @@ export function InjectDialog({
   /** Warn-and-ack for a schema-invalid payload; returns true when submission should pause. */
   function needsSchemaAck(type: string, errs: string[]): boolean {
     if (errs.length === 0 || schemaAck) return false;
-    const summary = errs.slice(0, 3).join("; ") + (errs.length > 3 ? ` (+${errs.length - 3} more)` : "");
+    const fields = schemaFields(schemaFor(type));
+    const humanized = humanizeSchemaErrors(errs, fields);
+    const summary = humanized.slice(0, 3).join("; ") + (humanized.length > 3 ? ` (+${humanized.length - 3} more)` : "");
     setClientError(
       `payload does not validate against the "${type}" input schema: ${summary}. Intake will admit it, but planning will park it human_needed. Inject anyway to proceed.`,
     );
@@ -807,7 +832,8 @@ export function InjectDialog({
     if (!isPlainObject(env) || typeof env.type !== "string") return [];
     const schema = schemaFor(env.type);
     if (!schema) return [];
-    return validate(schema, env.payload ?? {}).errors;
+    const rawErrs = validate(schema, env.payload ?? {}).errors;
+    return humanizeSchemaErrors(rawErrs, schemaFields(schema));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- schemaFor reads registryView
   }, [tab, text, registryView]);
 

--- a/event-runtime/web/src/lib/schema.test.ts
+++ b/event-runtime/web/src/lib/schema.test.ts
@@ -79,4 +79,11 @@ describe("validate (web port of lib/schema.mjs)", () => {
     };
     expect(validate(schema, { a: "x", toString: "evil" }).valid).toBe(false);
   });
+
+  test("pattern validation error does not expose raw regex", () => {
+    const { valid, errors } = validate({ type: "string", pattern: "^[0-9a-f]{40}$" }, "invalid");
+    expect(valid).toBe(false);
+    expect(errors[0]).toBe("$: does not match pattern");
+    expect(errors[0]).not.toContain("^[0-9a-f]{40}$");
+  });
 });

--- a/event-runtime/web/src/lib/schema.ts
+++ b/event-runtime/web/src/lib/schema.ts
@@ -80,7 +80,7 @@ function check(schema: unknown, value: unknown, path: string, errors: string[]):
       errors.push(`${path}: longer than maxLength ${s.maxLength}`);
     }
     if (hasOwn(s, "pattern") && typeof s.pattern === "string" && !new RegExp(s.pattern).test(str)) {
-      errors.push(`${path}: does not match pattern ${s.pattern}`);
+      errors.push(`${path}: does not match pattern`);
     }
   }
 


### PR DESCRIPTION
Fixes WM-179

## Summary
- Replace raw schema regex error messages in Inject-anyway banner and field validation with human-readable descriptions.
- Updated unit tests in InjectDialog.test.tsx and schema.test.ts.