### PR TITLE
feat(event-runtime): Cursor Agent CLI adapter + cursor-smoke@1

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -110,6 +110,12 @@ models:
     strong: gemini-3.7-flash
     standard: gemini-3.7-flash
     light: gemini-3.7-flash
+  # cursor (WM-440), Cursor Agent CLI login/subscription window.
+  # IDs from `agent --list-models` on 2026.08.11.
+  cursor:
+    strong: composer-2.5
+    standard: composer-2.5
+    light: composer-2.5-fast
 
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the

--- a/docs/event-runtime-conventions.md
+++ b/docs/event-runtime-conventions.md
@@ -227,10 +227,18 @@ it before useful work begins and throw a typed error with
 `cli_not_found` reason without retrying the same incapable worker.
 
 `pi.mjs:resolvePiCommand()` follows this rule (`pi`, then `npx pi`, otherwise
-`CliNotFoundError`). Claude currently relies on `spawn("claude", ...)` and a
+`CliNotFoundError`). `cursor.mjs:resolveCursorCommand()` does the same
+(`agent`, then `cursor-agent`). Claude currently relies on `spawn("claude", ...)` and a
 missing binary becomes the generic `adapter_error`; this is a known conformance
 gap tracked by [WM-296](https://linear.app/watt-mind/issue/WM-296/fixevent-runtime-make-claude-cli-absence-a-typed-preflight-refusal),
 not precedent for a new adapter.
+
+**Cursor (WM-440).** `lib/adapters/cursor.mjs` is a fourth LLM adapter on
+this same contract. Prompt is a positional argument (`-p` is a boolean);
+`--force` is always passed so `./result.json` can be written (print without
+it only proposes writes; `--mode ask|plan` is no-edits and is refused);
+`HARNESS_DENIAL_PATTERNS` is empty until a Cursor-authored refusal is
+confirmed. The `cursor` editor binary is not a fallback.
 
 ### Claude/pi conformance audit
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -395,13 +395,14 @@ per-route resolved value. Resolution order: per-definition `"model"` override
 wins) > tier map > adapter default (absent fields = no spec fields = today's
 behavior). A declared tier with no mapping for a routed model-consuming
 adapter is a **load error, fail closed** — never a silent fall-through to the
-adapter default. Only the LLM adapters (`claude`, `pi`) consume models; on
+adapter default. Only the LLM adapters (`claude`, `pi`, `agy`, `cursor`) consume models; on
 `command`/`actions`/`fake` routes a declared tier is recorded as not
-applicable (`model: null`), never an error. Since WM-215 every committed LLM
-route is `pi`, so `models.pi` is the map that has to cover every tier the
-registry declares (`strong`/`standard`/`light` → sol/terra/luna);
-`models.claude` stays populated for the per-route exception and for
-`--adapter-override claude`. Tier assignments are intent the runtime cannot
+applicable (`model: null`), never an error. Since WM-215 every committed
+production LLM route is `pi`, so `models.pi` is the map that has to cover
+every tier those routes declare (`strong`/`standard`/`light` →
+sol/terra/luna); `models.claude` stays populated for the per-route exception
+and for `--adapter-override claude`. `models.agy` and `models.cursor` cover
+their smoke routes (`agy-smoke@1`, `cursor-smoke@1`). Tier assignments are intent the runtime cannot
 yet audit: per-run usage observability (WM-66) is what will
 show whether a tier is over- or under-provisioned and inform re-mapping.
 
@@ -412,11 +413,12 @@ Codex, Gemini, Cursor, Pi); the event runtime admits only adapters with a
 passing conformance test covering structured output, timeout and shutdown
 behavior, and workspace confinement. The registry has entries for `pi`
 (OPS-296, the default LLM harness on the Codex subscription window, WM-215),
-`claude` (Claude Code, still fully supported), `command` (a closed argv
-template), `actions` (an approved action list resolved against a closed
-registry, remote-SSH or local-argv), and `fake` (tests and demo
-environments). It does not inherit the current runner's entire adapter
-surface.
+`claude` (Claude Code, still fully supported), `agy` (Antigravity/Gemini,
+WM-424), `cursor` (Cursor Agent CLI, WM-440 — smoke-only; no production
+route), `command` (a closed argv template), `actions` (an approved action
+list resolved against a closed registry, remote-SSH or local-argv), and
+`fake` (tests and demo environments). It does not inherit the current
+runner's entire adapter surface.
 
 **pi is the default harness, per route, not per mode (WM-215).** Every
 LLM-routed event type in `event-runtime/event-types.json` declares
@@ -429,6 +431,27 @@ what the per-route exception selects, and `--adapter-override claude`
 registry. Note that an adapter override changes execution only — the model
 still resolves against the **registered** route's adapter (§6, WM-135), so an
 overridden run carries the pinned `models.pi` value.
