### PR TITLE
fix(chain): recognize independent multi-action edges

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { budgetExhausted } from "../../lib/spend.mjs";
+import { buildChainInput } from "./chain.mjs";
 import { hashJson } from "./canonical.mjs";
 import { approveProposal } from "./proposals.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
@@ -347,6 +348,92 @@ const REGISTERED_COMMAND_EDGES = {
   "merge-verify@1": new Set(["factory.merge.requested"]),
 };
 
+function chainContextValue(expr, context) {
+  if (typeof expr !== "string" || !expr.startsWith("$.")) return expr;
+  const [root, ...segments] = expr.slice(2).split(".");
+  let value = context[root];
+  for (const segment of segments) {
+    if (value === null || typeof value !== "object" || !(segment in value))
+      throw new Error("chain selection path unresolved");
+    value = value[segment];
+  }
+  if (value === undefined) throw new Error("chain selection path unresolved");
+  return value;
+}
+
+/** Prove a sibling edge from the accepted artifact, not registry membership alone. */
+function independentlySelectedEdge(rule, spec, result, envelope) {
+  const artifactHash = {};
+  for (const entry of result.artifacts ?? []) {
+    if (entry.kind && entry.sha256 && artifactHash[entry.kind] === undefined)
+      artifactHash[entry.kind] = entry.sha256;
+  }
+  const context = {
+    input: spec.input ?? {},
+    artifact: result.artifact ?? {},
+    artifactHash,
+  };
+
+  for (const edge of Object.values(rule?.edges ?? {})) {
+    if (edge?.eventType !== envelope.type) continue;
+    try {
+      const itemsField = edge.itemsField ?? rule.itemsField;
+      if (itemsField !== undefined) {
+        const items =
+          typeof itemsField === "string" && itemsField.startsWith("$.")
+            ? chainContextValue(itemsField, context)
+            : context.artifact[itemsField] ?? context.input[itemsField];
+        if (!Array.isArray(items)) continue;
+        for (const item of items) {
+          const itemContext = { ...context, item };
+          const payload = buildChainInput(edge.input ?? {}, itemContext);
+          const itemKey = edge.itemKey ?? rule.itemKey;
+          if (itemKey && payload[itemKey] === undefined) {
+            const itemKeyValue =
+              item && typeof item === "object"
+                ? item[itemKey]
+                : typeof item === "string" || typeof item === "number"
+                  ? String(item)
+                  : undefined;
+            if (
+              itemKeyValue === undefined ||
+              itemKeyValue === null ||
+              String(itemKeyValue).trim() === ""
+            )
+              continue;
+            payload[itemKey] = itemKeyValue;
+          }
+          if (edge.perItem)
+            Object.assign(payload, buildChainInput(edge.perItem, itemContext));
+          if (sameJson(payload, envelope.payload ?? {})) return true;
+        }
+        continue;
+      }
+
+      // Independent single emits (the merge plan today) are selected by a
+      // non-empty artifact array carried into the exact emitted payload.
+      const selected = Object.values(edge.input ?? {}).some((expr) => {
+        if (typeof expr !== "string" || !expr.startsWith("$.")) return false;
+        const value = chainContextValue(expr, context);
+        return Array.isArray(value) && value.length > 0;
+      });
+      if (
+        selected &&
+        sameJson(
+          buildChainInput(edge.input ?? {}, context),
+          envelope.payload ?? {},
+        )
+      ) {
+        return true;
+      }
+    } catch {
+      // A declared edge whose selection or payload cannot be reconstructed is
+      // not approval evidence; the candidate remains watched.
+    }
+  }
+  return false;
+}
+
 /**
  * `source=chain` is necessary provenance, not sufficient authorization. The
  * predecessor/result and registered edge are re-read from the durable ledger
@@ -388,8 +475,18 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     ? result.artifact?.[rule.recommendationField]
     : undefined;
   const declaredEdge = rule?.edges?.[recommendation];
+  const independentEdge = independentlySelectedEdge(
+    rule,
+    spec,
+    result,
+    envelope,
+  );
   const commandEdge = REGISTERED_COMMAND_EDGES[spec.agent]?.has(envelope.type);
-  if (declaredEdge?.eventType !== envelope.type && !commandEdge)
+  if (
+    declaredEdge?.eventType !== envelope.type &&
+    !independentEdge &&
+    !commandEdge
+  )
     return "chain_edge_not_registered";
 
   // Registered command edges carry immutable identity from their predecessor.

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -361,8 +361,16 @@ function chainContextValue(expr, context) {
   return value;
 }
 
-/** Prove a sibling edge from the accepted artifact, not registry membership alone. */
+function chainArrayField(field, context) {
+  if (typeof field === "string" && field.startsWith("$."))
+    return chainContextValue(field, context);
+  return context.artifact[field] ?? context.input[field];
+}
+
+/** Prove an explicitly independent sibling edge from its declared selector and payload. */
 function independentlySelectedEdge(rule, spec, result, envelope) {
+  if (rule?.independent !== true) return false;
+
   const artifactHash = {};
   for (const entry of result.artifacts ?? []) {
     if (entry.kind && entry.sha256 && artifactHash[entry.kind] === undefined)
@@ -377,12 +385,13 @@ function independentlySelectedEdge(rule, spec, result, envelope) {
   for (const edge of Object.values(rule?.edges ?? {})) {
     if (edge?.eventType !== envelope.type) continue;
     try {
+      if (edge.whenItemsField === undefined) continue;
+      const selectedItems = chainArrayField(edge.whenItemsField, context);
+      if (!Array.isArray(selectedItems) || selectedItems.length === 0) continue;
+
       const itemsField = edge.itemsField ?? rule.itemsField;
       if (itemsField !== undefined) {
-        const items =
-          typeof itemsField === "string" && itemsField.startsWith("$.")
-            ? chainContextValue(itemsField, context)
-            : context.artifact[itemsField] ?? context.input[itemsField];
+        const items = chainArrayField(itemsField, context);
         if (!Array.isArray(items)) continue;
         for (const item of items) {
           const itemContext = { ...context, item };
@@ -410,15 +419,7 @@ function independentlySelectedEdge(rule, spec, result, envelope) {
         continue;
       }
 
-      // Independent single emits (the merge plan today) are selected by a
-      // non-empty artifact array carried into the exact emitted payload.
-      const selected = Object.values(edge.input ?? {}).some((expr) => {
-        if (typeof expr !== "string" || !expr.startsWith("$.")) return false;
-        const value = chainContextValue(expr, context);
-        return Array.isArray(value) && value.length > 0;
-      });
       if (
-        selected &&
         sameJson(
           buildChainInput(edge.input ?? {}, context),
           envelope.payload ?? {},

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -475,7 +475,8 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
   const recommendation = rule
     ? result.artifact?.[rule.recommendationField]
     : undefined;
-  const declaredEdge = rule?.edges?.[recommendation];
+  const declaredEdge =
+    rule?.independent === true ? undefined : rule?.edges?.[recommendation];
   const independentEdge = independentlySelectedEdge(
     rule,
     spec,

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -191,6 +191,31 @@ const auto = (db, options = {}) => {
   });
 };
 
+const independentMergeRegistry = ({ independent = true, selectors = {} } = {}) => {
+  const mergeRule = registry.edges["merge-scan@2"];
+  return {
+    ...registry,
+    edges: {
+      ...registry.edges,
+      "merge-scan@2": {
+        ...mergeRule,
+        independent,
+        edges: Object.fromEntries(
+          Object.entries(mergeRule.edges).map(([name, edge]) => [
+            name,
+            {
+              ...edge,
+              whenItemsField:
+                selectors[name] ??
+                { MERGE: "plan", FIX: "fix", ESCALATE: "escalate" }[name],
+            },
+          ]),
+        ),
+      },
+    },
+  };
+};
+
 describe("chain auto approval (WM-357)", () => {
   test("git-owned policy is an explicit closed allowlist", () => {
     const loaded = loadChainAutoApprovalPolicy();
@@ -552,6 +577,7 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     const result = auto(db, {
+      approvalRegistry: independentMergeRegistry(),
       policy: {
         ...policy,
         maxFixRounds: 2,
@@ -567,6 +593,126 @@ describe("chain auto approval (WM-357)", () => {
     for (const candidate of [merge, fix, escalation]) {
       expect(runState(db, candidate.runId)).toBe("QUEUED");
     }
+  });
+
+  test("a non-independent array sibling remains watched", () => {
+    const db = openDb(":memory:");
+    const mergeInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      deployBranch: "master",
+      plan: [
+        {
+          pr: 431,
+          headSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          headRef: "feat/WM-431",
+          ticket: "WM-431",
+          action: "merge_pr",
+          reason: "selected sibling",
+          checksGreen: true,
+          mergeable: true,
+          ownedPathsValid: true,
+          handoffValid: true,
+          testsFalsifiable: true,
+          policySafe: true,
+          sensitive: false,
+          ambiguous: false,
+        },
+      ],
+    };
+    const sibling = seed(db, {
+      id: "non-independent-array-sibling",
+      type: "factory.merge-apply.requested",
+      input: mergeInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        ...mergeInput,
+        fix: [],
+        escalate: [{ pr: 429, reason: "human review required" }],
+        summary: "merge and escalation selected",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(
+      auto(db, {
+        approvalRegistry: independentMergeRegistry({ independent: false }),
+        policy: {
+          ...policy,
+          autoMergeBase: new Set(["develop"]),
+          autoMergeOwners: new Set(["watt-mind"]),
+        },
+        runtimeGuard: () => null,
+      }).approved,
+    ).toEqual([]);
+    expect(runState(db, sibling.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
+  });
+
+  test("a sibling with a nonempty payload array but empty selector remains watched", () => {
+    const db = openDb(":memory:");
+    const mergeInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      deployBranch: "master",
+      plan: [
+        {
+          pr: 431,
+          headSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          headRef: "feat/WM-431",
+          ticket: "WM-431",
+          action: "merge_pr",
+          reason: "selected sibling",
+          checksGreen: true,
+          mergeable: true,
+          ownedPathsValid: true,
+          handoffValid: true,
+          testsFalsifiable: true,
+          policySafe: true,
+          sensitive: false,
+          ambiguous: false,
+        },
+      ],
+    };
+    const sibling = seed(db, {
+      id: "empty-independent-selector",
+      type: "factory.merge-apply.requested",
+      input: mergeInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        ...mergeInput,
+        fix: [],
+        escalate: [{ pr: 429, reason: "human review required" }],
+        summary: "merge payload exists but its selector is empty",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(
+      auto(db, {
+        approvalRegistry: independentMergeRegistry({
+          selectors: { MERGE: "fix" },
+        }),
+        policy: {
+          ...policy,
+          autoMergeBase: new Set(["develop"]),
+          autoMergeOwners: new Set(["watt-mind"]),
+        },
+        runtimeGuard: () => null,
+      }).approved,
+    ).toEqual([]);
+    expect(runState(db, sibling.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
   });
 
   test("a declared but unselected sibling edge still fails closed", () => {
@@ -641,10 +787,12 @@ describe("chain auto approval (WM-357)", () => {
         ...registry.edges,
         "merge-scan@2": {
           recommendationField: "recommendation",
+          independent: true,
           edges: {
             ESCALATE: registry.edges["merge-scan@2"].edges.ESCALATE,
             WORK: {
               eventType: "factory.work.requested",
+              whenItemsField: "$.artifact.repos",
               itemsField: "repos",
               itemKey: "repo",
               input: {},

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -35,6 +35,12 @@ function seed(
     runSpec = null,
     approvalPolicy = null,
     trustedPredecessor = source === "chain",
+    predecessorAgent = null,
+    predecessorRecommendation = null,
+    predecessorArtifact = null,
+    predecessorInput = input,
+    parentRunId = `parent-${id}`,
+    seedPredecessor = true,
   } = {},
 ) {
   const mapping = registry.eventTypes[type];
@@ -49,16 +55,20 @@ function seed(
       })),
     )
     .find((entry) => entry.edge.eventType === type);
-  const parentRunId = `parent-${id}`;
-  if (trustedPredecessor) {
+  if (trustedPredecessor && seedPredecessor) {
     if (!predecessor)
       throw new Error(`test fixture has no registered predecessor for ${type}`);
     const parentEventId = `parent-event-${id}`;
-    const parentSpec = { agent: predecessor.agent, input };
+    const parentAgent = predecessorAgent ?? predecessor.agent;
+    const parentRule = registry.edges[parentAgent];
+    const parentSpec = { agent: parentAgent, input: predecessorInput };
     const parentResult = {
-      artifact: {
-        [predecessor.rule.recommendationField]: predecessor.recommendation,
-      },
+      artifact:
+        predecessorArtifact ??
+        {
+          [parentRule.recommendationField]:
+            predecessorRecommendation ?? predecessor.recommendation,
+        },
     };
     const at = new Date(now).toISOString();
     db.query(
@@ -171,13 +181,15 @@ const dispatchOk = () => ({
   ok: true,
   evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
 });
-const auto = (db, options = {}) =>
-  autoApproveChains(db, registry, {
+const auto = (db, options = {}) => {
+  const { approvalRegistry = registry, ...approvalOptions } = options;
+  return autoApproveChains(db, approvalRegistry, {
     now,
     policy,
     dispatchEligibility: dispatchOk,
-    ...options,
+    ...approvalOptions,
   });
+};
 
 describe("chain auto approval (WM-357)", () => {
   test("git-owned policy is an explicit closed allowlist", () => {
@@ -458,6 +470,260 @@ describe("chain auto approval (WM-357)", () => {
     expect(runState(db, spoofed.runId)).toBe("PROPOSED");
     expect(openProposals(db, {})[0].reason).toContain(
       "chain_predecessor_or_result_missing",
+    );
+  });
+
+  test("a mixed merge result approves every selected edge while preserving escalation", () => {
+    const db = openDb(":memory:");
+    const mergeInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      deployBranch: "master",
+      plan: [
+        {
+          pr: 431,
+          headSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          headRef: "feat/WM-431",
+          ticket: "WM-431",
+          action: "merge_pr",
+          reason: "independently selected merge",
+          checksGreen: true,
+          mergeable: true,
+          ownedPathsValid: true,
+          handoffValid: true,
+          testsFalsifiable: true,
+          policySafe: true,
+          sensitive: false,
+          ambiguous: false,
+        },
+      ],
+    };
+    const fixItem = {
+      pr: 430,
+      headSha: "c".repeat(40),
+      baseSha: "d".repeat(40),
+      headRef: "feat/WM-430",
+      ticket: "WM-430",
+      finding: "mechanical in-scope fix",
+      findingHash: "e".repeat(64),
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: ["event-runtime/lib/chain.mjs"],
+    };
+    const fixInput = {
+      repo: mergeInput.repo,
+      github: mergeInput.github,
+      base: mergeInput.base,
+      ...fixItem,
+    };
+    const parentRunId = "parent-mixed-result";
+    const predecessorArtifact = {
+      recommendation: "ESCALATE",
+      ...mergeInput,
+      fix: [fixItem],
+      escalate: [{ pr: 429, reason: "human review required" }],
+      summary: "human review still required",
+    };
+    const merge = seed(db, {
+      id: "mixed-merge",
+      type: "factory.merge-apply.requested",
+      input: mergeInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact,
+      predecessorInput: { repo: "factory" },
+      parentRunId,
+    });
+    const fix = seed(db, {
+      id: "mixed-fix",
+      type: "factory.merge-fix.requested",
+      input: fixInput,
+      parentRunId,
+      seedPredecessor: false,
+    });
+    const escalation = seed(db, {
+      id: "mixed-escalation",
+      type: "factory.merge-escalate.requested",
+      input: { repo: "factory", summary: predecessorArtifact.summary },
+      parentRunId,
+      seedPredecessor: false,
+    });
+
+    const result = auto(db, {
+      policy: {
+        ...policy,
+        maxFixRounds: 2,
+        autoMergeBase: new Set(["develop"]),
+        autoMergeOwners: new Set(["watt-mind"]),
+      },
+      runtimeGuard: () => null,
+    });
+
+    expect(result.approved.map((row) => row.runId).sort()).toEqual(
+      [merge.runId, fix.runId, escalation.runId].sort(),
+    );
+    for (const candidate of [merge, fix, escalation]) {
+      expect(runState(db, candidate.runId)).toBe("QUEUED");
+    }
+  });
+
+  test("a declared but unselected sibling edge still fails closed", () => {
+    const db = openDb(":memory:");
+    const fabricated = seed(db, {
+      id: "unselected-merge",
+      type: "factory.merge-apply.requested",
+      input: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        plan: [
+          {
+            pr: 431,
+            headSha: "a".repeat(40),
+            baseSha: "b".repeat(40),
+            headRef: "feat/WM-431",
+            ticket: "WM-431",
+            action: "merge_pr",
+            reason: "fabricated sibling edge",
+            checksGreen: true,
+            mergeable: true,
+            ownedPathsValid: true,
+            handoffValid: true,
+            testsFalsifiable: true,
+            policySafe: true,
+            sensitive: false,
+            ambiguous: false,
+          },
+        ],
+      },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        plan: [],
+        fix: [],
+        escalate: [{ pr: 429, reason: "human review required" }],
+        summary: "only escalation was selected",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect(runState(db, fabricated.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
+  });
+
+  test("a primitive fan-out sibling reconstructs the router's injected item key", () => {
+    const db = openDb(":memory:");
+    const primitive = seed(db, {
+      id: "primitive-independent-item",
+      type: "factory.work.requested",
+      input: { repo: "factory" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repos: ["factory"],
+        summary: "independent primitive item",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+    const approvalRegistry = {
+      ...registry,
+      edges: {
+        ...registry.edges,
+        "merge-scan@2": {
+          recommendationField: "recommendation",
+          edges: {
+            ESCALATE: registry.edges["merge-scan@2"].edges.ESCALATE,
+            WORK: {
+              eventType: "factory.work.requested",
+              itemsField: "repos",
+              itemKey: "repo",
+              input: {},
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      auto(db, { approvalRegistry, runtimeGuard: () => null }).approved,
+    ).toEqual([{ proposalId: primitive.id, runId: primitive.runId }]);
+    expect(runState(db, primitive.runId)).toBe("QUEUED");
+  });
+
+  test("a selected sibling edge with a payload not derived from the artifact fails closed", () => {
+    const db = openDb(":memory:");
+    const selectedPlan = {
+      pr: 431,
+      headSha: "a".repeat(40),
+      baseSha: "b".repeat(40),
+      headRef: "feat/WM-431",
+      ticket: "WM-431",
+      action: "merge_pr",
+      reason: "selected predecessor payload",
+      checksGreen: true,
+      mergeable: true,
+      ownedPathsValid: true,
+      handoffValid: true,
+      testsFalsifiable: true,
+      policySafe: true,
+      sensitive: false,
+      ambiguous: false,
+    };
+    const tampered = seed(db, {
+      id: "tampered-independent-payload",
+      type: "factory.merge-apply.requested",
+      input: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        plan: [{ ...selectedPlan, headSha: "f".repeat(40) }],
+      },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        plan: [selectedPlan],
+        fix: [],
+        escalate: [{ pr: 429, reason: "human review required" }],
+        summary: "merge and escalation selected",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect(runState(db, tampered.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
+  });
+
+  test("an event type absent from the predecessor rule still fails closed", () => {
+    const db = openDb(":memory:");
+    const undeclared = seed(db, {
+      id: "undeclared-edge",
+      type: "factory.work.requested",
+      predecessorAgent: "merge-scan@2",
+      predecessorRecommendation: "ESCALATE",
+    });
+
+    expect(auto(db, { runtimeGuard: () => null }).approved).toEqual([]);
+    expect(runState(db, undeclared.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
     );
   });
 

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -595,6 +595,90 @@ describe("chain auto approval (WM-357)", () => {
     }
   });
 
+  test("an independent recommendation edge with an empty selector remains watched", () => {
+    const db = openDb(":memory:");
+    const escalation = seed(db, {
+      id: "independent-recommendation-empty-selector",
+      type: "factory.merge-escalate.requested",
+      input: { repo: "factory", summary: "selected escalation" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repo: "factory",
+        summary: "selected escalation",
+        plan: [],
+        fix: [],
+        escalate: [],
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(
+      auto(db, {
+        approvalRegistry: independentMergeRegistry(),
+        runtimeGuard: () => null,
+      }).approved,
+    ).toEqual([]);
+    expect(runState(db, escalation.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
+  });
+
+  test("an independent recommendation edge with a tampered payload remains watched", () => {
+    const db = openDb(":memory:");
+    const escalation = seed(db, {
+      id: "independent-recommendation-tampered-payload",
+      type: "factory.merge-escalate.requested",
+      input: { repo: "factory", summary: "tampered escalation" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repo: "factory",
+        summary: "selected escalation",
+        plan: [],
+        fix: [],
+        escalate: [{ pr: 429, reason: "human review required" }],
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(
+      auto(db, {
+        approvalRegistry: independentMergeRegistry(),
+        runtimeGuard: () => null,
+      }).approved,
+    ).toEqual([]);
+    expect(runState(db, escalation.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_edge_not_registered",
+    );
+  });
+
+  test("a non-independent recommendation edge preserves legacy approval", () => {
+    const db = openDb(":memory:");
+    const escalation = seed(db, {
+      id: "legacy-recommendation-edge",
+      type: "factory.merge-escalate.requested",
+      input: { repo: "factory", summary: "legacy escalation" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        recommendation: "ESCALATE",
+        repo: "factory",
+        summary: "legacy escalation",
+      },
+      predecessorInput: { repo: "factory" },
+    });
+
+    expect(
+      auto(db, {
+        approvalRegistry: independentMergeRegistry({ independent: false }),
+        runtimeGuard: () => null,
+      }).approved,
+    ).toEqual([{ proposalId: escalation.id, runId: escalation.runId }]);
+    expect(runState(db, escalation.runId)).toBe("QUEUED");
+  });
+
   test("a non-independent array sibling remains watched", () => {
     const db = openDb(":memory:");
     const mergeInput = {


### PR DESCRIPTION
## Summary
- require `rule.independent === true` before any sibling edge can inherit chain auto-approval
- require every independent edge—including the recommendation edge—to pass its nonempty `whenItemsField` selector and exact payload reconstruction
- preserve legacy recommendation-edge approval only for non-independent rules
- cover explicit independent selection, empty selectors, tampered payloads, non-independent compatibility, undeclared edges, and primitive fan-out keys

## Verification
- `bun test event-runtime/lib/auto-approval.test.mjs event-runtime/merge.test.mjs && bun build/emit.mjs --check && bun run format:check` — pass, 45 tests / 183 assertions; generated files and formatting clean
- the two recommendation-bypass regressions failed before the source fix and pass after it

UX critique: skipped — internal backend runtime authorization; no user-facing flow

Fixes WM-431
run:run_be38a261-04ad-44cc-b353-68d4011f6462
