### PR TITLE
feat(factory): add pulse and watchdog subcommands and evergreen ORCHESTRATOR guide

### DIFF
--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -1,0 +1,269 @@
+# Factory Master Orchestrator Guide
+
+You are the **Master Orchestrator** for the factory. The human operator observes and sets high-level strategy; you prioritize, decide, unblock, and execute autonomously without asking for per-step confirmation. Work continuously to drive and maintain the factory's self-sustaining loops.
+
+---
+
+## 1. Operating Philosophy & Core Goal
+
+### The Goal: Self-Sustaining Autonomous Loops
+Keep the factory operating at peak throughput (~10 concurrent worker runs):
+
+```
+triage-scan (refills supply) ──> work-scan (selects) ──> dispatch (executes in worktree)
+      │                                                                  │
+      └────── back to work-scan <── chain <── merge <── PR + critique <──┘
+```
+
+- **Volume is the point**: High throughput surfaces latent harness defects, contract violations, and race conditions.
+- **Fail-closed discipline**: The system must fail closed (treat unreadable APIs as full pools, block colliding globs, reject unverified tests).
+- **High agency**: Solve problems directly. If a run wedges, unstick it. If supply drops, run a triage sweep. If a merge gate fails on a fixable nit, fix it. Escalate to the human only when policy or security demands it.
+
+---
+
+## 2. Dynamic Boot & Assessment Routine
+
+When you begin an orchestrator session, **never assume state from past notes**. Assess live reality in a single command using `factory pulse`:
+
+```bash
+# Instant one-shot pulse of stack, workers, runs, Linear supply, PRs, and git freshness:
+factory pulse
+
+# Or check system health and detect wedged runs:
+factory watchdog --once
+```
+
+Alternatively, inspect individual components:
+- **Stack & Workers**: `curl -sf http://127.0.0.1:7381/health && bun event-runtime/cli.mjs status`
+- **Supply Queue**: `factory linear queue --team WM`
+- **Open PRs**: `gh pr list --state open`
+- **Git Freshness**: `git status --porcelain && git rev-list --count HEAD..origin/develop`
+
+### Step 2: Check Linear Supply & Queues
+```bash
+# Check dispatchable queue for target teams (e.g. WM, CLNT, OPS)
+factory linear queue --team WM
+factory linear queue --team CLNT
+```
+- **Healthy Supply**: 10–20+ tickets in `Todo` + `ai:agent-ready` + unassigned.
+- **Low Supply (<5 tickets)**: Immediately prioritize a Triage scan and detail-authoring sweep.
+
+### Step 3: Inspect Open PRs & In-Flight Branches
+```bash
+gh pr list --state open --json number,title,headRefName,statusCheckRollup,reviews
+```
+- Identify PRs ready for merge review vs PRs blocked on CI or critique revisions.
+
+### Step 4: Check Workspace Freshness
+```bash
+git fetch --quiet
+git rev-list --count HEAD..origin/develop     # >0 means behind
+git rev-list --count origin/develop..HEAD     # >0 means unpushed commits
+git status --porcelain                       # non-empty means dirty
+```
+
+---
+
+## 3. The 5 Core Orchestration Loops
+
+```mermaid
+flowchart TD
+    subgraph Supply [1. Supply Engine]
+        T[Linear Triage] -->|triage-scan| TS[Classify & Spec]
+        TS -->|write-detail| AR[Todo + ai:agent-ready]
+    end
+
+    subgraph Dispatch [2. Dispatch Engine]
+        AR -->|work-scan| WS[Candidate Selection]
+        WS -->|Check Owned Paths| CD[Collision Matrix & Slots]
+        CD -->|dispatch.requested| WRK[Isolated Worktree Worker]
+    end
+
+    subgraph Merge [3. Merge Pipeline]
+        WRK -->|Handoff + PR| PR[Open PR]
+        PR -->|Observe Fresh CI| CI[CI & UX Critique Gate]
+        CI -->|merge-scan / merge-apply| MRG[Auto-merge to develop]
+        MRG -->|Trigger chain edges| WS
+    end
+
+    subgraph Watchdog [4. Watchdog & Recovery]
+        WD[Watchdog Sweep] -->|Detect Wedged/Pinned| REC[cli.mjs retry --force / kill]
+    end
+
+    subgraph Decisions [5. Decision Engine]
+        ESC[needs_human / Auth / Infra] -->|factory notify| HUM[Operator Alert]
+    end
+```
+
+---
+
+### Loop 1: Supply & Triage Engine
+Workers idle if supply dries up. Ensure a continuous pipeline of dispatchable work:
+
+1. **Trigger Triage Scans**: Convert raw `Triage` issues into actionable candidates.
+2. **Author Specifications (`write-detail`)**:
+   - Ensure tickets have unambiguous **Acceptance criteria**.
+   - Ensure **Owned Paths** are explicit globs covering all required files.
+   - Ensure a deterministic **Verification** command is specified.
+3. **Guardrails for Ticket Authoring**:
+   - **Agent prompt edits (`.md`) must own their definition `.json`**: Updating an agent definition requires `bun event-runtime/cli.mjs update-pins`.
+   - **Source files require generated outputs**: Edits to `shared/**` must include `dist/**` in Owned Paths (checked by `bun build/emit.mjs --check`).
+   - **Satisfiability**: Acceptance criteria must be 100% achievable within declared Owned Paths.
+   - **Empty read trap**: Beware network drops reporting "0 issues" when Triage has work. Always verify raw counts before concluding supply is exhausted.
+
+---
+
+### Loop 2: Work Selection & Collision-Safe Dispatch
+
+1. **Capacity vs Collision Sets**:
+   - **Capacity**: Active `RUNNING` or `VERIFYING` runs occupy physical worker slots (up to max workers, e.g. 10).
+   - **Collision Matrix**: All in-flight runs *plus* pending `PROPOSED` runs claim their `Owned Paths`.
+   - A new ticket can ONLY be dispatched if its `Owned Paths` are strictly disjoint from all in-flight and proposed tickets.
+2. **Dispatching**:
+   - Dispatch via event-runtime proposal approval or CLI injection:
+     ```bash
+     bun event-runtime/cli.mjs propose dispatch.requested --payload '{"ticketId":"WM-123"}'
+     ```
+3. **Idempotency Pin Trap**:
+   - A `FAILED` or `BLOCKED` run pins its ticket's idempotency key. A duplicate `dispatch.requested` will be ignored as `noop`.
+   - To re-run: `bun event-runtime/cli.mjs retry <runId> --force`.
+
+---
+
+### Loop 3: Merge & Chain Pipeline
+
+The factory automatically merges PRs targeting `develop` once all gates pass.
+
+1. **The 4 Pre-Merge Verification Gates**:
+   - [ ] **Code Diff Read**: You must read the diff (`gh pr diff <PR>`). Never merge on green CI alone.
+   - [ ] **Live Observed CI**: You must observe the CI run in a non-completed state before accepting a green verdict. Rerunning via `gh run rerun` on a cached pass will not re-execute!
+   - [ ] **Structured Handoff**: PR must contain the mandatory `## Handoff` section with verification output, UX critique verdict, and file scope.
+   - [ ] **Branch Deletion Guard**: Delete only the head branch of the specific PR merged (`HEAD_REF`). **NEVER delete `develop`, `master`, or release PR branches (`develop -> master`)**.
+2. **Never Auto-Merge (Escalation Triggers)**:
+   - Escalate immediately with `ai:escalated` on Linear and `factory notify`:
+     - Auth / Authz logic changes
+     - Payment / Billing / Money movement
+     - Secret / Token / Credential handling
+     - Destructive database migrations
+     - Production infrastructure / Terraform / deploy pipelines
+     - `CLNT` security policy behavior
+3. **Chaining**:
+   - When a ticket completes and merges, review downstream dependencies (`edges.json`) and immediately trigger dependent `work-scan` proposals.
+
+---
+
+### Loop 4: Watchdog, Recovery & Self-Healing
+
+1. **Wedged Run Detection**:
+   - A run in `RUNNING` without heartbeats for >20 mins or holding a slot past its timeout must be investigated.
+   - Inspect: `bun event-runtime/cli.mjs inspect <runId>`
+   - Cancel / Clean: Terminate stuck process, unassign ticket back to `Todo` if clean, or mark `BLOCKED`.
+2. **Stack Refresh**:
+   - When agent markdown prompts, tools, or schemas are modified on `develop`, restart the live stack so workers load the new definitions:
+     ```bash
+     bin/live-stack.sh down
+     bin/live-stack.sh up --workers 3:10
+     ```
+3. **Fail-Closed Stance**:
+   - If the API (`:7381`) is unreachable or returns 500s, treat the worker pool as **FULL** and hold dispatch until recovery.
+
+---
+
+### Loop 5: Decision & Human Escalation Protocol
+
+Use the interrupt channel strictly for critical events requiring human operator action.
+
+#### Approved Telegram Notify Events
+Execute:
+```bash
+factory notify "<EVENT> <TICKET/PR>: <one answerable sentence>"
+```
+
+| Event Prefix | When to Use |
+| :--- | :--- |
+| `BLOCKED` | A ticket is blocked on missing credentials, contradictory specs, or unresolvable environment issues. |
+| `ESCALATED` | Security, auth, money movement, or destructive migration PR requires human review and merge approval. |
+| `CI RED` | `develop` trunk CI broken by an unexpected regression. All dispatch paused until trunk is green. |
+| `SMOKE RED` | Post-deploy smoke test failure on staging/production. |
+| `CIRCUIT BREAKER` | Repeated cascade failures across worker nodes (e.g. 5+ consecutive runner crashes). |
+| `RC READY` | Release candidate PR (`develop -> master`) prepared, green, and awaiting human sign-off. |
+
+*Routine updates (claims, routine merges, spec completions) belong in Linear comments and session summaries, never notify.*
+
+---
+
+## 4. Command Center Reference
+
+```bash
+# --- Orchestrator Pulse & Watchdog ---
+factory pulse                            # One-shot composite pulse (stack, workers, supply, PRs)
+factory pulse --json                     # Structured JSON pulse
+factory watchdog --once                  # One-shot health inspection & anomaly detection
+factory watchdog --interval-sec 300 --notify # Background daemon with Telegram alerts
+
+# --- Live Stack Management ---
+bin/live-stack.sh up --workers 3:10      # Start API, Web UI, and 10 workers
+bin/live-stack.sh down                   # Graceful shutdown
+bin/live-stack.sh ps                     # List running factory processes
+
+# --- Event Runtime CLI ---
+export FACTORY_EVENT_SECRET=$(cat ~/.factory/orchestration/event-secret.txt)
+bun event-runtime/cli.mjs status         # Summary of active pool, proposals, runs
+bun event-runtime/cli.mjs proposals      # Pending proposals awaiting execution
+bun event-runtime/cli.mjs runs           # In-flight and recent runs
+bun event-runtime/cli.mjs inspect <runId># Full execution receipt, lifecycle & logs
+bun event-runtime/cli.mjs retry <runId> --force # Force retry pinned failed run
+bun event-runtime/cli.mjs update-pins    # Regenerate agent definition hashes
+
+# --- Linear CLI (factory linear) ---
+factory linear queue --team WM           # Query dispatchable tickets
+factory linear get WM-123                # Read ticket, criteria, owned paths
+factory linear claim WM-123 --agent claude # Claim + assign + In Progress
+factory linear comment WM-123 "..."      # Post heartbeat or status
+factory linear state WM-123 "In Review" --add ai:needs-review # Advance state
+factory linear detail WM-123 "..."       # Append criteria / verification block
+factory linear file --team WM --title "..." --body "..." --type bug # File new issue
+
+# --- CI & GitHub Checks ---
+gh pr checks <PR> --watch --fail-fast    # Wait for checks to settle
+gh run watch <run-id> --exit-status      # Watch GitHub actions run without polling loops
+```
+
+---
+
+## 5. Catalog of Known Traps & Non-Negotiables
+
+| Trap | Mechanism | Hard-Won Rule |
+| :--- | :--- | :--- |
+| **CI Rerun Cache** | `gh run rerun` on a green run is refused; on a failed run, it reuses the run ID attempt. | Observe the CI run in an active/non-completed state before trusting a green verdict. |
+| **`GET /runs` No `spec`** | `GET /runs` lacks the `spec` field (WM-303). Reading `row.spec` yields empty. | Read run metadata and ticket identity from `eventId` or `cli.mjs inspect <runId>`. |
+| **Idempotency Pinning** | `FAILED`/`BLOCKED` runs pin their input hash key; re-injected `dispatch.requested` no-ops. | Always use `cli.mjs retry <runId> --force` to unstick a failed run. |
+| **`git stash` in Worktrees** | The stash stack (`.git/refs/stash`) is repo-global, not isolated per worktree. | **NEVER use `git stash` or `git rebase --autostash`** in agent worktrees. Use temporary patches or WIP commits. |
+| **macOS Bash 3.2** | Default macOS bash lacks `mapfile` / `readarray` and modern expansions. | Use POSIX `while IFS= read -r line` loops in all shell scripts. |
+| **Prettier Scope** | Running prettier across whole repo reformats hundreds of `.mjs` files unnecessarily. | Prettier is configured ONLY for `shared/**/*.md` (`bun run format:check`). |
+| **Label Replacement** | Direct GraphQL label mutations replace the whole array, wiping `type:*` and `area:*`. | Always use `--add` / `--remove` flags via `factory linear state` or `factory linear labels`. |
+
+---
+
+## 6. Orchestrator Cycle Checklist
+
+Execute this loop continuously during an orchestrator shift:
+
+1. **Assess Pool Capacity**: How many workers are active? Are any slots free?
+2. **Review Open PRs**:
+   - Are checks green? Has diff been reviewed?
+   - Is UX critique satisfied?
+   - Merge if safe, or request revisions / escalate if blocked.
+3. **Check Supply**:
+   - Are ready tickets $\ge$ available worker slots?
+   - If low, run `triage-scan` and `write-detail` on Linear backlog.
+4. **Dispatch Disjoint Candidates**:
+   - Select highest priority agent-ready tickets.
+   - Verify zero overlap in `Owned Paths` with all active + proposed runs.
+   - Dispatch to fill available worker slots.
+5. **Watchdog Sweep**:
+   - Scan for stalled runs, dead workers, or pinned idempotency keys.
+   - Auto-recover or notify if intervention is required.
+6. **Log Progress**:
+   - Heartbeat active tickets on Linear.
+   - Maintain concise, honest execution logs.

