### PR TITLE
fix(spec): support level 2-4 and numbered markdown headers in owned-paths and label-guard

### DIFF
--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -31,10 +31,10 @@ import { parseOwnedPaths } from "./owned-paths.mjs";
 
 const AI_AGENT_READY = "ai:agent-ready";
 
-/** Split `## Heading` sections, keyed by heading text and trimmed body. */
+/** Split markdown heading sections (levels 2-4), keyed by heading text and trimmed body. */
 function sections(description = "") {
   return description
-    .split(/^##\s+/m)
+    .split(/^#{2,4}\s+/m)
     .slice(1)
     .map((s) => {
       const nl = s.indexOf("\n");
@@ -83,7 +83,7 @@ export function templateGaps(description = "") {
   // A non-code ticket (deploy/env-var/business change) legitimately has no
   // repo paths -- linear.md's non-code exception applies here too. Accept an
   // explicit "not applicable" declaration in the section body.
-  const owned = secs.find((s) => s.heading.toLowerCase().includes("owned paths"));
+  const owned = secs.find((s) => /\bowned\s+paths\b/i.test(s.heading));
   const ownedNA = owned && NOT_APPLICABLE.test(owned.body);
   if (!parseOwnedPaths(description).length && !ownedNA) gaps.push("Owned Paths");
 
@@ -93,8 +93,10 @@ export function templateGaps(description = "") {
   // "## Production evidence" (proof the bug is real) is not a verification
   // method and must not satisfy this.
   const verified = secs.some((s) => {
-    const h = s.heading.toLowerCase();
-    return (h.includes("verification command") || /\bevidence\b.*\b(required|line)\b/.test(h)) && s.body.length > 0;
+    return (
+      (/\bverification\s+command\b/i.test(s.heading) || /\bevidence\b.*\b(required|line)\b/i.test(s.heading)) &&
+      s.body.length > 0
+    );
   });
   if (!verified) gaps.push("Verification Command");
 

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -134,3 +134,51 @@ Some prose that isn't a path list and gives no real answer either way.
 test("empty description fails both", () => {
   expect(templateGaps("")).toEqual(["Owned Paths", "Verification Command"]);
 });
+
+test("supports level 3 numbered headers (### 2. Owned Paths, ### 3. Verification Command) and colons", () => {
+  const desc = `## 1. Problem & Context
+
+Something is broken.
+
+### 2. Owned Paths:
+
+- \`orchestrator/owned-paths.mjs\`
+
+### 3. Verification Command:
+
+    bun test orchestrator/owned-paths.test.mjs`;
+  expect(templateGaps(desc)).toEqual([]);
+});
+
+test("supports level 4 headers (#### 4. Owned Paths)", () => {
+  const desc = `#### 1. Problem & Context
+
+Something is broken.
+
+#### 2. Owned Paths
+
+- \`orchestrator/owned-paths.mjs\`
+
+#### 3. Verification Command
+
+    bun test`;
+  expect(templateGaps(desc)).toEqual([]);
+});
+
+test("supports level 2 numbered headers with colons (## 2. Owned Paths:, ## 3. Verification Command:)", () => {
+  const desc = `## 2. Owned Paths:
+
+- \`orchestrator/owned-paths.mjs\`
+
+## 3. Verification Command:
+
+    bun test`;
+  expect(templateGaps(desc)).toEqual([]);
+});
+
+test("detects missing Verification Command even with level 3 numbered Owned Paths", () => {
+  const desc = `### 2. Owned Paths
+
+- \`orchestrator/owned-paths.mjs\``;
+  expect(templateGaps(desc)).toEqual(["Verification Command"]);
+});

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -17,13 +17,16 @@
  */
 
 /**
- * Extract the `## Owned Paths` bullet list from a Linear issue description.
+ * Extract the Owned Paths bullet list (levels 2-4) from a Linear issue description.
  * Returns [] when the section is missing or fails to parse — for dispatch,
  * use `effectiveOwnedPaths`, which turns that into "collides with
  * everything" rather than "not dispatchable".
  */
 export function parseOwnedPaths(description = "") {
-  const section = description.split(/^##\s+/m).find((s) => /^Owned Paths/i.test(s));
+  const section = description.split(/^#{2,4}\s+/m).find((s) => {
+    const heading = s.split("\n")[0];
+    return /\bOwned Paths\b/i.test(heading);
+  });
   if (!section) return [];
 
   // Real tickets write this section three different ways — bullet lists, fenced

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -149,3 +149,47 @@ test("a trailing change-kind annotation doesn't sink the path (CLNT-765/768/764 
     "src/analytics/kpis/existing.ts",
   ]);
 });
+
+test("supports level 3 numbered headers (### 2. Owned Paths) and colons", () => {
+  const desc = `## 1. Problem & Context
+
+Some background.
+
+### 2. Owned Paths:
+
+- \`orchestrator/owned-paths.mjs\`
+- \`orchestrator/owned-paths.test.mjs\`
+
+### 3. Verification Command
+
+    bun test`;
+  expectEqual(parseOwnedPaths(desc), [
+    "orchestrator/owned-paths.mjs",
+    "orchestrator/owned-paths.test.mjs",
+  ]);
+});
+
+test("supports level 2 numbered header (## 2. Owned Paths)", () => {
+  const desc = `## 2. Owned Paths
+
+- \`orchestrator/owned-paths.mjs\``;
+  expectEqual(parseOwnedPaths(desc), ["orchestrator/owned-paths.mjs"]);
+});
+
+test("supports colon in level 2 header (## Owned Paths:)", () => {
+  const desc = `## Owned Paths:
+
+- \`app/services/api.ts\`
+- \`app/services/auth.ts\``;
+  expectEqual(parseOwnedPaths(desc), [
+    "app/services/api.ts",
+    "app/services/auth.ts",
+  ]);
+});
+
+test("supports level 4 numbered headers (#### 4. Owned Paths)", () => {
+  const desc = `#### 4. Owned Paths
+
+- \`event-runtime/cli.mjs\``;
+  expectEqual(parseOwnedPaths(desc), ["event-runtime/cli.mjs"]);
+});


### PR DESCRIPTION
Fixes WM-243

## Summary
- Update heading splitter in owned-paths and label-guard to match level 2-4 headings (^#{2,4}\s+).
- Update section title matching to match 'Owned Paths' and 'Verification Command' across numbered, colon-terminated, and multi-level header variations.
- Added comprehensive unit tests for heading variations in owned-paths.test.mjs and label-guard.test.mjs.