### PR TITLE
fix(merge-scan): materialize pinned repository config (WM-425)

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -7,14 +7,16 @@
   "output_contract": "factory.merge-plan/v2",
   "model_tier": "strong",
   "workspace": {
-    "type": "ephemeral",
+    "type": "repository",
+    "checkoutDir": "repo",
     "retainOnFailure": true
   },
   "capabilities": {
     "filesystem": "workspace-only",
     "services": [
       "gh:read",
-      "linear:read"
+      "linear:read",
+      "repo:read"
     ]
   },
   "limits": {
@@ -23,8 +25,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:b51b2498ee7ec6b267d2074e595fc54e1b75ae9dccd8013e7e2881461fb03f52",
-    "schemas/merge-scan.input.json": "sha256:f41fcfbbaee8423923b9ee5c213bfa92d03ce711d271c5a65a893f08b5af873e",
+    "agents/merge-scan.md": "sha256:83a184eea1f0071471f4e8c1669f3c88082c6504b7e3d8891a4fac51376728ce",
+    "schemas/merge-scan.input.json": "sha256:5ea3b9702df503b438fb11f6bd566161fcb4d5bafcf298070e1535ecfa4737a5",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }
 }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -1,10 +1,25 @@
 # merge-scan — independent cold review and one-PR merge planning
 
 You are an independent cold reviewer. You did not write or fix any PR in this
-run. `input.json` names a configured repo. Read `config/repos.yaml` and
-`config/policy.yaml`, then enumerate **all** open PRs and classify every
-base-targeting, non-draft PR as exactly MERGE, FIX, or ESCALATE. Write
-`result.json`; never mutate GitHub or Linear.
+run. `./input.json` names a configured repo and contains a planner-injected
+`repoPin` with the exact commit SHA materialized for this run. The repo is
+checked out read-only at `./repo` at that SHA. Read
+`./repo/config/repos.yaml` and `./repo/config/policy.yaml` from that pinned
+snapshot, then enumerate **all** open PRs and classify every base-targeting,
+non-draft PR as exactly MERGE, FIX, or ESCALATE. Never modify the checkout,
+GitHub, or Linear. Write only `./result.json` in the workspace root.
+
+If either pinned config file is missing or unreadable, or the named repo's
+configuration is missing or malformed, fail closed with this complete result
+and stop:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "refused",
+  "reasonCode": "needs_human"
+}
+```
 
 For every PR record the live `headRefOid` and the current base ref SHA. Read the
 complete diff, PR body, every review, required checks, and the full Linear
@@ -47,6 +62,43 @@ one deterministic candidate (lowest PR number) in `plan` so only one PR can
 land per base-CI cycle. Every plan boolean is a positive assertion from your
 review; the schema rejects anything weaker. Include `base`, `deployBranch`,
 head/base SHA, and exact head branch. A moved SHA requires a new scan.
+
+## Result envelope
+
+`./result.json` must always be a `factory.agent-result/v1` wrapper. On a
+completed scan, put the complete `factory.merge-plan/v2` merge plan under
+`artifact`, never at the wrapper root. This is the required nesting (the
+values shown are only a valid NOOP example; emit the result of the actual
+review):
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "recommendation": "NOOP",
+    "repo": "factory",
+    "github": "watt-mind/factory",
+    "base": "develop",
+    "deployBranch": "master",
+    "plan": [],
+    "fix": [],
+    "escalate": [],
+    "summary": "No open pull requests target the configured base branch.",
+    "noopReason": "no_open_prs"
+  },
+  "evidence": {
+    "commands": []
+  }
+}
+```
+
+Do not place `recommendation`, `repo`, `github`, `base`, `deployBranch`,
+`plan`, `fix`, `escalate`, `summary`, or `noopReason` beside `schemaVersion`;
+all merge-plan fields belong inside `artifact`. Never omit `terminalState`.
+For any refusal, use the complete fail-closed wrapper shown above rather than
+writing a partial merge plan.
 
 After producing the artifact, do nothing else. In particular, never approve,
 merge, push, mark Done, or delete a branch.

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { substituteArgv } from "./lib/adapters/actions.mjs";
 import { resolveTemplate } from "./lib/adapters/command.mjs";