+
+**The `cursor` adapter (`lib/adapters/cursor.mjs`, WM-440) mirrors `pi.mjs`
+against the Cursor Agent CLI.** Binary is `agent` on PATH, else
+`cursor-agent` — never the `cursor` editor wrapper. Flags confirmed against
+the installed CLI (`agent` 2026.08.11): `-p` is a boolean and the prompt is
+a trailing positional (after `--`); `--output-format stream-json` is NDJSON
+without `--stream-partial-output` (those deltas would double-emit);
+`--trust` skips the workspace prompt; `--force` is required to *apply*
+writes — print without it only proposes them. `--mode ask|plan` is
+documented no-edits and is never passed: it would fail the result contract
+(OPS-518). Read-only containment is the workspace cwd plus the worker
+integrity gate, same audited-not-enforced framing as pi. `--worktree` is
+Cursor's own worktree feature and is never passed. `CURSOR_API_KEY` and
+`CURSOR_API_ENDPOINT` are stripped so the CLI uses the login session under
+`HOME`. Trace mapping targets the documented stream-json shapes:
+`assistant` (complete messages only) → `assistant_text`, `tool_call`
+started/completed → `tool_use`/`tool_result`, terminal `result` → `usage`
+(duration only; Cursor does not report tokens). A missing CLI is a typed
+`cli_not_found` preflight. The only committed route is
+`factory.cursor-smoke.requested` → `cursor-smoke@1`; no production event
+type is remapped.
 
 **The `pi` adapter (`lib/adapters/pi.mjs`, OPS-296) mirrors `claude.mjs`,
 adapted to a different CLI shape.** `pi -p --mode json` (prompt piped to

--- a/event-runtime/agents/cursor-smoke.json
+++ b/event-runtime/agents/cursor-smoke.json
@@ -1,0 +1,27 @@
+{
+  "id": "cursor-smoke",
+  "version": 1,
+  "prompt": "agents/cursor-smoke.md",
+  "input_schema": "schemas/cursor-smoke.input.json",
+  "output_schema": "schemas/cursor-smoke.output.json",
+  "output_contract": "factory.cursor-smoke/v1",
+  "model_tier": "light",
+  "workspace": {
+    "type": "ephemeral",
+    "retainOnFailure": true
+  },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": []
+  },
+  "limits": {
+    "timeout_seconds": 120,
+    "attempts": 1
+  },
+  "mutating": false,
+  "pins": {
+    "agents/cursor-smoke.md": "sha256:e5bab010bf6286de88bf9d54334569955d4fcd9fb60574970e9e442f0a6b9424",
+    "schemas/cursor-smoke.input.json": "sha256:d15fc6c2c98f1ba5cffbee88c399d5854a9c0a4f10b7ad696c051d4d82499e95",
+    "schemas/cursor-smoke.output.json": "sha256:766f8f600e1324d59ae5947a605394fa519f576d38d267d243c1c852a8fae60f"
+  }
+}

