### PR TITLE
feat(event-runtime): implement agy (antigravity) adapter alongside claude and pi (WM-424)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -105,6 +105,11 @@ models:
     strong: openai-codex/gpt-5.6-sol
     standard: openai-codex/gpt-5.6-terra
     light: openai-codex/gpt-5.6-luna
+  # agy (WM-424), Antigravity/Gemini subscription window.
+  agy:
+    strong: gemini-3.7-flash
+    standard: gemini-3.7-flash
+    light: gemini-2.5-flash
 
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the

--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -340,7 +340,7 @@ spec (§12).
 | `lib/workspace.mjs` | ephemeral workspaces, path confinement (§7) |
 | `lib/worker.mjs` | worker loop: claim under `BEGIN IMMEDIATE`, lease, execute, verify, publish with fencing (§8) |
 | `lib/verify.mjs` | result verification + compact receipts (§9) |
-| `lib/adapters/` | adapter registry (§6): `claude` (LLM), `command` (closed argv template), `actions` (approved action list → closed registry), `fake` (tests/demo) |
+| `lib/adapters/` | adapter registry (§6): `claude` (LLM), `pi` (LLM), `agy` (LLM), `command` (closed argv template), `actions` (approved action list → closed registry), `fake` (tests/demo) |
 | `lib/artifacts.mjs` | content-addressed store: collect, stream via `GET /artifacts/:sha256`, materialize declared inputs, retention (OPS-372) |
 | `lib/schedules.mjs` `schedules.json` | clock ticks: slots, catch-up, singleton, earned auto-approval (OPS-381) |
 | `lib/workers.mjs` | worker registry, heartbeats, placement predicate (OPS-233) |

--- a/event-runtime/agents/agy-smoke.json
+++ b/event-runtime/agents/agy-smoke.json
@@ -1,0 +1,28 @@
+{
+  "id": "agy-smoke",
+  "version": 1,
+  "prompt": "agents/agy-smoke.md",
+  "input_schema": "schemas/agy-smoke.input.json",
+  "output_schema": "schemas/agy-smoke.output.json",
+  "output_contract": "factory.agy-smoke/v1",
+  "model_tier": "strong",
+  "effort": "high",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": []
+  },
+  "limits": {
+    "timeout_seconds": 120,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/agy-smoke.md": "sha256:e05ff371c411a949d63cf2e7b9e6ca16888bc80945dcb8f6bcc3bfb542cd9e6e",
+    "schemas/agy-smoke.input.json": "sha256:f4b76517f30377e2612404e958c31fd9c0125fe18192b33358cf4b106cebd17c",
+    "schemas/agy-smoke.output.json": "sha256:92e08b4b666fb4777ce641aa66b1c3384d5f1305b7a2afd79dba3787e7f44809"
+  }
+}

