### PR TITLE
fix(event-runtime): pass prompt argument directly to agy adapter (WM-429)

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -42,9 +42,8 @@ export function resolveAgyCommand({ which = Bun.which } = {}) {
  * Build argv for spawning agy.
  * The prompt itself travels on stdin via `-p -`.
  */
-export function buildAgyArgv({ def, model, effort, workspaceDir, timeoutMs }) {
+export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeoutMs }) {
   const args = [
-    "-p", "-",
     "--output-format", "stream-json",
     "--dangerously-skip-permissions",
   ];
@@ -66,6 +65,10 @@ export function buildAgyArgv({ def, model, effort, workspaceDir, timeoutMs }) {
   const effectiveEffort = effort ?? def?.effort ?? tierEffort;
   if (typeof effectiveEffort === "string" && ["low", "medium", "high"].includes(effectiveEffort.toLowerCase())) {
     args.push("--effort", effectiveEffort.toLowerCase());
+  }
+
+  if (typeof prompt === "string" && prompt.length > 0) {
+    args.push("-p", prompt);
   }
 
   return args;
@@ -94,6 +97,12 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
     "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
   ]) {
     delete childEnv[key];
+  }
+
+  for (const key of Object.keys(childEnv)) {
+    if (key.startsWith("ANTIGRAVITY_")) {
+      delete childEnv[key];
+    }
   }
 
   if (!isMutating) {
@@ -202,6 +211,7 @@ export async function execute({
   const argv = [
     ...resolved.args,
     ...buildAgyArgv({
+      prompt,
       def,
       model: spec?.model,
       effort: spec?.effort ?? def?.effort,
@@ -214,12 +224,8 @@ export async function execute({
     const child = spawn(resolved.command, argv, {
       cwd: workspaceDir,
       env: childEnv,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
-
-    child.stdin.on("error", () => {});
-    child.stdin.write(prompt);
-    child.stdin.end();
 
     const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
     transcript.on("error", () => {});

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -137,11 +137,12 @@ describe("buildAgyArgv", () => {
   test("basic flags and stdin prompt format", () => {
     const argv = buildAgyArgv({
       def: { prompt: "agents/agy-smoke.md" },
+      prompt: "Execute smoke test",
       workspaceDir: "/tmp/ws",
       timeoutMs: 300000,
     });
     expect(argv).toContain("-p");
-    expect(argv).toContain("-");
+    expect(argv).toContain("Execute smoke test");
     expect(argv).toContain("--output-format");
     expect(argv).toContain("stream-json");
     expect(argv).toContain("--dangerously-skip-permissions");
@@ -187,12 +188,16 @@ describe("safeChildEnvironment", () => {
     const prev = { ...process.env };
     process.env.GEMINI_API_KEY = "secret-gemini";
     process.env.GOOGLE_API_KEY = "secret-google";
+    process.env.ANTIGRAVITY_AGENT = "1";
+    process.env.ANTIGRAVITY_LS_ADDRESS = "localhost:1234";
     process.env.SSH_AUTH_SOCK = "/tmp/ssh-sock";
     process.env.GITHUB_TOKEN = "gh-secret";
 
     const env = safeChildEnvironment({}, { mutating: true });
     expect(env.GEMINI_API_KEY).toBeUndefined();
     expect(env.GOOGLE_API_KEY).toBeUndefined();
+    expect(env.ANTIGRAVITY_AGENT).toBeUndefined();
+    expect(env.ANTIGRAVITY_LS_ADDRESS).toBeUndefined();
     expect(env.SSH_AUTH_SOCK).toBe("/tmp/ssh-sock");
     expect(env.GITHUB_TOKEN).toBe("gh-secret");
 


### PR DESCRIPTION
## Summary
- Passes prompt directly to `agy -p <prompt>` on argv in `lib/adapters/agy.mjs`, preventing print-mode timeouts from passing `'-'` literally.
- Strips `ANTIGRAVITY_*` session environment variables from child process environment to isolate child runs.
- Updates unit tests in `agy.test.mjs`.

Fixes WM-429