### PR TITLE
fix(merge): conform merge-fix results to contract

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -34,7 +34,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:ff834ffe712fc62389ab890d14ea08f1a92b9c5b99ad6dc688315680a3be220f",
+    "agents/merge-fix.md": "sha256:0c60e0346e1c58fe32a7eb86d4b8cd812d59a79174baff0b571142f0ce40a327",
     "schemas/merge-fix.input.json": "sha256:71a8c16d52dfc908972bf3f9ca6d942c93ab6b0213588298a1cd2715e265aa6c",
     "schemas/merge-fix.output.json": "sha256:0aa6ba59514abbb6609ef53c124f627c7e5ab09eca655696c99aa4e38e34ce46"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -23,3 +23,48 @@ new=<newSha>`. Do not merge, approve, mark Done, or delete anything.
 If the branch cannot be reconstructed safely, verification fails, a path is
 out of scope, or any evidence is uncertain, preserve the worktree/branch,
 block the ticket with one answerable reason, and return BLOCKED.
+
+## Result contract
+
+Write `result.json` as a completed `factory.agent-result/v1` result whose
+`artifact` conforms to `factory.merge-fix-result/v1`. Both artifacts must
+contain exactly these properties, in this order: `outcome`, `repo`, `ticket`,
+`pr`, `headSha`, `round`, `summary`. Do not add diagnostic properties; put the
+reason or change description in `summary`.
+
+Copy `repo`, `ticket`, `pr`, and `round` from `input.json`. Substitute the real
+values for the representative values below.
+
+### UPDATED artifact
+
+Use the new commit SHA that was successfully pushed as `headSha`:
+
+```json
+{
+  "outcome": "UPDATED",
+  "repo": "factory",
+  "ticket": "WM-500",
+  "pr": 42,
+  "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "round": 1,
+  "summary": "Applied the mechanical correction, verified it, and pushed the updated head."
+}
+```
+
+### BLOCKED artifact
+
+Use the pinned `input.json` `headSha` as the required `headSha`, including when
+the live PR head moved. Describe the observed mismatch or other blocking reason
+only in `summary`:
+
+```json
+{
+  "outcome": "BLOCKED",
+  "repo": "factory",
+  "ticket": "WM-500",
+  "pr": 42,
+  "headSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "round": 1,
+  "summary": "Blocked because the live PR head no longer matches the pinned input head."
+}
+```

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -20,6 +20,7 @@ import { admitEvent as persistEvent } from "./lib/intake.mjs";
 import { planAdmittedEvents } from "./lib/planner.mjs";
 import { approveProposal, openProposals } from "./lib/proposals.mjs";
 import { loadRegistry } from "./lib/registry.mjs";
+import { validate } from "./lib/schema.mjs";
 import { runOnce } from "./lib/worker.mjs";
 import {
   commandFixture,
@@ -279,6 +280,48 @@ function seedCompleted(db, { runId, agent, input, artifact }) {
      VALUES (?,1,?,'hash','{}','{}',?)`,
   ).run(runId, canonicalJson({ artifact }), now);
 }
+
+describe("merge-fix result contract (WM-447)", () => {
+  test("UPDATED and BLOCKED prompt artifacts exactly match the registered schema", () => {
+    const def = registry.agents.get("merge-fix@1");
+    const schema = def.outputSchema;
+    const prompt = readFileSync(def.promptPath, "utf8");
+    const declaration = prompt.match(
+      /Both artifacts must\s+contain exactly these properties, in this order:([\s\S]*?)\. Do not add/,
+    );
+
+    expect(declaration).not.toBeNull();
+    expect(
+      [...declaration[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]),
+    ).toEqual(schema.required);
+
+    for (const outcome of ["UPDATED", "BLOCKED"]) {
+      const example = prompt.match(
+        new RegExp(
+          `### ${outcome} artifact[\\s\\S]*?` +
+            "```json\\n([\\s\\S]*?)\\n```",
+        ),
+      );
+
+      expect(example).not.toBeNull();
+      const artifact = JSON.parse(example[1]);
+      expect(Object.keys(artifact)).toEqual(schema.required);
+      expect(artifact.outcome).toBe(outcome);
+      expect(validate(schema, artifact)).toEqual({ valid: true, errors: [] });
+    }
+  });
+
+  test("BLOCKED explicitly retains the pinned input head SHA", () => {
+    const prompt = readFileSync(
+      registry.agents.get("merge-fix@1").promptPath,
+      "utf8",
+    );
+
+    expect(prompt).toMatch(
+      /Use the pinned `input\.json` `headSha` as the required `headSha`, including when\s+the live PR head moved/,
+    );
+  });
+});
 
 describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {


### PR DESCRIPTION
## Summary
- document exact schema-valid UPDATED and BLOCKED merge-fix artifacts
- require BLOCKED results to retain the pinned input head SHA
- validate prompt examples and declared fields against the registered schema
- regenerate the merge-fix prompt integrity pin

## Verification
- `bun test event-runtime/merge.test.mjs && bun run format:check`

UX critique: skipped — internal agent prompt and contract regression only; no user-facing flow

Fixes WM-447