### PR TITLE
feat(merge-scan): target explicit PR numbers (WM-426)

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -25,8 +25,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:83a184eea1f0071471f4e8c1669f3c88082c6504b7e3d8891a4fac51376728ce",
-    "schemas/merge-scan.input.json": "sha256:5ea3b9702df503b438fb11f6bd566161fcb4d5bafcf298070e1535ecfa4737a5",
+    "agents/merge-scan.md": "sha256:973f8cd56f3f3c399173c874a8ab110bdcc6cd4bb8e16f3c100b35f9f1d9c111",
+    "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }
 }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -5,9 +5,23 @@ run. `./input.json` names a configured repo and contains a planner-injected
 `repoPin` with the exact commit SHA materialized for this run. The repo is
 checked out read-only at `./repo` at that SHA. Read
 `./repo/config/repos.yaml` and `./repo/config/policy.yaml` from that pinned
-snapshot, then enumerate **all** open PRs and classify every base-targeting,
-non-draft PR as exactly MERGE, FIX, or ESCALATE. Never modify the checkout,
-GitHub, or Linear. Write only `./result.json` in the workspace root.
+snapshot. When `prNumbers` is absent, enumerate **all** open PRs and classify
+every base-targeting, non-draft PR as exactly MERGE, FIX, or ESCALATE. When
+`prNumbers` is present, review exactly those PR numbers in the listed repo — do
+not add newer, related, or otherwise open PRs to the scan.
+
+Resolve every selected number directly, including numbers absent from an
+open-PR listing. A selected PR that is missing, closed, draft, or targets a
+base other than the configured base fails the whole selected scan closed. Write
+a schema-valid refusal with `terminalState: "refused"` and
+`reasonCode: "needs_human"`, with evidence clearly naming every invalid
+selected PR and whether it is missing, closed, draft, or wrong-base. Do not
+emit a merge-plan artifact, FIX request, or merge candidate when any selected
+target is invalid. This whole-run refusal is the explicit human escalation;
+never silently skip an invalid selected number.
+
+Never modify the checkout, GitHub, or Linear. Write only `./result.json` in the
+workspace root.
 
 If either pinned config file is missing or unreadable, or the named repo's
 configuration is missing or malformed, fail closed with this complete result
@@ -97,8 +111,9 @@ review):
 Do not place `recommendation`, `repo`, `github`, `base`, `deployBranch`,
 `plan`, `fix`, `escalate`, `summary`, or `noopReason` beside `schemaVersion`;
 all merge-plan fields belong inside `artifact`. Never omit `terminalState`.
-For any refusal, use the complete fail-closed wrapper shown above rather than
-writing a partial merge plan.
+For any refusal, use the fail-closed wrapper shown above rather than writing a
+partial merge plan. A selected-target refusal must additionally include the
+evidence required above.
 
 After producing the artifact, do nothing else. In particular, never approve,
 merge, push, mark Done, or delete a branch.

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -950,7 +950,11 @@ export function createApi({
       }
 
       if (route === "GET /schedules") {
-        return send(res, 200, { schedules: scheduleView(db, registry, { now: nowMs }) });
+        const schedules = scheduleView(db, registry, { now: nowMs }).map((item) => {
+          const repo = registry.schedules?.[item.loop]?.payload?.repo;
+          return { ...item, repo: typeof repo === "string" && repo !== "" ? repo : null };
+        });
+        return send(res, 200, { schedules });
       }
 
       // Ad-hoc loop trigger (OPS-401): distinct from slot ticks (source="operator",
@@ -965,6 +969,45 @@ export function createApi({
             schedules: Object.keys(registry.schedules ?? {}),
           });
         }
