### PR TITLE
fix(event-runtime-web): reset trace feed on run switch

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -49,6 +49,36 @@ async function waitForChrome(r: ReturnType<typeof renderTrace>) {
   return r.getByRole("tablist", { name: "Trace kind" });
 }
 
+describe("RunTrace feed", () => {
+  test("resets accumulated entries and cursor when runId changes (WM-245)", async () => {
+    const requests: Array<{ runId: string; since: number }> = [];
+    const firstRunEntry = entry(41, "assistant_text", { text: "first run trace" });
+    const secondRunEntry = entry(1, "assistant_text", { text: "second run trace" });
+    const r = renderWithClient(
+      <RunTrace runId="run_first" state="COMPLETED" variant="full" />,
+      {
+        apiMocks: {
+          trace: async (runId, since = 0) => {
+            requests.push({ runId, since });
+            const entries = runId === "run_first" ? [firstRunEntry] : [secondRunEntry];
+            return { head: entries[0].seq, entries };
+          },
+        },
+      },
+    );
+
+    await waitFor(() => expect(r.getByText("first run trace")).toBeTruthy());
+
+    r.rerender(<RunTrace runId="run_second" state="COMPLETED" variant="full" />);
+
+    await waitFor(() => expect(r.getByText("second run trace")).toBeTruthy());
+    expect(r.queryByText("first run trace")).toBeNull();
+    expect(requests.filter((request) => request.runId === "run_second")).toEqual([
+      { runId: "run_second", since: 0 },
+    ]);
+  });
+});
+
 describe("RunTrace a11y (WM-143)", () => {
   test("renders no emoji in trace chrome (tools, tokens, errors, jump, clear)", async () => {
     const r = renderTrace();

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -35,6 +35,12 @@ type TraceFilterKind = "all" | "tools" | "reasoning" | "errors" | "usage";
 function useTraceFeed(runId: string, live: boolean) {
   const acc = useRef<TraceEntry[]>([]);
   const cursor = useRef(0);
+
+  useEffect(() => {
+    acc.current = [];
+    cursor.current = 0;
+  }, [runId]);
+
   const query = useQuery<TraceEntry[]>({
     queryKey: ["trace", runId],
     queryFn: async () => {


### PR DESCRIPTION
## Summary
- reset the accumulated trace entries and cursor whenever `runId` changes
- cover in-place run switching with a regression test that verifies the new fetch starts at `since=0`

## Verification
- `cd event-runtime/web && bun test src/components/RunTrace.test.tsx` — 11 passed

UX critique: required — SHIP; evidence: http://127.0.0.1:8392/#/runs/run_bde5cf1a-7703-456a-89e9-f6615dda351d

Fixes WM-245