@@ -8,8 +18,9 @@ import { canonicalJson } from "./lib/canonical.mjs";
 import { openDb } from "./lib/db.mjs";
 import { admitEvent as persistEvent } from "./lib/intake.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
-import { openProposals } from "./lib/proposals.mjs";
+import { approveProposal, openProposals } from "./lib/proposals.mjs";
 import { loadRegistry } from "./lib/registry.mjs";
+import { runOnce } from "./lib/worker.mjs";
 import {
   commandFixture,
   runCommand,
@@ -332,6 +343,167 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
         approval: "auto",
         enabled: true,
       });
+    }
+  });
+});
+
+describe("merge-scan repository workspace and result contract (WM-425)", () => {
+  test("the definition and prompt declare the pinned repository contract", () => {
+    const def = registry.agents.get("merge-scan@2");
+    expect(def.workspace).toEqual({
+      type: "repository",
+      checkoutDir: "repo",
+      retainOnFailure: true,
+    });
+    expect(def.capabilities.services).toContain("repo:read");
+    expect(def.inputSchema.properties.repoPin.required).toEqual(["repo", "sha"]);
+    expect(def.inputSchema.properties.repoPin.properties.sha.pattern).toBe(
+      "^[0-9a-f]{40}$",
+    );
+
+    const prompt = readFileSync(def.promptPath, "utf8");
+    expect(prompt).toContain("./repo/config/repos.yaml");
+    expect(prompt).toContain("./repo/config/policy.yaml");
+    expect(prompt).toContain('"terminalState": "completed"');
+    expect(prompt).toContain('"artifact": {');
+    expect(prompt).toContain('"terminalState": "refused"');
+  });
+
+  test("a planned scan reads pinned config and a schema-valid fail-closed result is refused, not contract-invalid", async () => {
+    const fixture = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-scan-"));
+    const source = path.join(fixture, "source");
+    const eventHome = path.join(fixture, "event-home");
+    const workspaces = path.join(fixture, "workspaces");
+    const previousReposRoot = process.env.FACTORY_REPOS_ROOT;
+    const previousEventHome = process.env.FACTORY_EVENT_HOME;
+    const git = (args) =>
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "commit.gpgsign=false",
+          "-c",
+          "core.hooksPath=/dev/null",
+          "-c",
+          "commit.template=",
+          ...args,
+        ],
+        { cwd: source, encoding: "utf8" },
+      ).trim();
+
+    try {
+      mkdirSync(path.join(source, "config"), { recursive: true });
+      mkdirSync(eventHome, { recursive: true });
+      mkdirSync(workspaces, { recursive: true });
+      git(["init", "--quiet", "--initial-branch=develop"]);
+      git(["config", "user.email", "test@example.com"]);
+      git(["config", "user.name", "Test"]);
+      writeFileSync(
+        path.join(source, "config", "repos.yaml"),
+        `repos:\n  - name: mergefixture\n    path: ${source}\n    github: watt-mind/mergefixture\n    base: develop\n    deploy_branch: master\n`,
+      );
+      writeFileSync(
+        path.join(source, "config", "policy.yaml"),
+        "merge_fixture_policy: pinned\n",
+      );
+      git(["add", "config"]);
+      git(["commit", "--quiet", "-m", "pinned config"]);
+      const pinnedSha = git(["rev-parse", "HEAD"]);
+
+      process.env.FACTORY_REPOS_ROOT = source;
+      process.env.FACTORY_EVENT_HOME = eventHome;
+
+      const db = openDb(path.join(fixture, "runtime.db"));
+      persistEvent(
+        db,
+        registry,
+        envelope(
+          "factory.merge.requested",
+          { repo: "mergefixture" },
+          "merge-scan-workspace",
+        ),
+      );
+      planAdmittedEvents(db, registry, { policyVersion: PV });
+      const proposal = openProposals(db, {})[0];
+
+      expect(registry.agents.get("merge-scan@2").workspace).toEqual({
+        type: "repository",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      });
+      expect(proposal.spec.input.repoPin).toEqual({
+        repo: "mergefixture",
+        ref: "develop",
+        sha: pinnedSha,
+        github: "watt-mind/mergefixture",
+      });
+
+      writeFileSync(
+        path.join(source, "config", "policy.yaml"),
+        "merge_fixture_policy: moved\n",
+      );
+      git(["add", "config/policy.yaml"]);
+      git(["commit", "--quiet", "-m", "move config after planning"]);
+
+      approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        policyVersion: PV,
+      });
+      let observed = null;
+      const adapter = {
+        async execute({ workspaceDir }) {
+          observed = {
+            repos: readFileSync(
+              path.join(workspaceDir, "repo", "config", "repos.yaml"),
+              "utf8",
+            ),
+            policy: readFileSync(
+              path.join(workspaceDir, "repo", "config", "policy.yaml"),
+              "utf8",
+            ),
+          };
+          writeFileSync(
+            path.join(workspaceDir, "result.json"),
+            `${JSON.stringify({
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "refused",
+              reasonCode: "needs_human",
+            })}\n`,
+          );
+          return { exitCode: 0, timedOut: false };
+        },
+      };
+      const summary = await runOnce(
+        db,
+        registry,
+        { pi: adapter },
+        { workspacesRoot: workspaces, owner: "merge-test", policyVersion: PV },
+      );
+
+      expect(observed.repos).toContain("name: mergefixture");
+      expect(observed.policy).toBe("merge_fixture_policy: pinned\n");
+      expect(summary).toMatchObject({
+        terminalState: "REFUSED",
+        reasonCode: "needs_human",
+      });
+      expect(
+        JSON.parse(
+          db
+            .query("SELECT result_json FROM results WHERE run_id = ?")
+            .get(proposal.run_id).result_json,
+        ),
+      ).toMatchObject({
+        terminalState: "refused",
+        reasonCode: "needs_human",
+        verification: { status: "passed", checks: ["schema_valid"] },
+      });
+      db.close();
+    } finally {
+      if (previousReposRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
+      if (previousEventHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      else process.env.FACTORY_EVENT_HOME = previousEventHome;
+      rmSync(fixture, { recursive: true, force: true });
     }
   });
 });

