### PR TITLE
fix(web): return template focus to search (WM-161)

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -636,6 +636,21 @@ describe("InjectDialog keyboard search (WM-80)", () => {
       expect(radios.length).toBeGreaterThan(0);
       expect(document.activeElement).toBe(radios[0]);
     }));
+
+  test("ArrowUp from the first template result returns focus to search", () =>
+    withSchemaApi(async (r) => {
+      const search = r.getByPlaceholderText(/search event types/i) as HTMLInputElement;
+      act(() => {
+        fireEvent.keyDown(search, { key: "ArrowDown" });
+      });
+      const firstRadio = r.getAllByRole("radio")[0];
+      expect(document.activeElement).toBe(firstRadio);
+
+      act(() => {
+        fireEvent.keyDown(firstRadio, { key: "ArrowUp" });
+      });
+      expect(document.activeElement === search).toBe(true);
+    }));
 });
 
 describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -528,12 +528,18 @@ export function InjectDialog({
     if (!keys.includes(e.key)) return;
     if (!(e.target instanceof HTMLElement) || e.target.getAttribute("role") !== "radio") return;
     e.preventDefault();
+    const radios = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'));
+    const idx = radios.indexOf(e.target);
+    if (e.key === "ArrowUp" && idx === 0) {
+      searchRef.current?.focus();
+      return;
+    }
     const ids = templateIds();
-    const idx = checkedId === null ? ids.length - 1 : Math.max(ids.indexOf(checkedId), 0);
+    const selectedIdx = checkedId === null ? ids.length - 1 : Math.max(ids.indexOf(checkedId), 0);
     const delta = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
-    const nextIdx = (idx + delta + ids.length) % ids.length;
+    const nextIdx = (selectedIdx + delta + ids.length) % ids.length;
     applySelection(ids[nextIdx]);
-    listRef.current?.querySelectorAll<HTMLElement>('[role="radio"]')[nextIdx]?.focus();
+    radios[nextIdx]?.focus();
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- return focus to template search when ArrowUp is pressed on the first result
- preserve existing ArrowDown template navigation
- add a regression test for the search → first result → search keyboard flow

## Verification
- `cd event-runtime/web && bun test src/components/InjectDialog.test.tsx` — 26 passed, 0 failed

UX critique: required — SHIP in round 2; live evidence: http://127.0.0.1:7503/?wm161-round2=1

Fixes WM-161