### PR TITLE
fix(event-runtime): pass CURSOR_API_KEY through to agent -p (WM-443)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -443,9 +443,14 @@ writes — print without it only proposes them. `--mode ask|plan` is
 documented no-edits and is never passed: it would fail the result contract
 (OPS-518). Read-only containment is the workspace cwd plus the worker
 integrity gate, same audited-not-enforced framing as pi. `--worktree` is
-Cursor's own worktree feature and is never passed. `CURSOR_API_KEY` and
-`CURSOR_API_ENDPOINT` are stripped so the CLI uses the login session under
-`HOME`. Trace mapping targets the documented stream-json shapes:
+Cursor's own worktree feature and is never passed. `CURSOR_API_KEY` is
+passed through: CLI 2026.08.11 `agent -p` does not consume the
+`agent login` session and exits 1 without the key (WM-443). That key is a
+Cursor user credential and bills the account's plan / included usage
+pools, not a provider BYOK invoice. `CURSOR_API_ENDPOINT` and provider
+keys stay stripped. A non-zero CLI exit writes workspace `.stderr.txt`
+and a `lifecycle` trace (`note: adapter_stderr`) so inspect is not blank.
+Trace mapping targets the documented stream-json shapes:
 `assistant` (complete messages only) → `assistant_text`, `tool_call`
 started/completed → `tool_use`/`tool_result`, terminal `result` → `usage`
 (duration only; Cursor does not report tokens). A missing CLI is a typed

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -4,9 +4,10 @@
  * `agent -p --output-format stream-json` process (prompt as a positional
  * argument, the standard `./input.json` → `./result.json` PROMPT_SUFFIX
  * contract, cwd = workspace), enforces the run spec's timeout with
- * TERM→KILL(killGraceMs), strips provider API keys (including CURSOR_API_KEY)
- * so the CLI authenticates against the login/subscription session, and
- * captures full stdout as the `.transcript.json` artifact.
+ * TERM→KILL(killGraceMs), strips provider API keys and `CURSOR_API_ENDPOINT`,
+ * passes `CURSOR_API_KEY` through (`agent -p` does not consume the login
+ * session — WM-443), captures full stdout as the `.transcript.json` artifact,
+ * and on a non-zero exit writes `.stderr.txt` plus a `lifecycle` trace.
  *
  * Flags confirmed against the installed CLI (`agent` 2026.08.11,
  * `agent --help`), not inferred from Claude/Pi:
@@ -25,7 +26,7 @@
  * editor CLI.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, readFileSync } from "node:fs";
+import { createWriteStream, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { FACTORY_ROOT } from "../config.mjs";
@@ -89,6 +90,10 @@ export function buildCursorArgv({ prompt, model }) {
 export const BASE_INHERITED_ENV = [
   "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "PATH", "SHELL", "TERM",
   "TMPDIR", "USER", "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+  // `agent -p` ignores the login session and requires this Cursor user key
+  // (WM-443). It authenticates as the account and bills the user's plan —
+  // not a provider BYOK key. Still strip CURSOR_API_ENDPOINT below.
+  "CURSOR_API_KEY",
 ];
 
 /**
@@ -96,8 +101,9 @@ export const BASE_INHERITED_ENV = [
  * Fail-closed: only an explicit `mutating: true` (or a boolean `true`)
  * inherits push credentials (pi's rule, not Claude's legacy).
  *
- * `CURSOR_API_KEY` is stripped so the CLI uses the login session under HOME
- * rather than per-token billing — same rationale as the other LLM adapters.
+ * `CURSOR_API_KEY` is passed through: CLI 2026.08.11 `agent -p` does not
+ * use the `agent login` session (WM-443). Provider keys and
+ * `CURSOR_API_ENDPOINT` stay stripped.
  */
 export function safeChildEnvironment(env = {}, defOrOpts = {}) {
   const isMutating = typeof defOrOpts === "boolean" ? defOrOpts : defOrOpts?.mutating === true;
@@ -110,7 +116,7 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
   for (const key of [
     "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
     "GOOGLE_GENAI_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY",
-    "CURSOR_API_KEY", "CURSOR_API_ENDPOINT",
+    "CURSOR_API_ENDPOINT",
     "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
   ]) {
     delete childEnv[key];
@@ -278,6 +284,15 @@ export async function execute({
       child.stdout.pipe(transcript);
     }
 
+    const STDERR_FILE_CHARS = 16_384;
+    let stderrBuf = "";
+    if (child.stderr) {
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        stderrBuf = (stderrBuf + chunk).slice(-STDERR_FILE_CHARS);
+      });
+    }
+
     const policyDenials = [];
     let lastTool = null;
     const toolNames = new Map();
@@ -371,6 +386,18 @@ export async function execute({
         });
       } catch {
         // same
+      }
+      if (exitCode !== 0 && stderrBuf) {
+        try {
+          writeFileSync(path.join(workspaceDir, ".stderr.txt"), stderrBuf, "utf8");
+        } catch {
+          // workspace may already be gone; trace still carries the tail
+        }
+        try {
+          onTrace?.("lifecycle", { note: "adapter_stderr", text: clip(stderrBuf) });
+        } catch {
+          // observability
+        }
       }
       resolve({ exitCode, timedOut, policyDenials: exitCode === 0 ? [] : policyDenials });
     });

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -183,7 +183,7 @@ describe("safeChildEnvironment", () => {
     process.env = { ...originalEnv };
   });
 