+        const raw = await readBody(req);
+        const parsed = raw.length === 0 ? { value: {} } : parseJson(raw);
+        if (parsed.error) return send(res, 422, { error: parsed.error });
+        const triggerInput = parsed.value;
+        if (!triggerInput || typeof triggerInput !== "object" || Array.isArray(triggerInput)) {
+          return send(res, 422, { error: "trigger body must be an object" });
+        }
+
+        const isMergeSchedule = schedule.eventType === "factory.merge.requested";
+        const inputKeys = Object.keys(triggerInput);
+        if (!isMergeSchedule && inputKeys.length > 0) {
+          return send(res, 422, { error: `schedule "${loop}" does not accept trigger input` });
+        }
+        const unknownKeys = inputKeys.filter((key) => key !== "prNumbers");
+        if (isMergeSchedule && unknownKeys.length > 0) {
+          return send(res, 422, {
+            error: `merge schedule trigger accepts only prNumbers; unexpected: ${unknownKeys.join(", ")}`,
+          });
+        }
+
+        const schedulePayload = { ...(schedule.payload ?? {}) };
+        // Manual selection is operator input only. A static schedule payload
+        // cannot turn recurring or blank manual scans into targeted scans.
+        delete schedulePayload.prNumbers;
+
+        let prNumbers;
+        if (isMergeSchedule && triggerInput.prNumbers !== undefined) {
+          prNumbers = triggerInput.prNumbers;
+          if (!Array.isArray(prNumbers) || prNumbers.length === 0) {
+            return send(res, 422, { error: "prNumbers must be a nonempty array" });
+          }
+          if (!prNumbers.every((number) => Number.isInteger(number) && number > 0)) {
+            return send(res, 422, { error: "prNumbers must contain only positive integers" });
+          }
+          if (new Set(prNumbers).size !== prNumbers.length) {
+            return send(res, 422, { error: "prNumbers must not contain duplicates" });
+          }
+        }
+
         let cadenceSeconds;
         try {
           cadenceSeconds = parseCadence(schedule.every);
@@ -988,10 +1031,12 @@ export function createApi({
           correlationId: eventId,
           causationId: null,
           payload: {
+            ...schedulePayload,
             loop,
             slot: isoNow,
             ...(cadenceSeconds ? { cadenceSeconds } : {}),
             skippedSlots: 0,
+            ...(prNumbers ? { prNumbers } : {}),
           },
         };
         const outcome = admitEvent(db, registry, envelope, { now: nowMs });

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -1722,6 +1722,96 @@ describe("POST /schedules/:loop/run (OPS-401)", () => {
     expect(body.decision).toBe("run");
   });
 
+  test("manual merge trigger propagates selected PR numbers into the immutable event and planned input", async () => {
+    const mergeServer = await makeServer();
+    try {
+      const res = await fetch(mergeServer.url("/schedules/merge-factory/run"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prNumbers: [411, 426] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const event = mergeServer.db
+        .query(`SELECT envelope_json FROM events WHERE source = 'operator' AND event_id = ?`)
+        .get(body.eventId);
+      expect(JSON.parse(event.envelope_json).payload).toMatchObject({
+        repo: "factory",
+        loop: "merge-factory",
+        prNumbers: [411, 426],
+      });
+      const run = mergeServer.db
+        .query(`SELECT spec_json FROM runs WHERE run_id = ?`)
+        .get(body.runId);
+      expect(JSON.parse(run.spec_json).input.prNumbers).toEqual([411, 426]);
+    } finally {
+      mergeServer.close();
+    }
+  });
+
+  test("omitted merge selection preserves all-open behavior", async () => {
+    const mergeServer = await makeServer();
+    try {
+      const res = await fetch(mergeServer.url("/schedules/merge-factory/run"), {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const event = mergeServer.db
+        .query(`SELECT envelope_json FROM events WHERE source = 'operator' AND event_id = ?`)
+        .get(body.eventId);
+      const payload = JSON.parse(event.envelope_json).payload;
+      expect(payload.repo).toBe("factory");
+      expect(payload).not.toHaveProperty("prNumbers");
+    } finally {
+      mergeServer.close();
+    }
+  });
+
+  test("merge selection rejects empty, invalid, duplicate, and arbitrary values before admission", async () => {
+    const mergeServer = await makeServer();
+    try {
+      const invalidBodies = [
+        { prNumbers: [] },
+        { prNumbers: [0] },
+        { prNumbers: [-1] },
+        { prNumbers: [1.5] },
+        { prNumbers: ["42"] },
+        { prNumbers: [42, 42] },
+        { prNumbers: 42 },
+        { prNumbers: [42], payload: { forged: true } },
+      ];
+      for (const requestBody of invalidBodies) {
+        const before = mergeServer.db.query(`SELECT COUNT(*) AS n FROM events`).get().n;
+        const res = await fetch(mergeServer.url("/schedules/merge-factory/run"), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(requestBody),
+        });
+        expect(res.status, JSON.stringify(requestBody)).toBe(422);
+        expect(mergeServer.db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(before);
+      }
+    } finally {
+      mergeServer.close();
+    }
+  });
+
+  test("non-merge schedules reject payload overrides instead of forging an event", async () => {
+    const overrideServer = await makeServer();
+    try {
+      const res = await fetch(overrideServer.url("/schedules/reaper/run"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prNumbers: [42] }),
+      });
+      expect(res.status).toBe(422);
+      expect((await res.json()).error).toContain("does not accept trigger input");
+      expect(overrideServer.db.query(`SELECT COUNT(*) AS n FROM events`).get().n).toBe(0);
+    } finally {
+      overrideServer.close();
+    }
+  });
+
   test("two presses produce two distinct events and proposals (no dedup collapse)", async () => {
     const res1 = await fetch(s.url("/schedules/reaper/run"), { method: "POST" });
     const body1 = await res1.json();
@@ -1745,6 +1835,8 @@ describe("POST /schedules/:loop/run (OPS-401)", () => {
     const { schedules } = await schedRes.json();
     const reaper = schedules.find((sc) => sc.loop === "reaper");
     expect(reaper).toBeDefined();
+    expect(reaper.repo).toBeNull();
+    expect(schedules.find((sc) => sc.loop === "merge-factory").repo).toBe("factory");
     // lastSlot is still null because ad-hoc runs are source='operator', not 'schedule'
     expect(reaper.lastSlot).toBeNull();
   });

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -347,6 +347,26 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   });
 });
 
+describe("merge-scan selected PR contract (WM-426)", () => {
+  test("the input schema declares an optional nonempty list of positive PR numbers", () => {
+    const prNumbers = registry.agents.get("merge-scan@2").inputSchema.properties.prNumbers;
+    expect(prNumbers.type).toBe("array");
+    expect(prNumbers.minItems).toBe(1);
+    expect(prNumbers.items).toEqual({ type: "integer", minimum: 1 });
+    expect(registry.agents.get("merge-scan@2").inputSchema.required).not.toContain("prNumbers");
+  });
+
+  test("the prompt scopes selected scans exactly and fails invalid targets closed", () => {
+    const prompt = readFileSync(registry.agents.get("merge-scan@2").promptPath, "utf8");
+    expect(prompt).toContain("`prNumbers` is absent");
+    expect(prompt).toContain("exactly those PR numbers");
+    expect(prompt).toMatch(/missing, closed, draft, or targets a\s+base other than/);
+    expect(prompt).toContain('"terminalState": "refused"');
+    expect(prompt).toMatch(/evidence clearly naming every invalid\s+selected PR/);
+    expect(prompt).toMatch(/Do not\s+emit a merge-plan artifact/);
+  });
+});
+
 describe("merge-scan repository workspace and result contract (WM-425)", () => {
   test("the definition and prompt declare the pinned repository contract", () => {
     const def = registry.agents.get("merge-scan@2");

--- a/event-runtime/schemas/merge-scan.input.json
+++ b/event-runtime/schemas/merge-scan.input.json
@@ -35,6 +35,12 @@
         }
       }
     },
+    "prNumbers": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Optional explicit PR numbers for a manual scan. When omitted, review all open PRs targeting the configured base.",
+      "items": { "type": "integer", "minimum": 1 }
+    },
     "loop": { "type": "string", "minLength": 1 },
     "slot": { "type": "string", "minLength": 1 },
     "cadenceSeconds": { "type": "integer", "minimum": 1 },

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -113,13 +113,18 @@ export const api = {
   workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
   // The schedule registry: recurring loops, cadence, timing, and health.
   schedules: () => call<{ schedules: ScheduleItem[] }>("GET", "/schedules"),
-  // Trigger an ad-hoc run of a registered schedule loop.
-  triggerSchedule: (loop: string) =>
-    call<TriggerOutcome>("POST", `/schedules/${encodeURIComponent(loop)}/run`, {}),
+  // Trigger an ad-hoc run. Explicit PR numbers are accepted only by merge schedules.
+  triggerSchedule: (loop: string, prNumbers?: number[]) =>
+    call<TriggerOutcome>(
+      "POST",
+      `/schedules/${encodeURIComponent(loop)}/run`,
+      prNumbers === undefined ? {} : { prNumbers },
+    ),
 };
 
 export interface ScheduleItem {
   loop: string;
+  repo: string | null;
   every: string;
   cadenceSeconds: number | null;
   eventType: string;

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -329,7 +329,17 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
     })),
     workers: mock(async (): Promise<{ workers: Worker[] }> => ({ workers: [] })),
     schedules: mock(async (): Promise<{ schedules: any[] }> => ({ schedules: [] })),
