### PR TITLE
fix(adapters-agy): repair the agy harness — real stream-json mapping and print-timeout (WM-435, WM-439)

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -133,8 +133,81 @@ function clip(text) {
   return s.length > TEXT_PREVIEW_CHARS ? `${s.slice(0, TEXT_PREVIEW_CHARS)}…[truncated]` : s;
 }
 
+/** agy's token counters, renamed to the trace's shape. Absent fields stay absent. */
+function normalizeUsage(raw) {
+  const usage = {};
+  const map = {
+    input_tokens: "input",
+    output_tokens: "output",
+    thinking_tokens: "thinking",
+    cache_read_tokens: "cacheRead",
+    total_tokens: "total",
+  };
+  for (const [from, to] of Object.entries(map)) {
+    if (typeof raw?.[from] === "number") usage[to] = raw[from];
+  }
+  return usage;
+}
+
+/** agy reports step durations in fractional seconds; the trace speaks milliseconds. */
+function durationMsOf(seconds) {
+  return typeof seconds === "number" ? Math.round(seconds * 1000) : null;
+}
+
+/**
+ * Map agy's terminal `result` line to trace events.
+ *
+ * This is the only place the agent's final answer and its failure reason
+ * appear: step updates carry neither. Before WM-435 the whole event was
+ * dropped, so a failed agy run produced a completely blank trace even though
+ * the CLI had reported a status, an error string and full token counts.
+ */
+function mapResultEvent(result) {
+  if (!result || typeof result !== "object") return [];
+  const events = [];
+
+  const response = typeof result.response === "string" ? result.response.trim() : "";
+  if (response) {
+    events.push({ kind: "assistant_text", payload: { text: clip(response) } });
+  }
+
+  const status = result.status ?? null;
+  if (status && status !== "SUCCESS") {
+    events.push({
+      kind: "lifecycle",
+      payload: { note: "agent_error", status, error: result.error ?? null },
+    });
+  }
+
+  events.push({
+    kind: "usage",
+    payload: {
+      durationMs: durationMsOf(result.duration_seconds),
+      numTurns: typeof result.num_turns === "number" ? result.num_turns : null,
+      costUSD: null, // agy bills against the subscription; no per-run cost is reported
+      usage: normalizeUsage(result.usage),
+      status,
+      error: result.error ?? null,
+    },
+  });
+
+  return events;
+}
+
 /**
  * Map one parsed `agy` NDJSON stream line to factory.trace/v1 events.
+ *
+ * Verified against agy 1.1.13's real output (WM-435). What the CLI actually
+ * emits, and the constraints that follow:
+ *
+ * - Steps are keyed by `step_index`, not an id — so the same index correlates
+ *   a tool's ACTIVE and DONE/ERROR events, which is what lets the UI pair them.
+ * - `agent_response` steps carry `usage` and `duration_seconds` and **no text**.
+ *   The agent's prose only ever arrives on the terminal `result` event.
+ * - Tool steps carry no output either. A `tool_result` can honestly report the
+ *   tool, its parameters and how long it took — not what it returned.
+ * - Failure is signalled by `state: "ERROR"` with the detail at
+ *   `tool_info.error.message`; there is no `status` field on a step.
  *
  * @param {any} msg - one parsed NDJSON line from agy stream-json output
  * @returns {Array<{kind: string, payload: object}>}
@@ -142,34 +215,58 @@ function clip(text) {
 export function mapStreamEvent(msg) {
   if (!msg || typeof msg !== "object") return [];
 
-  if (msg.event === "step_update") {
-    const s = msg.step_update ?? {};
-    if (s.step_type === "tool" && s.state === "ACTIVE") {
+  if (msg.event === "result") return mapResultEvent(msg.result);
+  if (msg.event !== "step_update") return [];
+
+  const s = msg.step_update ?? {};
+  const stepIndex = s.step_index === undefined || s.step_index === null ? null : String(s.step_index);
+  const durationMs = durationMsOf(s.duration_seconds);
+
+  if (s.step_type === "tool") {
+    const info = s.tool_info ?? {};
+    const name = s.tool_name ?? info.name ?? "tool";
+    if (s.state === "ACTIVE") {
       return [{
         kind: "tool_use",
-        payload: {
-          id: s.step_id ?? null,
-          name: s.tool_name ?? "tool",
-          input: s.tool_info?.parameters ?? {},
-        },
+        payload: { id: stepIndex, name, input: info.parameters ?? {} },
       }];
     }
-    if (s.step_type === "tool" && s.state === "DONE") {
+    if (s.state === "DONE" || s.state === "ERROR") {
+      const isError = s.state === "ERROR";
       return [{
         kind: "tool_result",
         payload: {
-          toolUseId: s.step_id ?? null,
-          content: clip(s.output ?? s.result ?? ""),
-          isError: s.status === "ERROR",
+          toolUseId: stepIndex,
+          name,
+          content: isError
+            ? clip(info.error?.message ?? `${name} failed`)
+            : `${name} completed${durationMs == null ? "" : ` in ${(durationMs / 1000).toFixed(2)}s`}`,
+          isError,
+          durationMs,
         },
       }];
     }
-    if (s.step_type === "agent_response" && (s.text || s.text_delta)) {
-      return [{
-        kind: "assistant_text",
-        payload: { text: clip(s.text ?? s.text_delta) },
-      }];
-    }
+    return [];
+  }
+
+  if (s.step_type === "error_message") {
+    return [{ kind: "lifecycle", payload: { note: "error_message", stepIndex } }];
+  }
+
+  // agent_response and checkpoint steps exist to report incremental token
+  // spend; surfacing them keeps mid-run accounting available while the run
+  // is still going, which the terminal result alone cannot provide.
+  if (s.usage && typeof s.usage === "object") {
+    return [{
+      kind: "usage",
+      payload: {
+        durationMs,
+        numTurns: null,
+        costUSD: null,
+        usage: normalizeUsage(s.usage),
+        incremental: true,
+      },
+    }];
   }
 
   return [];
@@ -251,18 +348,37 @@ export async function execute({
     if (child.stdout) {
       const lines = createInterface({ input: child.stdout });
       lines.on("line", (line) => {
+        let parsed;
         try {
-          const parsed = JSON.parse(line);
+          parsed = JSON.parse(line);
+        } catch {
+          return; // not JSON — agy interleaves plain text on some paths
+        }
+
+        try {
           const usageInfo = extractUsage(parsed);
           if (usageInfo) {
             finalUsage = usageInfo.usage;
             onUsage?.(usageInfo.usage);
           }
-          for (const event of mapStreamEvent(parsed)) {
-            onTrace?.(event.kind, event.payload);
-          }
         } catch {
-          // not JSON — ignore
+          // usage is accounting, not correctness
+        }
+
+        // Guard each emission separately: one throwing observer must not cost
+        // us the rest of this line's events, nor the run (cf. WM-305 for pi).
+        let events = [];
+        try {
+          events = mapStreamEvent(parsed);
+        } catch {
+          events = [];
+        }
+        for (const event of events) {
+          try {
+            onTrace?.(event.kind, event.payload);
+          } catch {
+            // trace is observability, not correctness
+          }
         }
       });
     }

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -3,9 +3,10 @@
  * third LLM harness alongside `claude` and `pi`, on the Antigravity/Gemini
  * subscription and Google Cloud authentication window.
  *
- * Spawns a bounded `agy -p - --output-format stream-json --dangerously-skip-permissions`
- * process (prompt piped to stdin, the standard `./input.json` → `./result.json`
- * PROMPT_SUFFIX contract, cwd = workspace), enforces the run spec's timeout with
+ * Spawns a bounded `agy -p <prompt> --output-format stream-json --dangerously-skip-permissions`
+ * process (the prompt travels as an argv value and stdin is closed, the standard
+ * `./input.json` → `./result.json` PROMPT_SUFFIX contract, cwd = workspace),
+ * enforces the run spec's timeout with
  * TERM→KILL(killGraceMs), strips API keys so the CLI authenticates against the
  * session/subscription instead of per-token billing, and captures full stdout as
  * the `.transcript.json` artifact.
@@ -20,6 +21,16 @@ export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
 
 export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
+
+/**
+ * How much sooner agy's own print-mode wait expires than the worker's timeout.
+ *
+ * The CLI should give up just before the worker's TERM→KILL so it exits on its
+ * own terms and still emits the terminal `result` event — that event carries
+ * the status, error and token counts the trace and usage accounting depend on.
+ * Killing it first would discard them.
+ */
+export const PRINT_TIMEOUT_GRACE_MS = 5_000;
 
 export class CliNotFoundError extends Error {
   constructor(message) {
@@ -53,8 +64,11 @@ export function buildAgyArgv({ prompt, def, model, effort, workspaceDir, timeout
   }
 
   if (timeoutMs) {
-    const printMin = Math.max(1, Math.round(timeoutMs / 60000) - 2);
-    args.push("--print-timeout", `${printMin}m`);
+    // Seconds, not rounded minutes: `--print-timeout` takes Go duration syntax,
+    // and minute granularity used to floor every sub-three-minute budget to 1m
+    // (a 120s run gave agy 60s, so it quit while the worker still waited).
+    const printSeconds = Math.max(1, Math.round((timeoutMs - PRINT_TIMEOUT_GRACE_MS) / 1000));
+    args.push("--print-timeout", `${printSeconds}s`);
   }
 
   if (typeof model === "string" && model !== "" && model !== "default") {

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -15,83 +15,189 @@ import {
   safeChildEnvironment,
 } from "./agy.mjs";
 
-describe("mapStreamEvent (agy stream-json shapes)", () => {
-  test("agent_response step_update → assistant_text", () => {
-    const events = mapStreamEvent({
-      event: "step_update",
-      step_update: { step_type: "agent_response", state: "ACTIVE", text: "Checking the PR now." },
-    });
-    expect(events).toEqual([{ kind: "assistant_text", payload: { text: "Checking the PR now." } }]);
-  });
-
-  test("tool ACTIVE step_update → tool_use", () => {
-    const events = mapStreamEvent({
-      event: "step_update",
-      step_update: {
-        step_id: "step_123",
-        step_type: "tool",
-        state: "ACTIVE",
-        tool_name: "run_command",
-        tool_info: { parameters: { CommandLine: "bun test" } },
+/**
+ * Verbatim `--output-format stream-json` lines captured from agy 1.1.13 while
+ * it ran a real tool-using prompt (WM-435). These are the shapes the CLI
+ * actually emits; the fixtures they replaced were invented and asserted fields
+ * (`step_id`, `agent_response.text`, `tool.output`, `tool.status`) that agy
+ * has never produced, which is how the mapper shipped broken.
+ */
+const CAPTURED = {
+  toolActive: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    step_index: 3,
+    state: "ACTIVE",
+    step_type: "tool",
+    tool_name: "list_dir",
+    tool_info: { name: "list_dir", parameters: { DirectoryPath: "/tmp/ws" } },
+  },
+  toolDone: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    step_index: 3,
+    state: "DONE",
+    step_type: "tool",
+    tool_name: "list_dir",
+    duration_seconds: 0.099239,
+    tool_info: { name: "list_dir", parameters: { DirectoryPath: "/tmp/ws" } },
+  },
+  toolError: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    step_index: 6,
+    state: "ERROR",
+    step_type: "tool",
+    tool_name: "list_dir",
+    duration_seconds: 0.057997,
+    tool_info: {
+      name: "list_dir",
+      parameters: { DirectoryPath: "/Users/hdkiller/.gemini/antigravity-cli" },
+      error: {
+        type: "TOOL_ERROR",
+        message:
+          "Permission denied for read_file(/Users/hdkiller/.gemini/antigravity-cli). Matches hardcoded system protection boundary rule.",
       },
-    });
-    expect(events).toEqual([
+    },
+  },
+  agentResponse: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    step_index: 2,
+    state: "DONE",
+    step_type: "agent_response",
+    duration_seconds: 2.0848,
+    usage: {
+      input_tokens: 18496,
+      output_tokens: 325,
+      thinking_tokens: 273,
+      cache_read_tokens: 0,
+      total_tokens: 18821,
+    },
+  },
+  errorMessage: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    step_index: 8,
+    state: "DONE",
+    step_type: "error_message",
+  },
+  resultError: {
+    conversation_id: "ce4e067d-e0bb-44ad-8958-658194691858",
+    status: "ERROR",
+    response: "",
+    error: "timeout waiting for response",
+    duration_seconds: 79.744557,
+    num_turns: 1,
+    usage: {
+      input_tokens: 118982,
+      output_tokens: 3219,
+      thinking_tokens: 2055,
+      cache_read_tokens: 488163,
+      total_tokens: 122201,
+    },
+  },
+  resultSuccess: {
+    conversation_id: "aa11bb22-cc33-dd44-ee55-ff6677889900",
+    status: "SUCCESS",
+    response: "/tmp/ws\ninput.json\n",
+    error: null,
+    duration_seconds: 5.5,
+    num_turns: 1,
+    usage: { input_tokens: 100, output_tokens: 20, thinking_tokens: 5, cache_read_tokens: 0, total_tokens: 120 },
+  },
+};
+
+const step = (stepUpdate) => ({ event: "step_update", step_update: stepUpdate });
+
+describe("mapStreamEvent (real agy stream-json shapes)", () => {
+  test("tool ACTIVE → tool_use keyed by step_index", () => {
+    expect(mapStreamEvent(step(CAPTURED.toolActive))).toEqual([
       {
         kind: "tool_use",
-        payload: { id: "step_123", name: "run_command", input: { CommandLine: "bun test" } },
+        payload: { id: "3", name: "list_dir", input: { DirectoryPath: "/tmp/ws" } },
       },
     ]);
   });
 
-  test("tool DONE step_update → tool_result", () => {
-    const ok = mapStreamEvent({
-      event: "step_update",
-      step_update: {
-        step_id: "step_123",
-        step_type: "tool",
-        state: "DONE",
-        tool_name: "run_command",
-        output: "Tests passed\n",
-        status: "SUCCESS",
-      },
-    });
-    expect(ok).toEqual([
-      {
-        kind: "tool_result",
-        payload: { toolUseId: "step_123", content: "Tests passed\n", isError: false },
-      },
-    ]);
+  test("tool DONE → tool_result correlated to its tool_use", () => {
+    const [event] = mapStreamEvent(step(CAPTURED.toolDone));
+    expect(event.kind).toBe("tool_result");
+    // Same step_index as the ACTIVE event above: this is what makes pairing work.
+    expect(event.payload.toolUseId).toBe("3");
+    expect(event.payload.isError).toBe(false);
+    expect(event.payload.durationMs).toBe(99);
+    // agy streams no tool output, so content names what it does provide.
+    expect(event.payload.content).toContain("list_dir");
+  });
 
-    const err = mapStreamEvent({
-      event: "step_update",
-      step_update: {
-        step_id: "step_456",
-        step_type: "tool",
-        state: "DONE",
-        tool_name: "run_command",
-        output: "Failed to run\n",
-        status: "ERROR",
-      },
+  test("tool ERROR → tool_result carrying the error message (WM-435)", () => {
+    const [event] = mapStreamEvent(step(CAPTURED.toolError));
+    expect(event.kind).toBe("tool_result");
+    expect(event.payload.toolUseId).toBe("6");
+    expect(event.payload.isError).toBe(true);
+    expect(event.payload.content).toContain("Permission denied for read_file");
+    expect(event.payload.durationMs).toBe(58);
+  });
+
+  test("agent_response carries usage and no text, so it maps to usage", () => {
+    const [event] = mapStreamEvent(step(CAPTURED.agentResponse));
+    expect(event.kind).toBe("usage");
+    expect(event.payload.usage).toEqual({
+      input: 18496,
+      output: 325,
+      thinking: 273,
+      cacheRead: 0,
+      total: 18821,
     });
-    expect(err).toEqual([
-      {
-        kind: "tool_result",
-        payload: { toolUseId: "step_456", content: "Failed to run\n", isError: true },
-      },
+    expect(event.payload.durationMs).toBe(2085);
+  });
+
+  test("error_message steps surface instead of vanishing", () => {
+    expect(mapStreamEvent(step(CAPTURED.errorMessage))).toEqual([
+      { kind: "lifecycle", payload: { note: "error_message", stepIndex: "8" } },
     ]);
+  });
+
+  test("terminal result reaches the trace with status, error and tokens", () => {
+    const events = mapStreamEvent({ event: "result", result: CAPTURED.resultError });
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain("usage");
+    expect(kinds).toContain("lifecycle");
+
+    const failure = events.find((e) => e.kind === "lifecycle");
+    expect(failure.payload).toEqual({
+      note: "agent_error",
+      status: "ERROR",
+      error: "timeout waiting for response",
+    });
+
+    const usage = events.find((e) => e.kind === "usage");
+    expect(usage.payload.numTurns).toBe(1);
+    expect(usage.payload.durationMs).toBe(79745);
+    expect(usage.payload.usage.input).toBe(118982);
+    expect(usage.payload.usage.cacheRead).toBe(488163);
+
+    // The failed run whose blank trace prompted WM-435 must not be blank now.
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  test("successful result emits the final answer as assistant_text", () => {
+    const events = mapStreamEvent({ event: "result", result: CAPTURED.resultSuccess });
+    const text = events.find((e) => e.kind === "assistant_text");
+    expect(text.payload.text).toBe("/tmp/ws\ninput.json");
+    // A clean run has nothing to report as a failure.
+    expect(events.some((e) => e.kind === "lifecycle")).toBe(false);
   });
 
   test("unrecognized events are ignored silently", () => {
     expect(mapStreamEvent({ event: "init", conversation_id: "abc" })).toEqual([]);
     expect(mapStreamEvent(null)).toEqual([]);
     expect(mapStreamEvent("not an object")).toEqual([]);
+    expect(mapStreamEvent(step({ step_type: "checkpoint", state: "ACTIVE", step_index: 1 }))).toEqual([]);
   });
 
   test("very long assistant text is clipped", () => {
-    const [event] = mapStreamEvent({
-      event: "step_update",
-      step_update: { step_type: "agent_response", state: "ACTIVE", text: "y".repeat(10_000) },
+    const events = mapStreamEvent({
+      event: "result",
+      result: { ...CAPTURED.resultSuccess, response: "y".repeat(10_000) },
     });
+    const [event] = events;
     expect(event.kind).toBe("assistant_text");
     expect(event.payload.text.length).toBeLessThan(4100);
     expect(event.payload.text.endsWith("…[truncated]")).toBe(true);
@@ -249,17 +355,33 @@ describe("execute with fake binary", () => {
     if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("spawns agy, feeds stdin prompt, pipes transcript, records trace", async () => {
+  /** Fake agy emitting the line shapes captured from the real CLI (WM-435). */
+  function writeFakeAgy(binDir, lines) {
+    const fakeAgy = path.join(binDir, "agy");
+    const body = lines.map((l) => `echo ${JSON.stringify(JSON.stringify(l))}`).join("\n");
+    writeFileSync(fakeAgy, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+    return fakeAgy;
+  }
+
+  test("spawns agy, pipes transcript, records a trace of the real event shapes", async () => {
     tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
     const binDir = path.join(tmp, "bin");
     mkdirSync(binDir, { recursive: true });
-    const fakeAgy = path.join(binDir, "agy");
-    const script = `#!/usr/bin/env bash
-echo '{"event":"init","conversation_id":"c1"}'
-echo '{"event":"step_update","step_update":{"step_id":"s1","step_type":"agent_response","text":"Hello world"}}'
-echo '{"event":"result","result":{"status":"SUCCESS","duration_seconds":1,"usage":{"input_tokens":10,"output_tokens":20}}}'
-`;
-    writeFileSync(fakeAgy, script, { mode: 0o755 });
+    writeFakeAgy(binDir, [
+      { event: "init", conversation_id: "c1" },
+      { event: "step_update", step_update: CAPTURED.toolActive },
+      { event: "step_update", step_update: CAPTURED.toolDone },
+      {
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          response: "Listed the workspace.",
+          duration_seconds: 1,
+          num_turns: 2,
+          usage: { input_tokens: 10, output_tokens: 20 },
+        },
+      },
+    ]);
 
     const promptFile = path.join(tmp, "prompt.md");
     writeFileSync(promptFile, "Do task");
@@ -274,10 +396,83 @@ echo '{"event":"result","result":{"status":"SUCCESS","duration_seconds":1,"usage
     });
 
     expect(res.exitCode).toBe(0);
-    expect(traces).toEqual([
-      { kind: "assistant_text", payload: { text: "Hello world" } },
-    ]);
-    expect(res.usage).toEqual({ input: 10, output: 20 });
+    expect(traces.map((t) => t.kind)).toEqual(["tool_use", "tool_result", "assistant_text", "usage"]);
+    // The tool call and its result correlate by step_index.
+    expect(traces[0].payload.id).toBe("3");
+    expect(traces[1].payload.toolUseId).toBe("3");
+    expect(traces[2].payload.text).toBe("Listed the workspace.");
+    expect(res.usage).toEqual({ input: 10, output: 20, turns: 2 });
     expect(existsSync(path.join(tmp, ".transcript.json"))).toBe(true);
+  });
+
+  test("a failed run still produces a trace carrying the error (WM-435)", async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    const binDir = path.join(tmp, "bin");
+    mkdirSync(binDir, { recursive: true });
+    // The exact shape of the 2026-08-16 agy-smoke failures: init, then a
+    // terminal error result. It used to yield zero trace rows.
+    writeFakeAgy(binDir, [
+      { event: "init", conversation_id: "c1" },
+      {
+        event: "result",
+        result: {
+          status: "ERROR",
+          response: "",
+          error: "timeout waiting for response",
+          duration_seconds: 0,
+          num_turns: 0,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      },
+    ]);
+
+    const promptFile = path.join(tmp, "prompt.md");
+    writeFileSync(promptFile, "Do task");
+
+    const traces = [];
+    await execute({
+      spec: {},
+      def: { promptPath: promptFile },
+      workspaceDir: tmp,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+      onTrace: (kind, payload) => traces.push({ kind, payload }),
+    });
+
+    expect(traces.length).toBeGreaterThan(0);
+    const failure = traces.find((t) => t.payload?.note === "agent_error");
+    expect(failure.payload.error).toBe("timeout waiting for response");
+  });
+
+  test("a throwing onTrace observer cannot strand execution (cf. WM-305)", async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), "agy-test-"));
+    const binDir = path.join(tmp, "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFakeAgy(binDir, [
+      { event: "step_update", step_update: CAPTURED.toolActive },
+      {
+        event: "result",
+        result: { status: "SUCCESS", response: "done", duration_seconds: 1, num_turns: 1, usage: {} },
+      },
+    ]);
+
+    const promptFile = path.join(tmp, "prompt.md");
+    writeFileSync(promptFile, "Do task");
+
+    const attempted = [];
+    const res = await execute({
+      spec: {},
+      def: { promptPath: promptFile },
+      workspaceDir: tmp,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+      onTrace: (kind) => {
+        attempted.push(kind);
+        throw new Error("observer exploded");
+      },
+    });
+
+    expect(res.exitCode).toBe(0);
+    // Each event is guarded on its own: throwing on the tool_use must not
+    // swallow the terminal result's events too.
+    expect(attempted).toEqual(["tool_use", "assistant_text", "usage"]);
   });
 });

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -134,7 +134,7 @@ describe("extractUsage", () => {
 });
 
 describe("buildAgyArgv", () => {
-  test("basic flags and stdin prompt format", () => {
+  test("basic flags and argv prompt format", () => {
     const argv = buildAgyArgv({
       def: { prompt: "agents/agy-smoke.md" },
       prompt: "Execute smoke test",
@@ -149,7 +149,31 @@ describe("buildAgyArgv", () => {
     expect(argv).toContain("--add-dir");
     expect(argv).toContain("/tmp/ws");
     expect(argv).toContain("--print-timeout");
-    expect(argv).toContain("3m");
+    expect(argv[argv.indexOf("--print-timeout") + 1]).toBe("295s");
+  });
+
+  test("print-timeout tracks the run budget instead of flooring short runs (WM-439)", () => {
+    // agy-smoke's 120s budget used to round down to the 1m floor, so the CLI
+    // gave up at 60s while the worker was still waiting — the ~64s failures.
+    const argv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md" },
+      prompt: "Execute smoke test",
+      workspaceDir: "/tmp/ws",
+      timeoutMs: 120_000,
+    });
+    const bound = argv[argv.indexOf("--print-timeout") + 1];
+    expect(bound).not.toBe("1m");
+    expect(bound).toBe("115s");
+  });
+
+  test("print-timeout stays positive for a timeout smaller than the grace", () => {
+    const argv = buildAgyArgv({
+      def: { prompt: "agents/agy-smoke.md" },
+      prompt: "Execute smoke test",
+      workspaceDir: "/tmp/ws",
+      timeoutMs: 2_000,
+    });
+    expect(argv[argv.indexOf("--print-timeout") + 1]).toBe("1s");
   });
 
   test("model and effort parameters", () => {


### PR DESCRIPTION
Two fixes to the agy (Antigravity) harness, found while investigating why agy
runs never produced traces. The trace was a symptom; the harness was broken in
three independent ways, verified against **agy 1.1.13** by driving the real CLI
and capturing its raw output.

## WM-439 — print-timeout floored short runs

`buildAgyArgv` derived agy's own wait bound as `round(timeoutMs/60000) - 2`
minutes, so `agy-smoke@1`'s 120s budget became `--print-timeout 1m`: the CLI
gave up at 60s while the worker still waited 120s. That is exactly the ~64s
`agent_exit_1` failures of 2026-08-16.

Now expressed in seconds (Go duration syntax, which the CLI takes natively)
with a named 5s grace, so agy still quits just before the worker's TERM→KILL
and gets to emit its terminal `result` event. Also corrects the module
docstring, which still claimed the prompt is piped to stdin — WM-429 moved it
to argv and stdin is closed.

## WM-435 — the trace mapper targeted a schema agy does not emit

Captured raw `--output-format stream-json` from a real tool-using run. Every
branch of `mapStreamEvent` read at least one field the CLI has never produced:

| assumed | reality |
|---|---|
| `step_id` | `step_index` — so tool_use/tool_result ids were always `null` and could never be paired |
| `agent_response.text` | no text at all, only `usage`/`duration_seconds` — all 19 events dropped |
| `tool.output` | not present — `tool_result` content was always `""` |
| `tool.status === "ERROR"` | the signal is `state`, detail at `tool_info.error.message` — tool failures vanished |
| terminal `result` ignored | the only source of the final answer *and* the failure reason |

Fixed to the real shapes: correlation on `step_index`, tool and terminal
errors surfaced, `result.response` emitted as `assistant_text`, per-step usage
carried for mid-run accounting. Step durations now populate `durationMs`,
which drives the UI's timing waterfall for free.

Replaying the two captured transcripts through the new mapper:

| transcript | before | after |
|---|---|---|
| failed run | 0 trace rows | 58 (18 tool_use, 17 tool_result, 21 usage, 2 lifecycle incl. the permission error) |
| clean run | 0 trace rows | 7, including the final answer |

Fixtures are now verbatim captures. The invented ones they replace are how
this shipped broken, so the tests assert against real output by construction.
Each `onTrace` emission is also guarded separately, so one throwing observer
cannot swallow the rest of a line's events (cf. WM-305).

## Not included

**WM-438** — the root cause of agy never answering at all — is parked in
Triage, unassigned. agy blocks on MCP initialisation in print mode, and the
operator's global `~/.gemini/config/mcp_config.json` configured
`linear-mcp-server` as a *remote* server behind interactive OAuth, which can
never connect headless:

```
mcp_manager.go:848]  MCP: 1 server(s) still connecting after 30s: linear-mcp-server
printmode.go:592]    Print mode: timed out after 224 polls (printed=0)
```

Removing that entry takes `agy -p 'Reply with exactly: pong'` from a 60s+
timeout to a 6s reply. That unblock is applied on the operator's machine but
is not a property of the system — factory runs still inherit whatever MCP
servers the operator configures, which is both a hang risk and capability the
run spec never granted (`agy-smoke@1` declares `capabilities.services: []`).
The durable fix needs a factory-owned config home, and whether agy honours
`$HOME` is still unverified, so it was cut loose rather than blocking these
two. Evidence is recorded on the ticket.

**WM-442** — filed from this work: the web trace view renders an `agent_error`
lifecycle row as the bare note and omits it from the errors filter, so the
failure reason now in the trace is still not visible in the UI.

## Verification

```
bun test event-runtime/lib/adapters/agy.test.mjs   → 21 pass, 0 fail
bun test event-runtime/lib                          → 741 pass, 6 skip, 0 fail
```

Both new behaviours were observed failing before the fixes (8 mapping tests
red against the old mapper; `120_000ms → "1m"` reproduced).

Fixes WM-435
Fixes WM-439