--- a/event-runtime/agents/cursor-smoke.md
+++ b/event-runtime/agents/cursor-smoke.md
@@ -1,0 +1,20 @@
+# cursor-smoke — smoke test for the Cursor Agent CLI adapter
+
+`./input.json` names one `message` string. Read it and write `./result.json`
+echoing it back unchanged. This is a wiring smoke test (WM-440), not a real
+task — do nothing else: no other tool calls, no file writes beyond
+`./result.json`.
+
+## Output
+
+Write `./result.json`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": { "echo": "<input.json's message, unchanged>" },
+  "evidence": { "commands": [] }
+}
+```

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -21,6 +21,7 @@ import * as actions from "./lib/adapters/actions.mjs";
 import * as agy from "./lib/adapters/agy.mjs";
 import * as claude from "./lib/adapters/claude.mjs";
 import * as command from "./lib/adapters/command.mjs";
+import * as cursor from "./lib/adapters/cursor.mjs";
 import * as fake from "./lib/adapters/fake.mjs";
 import * as pi from "./lib/adapters/pi.mjs";
 import { apiClient } from "./lib/client.mjs";
@@ -361,7 +362,7 @@ async function serve(args) {
     fail(`serve: invalid port "${rawPort}" (must be integer 1-65535)`);
   }
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
-  const adapters = { actions, agy, claude, command, fake, pi };
+  const adapters = { actions, agy, claude, command, cursor, fake, pi };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`serve: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }
@@ -516,7 +517,7 @@ async function work(args) {
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
-  const adapters = { actions, agy, claude, command, fake, pi };
+  const adapters = { actions, agy, claude, command, cursor, fake, pi };
   if (adapterOverride && !adapters[adapterOverride]) {
     fail(`work: unknown --adapter-override "${adapterOverride}" (have: ${Object.keys(adapters).join(", ")})`);
   }

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -637,6 +637,110 @@ describe("cli", () => {
     expect(row?.state).toBe("COMPLETED");
   });
 
+  test("work --adapter-override cursor is accepted at the work call site (WM-440)", async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-cursor-"));
+    const child = spawn("bun", [CLI, "work", "--adapter-override", "cursor"], {
+      env: { ...process.env, FACTORY_EVENT_HOME: home },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    child.stdout.on("data", (b) => {
+      out += b;
+    });
+    child.stderr.on("data", (b) => {
+      out += b;
+    });
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline && !out.includes("adapter override")) {
+      await Bun.sleep(100);
+    }
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.once("exit", resolve));
+
+    expect(out).not.toContain('unknown --adapter-override "cursor"');
+    expect(out).toContain('adapter override: executing every run with "cursor"');
+  });
+
+  test("cursor-smoke@1 routes end-to-end through the cursor adapter via a fake shim (WM-440)", async () => {
+    const { createRun, transition } = await import("./lib/lifecycle.mjs");
+    const { canonicalJson, hashJson } = await import("./lib/canonical.mjs");
+    const { loadRegistry } = await import("./lib/registry.mjs");
+    const { claimNext, executeClaimed } = await import("./lib/worker.mjs");
+
+    const db = openDb(":memory:");
+    const registry = loadRegistry();
+
+    const input = { message: "hello from WM-440" };
+    const spec = {
+      schemaVersion: "factory.run-spec/v1",
+      runId: "run_cursor_smoke_test",
+      agent: "cursor-smoke@1",
+      input,
+      inputHash: hashJson(input),
+      workspace: { type: "ephemeral", retainOnFailure: true },
+      adapter: "cursor",
+      model: "composer-2.5-fast",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.cursor-smoke/v1",
+      capabilities: [],
+      timeoutSeconds: 5,
+      maxAttempts: 1,
+      idempotencyKey: "idem_cursor_smoke_test",
+    };
+
+    createRun(db, {
+      runId: spec.runId,
+      idempotencyKey: spec.idempotencyKey,
+      spec,
+      specJson: canonicalJson(spec),
+      specHash: hashJson(spec),
+      actor: "test",
+      policyVersion: "test",
+      now: Date.now(),
+    });
+    transition(db, { runId: spec.runId, to: "APPROVED", actor: "test", now: Date.now() });
+    transition(db, { runId: spec.runId, to: "QUEUED", actor: "test", now: Date.now() });
+
+    let cursorCalled = false;
+    const mockAdapters = {
+      cursor: {
+        execute: async ({ workspaceDir }) => {
+          cursorCalled = true;
+          const { readFileSync, writeFileSync } = await import("node:fs");
+          const { default: path } = await import("node:path");
+          const staged = JSON.parse(readFileSync(path.join(workspaceDir, "input.json"), "utf8"));
+          writeFileSync(
+            path.join(workspaceDir, "result.json"),
+            JSON.stringify({
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              reasonCode: "ok",
+              artifact: { echo: staged.message },
+              evidence: { commands: [] },
+            }),
+            "utf8",
+          );
+          return { exitCode: 0, timedOut: false };
+        },
+      },
+    };
+
+    const home = mkdtempSync(path.join(os.tmpdir(), "evrt-cursor-smoke-"));
+    const claim = claimNext(db, { owner: "w1" });
+    expect(claim).toBeTruthy();
+
+    const summary = await executeClaimed(db, registry, mockAdapters, claim, {
+      workspacesRoot: home,
+    });
+
+    expect(cursorCalled).toBe(true);
+    expect(summary.terminalState).toBe("COMPLETED");
+
+    const row = db.query(`SELECT state FROM runs WHERE run_id = ?`).get("run_cursor_smoke_test");
+    expect(row?.state).toBe("COMPLETED");
+  });
+
   test("tick runs notify as an isolated subsystem (WM-65): a throwing notifier step cannot break the tick", async () => {
     const { tick, TICK_SUBSYSTEMS } = await import("./cli.mjs");
     const { loadRegistry } = await import("./lib/registry.mjs");

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -277,5 +277,13 @@
       "inputHash"
     ],
     "proposalTtlSeconds": 1800
+  },
+  "factory.cursor-smoke.requested": {
+    "agent": "cursor-smoke@1",
+    "adapter": "cursor",
+    "idempotencyScope": [
+      "inputHash"
+    ],
+    "proposalTtlSeconds": 1800
   }
 }

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -1,0 +1,378 @@
+/**
+ * Cursor Agent CLI adapter (docs/event-runtime.md §6, §14; WM-440) — a fourth
+ * LLM harness alongside `claude`, `pi`, and `agy`. Spawns a bounded
+ * `agent -p --output-format stream-json` process (prompt as a positional
+ * argument, the standard `./input.json` → `./result.json` PROMPT_SUFFIX
+ * contract, cwd = workspace), enforces the run spec's timeout with
+ * TERM→KILL(killGraceMs), strips provider API keys (including CURSOR_API_KEY)
+ * so the CLI authenticates against the login/subscription session, and
+ * captures full stdout as the `.transcript.json` artifact.
+ *
+ * Flags confirmed against the installed CLI (`agent` 2026.08.11,
+ * `agent --help`), not inferred from Claude/Pi:
+ *   - `-p/--print` is a boolean; the prompt is a trailing positional
+ *   - `--output-format stream-json` is NDJSON (do not pass
+ *     `--stream-partial-output` — those deltas would double-emit)
+ *   - `--trust` skips the workspace prompt (unattended)
+ *   - `--force` is required to *apply* writes; print without it only
+ *     proposes them. `--mode ask|plan` is documented no-edits and would
+ *     fail the result contract (OPS-518), so it is never passed. Read-only
+ *     containment is the workspace cwd plus the worker integrity gate.
+ *   - `--worktree` is Cursor's own worktree feature — never passed; the
+ *     factory owns workspaces.
+ *
+ * Binary: `agent` on PATH, else `cursor-agent`. Not `cursor` — that is the
+ * editor CLI.
+ */
+import { spawn } from "node:child_process";
+import { createWriteStream, readFileSync } from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { FACTORY_ROOT } from "../config.mjs";
+import { DEFAULT_MODEL } from "../registry.mjs";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+
+export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
+
+export const KILL_GRACE_MS = 30_000;
+
+/** Terminate a detached CLI and every subprocess it started (WM-263). */
+export function killProcessGroup(child, signal = "SIGTERM", kill = process.kill) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
+const TEXT_PREVIEW_CHARS = 4000;
+
+export class CliNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CliNotFoundError";
+    this.code = "cli_not_found";
+  }
+}
+
+/**
+ * Resolve the Cursor Agent CLI: `agent` on PATH, else `cursor-agent`.
+ * `which` is injectable for tests; defaults to `Bun.which` scoped to the
+ * child's PATH. The `cursor` editor binary is deliberately not a fallback.
+ */
+export function resolveCursorCommand({ which = Bun.which } = {}) {
+  if (which("agent")) return { command: "agent", args: [] };
+  if (which("cursor-agent")) return { command: "cursor-agent", args: [] };
+  return null;
+}
+
+/**
+ * Build argv for spawning the Cursor Agent CLI.
+ * `-p` is a boolean; the prompt is a positional after `--` so a prompt that
+ * starts with `-` cannot be parsed as a flag.
+ */
+export function buildCursorArgv({ prompt, model }) {
+  const args = ["-p", "--output-format", "stream-json", "--trust", "--force"];
+  if (typeof model === "string" && model !== "" && model !== DEFAULT_MODEL) {
+    args.push("--model", model);
+  }
+  args.push("--", prompt);
+  return args;
+}
+
+export const BASE_INHERITED_ENV = [
+  "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
+  "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+];
+
+/**
+ * Keep untrusted model subprocesses from inheriting the worker's authority.
+ * Fail-closed: only an explicit `mutating: true` (or a boolean `true`)
+ * inherits push credentials (pi's rule, not Claude's legacy).
+ *
+ * `CURSOR_API_KEY` is stripped so the CLI uses the login session under HOME
+ * rather than per-token billing — same rationale as the other LLM adapters.
+ */
+export function safeChildEnvironment(env = {}, defOrOpts = {}) {
+  const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
+  const inherited = isMutating ? [...BASE_INHERITED_ENV, ...PUSH_CREDENTIAL_ENV] : BASE_INHERITED_ENV;
+  const childEnv = Object.fromEntries(
+    inherited.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]])),
+  );
+  Object.assign(childEnv, env);
+  childEnv.FACTORY_ROOT = FACTORY_ROOT;
+  for (const key of [
+    "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
+    "CURSOR_API_KEY", "CURSOR_API_ENDPOINT",
+    "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+  ]) {
+    delete childEnv[key];
+  }
+  if (!isMutating) {
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      delete childEnv[key];
+    }
+  }
+  return childEnv;
+}
+
+/** No confirmed Cursor-authored refusal shape yet (WM-127). */
+export const HARNESS_DENIAL_PATTERNS = [];
+
+export function isHarnessDenial(content) {
+  return typeof content === "string" && HARNESS_DENIAL_PATTERNS.some((re) => re.test(content));
+}
+
+function clip(text) {
+  const s = String(text ?? "");
+  return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((block) => block?.type === "text")
+      .map((block) => block.text ?? "")
+      .join("\n");
+  }
+  return "";
+}
+
+/** `readToolCall` → `read`; unknown keys stay as-is, lowercased first letter. */
+export function toolNameFromKey(key) {
+  if (typeof key !== "string" || key === "") return "tool";
+  const base = key.endsWith("ToolCall") ? key.slice(0, -8) : key;
+  if (!base) return "tool";
+  return base[0].toLowerCase() + base.slice(1);
+}
+
+export function describeToolCall(toolCall) {
+  if (!toolCall || typeof toolCall !== "object") return { name: "tool", input: {} };
+  if (toolCall.function && typeof toolCall.function === "object") {
+    let args = toolCall.function.arguments;
+    if (typeof args === "string") {
+      try {
+        args = JSON.parse(args);
+      } catch {
+        // keep the raw string — some tools send non-JSON arguments
+      }
+    }
+    return { name: toolCall.function.name ?? "tool", input: args ?? {} };
+  }
+  const key = Object.keys(toolCall)[0];
+  if (!key) return { name: "tool", input: {} };
+  return { name: toolNameFromKey(key), input: toolCall[key]?.args ?? {} };
+}
+
+function toolResultPayload(msg) {
+  const toolCall = msg.tool_call ?? {};
+  const inner = toolCall.function ?? Object.values(toolCall)[0] ?? {};
+  const result = inner.result ?? {};
+  const id = msg.call_id ?? null;
+  if (result.success !== undefined) {
+    const success = result.success;
+    const content = typeof success?.content === "string" ? success.content : JSON.stringify(success ?? {});
+    return { content: clip(content), toolUseId: id };
+  }
+  if (result.error !== undefined) {
+    const content = typeof result.error === "string" ? result.error : JSON.stringify(result.error);
+    return { content: clip(content), toolUseId: id, isError: true };
+  }
+  return { content: "", toolUseId: id };
+}
+
+/**
+ * Map one parsed `agent --output-format stream-json` line to factory.trace/v1.
+ * Pure. Skip `--stream-partial-output` deltas (`timestamp_ms` present) so a
+ * future flag flip cannot double-emit. Confirmed shapes from
+ * https://cursor.com/docs/cli/reference/output-format.md and the installed CLI.
+ *
+ * @param {any} msg
+ * @returns {Array<{kind: string, payload: object}>}
+ */
+export function mapStreamEvent(msg) {
+  if (!msg || typeof msg !== "object") return [];
+
+  if (msg.type === "assistant") {
+    if (msg.timestamp_ms != null) return [];
+    const blocks = msg.message?.content;
+    if (!Array.isArray(blocks)) return [];
+    const events = [];
+    for (const block of blocks) {
+      if (block?.type === "text" && block.text) {
+        events.push({ kind: "assistant_text", payload: { text: clip(block.text) } });
+      }
+    }
+    return events;
+  }
+
+  if (msg.type === "tool_call" && msg.subtype === "started") {
+    const { name, input } = describeToolCall(msg.tool_call);
+    return [{ kind: "tool_use", payload: { id: msg.call_id ?? null, name, input } }];
+  }
+
+  if (msg.type === "tool_call" && msg.subtype === "completed") {
+    const payload = toolResultPayload(msg);
+    return [{ kind: "tool_result", payload }];
+  }
+
+  return [];
+}
+
+/** Terminal `result` usage, or null. Cursor's documented result has duration, not tokens. */
+export function extractUsage(msg) {
+  if (!msg || msg.type !== "result") return null;
+  return {
+    usage: {},
+    costUSD: null,
+    durationMs: typeof msg.duration_ms === "number" ? msg.duration_ms : null,
+    isError: msg.is_error === true,
+  };
+}
+
+/**
+ * @returns {Promise<{ exitCode: number | null, timedOut: boolean, policyDenials?: object[] }>}
+ */
+export async function execute({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  killGraceMs = KILL_GRACE_MS,
+  env = {},
+  onTrace,
+  onUsage,
+  abortSignal,
+  signal,
+}) {
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  const childEnv = safeChildEnvironment(env, def);
+
+  const resolved = resolveCursorCommand({ which: (name) => Bun.which(name, { PATH: childEnv.PATH ?? "" }) });
+  if (!resolved) {
+    throw new CliNotFoundError(
+      "neither agent nor cursor-agent is on PATH — install the Cursor Agent CLI (docs/event-runtime.md §6)",
+    );
+  }
+  const argv = [...resolved.args, ...buildCursorArgv({ prompt, model: spec?.model })];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolved.command, argv, {
+      cwd: workspaceDir,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+
+    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+    transcript.on("error", () => {});
+    if (child.stdout) {
+      child.stdout.pipe(transcript);
+    }
+
+    const policyDenials = [];
+    let lastTool = null;
+    const toolNames = new Map();
+    let observedModel = null;
+    let finalUsage = null;
+    if (child.stdout) {
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        let parsed;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          return;
+        }
+        try {
+          if (parsed?.type === "system" && parsed?.subtype === "init" && typeof parsed.model === "string") {
+            observedModel = parsed.model;
+          }
+          const usageInfo = extractUsage(parsed);
+          if (usageInfo) finalUsage = usageInfo;
+          for (const event of mapStreamEvent(parsed)) {
+            if (event.kind === "tool_use") {
+              lastTool = event.payload?.name ?? null;
+              if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
+            }
+            onTrace?.(event.kind, event.payload);
+            const content = typeof event.payload?.content === "string" ? event.payload.content : "";
+            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
+              const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+              policyDenials.push(denial);
+              onTrace?.("lifecycle", { note: "policy_denial", ...denial });
+            }
+          }
+        } catch {
+          // a recorder failure must never fail the run
+        }
+      });
+    }
+
+    let timedOut = false;
+    let killTimer = null;
+    const termTimer = setTimeout(() => {
+      timedOut = true;
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+      killTimer.unref?.();
+    }, timeoutMs);
+
+    const onAbort = () => {
+      killProcessGroup(child, "SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(() => killProcessGroup(child, "SIGKILL"), killGraceMs);
+        killTimer.unref?.();
+      }
+    };
+    const abortSig = abortSignal ?? signal;
+    if (abortSig) {
+      if (abortSig.aborted) {
+        onAbort();
+      } else {
+        abortSig.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    child.on("error", (err) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      transcript.destroy();
+      reject(err);
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      try {
+        onUsage?.({
+          model: observedModel,
+          durationMs: finalUsage?.durationMs ?? null,
+          costUSD: finalUsage?.costUSD ?? null,
+        });
+      } catch {
+        // Usage is observability: a consumer failure must not change execution.
+      }
+      try {
+        onTrace?.("usage", {
+          durationMs: finalUsage?.durationMs ?? null,
+          numTurns: null,
+          costUSD: finalUsage?.costUSD ?? null,
+          usage: finalUsage?.usage ?? {},
+        });
+      } catch {
+        // same
+      }
+      resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
+    });
+  });
+}

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -1,0 +1,595 @@
+import { describe, expect, test, afterAll, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { FACTORY_ROOT } from "../config.mjs";
+import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import {
+  buildCursorArgv,
+  CliNotFoundError,
+  describeToolCall,
+  execute,
+  extractUsage,
+  isHarnessDenial,
+  KILL_GRACE_MS,
+  mapStreamEvent,
+  PUSH_CREDENTIAL_ENV,
+  resolveCursorCommand,
+  safeChildEnvironment,
+  toolNameFromKey,
+} from "./cursor.mjs";
+
+describe("isHarnessDenial (WM-127, no confirmed Cursor refusal shapes yet)", () => {
+  test("nothing matches — empty until a Cursor-authored shape is observed", () => {
+    expect(isHarnessDenial("Permission to use Shell has been denied.")).toBe(false);
+    expect(isHarnessDenial("Cursor requested permissions to use write, but you haven't granted it yet.")).toBe(false);
+    expect(isHarnessDenial("EACCES: permission denied, open '/var/log/system.log'")).toBe(false);
+    expect(isHarnessDenial(null)).toBe(false);
+  });
+});
+
+describe("mapStreamEvent (Cursor stream-json shapes from output-format.md)", () => {
+  test("assistant text → assistant_text", () => {
+    const events = mapStreamEvent({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "I'll read the file." }] },
+      session_id: "s-1",
+    });
+    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "I'll read the file." } }]);
+  });
+
+  test("assistant events with timestamp_ms are skipped (stream-partial deltas)", () => {
+    expect(mapStreamEvent({
+      type: "assistant",
+      timestamp_ms: 1,
+      message: { content: [{ type: "text", text: "delta" }] },
+    })).toEqual([]);
+  });
+
+  test("tool_call started readToolCall → tool_use", () => {
+    expect(mapStreamEvent({
+      type: "tool_call",
+      subtype: "started",
+      call_id: "toolu_1",
+      tool_call: { readToolCall: { args: { path: "README.md" } } },
+    })).toEqual([
+      { kind: "tool_use", payload: { id: "toolu_1", name: "read", input: { path: "README.md" } } },
+    ]);
+  });
+
+  test("tool_call completed readToolCall → tool_result", () => {
+    expect(mapStreamEvent({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "toolu_1",
+      tool_call: {
+        readToolCall: {
+          args: { path: "README.md" },
+          result: { success: { content: "# Project\n", totalLines: 1 } },
+        },
+      },
+    })).toEqual([
+      { kind: "tool_result", payload: { content: "# Project\n", toolUseId: "toolu_1" } },
+    ]);
+  });
+
+  test("tool_call completed with result.error → tool_result isError", () => {
+    expect(mapStreamEvent({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "toolu_2",
+      tool_call: { writeToolCall: { result: { error: "write failed" } } },
+    })).toEqual([
+      { kind: "tool_result", payload: { content: "write failed", toolUseId: "toolu_2", isError: true } },
+    ]);
+  });
+
+  test("function-shaped tool_call is mapped", () => {
+    expect(mapStreamEvent({
+      type: "tool_call",
+      subtype: "started",
+      call_id: "fn_1",
+      tool_call: { function: { name: "shell", arguments: "{\"command\":\"ls\"}" } },
+    })).toEqual([
+      { kind: "tool_use", payload: { id: "fn_1", name: "shell", input: { command: "ls" } } },
+    ]);
+  });
+
+  test("unrecognized events are ignored silently", () => {
+    expect(mapStreamEvent({ type: "user", message: { content: [] } })).toEqual([]);
+    expect(mapStreamEvent({ type: "system", subtype: "init" })).toEqual([]);
+    expect(mapStreamEvent(null)).toEqual([]);
+    expect(mapStreamEvent("not an object")).toEqual([]);
+  });
+
+  test("very long assistant text is clipped", () => {
+    const [event] = mapStreamEvent({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "y".repeat(10_000) }] },
+    });
+    expect(event.kind).toBe("assistant_text");
+    expect(event.payload.text.length).toBeLessThan(4100);
+    expect(event.payload.text.endsWith("…[truncated]")).toBe(true);
+  });
+});
+
+describe("describeToolCall / toolNameFromKey", () => {
+  test("strips ToolCall suffix", () => {
+    expect(toolNameFromKey("readToolCall")).toBe("read");
+    expect(toolNameFromKey("writeToolCall")).toBe("write");
+    expect(toolNameFromKey("")).toBe("tool");
+  });
+
+  test("empty or missing tool_call is a generic tool", () => {
+    expect(describeToolCall(null)).toEqual({ name: "tool", input: {} });
+    expect(describeToolCall({})).toEqual({ name: "tool", input: {} });
+  });
+});
+
+describe("extractUsage", () => {
+  test("reads duration from the terminal result; tokens stay empty (not fabricated)", () => {
+    expect(extractUsage({
+      type: "result",
+      subtype: "success",
+      duration_ms: 5234,
+      is_error: false,
+      result: "done",
+    })).toEqual({ usage: {}, costUSD: null, durationMs: 5234, isError: false });
+  });
+
+  test("returns null when the message is not a result", () => {
+    expect(extractUsage({ type: "assistant" })).toBeNull();
+    expect(extractUsage(null)).toBeNull();
+  });
+});
+
+describe("buildCursorArgv", () => {
+  test("print + stream-json + trust + force; prompt is positional after --", () => {
+    const argv = buildCursorArgv({ prompt: "Do the smoke" });
+    expect(argv).toEqual(["-p", "--output-format", "stream-json", "--trust", "--force", "--", "Do the smoke"]);
+    expect(argv).not.toContain("--mode");
+    expect(argv).not.toContain("--stream-partial-output");
+    expect(argv).not.toContain("--worktree");
+  });
+
+  test("planner-pinned model → --model; default/empty/null → no flag", () => {
+    const withModel = buildCursorArgv({ prompt: "x", model: "composer-2.5" });
+    expect(withModel).toContain("--model");
+    expect(withModel[withModel.indexOf("--model") + 1]).toBe("composer-2.5");
+
+    const unpinned = buildCursorArgv({ prompt: "x" });
+    expect(buildCursorArgv({ prompt: "x", model: "default" })).toEqual(unpinned);
+    expect(buildCursorArgv({ prompt: "x", model: null })).toEqual(unpinned);
+    expect(buildCursorArgv({ prompt: "x", model: "" })).toEqual(unpinned);
+    expect(unpinned).not.toContain("--model");
+  });
+});
+
+describe("resolveCursorCommand", () => {
+  test("agent on PATH wins; cursor-agent is the fallback; cursor editor is ignored", () => {
+    expect(resolveCursorCommand({ which: (n) => (n === "agent" ? "/usr/local/bin/agent" : null) }))
+      .toEqual({ command: "agent", args: [] });
+    expect(resolveCursorCommand({ which: (n) => (n === "cursor-agent" ? "/usr/local/bin/cursor-agent" : null) }))
+      .toEqual({ command: "cursor-agent", args: [] });
+    expect(resolveCursorCommand({ which: (n) => (n === "cursor" ? "/usr/local/bin/cursor" : null) })).toBeNull();
+    expect(resolveCursorCommand({ which: () => null })).toBeNull();
+  });
+});
+
+describe("safeChildEnvironment", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test("strips provider and Cursor API keys, keeps declared env", () => {
+    const env = safeChildEnvironment({
+      ANTHROPIC_API_KEY: "a",
+      OPENAI_API_KEY: "b",
+      CURSOR_API_KEY: "cursor-secret",
+      CURSOR_API_ENDPOINT: "https://evil.example",
+      CUSTOM_VAR: "kept",
+    });
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
+    expect(env.CURSOR_API_ENDPOINT).toBeUndefined();
+    expect(env.CUSTOM_VAR).toBe("kept");
+  });
+
+  test("strips push credentials for non-mutating runs", () => {
+    const childEnv = safeChildEnvironment({
+      SSH_AUTH_SOCK: "/tmp/test.sock",
+      GITHUB_TOKEN: "ghp_secret",
+      CURSOR_API_KEY: "sk",
+    }, { mutating: false });
+    for (const key of PUSH_CREDENTIAL_ENV) {
+      expect(childEnv[key]).toBeUndefined();
+    }
+    expect(childEnv.CURSOR_API_KEY).toBeUndefined();
+  });
+
+  test("preserves push credentials for mutating runs while still stripping API keys", () => {
+    const childEnv = safeChildEnvironment({
+      SSH_AUTH_SOCK: "/tmp/agent.sock",
+      GITHUB_TOKEN: "ghp_mutating",
+      CURSOR_API_KEY: "sk",
+    }, { mutating: true });
+    expect(childEnv.SSH_AUTH_SOCK).toBe("/tmp/agent.sock");
+    expect(childEnv.GITHUB_TOKEN).toBe("ghp_mutating");
+    expect(childEnv.CURSOR_API_KEY).toBeUndefined();
+  });
+
+  test("defaults to stripping when mutating is omitted", () => {
+    process.env.SSH_AUTH_SOCK = "/tmp/inherited.sock";
+    expect(safeChildEnvironment({}).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, {}).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, false).SSH_AUTH_SOCK).toBeUndefined();
+    expect(safeChildEnvironment({}, true).SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+  });
+
+  test("injects FACTORY_ROOT and refuses caller overrides", () => {
+    expect(safeChildEnvironment({}).FACTORY_ROOT).toBe(FACTORY_ROOT);
+    expect(safeChildEnvironment({ FACTORY_ROOT: "/tmp/untrusted" }).FACTORY_ROOT).toBe(FACTORY_ROOT);
+  });
+
+  test("shares one push-credential list with the claude adapter", () => {
+    expect(PUSH_CREDENTIAL_ENV).toBe(CLAUDE_PUSH_CREDENTIAL_ENV);
+  });
+});
+
+describe("execute conformance (WM-440, docs/event-runtime.md §6)", () => {
+  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-cursor-test-")));
+  const stubBinDir = path.join(tmpBase, "bin");
+  mkdirSync(stubBinDir, { recursive: true });
+  const emptyBinDir = path.join(tmpBase, "empty-bin");
+  mkdirSync(emptyBinDir, { recursive: true });
+
+  const stubAgentPath = path.join(stubBinDir, "agent");
+  const stubScript = `#!/usr/bin/env bun
+import { writeFileSync } from "node:fs";
+
+if (process.env.FACTORY_TEST_RECORD_FILE) {
+  writeFileSync(
+    process.env.FACTORY_TEST_RECORD_FILE,
+    JSON.stringify({ cwd: process.cwd(), env: process.env, argv: process.argv }),
+    "utf8",
+  );
+}
+
+const behavior = process.env.FACTORY_TEST_BEHAVIOR || "normal";
+
+if (behavior === "normal") {
+  process.stdout.write(JSON.stringify({
+    type: "system", subtype: "init", model: "Composer 2.5",
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text: "Working..." }] },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "result", subtype: "success", duration_ms: 1200, is_error: false, result: "Working...",
+  }) + "\\n");
+  process.exit(0);
+}
+
+if (behavior === "exit_code") {
+  process.exit(parseInt(process.env.FACTORY_TEST_EXIT_CODE || "1", 10));
+}
+
+if (behavior === "sleep_sigterm") {
+  setInterval(() => {}, 10_000);
+}
+
+if (behavior === "ignore_sigterm") {
+  process.on("SIGTERM", () => {});
+  setInterval(() => {}, 10_000);
+}
+
+if (behavior === "spawn_long_lived_grandchild") {
+  const grandchild = Bun.spawn([process.execPath, "-e", "setInterval(() => {}, 10_000)"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  writeFileSync(process.env.FACTORY_TEST_GRANDCHILD_PID_FILE, String(grandchild.pid), "utf8");
+  setInterval(() => {}, 10_000);
+}
+
+if (behavior === "emit_tool_then_success") {
+  process.stdout.write(JSON.stringify({
+    type: "tool_call",
+    subtype: "started",
+    call_id: "toolu_1",
+    tool_call: { readToolCall: { args: { path: "a.txt" } } },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "tool_call",
+    subtype: "completed",
+    call_id: "toolu_1",
+    tool_call: { readToolCall: { result: { success: { content: "hello world" } } } },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "text", text: "Done." }] },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "result", subtype: "success", duration_ms: 800, is_error: false, result: "Done.",
+  }) + "\\n");
+  process.exit(0);
+}
+
+if (behavior === "emit_error_tool_result") {
+  process.stdout.write(JSON.stringify({
+    type: "tool_call",
+    subtype: "started",
+    call_id: "toolu_err",
+    tool_call: { writeToolCall: { args: { path: "/etc/nope" } } },
+  }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    type: "tool_call",
+    subtype: "completed",
+    call_id: "toolu_err",
+    tool_call: { writeToolCall: { result: { error: "Permission to use write has been denied." } } },
+  }) + "\\n");
+  process.exit(1);
+}
+`;
+  writeFileSync(stubAgentPath, stubScript, { mode: 0o755 });
+
+  const promptFile = path.join(tmpBase, "prompt.md");
+  writeFileSync(promptFile, "You are a test agent.", "utf8");
+
+  afterAll(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const defaultDef = { ref: "test-cursor-agent@1", promptPath: promptFile, mutating: false };
+  const defaultSpec = { agent: "test-cursor-agent@1", input: { message: "hi" } };
+  const testProcessGroup = process.platform === "win32" ? test.skip : test;
+
+  async function waitForGrandchildPid(pidFile) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("stub did not report its grandchild PID");
+  }
+
+  function processExists(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return error?.code !== "ESRCH";
+    }
+  }
+
+  async function expectProcessExit(pid) {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (!processExists(pid)) return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(processExists(pid)).toBe(false);
+  }
+
+  function killIfRunning(pid) {
+    if (!pid || !processExists(pid)) return;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // exited between check and cleanup
+    }
+  }
+
+  test("executes stub binary in workspaceDir, strips keys, prompt on argv, captures transcript + trace", async () => {
+    const workspaceDir = ws();
+    const recordFile = path.join(workspaceDir, "record.json");
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec: { ...defaultSpec, model: "composer-2.5" },
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        CURSOR_API_KEY: "sk-must-be-stripped",
+        CUSTOM_VAR: "custom_value",
+        FACTORY_TEST_BEHAVIOR: "normal",
+        FACTORY_TEST_RECORD_FILE: recordFile,
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(existsSync(recordFile)).toBe(true);
+    const record = JSON.parse(readFileSync(recordFile, "utf8"));
+    expect(record.cwd).toBe(workspaceDir);
+    expect(record.env.CURSOR_API_KEY).toBeUndefined();
+    expect(record.env.CUSTOM_VAR).toBe("custom_value");
+    expect(record.argv).toContain("-p");
+    expect(record.argv).toContain("--output-format");
+    expect(record.argv).toContain("stream-json");
+    expect(record.argv).toContain("--trust");
+    expect(record.argv).toContain("--force");
+    expect(record.argv).toContain("--model");
+    expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("composer-2.5");
+    expect(record.argv.at(-2)).toBe("--");
+    expect(record.argv.at(-1)).toBe(`You are a test agent.${PROMPT_SUFFIX}`);
+
+    const transcriptPath = path.join(workspaceDir, ".transcript.json");
+    expect(existsSync(transcriptPath)).toBe(true);
+    expect(readFileSync(transcriptPath, "utf8")).toContain('"type":"assistant"');
+
+    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working...")).toBe(true);
+    const usageEvent = traceEvents.find((e) => e.kind === "usage");
+    expect(usageEvent.payload.durationMs).toBe(1200);
+    expect(usageEvent.payload.costUSD).toBeNull();
+    expect(usageEvent.payload.usage).toEqual({});
+  });
+
+  test("nonzero exit code propagates and timedOut is false", async () => {
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "exit_code",
+        FACTORY_TEST_EXIT_CODE: "42",
+      },
+    });
+    expect(outcome.exitCode).toBe(42);
+    expect(outcome.timedOut).toBe(false);
+  });
+
+  testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    const ac = new AbortController();
+    const runPromise = execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 6_000,
+      killGraceMs: 5000,
+      abortSignal: ac.signal,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+      },
+    });
+    let grandchildPid;
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(true);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
+  }, { timeout: 12_000 });
+
+  test("timeout escalates to SIGKILL when child ignores SIGTERM", async () => {
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 100,
+      killGraceMs: 100,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "ignore_sigterm",
+      },
+    });
+    expect(outcome.timedOut).toBe(true);
+  });
+
+  testProcessGroup("abort kills a real long-lived grandchild (WM-263)", async () => {
+    const workspaceDir = ws();
+    const pidFile = path.join(workspaceDir, "grandchild.pid");
+    const ac = new AbortController();
+    const runPromise = execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 10_000,
+      killGraceMs: 500,
+      abortSignal: ac.signal,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "spawn_long_lived_grandchild",
+        FACTORY_TEST_GRANDCHILD_PID_FILE: pidFile,
+      },
+    });
+    let grandchildPid;
+    try {
+      grandchildPid = await waitForGrandchildPid(pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+      ac.abort();
+      const outcome = await runPromise;
+      expect(outcome.timedOut).toBe(false);
+      await expectProcessExit(grandchildPid);
+    } finally {
+      ac.abort();
+      await runPromise;
+      killIfRunning(grandchildPid);
+    }
+  });
+
+  test("tool_call stream maps to tool_use / tool_result and a usage event", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_tool_then_success",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, policyDenials: [] });
+    expect(traceEvents.some((e) => e.kind === "tool_use" && e.payload.name === "read")).toBe(true);
+    expect(traceEvents.some((e) => e.kind === "tool_result" && e.payload.content === "hello world")).toBe(true);
+    expect(traceEvents.find((e) => e.kind === "usage")?.payload.durationMs).toBe(800);
+  });
+
+  test("a tool error that reads like a permission denial is never policy_denied (WM-127)", async () => {
+    const traceEvents = [];
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "emit_error_tool_result",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.policyDenials).toEqual([]);
+    expect(traceEvents.some((e) => e.kind === "lifecycle" && e.payload.note === "policy_denial")).toBe(false);
+  });
+
+  test("run with no output reports usage as explicit n/a, not a fabricated zero", async () => {
+    const traceEvents = [];
+    await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir: ws(),
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "exit_code",
+        FACTORY_TEST_EXIT_CODE: "0",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(traceEvents.find((e) => e.kind === "usage")?.payload).toEqual({
+      durationMs: null, numTurns: null, costUSD: null, usage: {},
+    });
+  });
+
+  test("missing agent and cursor-agent on PATH is a typed CliNotFoundError", async () => {
+    await expect(
+      execute({
+        spec: defaultSpec,
+        def: defaultDef,
+        workspaceDir: ws(),
+        timeoutMs: 1000,
+        env: { PATH: emptyBinDir },
+      }),
+    ).rejects.toMatchObject({ name: "CliNotFoundError", code: "cli_not_found" });
+    expect(CliNotFoundError).toBeDefined();
+    expect(KILL_GRACE_MS).toBe(30_000);
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -43,7 +43,7 @@ export const DEFAULT_MODEL = "default";
 
 /** Adapters that accept a model at all. command/actions/fake take none: a
  * declared tier there resolves to null (not applicable), never an error. */
-export const MODEL_ADAPTERS = new Set(["claude", "pi", "agy"]);
+export const MODEL_ADAPTERS = new Set(["claude", "pi", "agy", "cursor"]);
 
 /**
  * Read the `models:` tier map from config/policy.yaml (same root rule as

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -37,6 +37,11 @@ const PI_TIERS = {
     standard: "gemini-3.7-flash",
     light: "gemini-3.7-flash",
   },
+  cursor: {
+    strong: "composer-2.5",
+    standard: "composer-2.5",
+    light: "composer-2.5-fast",
+  },
 };
 
 describe("registry", () => {

--- a/event-runtime/schemas/cursor-smoke.input.json
+++ b/event-runtime/schemas/cursor-smoke.input.json
@@ -1,0 +1,13 @@
+{
+  "title": "cursor-smoke input — one message to echo back through the cursor adapter",
+  "type": "object",
+  "required": ["message"],
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Text for the agent to read and echo back, proving the cursor adapter ran end-to-end"
+    }
+  }
+}

--- a/event-runtime/schemas/cursor-smoke.output.json
+++ b/event-runtime/schemas/cursor-smoke.output.json
@@ -1,0 +1,13 @@
+{
+  "title": "factory.cursor-smoke/v1 output artifact — the input message echoed back",
+  "type": "object",
+  "required": ["echo"],
+  "additionalProperties": false,
+  "properties": {
+    "echo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The input message, unchanged"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `cursor` event-runtime adapter that spawns the installed Cursor Agent CLI (`agent` / `cursor-agent`) under the same worker contract as `claude` / `pi` / `agy`.
- Register `cursor-smoke@1` and `factory.cursor-smoke.requested` only — no existing event type is remapped off Pi.
- Pin `models.cursor` tiers to Composer 2.5 / 2.5-fast; `--adapter-override cursor` is accepted on `serve`/`work`.

## Test plan
- [x] `bun test event-runtime/lib/adapters/cursor.test.mjs event-runtime/lib/registry.test.mjs event-runtime/cli.test.mjs` — 80 pass
- [ ] Optional live smoke: inject `factory.cursor-smoke.requested` against a worker with `agent` on PATH (not required for merge)

UX critique: skipped — internal adapter and smoke agent; no user-completable flow.

Fixes WM-440

Made with [Cursor](https://cursor.com)