### PR TITLE
fix(event-runtime): stabilize SpecDiff overflow affordance (WM-164)

### DIFF
--- a/event-runtime/web/src/components/SpecDiff.test.tsx
+++ b/event-runtime/web/src/components/SpecDiff.test.tsx
@@ -86,6 +86,42 @@ describe("SpecDiff component", () => {
     Object.defineProperty(scroller, "scrollTop", { configurable: true, value: scrollTop, writable: true });
   }
 
+  test("does not re-subscribe the overflow observer when props are unchanged", () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let observerCount = 0;
+    let disconnectCount = 0;
+
+    class TrackingResizeObserver {
+      constructor(_callback: ResizeObserverCallback) {
+        observerCount++;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        disconnectCount++;
+      }
+    }
+
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: TrackingResizeObserver,
+    });
+
+    const before = { maxAttempts: 3 };
+    const after = { maxAttempts: 5 };
+    const r = render(<SpecDiff before={before} after={after} />);
+
+    r.rerender(<SpecDiff before={before} after={after} />);
+
+    expect(observerCount).toBe(1);
+    expect(disconnectCount).toBe(0);
+
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: originalResizeObserver,
+    });
+  });
+
   test("does not show overflow affordance when diff fits within max height", () => {
     const before = { maxAttempts: 3 };
     const after = { maxAttempts: 5 };
@@ -114,7 +150,14 @@ describe("SpecDiff component", () => {
       fireEvent.scroll(scroller);
     });
 
-    expect(r.getByText(/\d+ more lines below/)).toBeDefined();
+    const hint = r.getByText(/\d+ more lines below/);
+    expect(hint).toBeDefined();
+
+    const stickyBottomNodes = [...scroller.querySelectorAll(".sticky.bottom-0")];
+    expect(stickyBottomNodes).toHaveLength(1);
+    expect(stickyBottomNodes[0]?.contains(hint)).toBe(true);
+    expect(stickyBottomNodes[0]?.className).toContain("-mt-10");
+    expect(stickyBottomNodes[0]?.className).toContain("h-10");
   });
 
   test("preserves JSON indent after dropping pre (whitespace-pre-wrap on body)", () => {

--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -1,7 +1,7 @@
 // Line diff for two RunSpecs — the §12 replan path must show the operator
 // exactly what changed before they approve the re-planned spec.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, copyText } from "./ui";
 
 export type DiffLine = { type: "same" | "del" | "add"; text: string };
@@ -53,9 +53,11 @@ function countLinesBelowViewport(scroller: HTMLElement): number {
 }
 
 export function SpecDiff({ before, after }: { before: unknown; after: unknown }) {
-  const lines = diffLines(
-    JSON.stringify(before, null, 2).split("\n"),
-    JSON.stringify(after, null, 2).split("\n"),
+  const beforeJson = JSON.stringify(before, null, 2);
+  const afterJson = JSON.stringify(after, null, 2);
+  const lines = useMemo(
+    () => diffLines(beforeJson.split("\n"), afterJson.split("\n")),
+    [beforeJson, afterJson],
   );
   const changed = lines.filter((l) => l.type !== "same").length;
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -140,15 +142,9 @@ export function SpecDiff({ before, after }: { before: unknown; after: unknown })
         ))}
       </div>
       {linesBelow > 0 && (
-        <>
-          <div
-            className="pointer-events-none sticky bottom-0 -mt-8 h-8 bg-linear-to-t from-(--surface-3) to-transparent"
-            aria-hidden
-          />
-          <div className="sticky bottom-0 bg-(--surface-0) px-3 pb-2 pt-0.5 text-center text-[10px] text-(--text-faint)">
-            {`${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`}
-          </div>
-        </>
+        <div className="pointer-events-none sticky bottom-0 -mt-10 flex h-10 items-end justify-center bg-linear-to-t from-(--surface-3) to-transparent px-3 pb-2 text-center text-[10px] text-(--text-faint)">
+          {`${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- memoize serialized diff inputs so the overflow observer remains subscribed across unrelated renders
- combine the fade and remaining-line hint into one flow-neutral sticky affordance
- add regression coverage for observer churn and overlapping sticky nodes

## Verification
- `cd event-runtime/web && bun test src/components/SpecDiff.test.tsx` — 12 pass, 0 fail
- `cd event-runtime/web && bun run build` — typecheck and production build pass

UX critique: required — SHIP (round 1)
Evidence: http://127.0.0.1:7797/#/proposals/prop_9d5af7f4-1b84-44c6-863e-260d32b5b949; `/var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/WM-164-specdiff-top.png`; `/var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/WM-164-specdiff-bottom.png`

Fixes WM-164