### PR TITLE
feat(event-runtime): configure agy light tier with gemini-3.7-flash and low thinking effort (WM-428)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -105,11 +105,11 @@ models:
     strong: openai-codex/gpt-5.6-sol
     standard: openai-codex/gpt-5.6-terra
     light: openai-codex/gpt-5.6-luna
-  # agy (WM-424), Antigravity/Gemini subscription window.
+  # agy (WM-424, WM-428), Antigravity/Gemini subscription window.
   agy:
     strong: gemini-3.7-flash
     standard: gemini-3.7-flash
-    light: gemini-2.5-flash
+    light: gemini-3.7-flash
 
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -62,7 +62,8 @@ export function buildAgyArgv({ def, model, effort, workspaceDir, timeoutMs }) {
     args.push("--model", model);
   }
 
-  const effectiveEffort = effort ?? def?.effort;
+  const tierEffort = def?.model_tier === "light" ? "low" : (def?.model_tier === "strong" ? "high" : (def?.model_tier === "standard" ? "medium" : null));
+  const effectiveEffort = effort ?? def?.effort ?? tierEffort;
   if (typeof effectiveEffort === "string" && ["low", "medium", "high"].includes(effectiveEffort.toLowerCase())) {
     args.push("--effort", effectiveEffort.toLowerCase());
   }

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -162,6 +162,24 @@ describe("buildAgyArgv", () => {
     expect(argv).toContain("--effort");
     expect(argv).toContain("high");
   });
+
+  test("defaults effort to low for light tier and high for strong tier (WM-428)", () => {
+    const lightArgv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md", model_tier: "light" },
+      model: "gemini-3.7-flash",
+      workspaceDir: "/tmp/ws",
+    });
+    expect(lightArgv).toContain("--effort");
+    expect(lightArgv[lightArgv.indexOf("--effort") + 1]).toBe("low");
+
+    const strongArgv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md", model_tier: "strong" },
+      model: "gemini-3.7-flash",
+      workspaceDir: "/tmp/ws",
+    });
+    expect(strongArgv).toContain("--effort");
+    expect(strongArgv[strongArgv.indexOf("--effort") + 1]).toBe("high");
+  });
 });
 
 describe("safeChildEnvironment", () => {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -35,7 +35,7 @@ const PI_TIERS = {
   agy: {
     strong: "gemini-3.7-flash",
     standard: "gemini-3.7-flash",
-    light: "gemini-2.5-flash",
+    light: "gemini-3.7-flash",
   },
 };
 


### PR DESCRIPTION
## Summary
- Sets `models.agy.light` to `gemini-3.7-flash` in `config/policy.yaml`.
- Implements default reasoning effort resolution in `agy.mjs` so agents running on the `light` tier default to `--effort low` (and `strong` to `--effort high`).
- Adds unit tests in `agy.test.mjs` and updates test fixtures in `registry.test.mjs`.

Fixes WM-428