--- a/bin/factory
+++ b/bin/factory
@@ -68,6 +68,8 @@ case "$cmd" in
   next)         run_bun orchestrator/next.mjs "$@" ;;
   state)        run_bun orchestrator/state.mjs "$@" ;;
   status)       run_bun orchestrator/status.mjs "$@" ;;
+  pulse)        run_bun orchestrator/pulse.mjs "$@" ;;
+  watchdog)     run_bun orchestrator/watchdog.mjs "$@" ;;
   ps)           run_bun orchestrator/ps.mjs "$@" ;;
   workers)      run_bun orchestrator/workers.mjs "$@" ;;
   friction)     run_bun orchestrator/friction.mjs "$@" ;;
@@ -239,6 +241,8 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   next          orchestrator/next.mjs
   state         orchestrator/state.mjs
   status        orchestrator/status.mjs (repo, deployment, and factory snapshot)
+  pulse         orchestrator/pulse.mjs (composite stack, worker, supply, and PR pulse)
+  watchdog      orchestrator/watchdog.mjs (health monitor, wedged run detector, and circuit breaker)
   ps            orchestrator/ps.mjs (factory processes, ports, workers, and agents)
   workers       orchestrator/workers.mjs (remote worker fleet and version skew)
   friction      orchestrator/friction.mjs

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -174,3 +174,29 @@ test("factory inject delegates to event-runtime/cli.mjs", () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr.toString()).toContain("usage: inject <envelope.json|->");
 });
