### PR TITLE
Replace ChipInput native datalist (WM-160)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
+import { Button, ChipInput, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { modal } from "../hooks";
 import { changeInput, typeText } from "../test-render";
@@ -704,6 +704,77 @@ describe("SuggestInput popover (WM-79)", () => {
     expect(r.getByRole("listbox")).toBeTruthy();
     fireEvent.keyDown(input, { key: "Escape" });
     expect(r.queryByRole("listbox")).toBeNull();
+  });
+});
+
+describe("ChipInput popover (WM-160)", () => {
+  function Harness() {
+    const [values, setValues] = useState(["bj29"]);
+    return (
+      <>
+        <label htmlFor="repos">Repos</label>
+        <ChipInput
+          id="repos"
+          values={values}
+          onChange={setValues}
+          suggestions={["bj29", "factory", "watt-mind/bj29"]}
+        />
+      </>
+    );
+  }
+
+  test("uses a combobox and styled listbox instead of a native datalist", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "Repos" });
+    expect(input.getAttribute("list")).toBeNull();
+    expect(r.container.querySelector("datalist")).toBeNull();
+
+    fireEvent.focus(input);
+    const listbox = r.getByRole("listbox", { name: "Suggestions" });
+    expect(listbox.parentElement).toBe(document.body);
+    expect(classes(listbox)).toContain("fixed");
+    expect(r.queryByRole("option", { name: "bj29" })).toBeNull();
+    expect(r.getByRole("option", { name: "factory" })).toBeTruthy();
+  });
+
+  test("filters available suggestions and supports ArrowDown / ArrowUp / Enter / Escape", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "Repos" }) as HTMLInputElement;
+    fireEvent.focus(input);
+
+    const options = r.getAllByRole("option");
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(options[1].getAttribute("aria-selected")).toBe("true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(options[1].getAttribute("aria-selected")).toBe("true");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(r.getByRole("button", { name: "Remove watt-mind/bj29" })).toBeTruthy();
+    expect(r.queryByRole("listbox")).toBeNull();
+
+    fireEvent.focus(input);
+    act(() => {
+      changeInput(input, "fact");
+    });
+    expect(r.getAllByRole("option")).toHaveLength(1);
+    expect(r.getByRole("option", { name: "factory" })).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(r.queryByRole("listbox")).toBeNull();
+  });
+
+  test("preserves free-text chip entry when no suggestion matches", () => {
+    const r = render(<Harness />);
+    const input = r.getByRole("combobox", { name: "Repos" }) as HTMLInputElement;
+    fireEvent.focus(input);
+    act(() => {
+      changeInput(input, "custom-repo");
+    });
+    expect(r.queryByRole("listbox")).toBeNull();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(r.getByRole("button", { name: "Remove custom-repo" })).toBeTruthy();
+    expect(input.value).toBe("");
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { modal, useFocusReturn, useNow } from "../hooks";
 import type { Section, SortDir } from "../displayOptions";
 import { tokenizeJson, TOKEN_CLASSES } from "../highlight";
@@ -1657,12 +1658,49 @@ export function ChipInput({
   placeholder?: string;
 }) {
   const [draft, setDraft] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const [popoverRect, setPopoverRect] = useState<{ top: number; left: number; width: number } | null>(null);
   const listId = useId();
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const items = useMemo(() => {
+    if (!suggestions || suggestions.length === 0) return [];
+    const q = draft.trim().toLowerCase();
+    return suggestions.filter((s) => !values.includes(s) && (!q || s.toLowerCase().includes(q)));
+  }, [draft, suggestions, values]);
+  const show = open && items.length > 0;
+
+  useEffect(() => {
+    if (!show || !anchorRef.current) {
+      setPopoverRect(null);
+      return;
+    }
+    const position = () => {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (rect) setPopoverRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+    };
+    position();
+    window.addEventListener("resize", position);
+    window.addEventListener("scroll", position, true);
+    return () => {
+      window.removeEventListener("resize", position);
+      window.removeEventListener("scroll", position, true);
+    };
+  }, [show]);
+
+  useEffect(() => {
+    if (!show || !listRef.current) return;
+    listRef.current.querySelector<HTMLElement>('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [highlight, show]);
+
   const add = (raw: string) => {
     const v = raw.trim();
     if (!v) return;
     if (!values.includes(v)) onChange([...values, v]);
     setDraft("");
+    setOpen(false);
   };
   return (
     <div className="rounded-md border border-(--border) bg-(--surface-0) p-1.5">
@@ -1685,32 +1723,85 @@ export function ChipInput({
           ))}
         </div>
       )}
-      <div className="flex items-center gap-1">
+      <div ref={anchorRef} className="relative flex items-center gap-1">
         <input
           id={id}
           type="text"
+          role="combobox"
+          aria-expanded={show}
+          aria-autocomplete="list"
+          aria-controls={show ? listId : undefined}
+          aria-activedescendant={show && items[highlight] ? `${listId}-opt-${highlight}` : undefined}
           value={draft}
-          list={suggestions && suggestions.length > 0 ? listId : undefined}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setHighlight(0);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
           onKeyDown={(e) => {
+            if (e.key === "ArrowDown") {
+              if (items.length === 0) return;
+              e.preventDefault();
+              setOpen(true);
+              if (show) setHighlight((i) => (i + 1) % items.length);
+              return;
+            }
+            if (e.key === "ArrowUp") {
+              if (!show || items.length === 0) return;
+              e.preventDefault();
+              setHighlight((i) => (i - 1 + items.length) % items.length);
+              return;
+            }
+            if (e.key === "Escape" && show) {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(false);
+              return;
+            }
             if (e.key !== "Enter") return;
             e.preventDefault();
             e.stopPropagation();
-            add(draft);
+            add(show && items[highlight] ? items[highlight] : draft);
           }}
           placeholder={placeholder ?? "add…"}
           spellCheck={false}
           className="mono w-full rounded border-0 bg-transparent px-1 py-0.5 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint)"
         />
-        {suggestions && suggestions.length > 0 && (
-          <datalist id={listId}>
-            {suggestions
-              .filter((s) => !values.includes(s))
-              .map((s) => (
-                <option key={s} value={s} />
+        {show &&
+          popoverRect &&
+          createPortal(
+            <ul
+              ref={listRef}
+              id={listId}
+              role="listbox"
+              aria-label="Suggestions"
+              style={popoverRect}
+              className="fixed z-50 max-h-60 overflow-auto rounded-md border border-(--border-strong) bg-(--surface-1) p-1 text-[12px] shadow-xl outline-none"
+            >
+              {items.map((s, idx) => (
+                <li
+                  key={s}
+                  id={`${listId}-opt-${idx}`}
+                  role="option"
+                  aria-selected={idx === highlight}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    add(s);
+                  }}
+                  className={`mono cursor-pointer truncate rounded px-2 py-1 select-none ${
+                    idx === highlight
+                      ? "bg-(--surface-3) text-(--text)"
+                      : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+                  }`}
+                >
+                  {s}
+                </li>
               ))}
-          </datalist>
-        )}
+            </ul>,
+            document.body,
+          )}
         <button
           type="button"
           onClick={() => add(draft)}


### PR DESCRIPTION
## Summary
- replace ChipInput native datalist with a styled ARIA combobox/listbox popover
- filter unused repo suggestions while preserving unmatched free-text chips
- support ArrowUp/ArrowDown, Enter, Escape, mouse selection, and unclipped portal positioning
- add regression coverage for accessibility, filtering, keyboard selection, and free text

## Verification
- `cd event-runtime/web && bun test src/components/ui.test.tsx` — 45 pass, 0 fail
- `cd event-runtime/web && bun run build` — TypeScript and production build pass

UX critique: required — SHIP after 2 rounds; observed at http://127.0.0.1:7543/#/overview with desktop and mobile screenshot evidence.

Fixes WM-160