--- a/event-runtime/schemas/merge-scan.input.json
+++ b/event-runtime/schemas/merge-scan.input.json
@@ -9,6 +9,32 @@
       "minLength": 1,
       "description": "Short repo name as configured in config/repos.yaml — not the GitHub owner/name slug"
     },
+    "repoPin": {
+      "type": "object",
+      "required": ["repo", "sha"],
+      "additionalProperties": false,
+      "description": "Filled by the planner (pinRepo) at plan time — not operator-supplied",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Echo of the pinned short repo name"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Ref the pin was resolved from"
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Commit SHA the scan runs against"
+        },
+        "github": {
+          "type": ["string", "null"],
+          "description": "GitHub owner/name slug of the repo, or null when it has no GitHub remote"
+        }
+      }
+    },
     "loop": { "type": "string", "minLength": 1 },
     "slot": { "type": "string", "minLength": 1 },
     "cadenceSeconds": { "type": "integer", "minimum": 1 },


### PR DESCRIPTION
## Summary
- materialize `merge-scan@2` in a read-only repository workspace pinned at plan time
- permit the planner-injected `repoPin` and read merge policy/config from the pinned snapshot
- require valid `factory.agent-result/v1` nesting and schema-valid fail-closed refusals
- add a regression covering the pinned checkout/config and refusal acceptance path

## Verification
- `bun test event-runtime/merge.test.mjs event-runtime/lib/workspace.test.mjs && bun event-runtime/cli.mjs update-pins && bun build/emit.mjs --check && bun run format:check`
- pass: 37 tests, pins current, 90 generated files matched, formatting passed

## Review
- UX critique: skipped — internal runtime workspace/result-contract change with no user-completable flow
- Security review: required — this changes security-relevant autonomous merge-scan behavior and must be reviewed by a human
- Optional PR scoping is intentionally not included

Fixes WM-425