+
+test("factory pulse executes via CLI", () => {
+  const result = Bun.spawnSync({
+    cmd: ["bash", FACTORY, "pulse", "--json"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  const json = JSON.parse(result.stdout.toString());
+  expect(json).toHaveProperty("stack");
+  expect(json).toHaveProperty("supply");
+  expect(json).toHaveProperty("workspace");
+});
+
+test("factory watchdog executes via CLI", () => {
+  const result = Bun.spawnSync({
+    cmd: ["bash", FACTORY, "watchdog", "--json", "--once"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.stdout.toString().length).toBeGreaterThan(0);
+  const json = JSON.parse(result.stdout.toString());
+  expect(json).toHaveProperty("ok");
+  expect(json).toHaveProperty("issues");
+  expect(json).toHaveProperty("metrics");
+});

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env bun
+/**
+ * Factory Pulse — single-shot composite status report for master orchestrator.
+ *
+ *   factory pulse
+ *   factory pulse --repo factory
+ *   factory pulse --json
+ *
+ * Gathers stack health, worker capacity, in-flight runs, Linear supply depth,
+ * and open PR status in a single pass.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { gql } from "./reaper.mjs";
+import { ROOT } from "../lib/schedule.mjs";
+
+const c = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+};
+
+function sh(args, cwd = ROOT) {
+  try {
+    const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
+    return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+  } catch (err) {
+    return { ok: false, out: "", err: String(err) };
+  }
+}
+
+export async function gatherPulse({
+  port = 7381,
+  host = "127.0.0.1",
+  repoName = "factory",
+  fetchLinear = true,
+  fetchGitHub = true,
+} = {}) {
+  const pulse = {
+    timestamp: new Date().toISOString(),
+    stack: { api: { ok: false }, web: { ok: false }, workers: { total: 0, busy: 0, idle: 0, list: [] } },
+    runs: { active: [], proposed: 0, byState: {} },
+    supply: { repo: repoName, team: "WM", dispatchable: 0, triage: 0, tickets: [] },
+    prs: { total: 0, candidates: [] },
+    workspace: { branch: "unknown", head: "unknown", behind: 0, ahead: 0, clean: true },
+  };
+
+  // 1. API Health & Status
+  try {
+    const healthRes = await fetch(`http://${host}:${port}/health`, { signal: AbortSignal.timeout(3000) });
+    if (healthRes.ok) {
+      const healthJson = await healthRes.json();
+      pulse.stack.api = { ok: true, policyVersion: healthJson.policyVersion, env: healthJson.env?.name };
+    }
+  } catch (err) {
+    pulse.stack.api = { ok: false, error: err.message };
+  }
+
+  // 2. Web UI Health
+  try {
+    const webRes = await fetch(`http://${host}:7382/`, { signal: AbortSignal.timeout(2000) });
+    pulse.stack.web = { ok: webRes.ok || webRes.status === 404 }; // serving HTTP
+  } catch {
+    pulse.stack.web = { ok: false };
+  }
+
+  // 3. Status & Workers & Runs from API (if alive)
+  if (pulse.stack.api.ok) {
+    try {
+      const [statusRes, workersRes, runsRes] = await Promise.all([
+        fetch(`http://${host}:${port}/status`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/workers`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+        fetch(`http://${host}:${port}/runs?state=RUNNING`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+      ]);
+
+      if (workersRes?.workers) {
+        const workers = workersRes.workers;
+        pulse.stack.workers = {
+          total: workers.length,
+          busy: workers.filter((w) => w.state === "busy").length,
+          idle: workers.filter((w) => w.state === "idle").length,
+          list: workers.map((w) => ({ id: w.workerId, state: w.state, host: w.host, runId: w.runId })),
+        };
+      }
+
+      if (statusRes?.runs?.byState) {
+        pulse.runs.byState = statusRes.runs.byState;
+      }
+      if (statusRes?.proposals?.open) {
+        pulse.runs.proposed = statusRes.proposals.open;
+      }
+
+      if (runsRes?.runs) {
+        pulse.runs.active = runsRes.runs.map((r) => ({
+          runId: r.runId,
+          agent: r.agent,
+          state: r.state,
+          eventId: r.eventId,
+          model: r.model,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
+        }));
+      }
+    } catch {
+      // partial fetch failure handled gracefully
+    }
+  }
+
+  // 4. Linear Supply
+  if (fetchLinear) {
+    try {
+      // Find repo team from repos.yaml
+      let team = "WM";
+      try {
+        const reposCfg = Bun.YAML.parse(readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"));
+        const match = (reposCfg.repos ?? []).find((r) => r.name === repoName);
+        if (match?.team) team = match.team;
+      } catch {}
+      pulse.supply.team = team;
+
+      const d = await gql(
+        `query($t:String!){
+          issues(first:100, filter:{ team:{key:{eq:$t}}, state:{type:{nin:["completed","canceled"]}} }){
+            nodes{ id identifier title state{ name } labels(first:20){ nodes{ name } } assignee{ name } }
+          }
+        }`,
+        { t: team },
+      );
+
+      const nodes = d?.issues?.nodes ?? [];
+      const ready = nodes.filter(
+        (i) =>
+          i.state?.name === "Todo" &&
+          !i.assignee &&
+          (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"),
+      );
+      const triage = nodes.filter((i) => i.state?.name === "Triage");
+
+      pulse.supply.dispatchable = ready.length;
+      pulse.supply.triage = triage.length;
+      pulse.supply.tickets = ready.slice(0, 5).map((i) => ({ identifier: i.identifier, title: i.title }));
+    } catch (err) {
+      pulse.supply.error = err.message;
+    }
+  }
+
+  // 5. Open GitHub PRs
+  if (fetchGitHub) {
+    try {
+      const p = sh(["gh", "pr", "list", "--state", "open", "--limit", "15", "--json", "number,title,headRefName,isDraft,statusCheckRollup"]);
+      if (p.ok && p.out) {
+        const prs = JSON.parse(p.out);
+        pulse.prs.total = prs.length;
+        pulse.prs.candidates = prs.map((pr) => {
+          const checks = pr.statusCheckRollup ?? [];
+          let ciStatus = "NONE";
+          if (checks.length > 0) {
+            const hasFailure = checks.some((c) => c.conclusion === "FAILURE");
+            const hasPending = checks.some((c) => c.status === "IN_PROGRESS" || c.status === "QUEUED");
+            const allSuccess = checks.every((c) => c.conclusion === "SUCCESS");
+            if (hasFailure) ciStatus = "FAILING";
+            else if (hasPending) ciStatus = "PENDING";
+            else if (allSuccess) ciStatus = "PASSING";
+          }
+          return {
+            number: pr.number,
+            title: pr.title,
+            headRefName: pr.headRefName,
+            isDraft: pr.isDraft,
+            ciStatus,
+          };
+        });
+      }
+    } catch {
+      // gh CLI not available or errored
+    }
+  }
+
+  // 6. Workspace Freshness
+  try {
+    const branchRes = sh(["git", "branch", "--show-current"]);
+    const headRes = sh(["git", "rev-parse", "--short", "HEAD"]);
+    const statusRes = sh(["git", "status", "--porcelain"]);
+    const behindRes = sh(["git", "rev-list", "--count", "HEAD..origin/develop"]);
+    const aheadRes = sh(["git", "rev-list", "--count", "origin/develop..HEAD"]);
+
+    pulse.workspace = {
+      branch: branchRes.ok ? branchRes.out : "unknown",
+      head: headRes.ok ? headRes.out : "unknown",
+      behind: behindRes.ok ? parseInt(behindRes.out, 10) || 0 : 0,
+      ahead: aheadRes.ok ? parseInt(aheadRes.out, 10) || 0 : 0,
+      clean: statusRes.ok && statusRes.out.length === 0,
+    };
+  } catch {}
+
+  return pulse;
+}
+
+export function formatPulse(pulse) {
+  const lines = [];
+  lines.push(c.bold(`FACTORY PULSE — ${new Date(pulse.timestamp).toUTCString()}`));
+  lines.push("");
+
+  // Stack & Workers
+  lines.push(c.bold("STACK & WORKERS"));
+  const apiStatus = pulse.stack.api.ok
+    ? `${c.green("✓ healthy")} ${c.dim(`(policy: ${pulse.stack.api.policyVersion || "unknown"})`)}`
+    : c.red("✗ down");
+  lines.push(`  API (:7381):     ${apiStatus}`);
+
+  const webStatus = pulse.stack.web.ok ? c.green("✓ up") : c.yellow("! down or unreachable");
+  lines.push(`  Web (:7382):     ${webStatus}`);
+
+  const workers = pulse.stack.workers;
+  const workerDetail = workers.total > 0
+    ? `${workers.total} registered (${c.green(`${workers.busy} busy`)}, ${workers.idle} idle)`
+    : c.yellow("0 registered");
+  lines.push(`  Workers:         ${workerDetail}`);
+  lines.push("");
+
+  // In-Flight Runs
+  const activeRuns = pulse.runs.active;
+  lines.push(c.bold(`IN-FLIGHT RUNS (${activeRuns.length} active, ${pulse.runs.proposed} proposed)`));
+  if (activeRuns.length === 0) {
+    lines.push(c.dim("  No runs currently executing"));
+  } else {
+    for (const r of activeRuns) {
+      const ageMs = Date.now() - new Date(r.created_at || Date.now()).getTime();
+      const ageMin = Math.round(ageMs / 60000);
+      lines.push(`  ${c.cyan(r.runId.slice(0, 12))} ${c.bold(r.agent)} [${r.state}] (${ageMin}m) ${c.dim(r.eventId || "")}`);
+    }
+  }
+  lines.push("");
+
+  // Linear Supply
+  lines.push(c.bold(`LINEAR SUPPLY (${pulse.supply.team || "WM"})`));
+  if (pulse.supply.error) {
+    lines.push(`  ${c.red("Linear read error:")} ${pulse.supply.error}`);
+  } else {
+    const supplyColor = pulse.supply.dispatchable >= 5 ? c.green : (pulse.supply.dispatchable > 0 ? c.yellow : c.red);
+    lines.push(`  Dispatchable:    ${supplyColor(`${pulse.supply.dispatchable} tickets`)} in Todo (ai:agent-ready, unassigned)`);
+    lines.push(`  Triage Backlog:  ${pulse.supply.triage} tickets in Triage`);
+    if (pulse.supply.tickets.length > 0) {
+      lines.push(c.dim("  Next up:"));
+      for (const t of pulse.supply.tickets) {
+        lines.push(`    ${c.bold(t.identifier)}  ${t.title}`);
+      }
+    }
+  }
+  lines.push("");
+
+  // Open PRs
+  lines.push(c.bold(`OPEN PULL REQUESTS (${pulse.prs.total} open)`));
+  if (pulse.prs.candidates.length === 0) {
+    lines.push(c.dim("  No open pull requests"));
+  } else {
+    for (const pr of pulse.prs.candidates.slice(0, 8)) {
+      let ciBadge = c.dim("[NO CI]");
+      if (pr.ciStatus === "PASSING") ciBadge = c.green("[CI PASS]");
+      else if (pr.ciStatus === "FAILING") ciBadge = c.red("[CI FAIL]");
+      else if (pr.ciStatus === "PENDING") ciBadge = c.yellow("[CI PENDING]");
+
+      const draftBadge = pr.isDraft ? c.dim("(draft) ") : "";
+      lines.push(`  ${c.bold(`#${pr.number}`)} ${ciBadge} ${draftBadge}${pr.title.slice(0, 60)}`);
+    }
+  }
+  lines.push("");
+
+  // Workspace
+  lines.push(c.bold("WORKSPACE"));
+  const cleanStatus = pulse.workspace.clean ? c.green("clean") : c.yellow("dirty (uncommitted changes)");
+  const syncStatus = pulse.workspace.behind > 0
+    ? c.yellow(`behind origin/develop by ${pulse.workspace.behind}`)
+    : (pulse.workspace.ahead > 0 ? c.cyan(`ahead of origin/develop by ${pulse.workspace.ahead}`) : c.green("up to date"));
+  lines.push(`  Branch:          ${c.bold(pulse.workspace.branch)} @ ${pulse.workspace.head} (${syncStatus})`);
+  lines.push(`  Working tree:    ${cleanStatus}`);
+
+  return lines.join("\n");
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const jsonOut = argv.includes("--json");
+  const repoIdx = argv.indexOf("--repo");
+  const repoName = repoIdx !== -1 ? argv[repoIdx + 1] : "factory";
+
+  const pulse = await gatherPulse({ repoName });
+  if (jsonOut) {
+    console.log(JSON.stringify(pulse, null, 2));
+  } else {
+    console.log(formatPulse(pulse));
+  }
+}

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -33,6 +33,23 @@ function sh(args, cwd = ROOT) {
   }
 }
 
+function hasLinearKey() {
+  if (process.env.LINEAR_API_KEY) return true;
+  const envPaths = [
+    path.join(homedir(), "Develop/hdkiller/.env"),
+    path.join(process.cwd(), ".env"),
+  ];
+  for (const envPath of envPaths) {
+    if (existsSync(envPath)) {
+      try {
+        const content = readFileSync(envPath, "utf8");
+        if (content.includes("LINEAR_API_KEY=")) return true;
+      } catch {}
+    }
+  }
+  return false;
+}
+
 export async function gatherPulse({
   port = 7381,
   host = "127.0.0.1",
@@ -122,27 +139,31 @@ export async function gatherPulse({
       } catch {}
       pulse.supply.team = team;
 
-      const d = await gql(
-        `query($t:String!){
-          issues(first:100, filter:{ team:{key:{eq:$t}}, state:{type:{nin:["completed","canceled"]}} }){
-            nodes{ id identifier title state{ name } labels(first:20){ nodes{ name } } assignee{ name } }
-          }
-        }`,
-        { t: team },
-      );
+      if (!hasLinearKey()) {
+        pulse.supply.error = "LINEAR_API_KEY not configured";
+      } else {
+        const d = await gql(
+          `query($t:String!){
+            issues(first:100, filter:{ team:{key:{eq:$t}}, state:{type:{nin:["completed","canceled"]}} }){
+              nodes{ id identifier title state{ name } labels(first:20){ nodes{ name } } assignee{ name } }
+            }
+          }`,
+          { t: team },
+        );
 
-      const nodes = d?.issues?.nodes ?? [];
-      const ready = nodes.filter(
-        (i) =>
-          i.state?.name === "Todo" &&
-          !i.assignee &&
-          (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"),
-      );
-      const triage = nodes.filter((i) => i.state?.name === "Triage");
+        const nodes = d?.issues?.nodes ?? [];
+        const ready = nodes.filter(
+          (i) =>
+            i.state?.name === "Todo" &&
+            !i.assignee &&
+            (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"),
+        );
+        const triage = nodes.filter((i) => i.state?.name === "Triage");
 
-      pulse.supply.dispatchable = ready.length;
-      pulse.supply.triage = triage.length;
-      pulse.supply.tickets = ready.slice(0, 5).map((i) => ({ identifier: i.identifier, title: i.title }));
+        pulse.supply.dispatchable = ready.length;
+        pulse.supply.triage = triage.length;
+        pulse.supply.tickets = ready.slice(0, 5).map((i) => ({ identifier: i.identifier, title: i.title }));
+      }
     } catch (err) {
       pulse.supply.error = err.message;
     }

--- a/orchestrator/pulse.test.mjs
+++ b/orchestrator/pulse.test.mjs
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test";
+import { formatPulse, gatherPulse } from "./pulse.mjs";
+
+test("formatPulse renders structured pulse text", () => {
+  const samplePulse = {
+    timestamp: "2026-08-16T20:00:00.000Z",
+    stack: {
+      api: { ok: true, policyVersion: "git:test1234" },
+      web: { ok: true },
+      workers: { total: 3, busy: 1, idle: 2, list: [] },
+    },
+    runs: {
+      active: [
+        {
+          runId: "run_test_123456",
+          agent: "dispatch@1",
+          state: "RUNNING",
+          created_at: new Date(Date.now() - 5 * 60000).toISOString(),
+          eventId: "test:event",
+        },
+      ],
+      proposed: 0,
+      byState: { RUNNING: 1, COMPLETED: 10 },
+    },
+    supply: {
+      repo: "factory",
+      team: "WM",
+      dispatchable: 5,
+      triage: 20,
+      tickets: [{ identifier: "WM-100", title: "Sample ticket title" }],
+    },
+    prs: {
+      total: 1,
+      candidates: [
+        {
+          number: 99,
+          title: "Fix sample bug",
+          headRefName: "feat/sample",
+          isDraft: false,
+          ciStatus: "PASSING",
+        },
+      ],
+    },
+    workspace: {
+      branch: "develop",
+      head: "abc1234",
+      behind: 0,
+      ahead: 0,
+      clean: true,
+    },
+  };
+
+  const output = formatPulse(samplePulse);
+  expect(output).toContain("FACTORY PULSE");
+  expect(output).toContain("STACK & WORKERS");
+  expect(output).toContain("API (:7381):");
+  expect(output).toContain("git:test1234");
+  expect(output).toContain("IN-FLIGHT RUNS");
+  expect(output).toContain("run_test_123");
+  expect(output).toContain("LINEAR SUPPLY (WM)");
+  expect(output).toContain("5 tickets");
+  expect(output).toContain("WM-100");
+  expect(output).toContain("#99");
+  expect(output).toContain("[CI PASS]");
+});
+
+test("gatherPulse handles unreachable API gracefully", async () => {
+  const pulse = await gatherPulse({
+    port: 59999, // unreachable port
+    fetchLinear: false,
+    fetchGitHub: false,
+  });
+
+  expect(pulse.stack.api.ok).toBe(false);
+  expect(pulse.stack.workers.total).toBe(0);
+  expect(pulse.runs.active.length).toBe(0);
+});

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env bun
+/**
+ * Factory Watchdog — health inspection, wedged run detection, and circuit breaker.
+ *
+ *   factory watchdog --once
+ *   factory watchdog --interval-sec 300 --notify
+ *   factory watchdog --json
+ *
+ * Checks API/Web health, worker fleet, wedged runs, idle stalls, and CI runner status.
+ * Emits factory notify alerts on critical failures.
+ */
+import { existsSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { ROOT } from "../lib/schedule.mjs";
+
+const c = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+};
+
+function sh(args, cwd = ROOT) {
+  try {
+    const result = Bun.spawnSync({ cmd: args, cwd, stdout: "pipe", stderr: "pipe" });
+    return { ok: result.exitCode === 0, out: result.stdout.toString().trim(), err: result.stderr.toString().trim() };
+  } catch (err) {
+    return { ok: false, out: "", err: String(err) };
+  }
+}
+
+export async function runWatchdogCheck({
+  host = "127.0.0.1",
+  port = 7381,
+  webPort = 7382,
+  stuckMinutes = 45,
+  checkShadowFleet = true,
+} = {}) {
+  const issues = [];
+  const metrics = {
+    apiOk: false,
+    webOk: false,
+    workersCount: 0,
+    runningRuns: 0,
+    wedgedRuns: 0,
+    queuedRuns: 0,
+    anomalies: [],
+  };
+
+  // 1. Control API Health
+  try {
+    const res = await fetch(`http://${host}:${port}/health`, { signal: AbortSignal.timeout(3000) });
+    if (res.ok) {
+      metrics.apiOk = true;
+    } else {
+      issues.push({ severity: "CRITICAL", code: "API_ERROR", message: `Control API returned HTTP ${res.status}` });
+    }
+  } catch (err) {
+    issues.push({ severity: "CRITICAL", code: "API_DOWN", message: `Control API on :${port} unreachable: ${err.message}` });
+  }
+
+  // 2. Web UI Health
+  try {
+    const webRes = await fetch(`http://${host}:${webPort}/`, { signal: AbortSignal.timeout(2000) });
+    metrics.webOk = webRes.ok || webRes.status === 404;
+  } catch {
+    issues.push({ severity: "WARNING", code: "WEB_DOWN", message: `Web UI on :${webPort} unreachable` });
+  }
+
+  // If API is down, we cannot perform status/workers checks
+  if (!metrics.apiOk) {
+    return { ok: false, issues, metrics };
+  }
+
+  // 3. Workers & Runs Status from API
+  try {
+    const [statusRes, workersRes, runningRes] = await Promise.all([
+      fetch(`http://${host}:${port}/status`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+      fetch(`http://${host}:${port}/workers`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+      fetch(`http://${host}:${port}/runs?state=RUNNING`, { signal: AbortSignal.timeout(3000) }).then((r) => r.json()),
+    ]);
+
+    const workers = workersRes?.workers ?? [];
+    metrics.workersCount = workers.length;
+    if (workers.length === 0) {
+      issues.push({ severity: "CRITICAL", code: "NO_WORKERS", message: "No live workers registered in event runtime" });
+    }
+
+    const runs = runningRes?.runs ?? [];
+    metrics.runningRuns = runs.length;
+    const now = Date.now();
+    const wedged = runs.filter((r) => {
+      const created = new Date(r.created_at || now).getTime();
+      const updated = new Date(r.updated_at || r.created_at || now).getTime();
+      const ageMin = (now - created) / 60000;
+      const quietMin = (now - updated) / 60000;
+      return ageMin > stuckMinutes && quietMin > stuckMinutes / 2;
+    });
+
+    metrics.wedgedRuns = wedged.length;
+    for (const w of wedged) {
+      const ageMin = Math.round((now - new Date(w.created_at).getTime()) / 60000);
+      issues.push({
+        severity: "CRITICAL",
+        code: "WEDGED_RUN",
+        message: `Run ${w.runId} (${w.agent}) in ${w.state} for ${ageMin}m without progress`,
+      });
+    }
+
+    metrics.queuedRuns = statusRes?.runs?.byState?.QUEUED ?? 0;
+    const idleWorkers = workers.filter((w) => w.state === "idle").length;
+    if (metrics.queuedRuns > 0 && idleWorkers > 0 && metrics.runningRuns === 0) {
+      issues.push({
+        severity: "WARNING",
+        code: "IDLE_STALL",
+        message: `${metrics.queuedRuns} runs queued with ${idleWorkers} idle workers, but 0 running`,
+      });
+    }
+
+    if (statusRes?.anomalies) {
+      const anomalyList = [];
+      for (const [key, val] of Object.entries(statusRes.anomalies)) {
+        if (Array.isArray(val) && val.length > 0) {
+          anomalyList.push(`${key}: ${val.length}`);
+        } else if (typeof val === "number" && val > 0) {
+          anomalyList.push(`${key}: ${val}`);
+        }
+      }
+      metrics.anomalies = anomalyList;
+      if (anomalyList.length > 0) {
+        issues.push({
+          severity: "WARNING",
+          code: "RUNTIME_ANOMALIES",
+          message: `Runtime reported anomalies (${anomalyList.join(", ")})`,
+        });
+      }
+    }
+  } catch (err) {
+    issues.push({ severity: "WARNING", code: "STATUS_FETCH_ERROR", message: `Failed fetching status details: ${err.message}` });
+  }
+
+  // 4. CI Runner Fleet Check
+  if (checkShadowFleet) {
+    try {
+      const ciqRes = sh(["gh", "run", "list", "--repo", "watt-mind/factory", "--limit", "10", "--json", "status", "-q", "[.[] | select(.status==\"queued\")] | length"]);
+      const queuedCount = parseInt(ciqRes.out, 10) || 0;
+      if (queuedCount > 2) {
+        const shadowRes = sh(["gh", "api", "orgs/watt-mind/actions/runners", "--jq", "[.runners[] | select(.labels | map(.name) | index(\"shadow\")) | select(.status==\"online\")] | length"]);
+        const onlineShadows = parseInt(shadowRes.out, 10) || 0;
+        if (onlineShadows === 0) {
+          issues.push({
+            severity: "CRITICAL",
+            code: "FLEET_OFFLINE",
+            message: `${queuedCount} CI runs queued with 0 online shadow runners (actions.runner fleet down)`,
+          });
+        }
+      }
+    } catch {}
+  }
+
+  const hasCritical = issues.some((i) => i.severity === "CRITICAL");
+  return {
+    ok: !hasCritical,
+    issues,
+    metrics,
+  };
+}
+
+export function formatWatchdogReport(result) {
+  const lines = [];
+  const ts = new Date().toUTCString();
+  if (result.ok && result.issues.length === 0) {
+    lines.push(`${c.green("✓")} ${c.bold("WATCHDOG OK")} — ${ts}`);
+    lines.push(`  Workers: ${result.metrics.workersCount} | Running: ${result.metrics.runningRuns} | Wedged: ${result.metrics.wedgedRuns}`);
+  } else {
+    const badge = result.ok ? c.yellow("! WATCHDOG WARNING") : c.red("✗ WATCHDOG CRITICAL");
+    lines.push(`${badge} — ${ts}`);
+    for (const issue of result.issues) {
+      const col = issue.severity === "CRITICAL" ? c.red : c.yellow;
+      lines.push(`  ${col(`[${issue.severity}]`)} ${c.bold(issue.code)}: ${issue.message}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function sendWatchdogNotification(issues) {
+  const critical = issues.filter((i) => i.severity === "CRITICAL");
+  if (critical.length === 0) return;
+
+  const eventType = critical.some((i) => i.code === "FLEET_OFFLINE" || i.code === "API_DOWN")
+    ? "CIRCUIT BREAKER"
+    : "BLOCKED";
+
+  const msg = `${eventType} watchdog: ${critical.map((i) => i.message).join("; ")}`;
+  try {
+    const result = Bun.spawnSync({
+      cmd: ["factory", "notify", msg],
+      cwd: ROOT,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const jsonOut = argv.includes("--json");
+  const once = argv.includes("--once");
+  const shouldNotify = argv.includes("--notify");
+  const intervalIdx = argv.indexOf("--interval-sec");
+  const intervalSec = intervalIdx !== -1 ? parseInt(argv[intervalIdx + 1], 10) || 300 : 300;
+
+  async function tick() {
+    const result = await runWatchdogCheck();
+    if (jsonOut) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatWatchdogReport(result));
+    }
+
+    if (shouldNotify && !result.ok) {
+      await sendWatchdogNotification(result.issues);
+    }
+    return result;
+  }
+
+  if (once) {
+    const result = await tick();
+    process.exit(result.ok ? 0 : 1);
+  } else {
+    console.log(c.bold(`Starting factory watchdog daemon (checking every ${intervalSec}s)...`));
+    await tick();
+    setInterval(async () => {
+      await tick();
+    }, intervalSec * 1000);
+  }
+}

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import { formatWatchdogReport, runWatchdogCheck } from "./watchdog.mjs";
+
+test("formatWatchdogReport formats clean watchdog status", () => {
+  const cleanResult = {
+    ok: true,
+    issues: [],
+    metrics: {
+      apiOk: true,
+      webOk: true,
+      workersCount: 3,
+      runningRuns: 1,
+      wedgedRuns: 0,
+      queuedRuns: 0,
+      anomalies: [],
+    },
+  };
+
+  const formatted = formatWatchdogReport(cleanResult);
+  expect(formatted).toContain("WATCHDOG OK");
+  expect(formatted).toContain("Workers: 3");
+  expect(formatted).toContain("Running: 1");
+});
+
+test("formatWatchdogReport formats critical issues", () => {
+  const badResult = {
+    ok: false,
+    issues: [
+      {
+        severity: "CRITICAL",
+        code: "WEDGED_RUN",
+        message: "Run run_test_123 in RUNNING for 55m without progress",
+      },
+      {
+        severity: "WARNING",
+        code: "WEB_DOWN",
+        message: "Web UI on :7382 unreachable",
+      },
+    ],
+    metrics: {
+      apiOk: true,
+      webOk: false,
+      workersCount: 2,
+      runningRuns: 1,
+      wedgedRuns: 1,
+      queuedRuns: 0,
+      anomalies: [],
+    },
+  };
+
+  const formatted = formatWatchdogReport(badResult);
+  expect(formatted).toContain("WATCHDOG CRITICAL");
+  expect(formatted).toContain("[CRITICAL]");
+  expect(formatted).toContain("WEDGED_RUN");
+  expect(formatted).toContain("[WARNING]");
+  expect(formatted).toContain("WEB_DOWN");
+});
+
+test("runWatchdogCheck detects unreachable API as critical", async () => {
+  const result = await runWatchdogCheck({
+    port: 59998, // unreachable
+    webPort: 59997,
+    checkShadowFleet: false,
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.issues.some((i) => i.code === "API_DOWN")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Replaces point-in-time `HANDOFF.md` with an evergreen `ORCHESTRATOR.md` operational guide for master orchestrator agents.
- Implements `factory pulse` (`orchestrator/pulse.mjs`) for a single-shot composite environment dashboard.
- Implements `factory watchdog` (`orchestrator/watchdog.mjs`) for automated health checks, wedged run detection, and circuit breaker alerting.
- Adds comprehensive unit tests for `pulse`, `watchdog`, and CLI routing.

## Handoff
- Verification: `bun test orchestrator/pulse.test.mjs orchestrator/watchdog.test.mjs bin/factory.test.mjs && bun run check` — pass, all 15 tests passed and 90 generated files match
- UX critique: skipped — CLI tooling and documentation
- Files: 7 changed, all within Owned Paths
- Risks: none known

Fixes WM-437
Fixes WM-441