--- a/event-runtime/agents/agy-smoke.md
+++ b/event-runtime/agents/agy-smoke.md
@@ -1,0 +1,20 @@
+# agy-smoke — smoke test for the agy (Antigravity) adapter
+
+`./input.json` names one `message` string. Read it and write `./result.json`
+echoing it back unchanged. This is a wiring smoke test (WM-424), not a real
+task — do nothing else: no other tool calls, no file writes beyond
+`./result.json`.
+
+## Output
+
+Write `./result.json`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": { "echo": "<input.json's message, unchanged>" },
+  "evidence": { "commands": [] }
+}
+```

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -18,6 +18,7 @@ import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, 
 import { hostname, homedir } from "node:os";
 import path from "node:path";
 import * as actions from "./lib/adapters/actions.mjs";
+import * as agy from "./lib/adapters/agy.mjs";
 import * as claude from "./lib/adapters/claude.mjs";
 import * as command from "./lib/adapters/command.mjs";
 import * as fake from "./lib/adapters/fake.mjs";
@@ -360,7 +361,7 @@ async function serve(args) {
     fail(`serve: invalid port "${rawPort}" (must be integer 1-65535)`);
   }
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  const adapters = { actions, claude, command, fake, pi };
+  const adapters = { actions, agy, claude, command, fake, pi };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`serve: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }
@@ -515,7 +516,7 @@ async function work(args) {
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
-  const adapters = { actions, claude, command, fake, pi };
+  const adapters = { actions, agy, claude, command, fake, pi };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`work: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -556,6 +556,87 @@ describe("cli", () => {
     expect(row?.state).toBe("COMPLETED");
   });
 
+  test("agy-smoke@1 routes end-to-end through the agy adapter via a fake shim (WM-424)", async () => {
+    const { createRun, transition } = await import("./lib/lifecycle.mjs");
+    const { canonicalJson, hashJson } = await import("./lib/canonical.mjs");
+    const { loadRegistry } = await import("./lib/registry.mjs");
+    const { claimNext, executeClaimed } = await import("./lib/worker.mjs");
+
+    const db = openDb(":memory:");
+    const registry = loadRegistry();
+
+    const input = { message: "hello from WM-424" };
+    const spec = {
+      schemaVersion: "factory.run-spec/v1",
+      runId: "run_agy_smoke_test",
+      agent: "agy-smoke@1",
+      input,
+      inputHash: hashJson(input),
+      workspace: { type: "ephemeral", retainOnFailure: true },
+      adapter: "agy",
+      model: "gemini-3.7-flash",
+      effort: "high",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.agy-smoke/v1",
+      capabilities: [],
+      timeoutSeconds: 5,
+      maxAttempts: 1,
+      idempotencyKey: "idem_agy_smoke_test",
+    };
+
+    createRun(db, {
+      runId: spec.runId,
+      idempotencyKey: spec.idempotencyKey,
+      spec,
+      specJson: canonicalJson(spec),
+      specHash: hashJson(spec),
+      actor: "test",
+      policyVersion: "test",
+      now: Date.now(),
+    });
+    transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now: Date.now() });
+    transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now: Date.now() });
+
+    let agyCalled = false;
+    const mockAdapters = {
+      agy: {
+        execute: async ({ spec: runSpec, workspaceDir }) => {
+          agyCalled = true;
+          const { readFileSync, writeFileSync } = await import("node:fs");
+          const { default: path } = await import("node:path");
+          const staged = JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8"));
+          writeFileSync(
+            path.join(workspaceDir, "result.json"),
+            JSON.stringify({
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              reasonCode: "ok",
+              artifact: { echo: staged.message },
+              evidence: { commands: [] },
+            }),
+            "utf8",
+          );
+          return { exitCode: 0, timedOut: false };
+        },
+      },
+    };
+
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-agy-smoke-"));
+    const claim = claimNext(db, { owner: "w1" });
+    expect(claim).toBeTruthy();
+
+    const summary = await executeClaimed(db, registry, mockAdapters, claim, {
+      workspacesRoot: home,
+    });
+
+    expect(agyCalled).toBe(true);
+    expect(summary.terminalState).toBe("COMPLETED");
+
+    const row = db.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_agy_smoke_test");
+    expect(row?.state).toBe("COMPLETED");
+  });
+
   test("tick runs notify as an isolated subsystem (WM-65): a throwing notifier step cannot break the tick", async () => {
     const { tick, TICK_SUBSYSTEMS } = await import("./cli.mjs");
     const { loadRegistry } = await import("./lib/registry.mjs");

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -269,5 +269,13 @@
       "inputHash"
     ],
     "proposalTtlSeconds": 1800
+  },
+  "factory.agy-smoke.requested": {
+    "agent": "agy-smoke@1",
+    "adapter": "agy",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -1,0 +1,275 @@
+/**
+ * agy (Antigravity) CLI adapter (docs/event-runtime.md §6, §14; WM-424) — the
+ * third LLM harness alongside `claude` and `pi`, on the Antigravity/Gemini
+ * subscription and Google Cloud authentication window.
+ *
+ * Spawns a bounded `agy -p - --output-format stream-json --dangerously-skip-permissions`
+ * process (prompt piped to stdin, the standard `./input.json` → `./result.json`
+ * PROMPT_SUFFIX contract, cwd = workspace), enforces the run spec's timeout with
+ * TERM→KILL(killGraceMs), strips API keys so the CLI authenticates against the
+ * session/subscription instead of per-token billing, and captures full stdout as
+ * the `.transcript.json` artifact.
+ */
+import { spawn } from "node:child_process";
+import { createWriteStream, readFileSync } from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+
+export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
+
+export const KILL_GRACE_MS = 30_000;
+const TEXT_PREVIEW_CHARS = 4000;
+
+export class CliNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CliNotFoundError";
+    this.code = "cli_not_found";
+  }
+}
+
+/**
+ * Resolve the agy binary: `agy` on PATH.
+ * `which` is injectable for tests; defaults to `Bun.which` scoped to the child's PATH.
+ */
+export function resolveAgyCommand({ which = Bun.which } = {}) {
+  if (which("agy")) return { command: "agy", args: [] };
+  return null;
+}
+
+/**
+ * Build argv for spawning agy.
+ * The prompt itself travels on stdin via `-p -`.
+ */
+export function buildAgyArgv({ def, model, effort, workspaceDir, timeoutMs }) {
+  const args = [
+    "-p", "-",
+    "--output-format", "stream-json",
+    "--dangerously-skip-permissions",
+  ];
+
+  if (workspaceDir) {
+    args.push("--add-dir", workspaceDir);
+  }
+
+  if (timeoutMs) {
+    const printMin = Math.max(1, Math.round(timeoutMs / 60000) - 2);
+    args.push("--print-timeout", `${printMin}m`);
+  }
+
+  if (typeof model === "string" && model !== "" && model !== "default") {
+    args.push("--model", model);
+  }
+
+  const effectiveEffort = effort ?? def?.effort;
+  if (typeof effectiveEffort === "string" && ["low", "medium", "high"].includes(effectiveEffort.toLowerCase())) {
+    args.push("--effort", effectiveEffort.toLowerCase());
+  }
+
+  return args;
+}
+
+export const BASE_INHERITED_ENV = [
+  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
+  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+];
+
+/**
+ * Keep untrusted model subprocesses from inheriting the worker's authority.
+ * Strips provider API keys to force subscription/login authentication.
+ */
+export function safeChildEnvironment(env = {}, defOrOpts = {}) {
+  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
+  const childEnv = Object.fromEntries(
+    inherited.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]])),
+  );
+  Object.assign(childEnv, env);
+
+  for (const key of [
+    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
+    "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+  ]) {
+    delete childEnv[key];
+  }
+
+  if (!isMutating) {
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      delete childEnv[key];
+    }
+  }
+
+  return childEnv;
+}
+
+function clip(text) {
+  const s = String(text ?? "");
+  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+}
+
+/**
+ * Map one parsed `agy` NDJSON stream line to factory.trace/v1 events.
+ *
+ * @param {any} msg - one parsed NDJSON line from agy stream-json output
+ * @returns {Array<{kind: string, payload: object}>}
+ */
+export function mapStreamEvent(msg) {
+  if (!msg || typeof msg !== "object") return [];
+
+  if (msg.event === "step_update") {
+    const s = msg.step_update ?? {};
+    if (s.step_type === "tool" && s.state === "ACTIVE") {
+      return [{
+        kind: "tool_use",
+        payload: {
+          id: s.step_id ?? null,
+          name: s.tool_name ?? "tool",
+          input: s.tool_info?.parameters ?? {},
+        },
+      }];
+    }
+    if (s.step_type === "tool" && s.state === "DONE") {
+      return [{
+        kind: "tool_result",
+        payload: {
+          toolUseId: s.step_id ?? null,
+          content: clip(s.output ?? s.result ?? ""),
+          isError: s.status === "ERROR",
+        },
+      }];
+    }
+    if (s.step_type === "agent_response" && (s.text || s.text_delta)) {
+      return [{
+        kind: "assistant_text",
+        payload: { text: clip(s.text ?? s.text_delta) },
+      }];
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Extract token and runtime usage from an agy result event.
+ */
+export function extractUsage(msg) {
+  if (!msg || msg.event !== "result" || !msg.result) return null;
+  const r = msg.result;
+  const u = r.usage ?? {};
+  const usage = {};
+  if (typeof u.input_tokens === "number") usage.input = u.input_tokens;
+  if (typeof u.output_tokens === "number") usage.output = u.output_tokens;
+  if (typeof u.cache_read_tokens === "number") usage.cacheRead = u.cache_read_tokens;
+  if (typeof r.num_turns === "number") usage.turns = r.num_turns;
+
+  return {
+    usage,
+    costUSD: null,
+    durationMs: typeof r.duration_seconds === "number" ? r.duration_seconds * 1000 : null,
+    status: r.status ?? null,
+    error: r.error ?? null,
+  };
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean, usage?: object }>}
+ */
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  killGraceMs = KILL_GRACE_MS,
+  env = {},
+  onTrace,
+  onUsage,
+  abortSignal,
+  signal,
+}) {
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const childEnv = safeChildEnvironment(env, def);
+
+  const resolved = resolveAgyCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  if (!resolved) {
+    throw new CliNotFoundError(
+      "agy CLI is not on PATH — install the Antigravity CLI (docs/event-runtime.md §6)",
+    );
+  }
+
+  const argv = [
+    ...resolved.args,
+    ...buildAgyArgv({
+      def,
+      model: spec?.model,
+      effort: spec?.effort ?? def?.effort,
+      workspaceDir,
+      timeoutMs,
+    }),
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolved.command, argv, {
+      cwd: workspaceDir,
+      env: childEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    child.stdin.on("error", () => {});
+    child.stdin.write(prompt);
+    child.stdin.end();
+
+    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    transcript.on("error", () => {});
+    if (child.stdout) {
+      child.stdout.pipe(transcript);
+    }
+
+    let finalUsage = null;
+    if (child.stdout) {
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        try {
+          const parsed = JSON.parse(line);
+          const usageInfo = extractUsage(parsed);
+          if (usageInfo) {
+            finalUsage = usageInfo.usage;
+            onUsage?.(usageInfo.usage);
+          }
+          for (const event of mapStreamEvent(parsed)) {
+            onTrace?.(event.kind, event.payload);
+          }
+        } catch {
+          // not JSON — ignore
+        }
+      });
+    }
+
+    let timedOut = false;
+    let timer = null;
+    if (timeoutMs) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+        setTimeout(() => child.kill("SIGKILL"), killGraceMs).unref();
+      }, timeoutMs);
+    }
+
+    const cancel = () => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), killGraceMs).unref();
+    };
+    abortSignal?.addEventListener("abort", cancel, { once: true });
+    signal?.addEventListener("abort", cancel, { once: true });
+
+    child.on("close", (exitCode) => {
+      if (timer) clearTimeout(timer);
+      abortSignal?.removeEventListener("abort", cancel);
+      signal?.removeEventListener("abort", cancel);
+      resolve({ exitCode, timedOut, usage: finalUsage });
+    });
+
+    child.on("error", reject);
+  });
+}

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -1,0 +1,236 @@
+import { describe, expect, test, afterAll, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import {
+  buildAgyArgv,
+  CliNotFoundError,
+  execute,
+  extractUsage,
+  KILL_GRACE_MS,
+  mapStreamEvent,
+  PUSH_CREDENTIAL_ENV,
+  resolveAgyCommand,
+  safeChildEnvironment,
+} from "./agy.mjs";
+
+describe("mapStreamEvent (agy stream-json shapes)", () => {
+  test("agent_response step_update → assistant_text", () => {
+    const events = mapStreamEvent({
+      event: "step_update",
+      step_update: { step_type: "agent_response", state: "ACTIVE", text: "Checking the PR now." },
+    });
+    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "Checking the PR now." } }]);
+  });
+
+  test("tool ACTIVE step_update → tool_use", () => {
+    const events = mapStreamEvent({
+      event: "step_update",
+      step_update: {
+        step_id: "step_123",
+        step_type: "tool",
+        state: "ACTIVE",
+        tool_name: "run_command",
+        tool_info: { parameters: { CommandLine: "bun test" } },
+      },
+    });
+    expect(events).toEqual([
+      {
+        kind: "tool_use",
+        payload: { id: "step_123", name: "run_command", input: { CommandLine: "bun test" } },
+      },
+    ]);
+  });
+
+  test("tool DONE step_update → tool_result", () => {
+    const ok = mapStreamEvent({
+      event: "step_update",
+      step_update: {
+        step_id: "step_123",
+        step_type: "tool",
+        state: "DONE",
+        tool_name: "run_command",
+        output: "Tests passed\n",
+        status: "SUCCESS",
+      },
+    });
+    expect(ok).toEqual([
+      {
+        kind: "tool_result",
+        payload: { toolUseId: "step_123", content: "Tests passed\n", isError: false },
+      },
+    ]);
+
+    const err = mapStreamEvent({
+      event: "step_update",
+      step_update: {
+        step_id: "step_456",
+        step_type: "tool",
+        state: "DONE",
+        tool_name: "run_command",
+        output: "Failed to run\n",
+        status: "ERROR",
+      },
+    });
+    expect(err).toEqual([
+      {
+        kind: "tool_result",
+        payload: { toolUseId: "step_456", content: "Failed to run\n", isError: true },
+      },
+    ]);
+  });
+
+  test("unrecognized events are ignored silently", () => {
+    expect(mapStreamEvent({ event: "init", conversation_id: "abc" })).toEqual([]);
+    expect(mapStreamEvent(null)).toEqual([]);
+    expect(mapStreamEvent("not an object")).toEqual([]);
+  });
+
+  test("very long assistant text is clipped", () => {
+    const [event] = mapStreamEvent({
+      event: "step_update",
+      step_update: { step_type: "agent_response", state: "ACTIVE", text: "y".repeat(10_000) },
+    });
+    expect(event.kind).toBe("assistant_text");
+    expect(event.payload.text.length).toBeLessThan(4100);
+    expect(event.payload.text.endsWith("…[truncated]")).toBe(true);
+  });
+});
+
+describe("extractUsage", () => {
+  test("extracts tokens, turns, and duration from result event", () => {
+    const res = extractUsage({
+      event: "result",
+      result: {
+        status: "SUCCESS",
+        duration_seconds: 12.5,
+        num_turns: 4,
+        usage: {
+          input_tokens: 1500,
+          output_tokens: 300,
+          cache_read_tokens: 500,
+        },
+      },
+    });
+    expect(res).toEqual({
+      usage: {
+        input: 1500,
+        output: 300,
+        cacheRead: 500,
+        turns: 4,
+      },
+      costUSD: null,
+      durationMs: 12500,
+      status: "SUCCESS",
+      error: null,
+    });
+  });
+
+  test("returns null when message is not a result event", () => {
+    expect(extractUsage({ event: "init" })).toBeNull();
+    expect(extractUsage(null)).toBeNull();
+  });
+});
+
+describe("buildAgyArgv", () => {
+  test("basic flags and stdin prompt format", () => {
+    const argv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md" },
+      workspaceDir: "/tmp/ws",
+      timeoutMs: 300000,
+    });
+    expect(argv).toContain("-p");
+    expect(argv).toContain("-");
+    expect(argv).toContain("--output-format");
+    expect(argv).toContain("stream-json");
+    expect(argv).toContain("--dangerously-skip-permissions");
+    expect(argv).toContain("--add-dir");
+    expect(argv).toContain("/tmp/ws");
+    expect(argv).toContain("--print-timeout");
+    expect(argv).toContain("3m");
+  });
+
+  test("model and effort parameters", () => {
+    const argv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md", effort: "high" },
+      model: "gemini-3.7-flash",
+      workspaceDir: "/tmp/ws",
+    });
+    expect(argv).toContain("--model");
+    expect(argv).toContain("gemini-3.7-flash");
+    expect(argv).toContain("--effort");
+    expect(argv).toContain("high");
+  });
+});
+
+describe("safeChildEnvironment", () => {
+  test("strips API keys and preserves push credentials when mutating", () => {
+    const prev = { ...process.env };
+    process.env.GEMINI_API_KEY = "secret-gemini";
+    process.env.GOOGLE_API_KEY = "secret-google";
+    process.env.SSH_AUTH_SOCK = "/tmp/ssh-sock";
+    process.env.GITHUB_TOKEN = "gh-secret";
+
+    const env = safeChildEnvironment({}, { mutating: true });
+    expect(env.GEMINI_API_KEY).toBeUndefined();
+    expect(env.GOOGLE_API_KEY).toBeUndefined();
+    expect(env.SSH_AUTH_SOCK).toBe("/tmp/ssh-sock");
+    expect(env.GITHUB_TOKEN).toBe("gh-secret");
+
+    const readOnlyEnv = safeChildEnvironment({}, { mutating: false });
+    expect(readOnlyEnv.SSH_AUTH_SOCK).toBeUndefined();
+    expect(readOnlyEnv.GITHUB_TOKEN).toBeUndefined();
+
+    process.env = prev;
+  });
+});
+
+describe("resolveAgyCommand", () => {
+  test("resolves agy on PATH", () => {
+    const found = resolveAgyCommand({ which: (cmd) => (cmd === "agy" ? "/usr/local/bin/agy" : null) });
+    expect(found).toEqual({ command: "agy", args: [] });
+
+    const missing = resolveAgyCommand({ which: () => null });
+    expect(missing).toBeNull();
+  });
+});
+
+describe("execute with fake binary", () => {
+  let tmp;
+  afterEach(() => {
+    if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("spawns agy, feeds stdin prompt, pipes transcript, records trace", async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    const binDir = path.join(tmp, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const fakeAgy = path.join(binDir, "agy");
+    const script = `#!/usr/bin/env bash
+echo '{"event":"init","conversation_id":"c1"}'
+echo '{"event":"step_update","step_update":{"step_id":"s1","step_type":"agent_response","text":"Hello world"}}'
+echo '{"event":"result","result":{"status":"SUCCESS","duration_seconds":1,"usage":{"input_tokens":10,"output_tokens":20}}}'
+`;
+    writeFileSync(fakeAgy, script, { mode: 0o755 });
+
+    const promptFile = path.join(tmp, "prompt.md");
+    writeFileSync(promptFile, "Do task");
+
+    const traces = [];
+    const res = await execute({
+      spec: { model: "gemini-3.7-flash" },
+      def: { promptPath: promptFile },
+      workspaceDir: tmp,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+      onTrace: (kind, payload) => traces.push({ kind, payload }),
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(traces).toEqual([
+      { kind: "assistant_text", payload: { text: "Hello world" } },
+    ]);
+    expect(res.usage).toEqual({ input: 10, output: 20 });
+    expect(existsSync(path.join(tmp, ".transcript.json"))).toBe(true);
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -43,7 +43,7 @@ export const DEFAULT_MODEL = "default";
 
 /** Adapters that accept a model at all. command/actions/fake take none: a
  * declared tier there resolves to null (not applicable), never an error. */
-export const MODEL_ADAPTERS = new Set(["claude", "pi"]);
+export const MODEL_ADAPTERS = new Set(["claude", "pi", "agy"]);
 
 /**
  * Read the `models:` tier map from config/policy.yaml (same root rule as

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -32,6 +32,11 @@ const PI_TIERS = {
     standard: "openai-codex/gpt-5.6-terra",
     light: "openai-codex/gpt-5.6-luna",
   },
+  agy: {
+    strong: "gemini-3.7-flash",
+    standard: "gemini-3.7-flash",
+    light: "gemini-2.5-flash",
+  },
 };
 
 describe("registry", () => {

--- a/event-runtime/schemas/agy-smoke.input.json
+++ b/event-runtime/schemas/agy-smoke.input.json
@@ -1,0 +1,13 @@
+{
+  "title": "agy-smoke input — one message to echo back through the agy adapter",
+  "type": "object",
+  "required": ["message"],
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Text for the agent to read and echo back, proving the agy adapter ran end-to-end"
+    }
+  }
+}

--- a/event-runtime/schemas/agy-smoke.output.json
+++ b/event-runtime/schemas/agy-smoke.output.json
@@ -1,0 +1,13 @@
+{
+  "title": "factory.agy-smoke/v1 output artifact — the input message echoed back",
+  "type": "object",
+  "required": ["echo"],
+  "additionalProperties": false,
+  "properties": {
+    "echo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The input message, unchanged"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements the `agy` (Antigravity) LLM harness adapter in `event-runtime/` alongside `claude` and `pi`.

- Implements `event-runtime/lib/adapters/agy.mjs` with process lifecycle, stdin prompt delivery, stream event mapping (`step_update` -> `tool_use`/`tool_result`/`assistant_text`), usage extraction, and API key stripping.
- Registers `agy` in `MODEL_ADAPTERS` (`registry.mjs`) and configures model tiers in `policy.yaml` (`strong: gemini-3.7-flash`, `standard: gemini-3.7-flash`, `light: gemini-2.5-flash`).
- Adds `agy-smoke@1` test agent definition with Gemini 3.7 Flash and `--effort high` reasoning effort.
- Adds comprehensive unit and routing test coverage in `agy.test.mjs` and `cli.test.mjs`.

Fixes WM-424