-    triggerSchedule: mock(async (_loop: string) => ({ triggered: true, runId: "run_mock_1" })),
+    triggerSchedule: mock(async (_loop: string, _prNumbers?: number[]) => ({
+      admitted: true,
+      duplicate: false,
+      eventId: "manual:fixture",
+      proposalId: null,
+      runId: "run_mock_1",
+      decision: "run",
+      reason: null,
+      disabled: false,
+      loop: _loop,
+    })),
   };
 }
 

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Schedules, scheduleFilterTokens, type ScheduleItem } from "./Schedules";
 import { api } from "../api";
 import { useContextActions } from "../palette";
+import { changeInput } from "../test-render";
 
 afterEach(() => {
   cleanup();
@@ -22,6 +23,7 @@ const noop = () => {};
 
 function schedule(overrides: Partial<ScheduleItem> & Pick<ScheduleItem, "loop">): ScheduleItem {
   return {
+    repo: null,
     every: "5m",
     cadenceSeconds: 300,
     eventType: "tick.test",
@@ -51,6 +53,7 @@ const rows: ScheduleItem[] = [
 const origFetch = globalThis.fetch;
 const origAgents = api.agents;
 const origEvents = api.events;
+const origTriggerSchedule = api.triggerSchedule;
 
 beforeEach(() => {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -71,6 +74,7 @@ afterEach(() => {
   globalThis.fetch = origFetch;
   api.agents = origAgents;
   api.events = origEvents;
+  api.triggerSchedule = origTriggerSchedule;
 });
 
 function scheduleViewProps(
@@ -370,6 +374,109 @@ describe("Schedules action shortcut badge (WM-236)", () => {
     expect(badge).toBeTruthy();
     expect(badge!.textContent).toBe("r");
     expect(badge!.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("Schedules manual merge targeting (WM-426)", () => {
+  const mergeSchedule = schedule({
+    loop: "merge-factory",
+    eventType: "factory.merge.requested",
+    approval: "auto",
+    repo: "factory",
+  });
+
+  function serveMergeSchedule() {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.startsWith("/api/schedules")) {
+        return new Response(JSON.stringify({ schedules: [mergeSchedule] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return origFetch(input, init);
+    }) as typeof fetch;
+  }
+
+  test("submits explicit PR numbers from the merge confirmation", async () => {
+    serveMergeSchedule();
+    const calls: Array<{ loop: string; prNumbers?: number[] }> = [];
+    api.triggerSchedule = async (loop, prNumbers) => {
+      calls.push({ loop, prNumbers });
+      return {
+        admitted: true,
+        duplicate: false,
+        eventId: "manual:merge-factory:test",
+        proposalId: null,
+        runId: "run-test",
+        decision: "run",
+        reason: null,
+        disabled: false,
+        loop,
+      };
+    };
+
+    const view = renderWithClient(
+      <StatefulSchedules connected={true} initialLoop="merge-factory" />,
+    );
+    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
+
+    const input = await view.findByRole("textbox", { name: "PR numbers (optional)" });
+    expect(view.getByText(/Leave blank to review all open PRs in factory/)).toBeTruthy();
+    expect(view.getByText("Autonomous merge automation")).toBeTruthy();
+    expect(view.getByText(/mutating downstream automation without another confirmation/)).toBeTruthy();
+    expect(input.getAttribute("aria-describedby")).toBe("schedule-pr-numbers-help");
+    act(() => changeInput(input, "411, 426"));
+    fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
+
+    await waitFor(() => expect(calls).toEqual([{ loop: "merge-factory", prNumbers: [411, 426] }]));
+  });
+
+  test("invalid merge selection exposes an input-associated error", async () => {
+    serveMergeSchedule();
+    const view = renderWithClient(
+      <StatefulSchedules connected={true} initialLoop="merge-factory" />,
+    );
+    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
+    const input = await view.findByRole("textbox", { name: "PR numbers (optional)" });
+    act(() => changeInput(input, "426, 426"));
+    fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
+
+    const error = await view.findByRole("alert");
+    expect(error.textContent).toContain("only once");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toContain(error.id);
+  });
+
+  test("blank merge selection submits no override and means all open PRs", async () => {
+    serveMergeSchedule();
+    const calls: Array<{ loop: string; prNumbers?: number[] }> = [];
+    api.triggerSchedule = async (loop, prNumbers) => {
+      calls.push({ loop, prNumbers });
+      return {
+        admitted: true,
+        duplicate: false,
+        eventId: "manual:merge-factory:all",
+        proposalId: null,
+        runId: "run-all",
+        decision: "run",
+        reason: null,
+        disabled: false,
+        loop,
+      };
+    };
+
+    const view = renderWithClient(
+      <StatefulSchedules connected={true} initialLoop="merge-factory" />,
+    );
+    await waitFor(() => expect(view.getAllByRole("button", { name: "Run now…" }).length).toBeGreaterThan(0));
+    fireEvent.click(view.getAllByRole("button", { name: "Run now…" })[0]!);
+    await view.findByRole("textbox", { name: "PR numbers (optional)" });
+    fireEvent.click(view.getByRole("button", { name: "Trigger Run" }));
+
+    await waitFor(() => expect(calls).toEqual([{ loop: "merge-factory", prNumbers: undefined }]));
   });
 });
 

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -178,10 +178,14 @@ export function Schedules({
   }, [sel, allEvents]);
 
   const [confirmLoop, setConfirmLoop] = useState<ScheduleItem | null>(null);
+  const [prNumbersInput, setPrNumbersInput] = useState("");
+  const [triggerInputError, setTriggerInputError] = useState<string | null>(null);
 
   const triggerMut = useMutation({
-    mutationFn: (loop: string) => api.triggerSchedule(loop),
-    onSuccess: (outcome, loop) => {
+    mutationFn: ({ loop, prNumbers }: { loop: string; prNumbers?: number[] }) =>
+      api.triggerSchedule(loop, prNumbers),
+    onSuccess: (outcome, request) => {
+      const { loop } = request;
       queryClient.invalidateQueries({ queryKey: ["schedules"] });
       queryClient.invalidateQueries({ queryKey: ["events"] });
       queryClient.invalidateQueries({ queryKey: ["proposals"] });
@@ -199,12 +203,47 @@ export function Schedules({
   });
 
   useEffect(() => {
+    setPrNumbersInput("");
+    setTriggerInputError(null);
+  }, [confirmLoop]);
+
+  useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, rejumpEpoch]);
 
   useEffect(() => {
     if (focusScheduleLoop) setFilter("");
   }, [focusScheduleLoop]);
+
+  const submitTrigger = () => {
+    if (!confirmLoop) return;
+    if (confirmLoop.eventType !== "factory.merge.requested") {
+      triggerMut.mutate({ loop: confirmLoop.loop });
+      return;
+    }
+
+    const raw = prNumbersInput.trim();
+    if (raw === "") {
+      triggerMut.mutate({ loop: confirmLoop.loop });
+      return;
+    }
+    const tokens = raw.split(/[\s,]+/);
+    if (tokens.some((token) => !/^\d+$/.test(token))) {
+      setTriggerInputError("Enter positive PR numbers separated by commas or spaces.");
+      return;
+    }
+    const prNumbers = tokens.map(Number);
+    if (prNumbers.some((number) => !Number.isSafeInteger(number) || number <= 0)) {
+      setTriggerInputError("Enter positive PR numbers separated by commas or spaces.");
+      return;
+    }
+    if (new Set(prNumbers).size !== prNumbers.length) {
+      setTriggerInputError("Each PR number may be entered only once.");
+      return;
+    }
+    setTriggerInputError(null);
+    triggerMut.mutate({ loop: confirmLoop.loop, prNumbers });
+  };
 
   const pendingC = useRef<number>(0);
 
@@ -690,8 +729,58 @@ export function Schedules({
               <code className="mono rounded bg-(--surface-2) px-1 py-0.5 text-(--text)">
                 operator
               </code>
-              . It creates an open proposal for review and does not alter the schedule&apos;s normal slot timer.
+              . It {confirmLoop.approval === "watched"
+                ? "creates an open proposal for review"
+                : "uses the schedule’s auto-approval policy"} and does not alter the schedule&apos;s normal slot timer.
             </p>
+
+            {confirmLoop.eventType === "factory.merge.requested" && (
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="schedule-pr-numbers"
+                  className="block text-[12px] font-medium text-(--text)"
+                >
+                  PR numbers (optional)
+                </label>
+                <input
+                  id="schedule-pr-numbers"
+                  type="text"
+                  autoFocus
+                  inputMode="numeric"
+                  value={prNumbersInput}
+                  aria-invalid={triggerInputError ? true : undefined}
+                  aria-describedby={`schedule-pr-numbers-help${triggerInputError ? " schedule-pr-numbers-error" : ""}`}
+                  onChange={(event) => {
+                    setPrNumbersInput(event.target.value);
+                    setTriggerInputError(null);
+                  }}
+                  placeholder="411, 426"
+                  className="mono w-full rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[13px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+                />
+                <p id="schedule-pr-numbers-help" className="text-[11px] text-(--text-faint)">
+                  Enter unique positive PR numbers separated by commas or spaces. Leave blank to review all open PRs in {confirmLoop.repo ?? "the configured repository"}.
+                </p>
+                {triggerInputError && (
+                  <div
+                    id="schedule-pr-numbers-error"
+                    role="alert"
+                    className="text-[12px] text-(--hue-err)"
+                  >
+                    {triggerInputError}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {confirmLoop.eventType === "factory.merge.requested" && (
+              <div className="rounded-md border border-(--hue-warn) bg-[color-mix(in_oklch,var(--hue-warn)_10%,var(--surface-1))] p-3 text-[12px]">
+                <div className="font-semibold text-(--hue-warn)">Autonomous merge automation</div>
+                <p className="mt-1 text-(--text-dim)">
+                  The scanner is read-only, but a MERGE or FIX recommendation can launch mutating downstream automation without another confirmation.
+                  {confirmLoop.approval === "auto" && " This schedule is auto-approved, so the scan starts unattended."}
+                </p>
+              </div>
+            )}
 
             {confirmLoop && (
               <div className="rounded-md border border-(--border) bg-(--surface-2) p-3 space-y-2">
@@ -754,7 +843,7 @@ export function Schedules({
               <Button
                 variant="primary"
                 disabled={triggerMut.isPending || connected === false}
-                onClick={() => triggerMut.mutate(confirmLoop.loop)}
+                onClick={submitTrigger}
               >
                 {triggerMut.isPending ? "Triggering…" : "Trigger Run"}
               </Button>


### PR DESCRIPTION
## Summary
- accept optional unique positive `prNumbers` on manual merge-schedule triggers and preserve blank/all-open behavior
- reject invalid merge selections and all payload overrides on non-merge schedules before admission
- scope merge-scan to selected PRs with whole-run fail-closed escalation for missing, closed, draft, or wrong-base targets
- add repository-scoped Schedules input, accessible validation, and an explicit downstream autonomous-merge warning

## Verification
- `bun test event-runtime/lib/api.test.mjs event-runtime/merge.test.mjs event-runtime/web/src/views/Schedules.test.tsx && bun event-runtime/cli.mjs update-pins && bun build/emit.mjs --check && bun run format:check`
- 126 tests passed; pins current; generated files match; Prettier check passed
- Required UX critique: FIX-FIRST findings resolved in 1 remediation round; round 2 verdict SHIP

## Risk
This changes security-relevant autonomous merge targeting and fail-closed behavior. It is intentionally escalated for human review and must not auto-merge.

Fixes WM-426