-  test("strips provider and Cursor API keys, keeps declared env", () => {
+  test("keeps CURSOR_API_KEY, strips provider keys and CURSOR_API_ENDPOINT (WM-443)", () => {
     const env = safeChildEnvironment({
       ANTHROPIC_API_KEY: "a",
       OPENAI_API_KEY: "b",
@@ -192,12 +192,19 @@ describe("safeChildEnvironment", () => {
       CUSTOM_VAR: "kept",
     });
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
-    expect(env.CURSOR_API_KEY).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBe("cursor-secret");
     expect(env.CURSOR_API_ENDPOINT).toBeUndefined();
     expect(env.CUSTOM_VAR).toBe("kept");
   });
 
-  test("strips push credentials for non-mutating runs", () => {
+  test("inherits CURSOR_API_KEY from process.env when caller env omits it (WM-443)", () => {
+    process.env.CURSOR_API_KEY = "from-process";
+    const env = safeChildEnvironment({ CUSTOM_VAR: "kept" });
+    expect(env.CURSOR_API_KEY).toBe("from-process");
+    expect(env.CUSTOM_VAR).toBe("kept");
+  });
+
+  test("strips push credentials for non-mutating runs and still keeps CURSOR_API_KEY", () => {
     const childEnv = safeChildEnvironment({
       SSH_AUTH_SOCK: "/tmp/test.sock",
       GITHUB_TOKEN: "ghp_secret",
@@ -206,10 +213,10 @@ describe("safeChildEnvironment", () => {
     for (const key of PUSH_CREDENTIAL_ENV) {
       expect(childEnv[key]).toBeUndefined();
     }
-    expect(childEnv.CURSOR_API_KEY).toBeUndefined();
+    expect(childEnv.CURSOR_API_KEY).toBe("sk");
   });
 
-  test("preserves push credentials for mutating runs while still stripping API keys", () => {
+  test("preserves push credentials for mutating runs and keeps CURSOR_API_KEY", () => {
     const childEnv = safeChildEnvironment({
       SSH_AUTH_SOCK: "/tmp/agent.sock",
       GITHUB_TOKEN: "ghp_mutating",
@@ -217,7 +224,7 @@ describe("safeChildEnvironment", () => {
     }, { mutating: true });
     expect(childEnv.SSH_AUTH_SOCK).toBe("/tmp/agent.sock");
     expect(childEnv.GITHUB_TOKEN).toBe("ghp_mutating");
-    expect(childEnv.CURSOR_API_KEY).toBeUndefined();
+    expect(childEnv.CURSOR_API_KEY).toBe("sk");
   });
 
   test("defaults to stripping when mutating is omitted", () => {
@@ -274,6 +281,11 @@ if (behavior === "normal") {
 }
 
 if (behavior === "exit_code") {
+  process.exit(parseInt(process.env.FACTORY_TEST_EXIT_CODE || "1", 10));
+}
+
+if (behavior === "stderr_then_exit") {
+  process.stderr.write(process.env.FACTORY_TEST_STDERR || "Error: Authentication required.\\n");
   process.exit(parseInt(process.env.FACTORY_TEST_EXIT_CODE || "1", 10));
 }
 
@@ -382,7 +394,7 @@ if (behavior === "emit_error_tool_result") {
     }
   }
 
-  test("executes stub binary in workspaceDir, strips keys, prompt on argv, captures transcript + trace", async () => {
+  test("executes stub binary in workspaceDir, passes CURSOR_API_KEY, prompt on argv, captures transcript + trace", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");
     const traceEvents = [];
@@ -394,7 +406,7 @@ if (behavior === "emit_error_tool_result") {
       timeoutMs: 5000,
       env: {
         PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
-        CURSOR_API_KEY: "sk-must-be-stripped",
+        CURSOR_API_KEY: "sk-must-be-passed",
         CUSTOM_VAR: "custom_value",
         FACTORY_TEST_BEHAVIOR: "normal",
         FACTORY_TEST_RECORD_FILE: recordFile,
@@ -406,7 +418,7 @@ if (behavior === "emit_error_tool_result") {
     expect(existsSync(recordFile)).toBe(true);
     const record = JSON.parse(readFileSync(recordFile, "utf8"));
     expect(record.cwd).toBe(workspaceDir);
-    expect(record.env.CURSOR_API_KEY).toBeUndefined();
+    expect(record.env.CURSOR_API_KEY).toBe("sk-must-be-passed");
     expect(record.env.CUSTOM_VAR).toBe("custom_value");
     expect(record.argv).toContain("-p");
     expect(record.argv).toContain("--output-format");
@@ -443,6 +455,32 @@ if (behavior === "emit_error_tool_result") {
     });
     expect(outcome.exitCode).toBe(42);
     expect(outcome.timedOut).toBe(false);
+  });
+
+  test("nonzero exit writes .stderr.txt and emits adapter_stderr lifecycle (WM-443)", async () => {
+    const workspaceDir = ws();
+    const traceEvents = [];
+    const stderr = "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.\n";
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "stderr_then_exit",
+        FACTORY_TEST_STDERR: stderr,
+        FACTORY_TEST_EXIT_CODE: "1",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+    expect(outcome.exitCode).toBe(1);
+    expect(readFileSync(path.join(workspaceDir, ".stderr.txt"), "utf8")).toBe(stderr);
+    expect(traceEvents.some((e) => (
+      e.kind === "lifecycle"
+      && e.payload?.note === "adapter_stderr"
+      && String(e.payload?.text ?? "").includes("Authentication required")
+    ))).toBe(true);
   });
 
   testProcessGroup("timeout kills a real long-lived grandchild (WM-263)", async () => {


### PR DESCRIPTION
## Summary
- `agent -p` does not use the `agent login` session (CLI 2026.08.11). Live `cursor-smoke@1` failed with `agent_exit_1` because the adapter stripped `CURSOR_API_KEY`.
- Pass that Cursor user key through so print mode can authenticate against the account plan / included Ultra pools. Keep stripping `CURSOR_API_ENDPOINT` and provider BYOK keys.
- On a non-zero CLI exit, write workspace `.stderr.txt` and emit a `lifecycle` trace (`note: adapter_stderr`) so inspect is not a blank transcript.

## Test plan
- [x] `bun test event-runtime/lib/adapters/cursor.test.mjs` — 33 pass (new tests observed failing before the fix)
- [ ] After merge + worker reload: inject `factory.cursor-smoke.requested`, approve, confirm COMPLETED echo

## Risks
Credential handling: the child now inherits `CURSOR_API_KEY`. That is the documented headless auth for this CLI, not a provider API key. Do not auto-merge.

UX critique: skipped — adapter/env/docs only; no user-completable UI flow.

Fixes WM-443

Made with [Cursor](https://cursor.com)