### PR TITLE
feat(merge): route mixed scan actions independently (WM-430)

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -25,7 +25,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:9a48ebfe5d02fc320e2ed3f3fbfdedd39d342002c8a91f98eb99194edc656b67",
+    "agents/merge-scan.md": "sha256:28eea86ca911bc5f224b75449931f96ce47bf61a8de1c4948d58f0c1e7db462f",
     "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -93,12 +93,16 @@ round and SHA-256 hash of the exact finding. Exhausted, outside-scope,
 security, or ambiguous findings are ESCALATE, never FIX.
 
 Fail closed if GitHub, Linear, config, mergeability, base SHA, or checks are
-uncertain. Use recommendation precedence ESCALATE, then FIX, then MERGE, then
-NOOP. FIX emits every fix item; ESCALATE emits no merge; MERGE emits exactly
-one deterministic candidate (lowest PR number) in `plan` so only one PR can
-land per base-CI cycle. Every plan boolean is a positive assertion from your
-review; the schema rejects anything weaker. Include `base`, `deployBranch`,
-head/base SHA, and exact head branch. A moved SHA requires a new scan.
+uncertain. Populate `escalate`, `fix`, and `plan` independently per PR: an
+escalated or held PR appears in `escalate` but suppresses only itself, never an
+eligible fix or safe merge for another PR. Include every eligible mechanical
+fix in `fix`, and put exactly one deterministic safe candidate (lowest PR
+number) in `plan` so only one PR can land per base-CI cycle. The legacy
+`recommendation` remains a batch summary using precedence ESCALATE, then FIX,
+then MERGE, then NOOP; it does not suppress any populated action array. Every
+plan boolean is a positive assertion from your review; the schema rejects
+anything weaker. Include `base`, `deployBranch`, head/base SHA, and exact head
+branch. A moved SHA requires a new scan.
 
 ## Result envelope
 

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -138,9 +138,12 @@
   },
   "merge-scan@2": {
     "recommendationField": "recommendation",
+    "independent": true,
     "edges": {
       "MERGE": {
         "eventType": "factory.merge-apply.requested",
+        "whenItemsField": "plan",
+        "mixedEventId": "chain-${runId}-merge",
         "input": {
           "repo": "$.artifact.repo",
           "github": "$.artifact.github",
@@ -151,6 +154,8 @@
       },
       "FIX": {
         "eventType": "factory.merge-fix.requested",
+        "whenItemsField": "fix",
+        "mixedEventId": "chain-${runId}-fix-${item.pr}-${item.findingHash}",
         "itemsField": "fix",
         "itemKey": "ticket",
         "input": {
@@ -174,6 +179,8 @@
       },
       "ESCALATE": {
         "eventType": "factory.merge-escalate.requested",
+        "whenItemsField": "escalate",
+        "mixedEventId": "chain-${runId}-escalate",
         "input": {
           "repo": "$.artifact.repo",
           "summary": "$.artifact.summary"

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -373,9 +373,42 @@ describe("chain auto approval (WM-357)", () => {
   test("operator proposals and protected or incomplete merge/ship proposals remain watched", () => {
     const db = openDb(":memory:");
     const manual = seed(db, { id: "manual", source: "operator" });
+    const mergeInput = {
+      repo: "factory",
+      github: "untrusted-owner/factory",
+      base: "develop",
+      deployBranch: "master",
+      plan: [
+        {
+          pr: 430,
+          headSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          headRef: "feat/WM-430",
+          ticket: "WM-430",
+          action: "merge_pr",
+          reason: "fixture reaches repository policy",
+          checksGreen: true,
+          mergeable: true,
+          ownedPathsValid: true,
+          handoffValid: true,
+          testsFalsifiable: true,
+          policySafe: true,
+          sensitive: false,
+          ambiguous: false,
+        },
+      ],
+    };
     const merge = seed(db, {
       id: "merge",
       type: "factory.merge-apply.requested",
+      input: mergeInput,
+      predecessorArtifact: {
+        recommendation: "MERGE",
+        ...mergeInput,
+        fix: [],
+        escalate: [],
+        summary: "one selected merge",
+      },
     });
     const ship = seed(db, { id: "ship", type: "factory.ship-apply.requested" });
 

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -7,7 +7,7 @@
  * The chain emits an **internal event through the same intake as a webhook**
  * — same dedup, same planner, same watched approval — with:
  *
- *   eventId       chain-<runId>            (one chain event per run, ever)
+ *   eventId       chain-<runId>[-<action/item>]
  *   correlationId inherited from the originating event
  *   causationId   the source runId
  *
@@ -53,7 +53,24 @@ export function buildChainInput(mapping, context) {
   return input;
 }
 
-/** Completed runs whose agent has registered edges and no chain event yet. */
+function resolveItems(itemsField, context) {
+  if (typeof itemsField === "string" && itemsField.startsWith("$.")) {
+    return resolvePath(itemsField, context);
+  }
+  return context.artifact?.[itemsField] ?? context.input?.[itemsField];
+}
+
+function chainEventId(edge, row, context, fallback, { mixed = false } = {}) {
+  const template = mixed ? edge.mixedEventId : edge.eventId;
+  if (typeof template !== "string") return fallback;
+  return template.replace(/\$\{([^}]+)\}/g, (_, expr) => {
+    if (expr === "runId") return row.run_id;
+    if (expr.startsWith("item.")) return context.item?.[expr.slice(5)] ?? "";
+    return String(resolvePath(`$.${expr}`, context) ?? "");
+  });
+}
+
+/** Completed runs whose agent has registered edges and no derived chain event yet. */
 function chainCandidates(db, edges) {
   const agents = Object.keys(edges);
   if (agents.length === 0) return [];
@@ -67,22 +84,17 @@ function chainCandidates(db, edges) {
        JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE r.state = 'COMPLETED'
-         AND json_extract(r.spec_json, '$.agent') IN (${placeholders})
-         AND NOT EXISTS (
-           SELECT 1 FROM events ce
-           WHERE ce.source = '${CHAIN_SOURCE}'
-             AND (ce.causation_id = r.run_id OR ce.event_id = 'chain-' || r.run_id OR ce.event_id LIKE 'chain-' || r.run_id || '-%')
-         )`,
+         AND json_extract(r.spec_json, '$.agent') IN (${placeholders})`,
     )
     .all(...agents);
 }
 
 /**
  * One deterministic pass: emit chain events for eligible completed runs.
- * Supports single-emit (eventId chain-<runId>) and multi-emit fan-out edges
- * (eventId chain-<runId>-<itemKey>) (OPS-223, WM-119). Idempotent — the derived
- * eventId dedups at intake, and candidates with existing chain events are
- * excluded up front.
+ * Supports legacy recommendation routing, multi-emit fan-out, and opt-in
+ * independent edges selected by non-empty artifact arrays (OPS-223, WM-119,
+ * WM-430). Idempotent — derived event IDs dedup at intake, fully emitted sets
+ * are zero-ops, and partially emitted sets resume with only missing siblings.
  *
  * @returns {{ emitted: number, skipped: number, errors: string[] }}
  */
@@ -96,16 +108,26 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
     const rule = edges[spec.agent];
     try {
       const recommendation = result.artifact?.[rule.recommendationField];
-      const edge = rule.edges[recommendation];
-      if (edge === undefined) {
-        // An unmapped value is a legitimate terminal — record nothing, chain nothing.
+      const artifact = result.artifact ?? {};
+      const selectionContext = { input: spec.input, artifact };
+      const selectedEdges = rule.independent
+        ? Object.entries(rule.edges).filter(([, candidate]) => {
+            const items = resolveItems(candidate.whenItemsField, selectionContext);
+            if (!Array.isArray(items)) {
+              throw new Error(`independent chain selector "${candidate.whenItemsField}" is not an array`);
+            }
+            return items.length > 0;
+          })
+        : [[recommendation, rule.edges[recommendation]]].filter(([, candidate]) => candidate !== undefined);
+      if (selectedEdges.length === 0) {
+        // An unmapped value or an independent result with no actionable items
+        // is a legitimate terminal — record nothing, chain nothing.
         outcome.skipped += 1;
         continue;
       }
+
       // A chain may pass an artifact by content hash — `$.artifactHash.<kind>`
       // resolves against the accepted result's stored artifacts (OPS-372).
-      // Values, not bytes, travel through events; the downstream workspace
-      // materializes the bytes from the store.
       const artifactHash = {};
       for (const entry of result.artifacts ?? []) {
         if (entry.kind && entry.sha256 && artifactHash[entry.kind] === undefined) {
@@ -113,102 +135,104 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
         }
       }
 
-      const itemsField = edge.itemsField ?? rule.itemsField;
-      const itemKey = edge.itemKey ?? rule.itemKey;
+      // Build and validate the complete deterministic emission set before any
+      // admission. Independent edges use distinct IDs only for a genuinely
+      // mixed result; a sole selected edge preserves the legacy envelope ID.
+      const envelopes = [];
+      const mixed = selectedEdges.length > 1;
+      for (const [, edge] of selectedEdges) {
+        const itemsField = edge.itemsField ?? rule.itemsField;
+        const itemKey = edge.itemKey ?? rule.itemKey;
 
-      if (itemsField !== undefined) {
-        // Multi-emit / fan-out edge (WM-119)
-        let items;
-        if (typeof itemsField === "string" && itemsField.startsWith("$.")) {
-          items = resolvePath(itemsField, {
+        if (itemsField !== undefined) {
+          const items = resolveItems(itemsField, {
             input: spec.input,
-            artifact: result.artifact ?? {},
+            artifact,
             artifactHash,
           });
-        } else {
-          items = result.artifact?.[itemsField] ?? spec.input?.[itemsField];
-        }
-
-        if (!Array.isArray(items) || items.length === 0) {
-          outcome.skipped += 1;
-          continue;
-        }
-
-        for (const item of items) {
-          let itemKeyVal;
-          if (typeof item === "object" && item !== null) {
-            itemKeyVal = itemKey ? item[itemKey] : undefined;
-          } else if (typeof item === "string" || typeof item === "number") {
-            itemKeyVal = String(item);
-          }
-          if (itemKeyVal === undefined || itemKeyVal === null || String(itemKeyVal).trim() === "") {
-            throw new Error(`multi-emit chain item missing key "${itemKey}"`);
+          if (!Array.isArray(items) || items.length === 0) {
+            outcome.skipped += 1;
+            continue;
           }
 
-          const itemContext = {
-            input: spec.input,
-            artifact: result.artifact ?? {},
-            artifactHash,
-            item,
-          };
-          const itemPayload = buildChainInput(edge.input ?? {}, itemContext);
-          if (itemKey && itemPayload[itemKey] === undefined) {
-            itemPayload[itemKey] = itemKeyVal;
-          }
-          if (edge.perItem) {
-            const perItemInput = buildChainInput(edge.perItem, itemContext);
-            Object.assign(itemPayload, perItemInput);
-          }
+          const fallbackIds = items.map((item) => {
+            if (typeof item === "object" && item !== null) return itemKey ? item[itemKey] : undefined;
+            if (typeof item === "string" || typeof item === "number") return String(item);
+            return undefined;
+          });
+          const duplicateFallback = new Set(fallbackIds.map(String)).size !== fallbackIds.length;
 
-          let eventId;
-          if (typeof edge.eventId === "string") {
-            eventId = edge.eventId.replace(/\$\{([^}]+)\}/g, (_, expr) => {
-              if (expr === "runId") return row.run_id;
-              if (expr.startsWith("item.")) return item?.[expr.slice(5)] ?? "";
-              return String(resolvePath(`$.${expr}`, itemContext) ?? "");
+          for (const [index, item] of items.entries()) {
+            const itemKeyVal = fallbackIds[index];
+            if (itemKeyVal === undefined || itemKeyVal === null || String(itemKeyVal).trim() === "") {
+              throw new Error(`multi-emit chain item missing key "${itemKey}"`);
+            }
+            const itemContext = {
+              input: spec.input,
+              artifact,
+              artifactHash,
+              item,
+            };
+            const payload = buildChainInput(edge.input ?? {}, itemContext);
+            if (itemKey && payload[itemKey] === undefined) payload[itemKey] = itemKeyVal;
+            if (edge.perItem) Object.assign(payload, buildChainInput(edge.perItem, itemContext));
+
+            envelopes.push({
+              schemaVersion: "factory.event/v1",
+              eventId: chainEventId(edge, row, itemContext, `chain-${row.run_id}-${itemKeyVal}`, {
+                mixed: mixed || duplicateFallback,
+              }),
+              type: edge.eventType,
+              source: CHAIN_SOURCE,
+              subject: spec.agent,
+              occurredAt: new Date(now).toISOString(),
+              correlationId: row.correlation_id ?? row.origin_event_id,
+              causationId: row.run_id,
+              payload,
             });
-          } else {
-            eventId = `chain-${row.run_id}-${itemKeyVal}`;
           }
-
-          const envelope = {
+        } else {
+          const eventContext = {
+            input: spec.input,
+            artifact,
+            artifactHash,
+          };
+          envelopes.push({
             schemaVersion: "factory.event/v1",
-            eventId,
+            eventId: chainEventId(edge, row, eventContext, `chain-${row.run_id}`, { mixed }),
             type: edge.eventType,
             source: CHAIN_SOURCE,
             subject: spec.agent,
             occurredAt: new Date(now).toISOString(),
             correlationId: row.correlation_id ?? row.origin_event_id,
             causationId: row.run_id,
-            payload: itemPayload,
-          };
-          const admitted = admitChainEvent(db, registry, envelope, { now });
-          if (admitted.admitted) outcome.emitted += 1;
-          else if (admitted.duplicate) outcome.skipped += 1;
-          else outcome.errors.push(`${eventId}: ${admitted.errors.join("; ")}`);
+            payload: buildChainInput(edge.input, eventContext),
+          });
         }
-      } else {
-        // Single-emit edge (OPS-223)
-        const eventId = `chain-${row.run_id}`;
-        const envelope = {
-          schemaVersion: "factory.event/v1",
-          eventId,
-          type: edge.eventType,
-          source: CHAIN_SOURCE,
-          subject: spec.agent,
-          occurredAt: new Date(now).toISOString(),
-          correlationId: row.correlation_id ?? row.origin_event_id,
-          causationId: row.run_id,
-          payload: buildChainInput(edge.input, {
-            input: spec.input,
-            artifact: result.artifact ?? {},
-            artifactHash,
-          }),
-        };
+      }
+
+      const ids = envelopes.map((envelope) => envelope.eventId);
+      if (new Set(ids).size !== ids.length) {
+        throw new Error(`chain event IDs are not unique: ${ids.join(", ")}`);
+      }
+
+      // A prior process may have stopped after admitting only part of a mixed
+      // set. Reconstruct the full set and admit only the missing siblings. An
+      // event from an older routing configuration is a durable completion
+      // marker, not permission to backfill stale actions under today's edges.
+      const existingIds = new Set(
+        db
+          .query(`SELECT event_id FROM events WHERE source = ? AND causation_id = ?`)
+          .all(CHAIN_SOURCE, row.run_id)
+          .map((event) => event.event_id),
+      );
+      if ([...existingIds].some((eventId) => !ids.includes(eventId))) continue;
+      const pending = envelopes.filter((envelope) => !existingIds.has(envelope.eventId));
+      for (const envelope of pending) {
         const admitted = admitChainEvent(db, registry, envelope, { now });
         if (admitted.admitted) outcome.emitted += 1;
         else if (admitted.duplicate) outcome.skipped += 1;
-        else outcome.errors.push(`${eventId}: ${admitted.errors.join("; ")}`);
+        else outcome.errors.push(`${envelope.eventId}: ${admitted.errors.join("; ")}`);
       }
     } catch (err) {
       outcome.errors.push(`chain-${row.run_id}: ${err.message}`);

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -226,6 +226,44 @@ describe("registry gates (OPS-223)", () => {
       JSON.stringify({ "ci-doctor@2": { recommendationField: "verdict", edges: { FLAKE: { eventType: "factory.ci-rerun.requested", input: { x: "$.secrets.key" } } } } }),
     );
     expect(() => loadRegistry({ root })).toThrow("only $.input.*, $.artifact.* and $.artifactHash.*");
+
+    const independentRule = (edge) => ({
+      "ci-doctor@2": {
+        recommendationField: "verdict",
+        independent: true,
+        edges: { FLAKE: edge },
+      },
+    });
+    writeFileSync(
+      path.join(root, "edges.json"),
+      JSON.stringify(independentRule({ eventType: "factory.ci-rerun.requested", input: {} })),
+    );
+    expect(() => loadRegistry({ root })).toThrow("independent edge has no whenItemsField");
+
+    writeFileSync(
+      path.join(root, "edges.json"),
+      JSON.stringify(
+        independentRule({
+          eventType: "factory.ci-rerun.requested",
+          whenItemsField: "signals",
+          input: {},
+        }),
+      ),
+    );
+    expect(() => loadRegistry({ root })).toThrow("independent edge needs a mixedEventId containing ${runId}");
+
+    writeFileSync(
+      path.join(root, "edges.json"),
+      JSON.stringify(
+        independentRule({
+          eventType: "factory.ci-rerun.requested",
+          whenItemsField: "signals",
+          mixedEventId: "chain-${runId}-flake",
+          input: {},
+        }),
+      ),
+    );
+    expect(() => loadRegistry({ root })).not.toThrow();
   });
 });
 

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -250,7 +250,30 @@ export function loadRegistry({ root = RUNTIME_ROOT, modelTiers = loadModelTierMa
       if (typeof rule.recommendationField !== "string" || !rule.recommendationField) {
         throw new RegistryError(`edges.json: ${agentRef} has no recommendationField`);
       }
+      if (rule.independent !== undefined && rule.independent !== true) {
+        throw new RegistryError(`edges.json: ${agentRef}.independent must be true when present`);
+      }
       for (const [value, edge] of Object.entries(rule.edges ?? {})) {
+        if (rule.independent === true) {
+          if (typeof edge.whenItemsField !== "string" || !edge.whenItemsField) {
+            throw new RegistryError(`edges.json: ${agentRef}.${value} independent edge has no whenItemsField`);
+          }
+          if (typeof edge.mixedEventId !== "string" || !edge.mixedEventId.includes("${runId}")) {
+            throw new RegistryError(
+              `edges.json: ${agentRef}.${value} independent edge needs a mixedEventId containing \${runId}`,
+            );
+          }
+          if (edge.itemsField !== undefined && !edge.mixedEventId.includes("${item.")) {
+            throw new RegistryError(
+              `edges.json: ${agentRef}.${value} independent multi edge needs an item placeholder in mixedEventId`,
+            );
+          }
+        }
+        for (const field of ["eventId", "mixedEventId"]) {
+          if (edge[field] !== undefined && (typeof edge[field] !== "string" || edge[field].trim() === "")) {
+            throw new RegistryError(`edges.json: ${agentRef}.${value} ${field} must be a non-empty string`);
+          }
+        }
         if (!eventTypes[edge.eventType]) {
           throw new RegistryError(`edges.json: ${agentRef}.${value} targets unregistered event type ${edge.eventType}`);
         }

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -209,15 +209,41 @@ function admitEvent(db, registryForAdmission, env) {
         : env.type === "factory.merge-fix.requested"
           ? "FIX"
           : "UPDATED";
+    let artifact;
+    if (recommendation === "MERGE") {
+      artifact = {
+        recommendation,
+        ...env.payload,
+        fix: [],
+        escalate: [],
+        summary: "one selected merge",
+      };
+    } else if (recommendation === "FIX") {
+      const { repo, github, base, deployBranch = "master", ...fixItem } =
+        env.payload;
+      artifact = {
+        recommendation,
+        repo,
+        github,
+        base,
+        deployBranch,
+        plan: [],
+        fix: [fixItem],
+        escalate: [],
+        summary: "one selected fix",
+      };
+    } else {
+      artifact = {
+        recommendation,
+        outcome: recommendation,
+        repo: env.payload.repo,
+      };
+    }
     seedCompleted(db, {
       runId: parent,
       agent: recommendation === "UPDATED" ? "merge-fix@1" : "merge-scan@2",
       input: env.payload,
-      artifact: {
-        recommendation,
-        outcome: recommendation,
-        repo: env.payload.repo,
-      },
+      artifact,
     });
   }
   return persistEvent(
@@ -848,11 +874,11 @@ describe("merge transition chains", () => {
       skipped: 0,
       errors: [],
     });
-    const payload = JSON.parse(
-      db.query(`SELECT envelope_json FROM events WHERE source='chain'`).get()
-        .envelope_json,
-    ).payload;
-    expect(payload).toEqual(applyPayload());
+    const event = db
+      .query(`SELECT event_id,envelope_json FROM events WHERE source='chain'`)
+      .get();
+    expect(event.event_id).toBe("chain-scan-merge");
+    expect(JSON.parse(event.envelope_json).payload).toEqual(applyPayload());
   });
 
   test("FIX fans out one durable request per PR with round and finding hash", () => {
@@ -889,9 +915,13 @@ describe("merge transition chains", () => {
     expect(resolveChains(db, registry).emitted).toBe(2);
     const rows = db
       .query(
-        `SELECT envelope_json FROM events WHERE source='chain' ORDER BY event_id`,
+        `SELECT event_id,envelope_json FROM events WHERE source='chain' ORDER BY event_id`,
       )
       .all();
+    expect(rows.map((row) => row.event_id)).toEqual([
+      "chain-scan-fix-WM-501",
+      "chain-scan-fix-WM-502",
+    ]);
     expect(
       rows.map((row) => JSON.parse(row.envelope_json).payload.ticket),
     ).toEqual(["WM-501", "WM-502"]);
@@ -899,6 +929,185 @@ describe("merge transition chains", () => {
       round: 1,
       findingHash: FINDING_HASH,
       mechanical: true,
+    });
+  });
+
+  test("duplicate fix tickets still derive one stable event per accepted item", () => {
+    const db = openDb(":memory:");
+    const fix = [61, 62].map((pr, index) => ({
+      pr,
+      headSha: SHA,
+      baseSha: BASE_SHA,
+      headRef: `feat/WM-560-${index}`,
+      ticket: "WM-560",
+      finding: `mechanical ${index}`,
+      findingHash: String(index + 1).repeat(64),
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: [`src/${index}.mjs`],
+    }));
+    seedCompleted(db, {
+      runId: "scan-duplicate-fix-ticket",
+      agent: "merge-scan@2",
+      input: { repo: "factory" },
+      artifact: {
+        recommendation: "FIX",
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        deployBranch: "master",
+        plan: [],
+        fix,
+        escalate: [],
+        summary: "two fixes share one ticket",
+      },
+    });
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 2,
+      skipped: 0,
+      errors: [],
+    });
+    expect(
+      db
+        .query(`SELECT event_id FROM events WHERE source='chain' ORDER BY event_id`)
+        .all()
+        .map((row) => row.event_id),
+    ).toEqual([
+      `chain-scan-duplicate-fix-ticket-fix-61-${"1".repeat(64)}`,
+      `chain-scan-duplicate-fix-ticket-fix-62-${"2".repeat(64)}`,
+    ]);
+  });
+
+  test("a legacy aggregate event prevents stale mixed-action backfill after routing changes", () => {
+    const db = openDb(":memory:");
+    seedCompleted(db, {
+      runId: "scan-historical-mixed",
+      agent: "merge-scan@2",
+      input: { repo: "factory" },
+      artifact: {
+        recommendation: "ESCALATE",
+        ...applyPayload(63, "WM-563"),
+        fix: [],
+        escalate: [
+          {
+            pr: 64,
+            headSha: SHA,
+            ticket: "WM-564",
+            reason: "historical hold",
+          },
+        ],
+        summary: "historical aggregate escalation",
+      },
+    });
+    expect(
+      persistEvent(db, registry, {
+        schemaVersion: "factory.event/v1",
+        eventId: "chain-scan-historical-mixed",
+        type: "factory.merge-escalate.requested",
+        source: "chain",
+        subject: "merge-scan@2",
+        occurredAt: "2026-08-16T12:00:00.000Z",
+        correlationId: "historical-mixed",
+        causationId: "scan-historical-mixed",
+        payload: {
+          repo: "factory",
+          summary: "historical aggregate escalation",
+        },
+      }).admitted,
+    ).toBe(true);
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+    expect(
+      db.query(`SELECT COUNT(*) AS n FROM events WHERE source='chain'`).get().n,
+    ).toBe(1);
+  });
+
+  test("a mixed scan independently emits escalation, bounded fixes, and one globally serialized merge", () => {
+    const db = openDb(":memory:");
+    const fix = ["WM-511", "WM-512"].map((ticket, index) => ({
+      pr: 51 + index,
+      headSha: SHA,
+      baseSha: BASE_SHA,
+      headRef: `feat/${ticket}`,
+      ticket,
+      finding: `mechanical ${index}`,
+      findingHash: FINDING_HASH,
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: [`src/${index}.mjs`],
+    }));
+    seedCompleted(db, {
+      runId: "scan-mixed",
+      agent: "merge-scan@2",
+      input: { repo: "factory" },
+      artifact: {
+        recommendation: "ESCALATE",
+        ...applyPayload(53, "WM-513"),
+        fix,
+        escalate: [
+          {
+            pr: 54,
+            headSha: SHA,
+            ticket: "WM-514",
+            reason: "draft hold remains visible",
+          },
+        ],
+        summary: "one hold, two mechanical fixes, and one safe merge",
+      },
+    });
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 4,
+      skipped: 0,
+      errors: [],
+    });
+    const events = db
+      .query(`SELECT event_id,type FROM events WHERE source='chain' ORDER BY event_id`)
+      .all();
+    expect(events.map((event) => event.type).sort()).toEqual([
+      "factory.merge-apply.requested",
+      "factory.merge-escalate.requested",
+      "factory.merge-fix.requested",
+      "factory.merge-fix.requested",
+    ]);
+    expect(events.map((event) => event.event_id)).toEqual([
+      "chain-scan-mixed-escalate",
+      `chain-scan-mixed-fix-51-${FINDING_HASH}`,
+      `chain-scan-mixed-fix-52-${FINDING_HASH}`,
+      "chain-scan-mixed-merge",
+    ]);
+
+    // A process interruption after one admission must not suppress the other
+    // three actions when the same accepted result is resolved again.
+    db.query(
+      `DELETE FROM events WHERE source='chain' AND event_id != 'chain-scan-mixed-escalate'`,
+    ).run();
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 3,
+      skipped: 0,
+      errors: [],
+    });
+    expect(
+      db.query(`SELECT COUNT(*) AS n FROM events WHERE source='chain'`).get().n,
+    ).toBe(4);
+
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+    expect(
+      db.query(
+        `SELECT COUNT(*) AS n FROM runs WHERE state='QUEUED' AND json_extract(spec_json,'$.agent')='merge-apply@2'`,
+      ).get().n,
+    ).toBe(1);
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
     });
   });
 


### PR DESCRIPTION
## Summary
- route merge-scan plan, fix, and escalation arrays independently in one deterministic resolution pass
- resume partially emitted mixed sets without backfilling stale historical results
- preserve legacy single-outcome IDs and unchanged exact-SHA, CI, provenance, and global merge-barrier gates

## Verification
- `bun test event-runtime/lib/chain.test.mjs event-runtime/lib/registry.test.mjs event-runtime/merge.test.mjs event-runtime/lib/auto-approval.test.mjs && bun event-runtime/cli.mjs update-pins && bun build/emit.mjs --check && bun run format:check`
- 79 tests passed; pins current; generated files and shared Markdown formatting clean

UX critique: skipped — backend event-runtime routing; no user-facing surface

Independent security review: SHIP. Human approval remains required before merge.

Fixes WM-430