### PR TITLE
fix(event-runtime-web): preserve lifecycle reason tooltips

### DIFF
--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -176,10 +176,14 @@ describe("Lifecycle reason readability (WM-145)", () => {
     );
     expect(failedRow).toBeTruthy();
 
-    const titled = Array.from(failedRow!.querySelectorAll("[title]")).filter((el) =>
-      (el.getAttribute("title") ?? "").includes(LONG_REASON),
+    const expectedTitle = `worker_test · ${LONG_REASON}`;
+    const titled = Array.from(failedRow!.querySelectorAll("[title]")).filter(
+      (el) => el.getAttribute("title") === expectedTitle,
     );
-    expect(titled.length).toBeGreaterThan(0);
+    // Both the reason wrapper and the nested ActorRef jump link expose the
+    // composite title, so hovering the actor cannot mask the reason.
+    expect(titled.length).toBe(2);
+    expect(failedRow!.querySelector("button")?.getAttribute("title")).toBe(expectedTitle);
 
     const truncated = Array.from(failedRow!.querySelectorAll(".truncate")).filter((el) =>
       el.textContent?.includes(LONG_REASON),

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -184,14 +184,22 @@ export function isWorkerId(actor: string): boolean {
   return /^worker_.+/.test(actor);
 }
 
-export function ActorRef({ actor, className }: { actor: string; className?: string }) {
-  if (!isWorkerId(actor)) return <span title={actor}>{actor}</span>;
+export function ActorRef({
+  actor,
+  className,
+  title = actor,
+}: {
+  actor: string;
+  className?: string;
+  title?: string;
+}) {
+  if (!isWorkerId(actor)) return <span title={title}>{actor}</span>;
   return (
     <JumpLink
       onClick={() => {
         window.location.hash = `#/${withProject(hashPath("workers", actor), hashProject(window.location.hash))}`;
       }}
-      title={actor}
+      title={title}
       className={className}
     >
       {shortId(actor)}
@@ -609,7 +617,11 @@ export function RunDetailBlocks({
                     className="min-w-0 flex-1 break-words whitespace-pre-wrap text-[11.5px] leading-relaxed text-(--text-faint)"
                     title={e.reason ? `${e.actor} · ${e.reason}` : e.actor}
                   >
-                    <ActorRef actor={e.actor} className="text-[11.5px]" />
+                    <ActorRef
+                      actor={e.actor}
+                      className="text-[11.5px]"
+                      title={e.reason ? `${e.actor} · ${e.reason}` : e.actor}
+                    />
                     {e.reason ? ` · ${e.reason}` : ""}
                   </span>
                 </span>

--- a/event-runtime/web/src/isWorkerId.test.ts
+++ b/event-runtime/web/src/isWorkerId.test.ts
@@ -50,6 +50,7 @@ describe("ActorRef component", () => {
       const { container, queryByRole } = render(createElement(ActorRef, { actor }));
       expect(queryByRole("button")).toBeNull();
       expect(container.textContent).toBe(actor);
+      expect(container.querySelector("span")?.getAttribute("title")).toBe(actor);
     },
   );
 
@@ -63,6 +64,15 @@ describe("ActorRef component", () => {
     fireEvent.click(link);
     expect(window.location.hash).toBe(`#/workers/${workerId}`);
   });
+
+  test.each(["planner", "worker_12345_a1b2c3d4"])(
+    "uses an explicit title for actor '%s'",
+    (actor) => {
+      const title = `${actor} · attempt timed out`;
+      const { container } = render(createElement(ActorRef, { actor, title }));
+      expect(container.querySelector("[title]")?.getAttribute("title")).toBe(title);
+    },
+  );
 
   test("short worker id renders a jump link and updates hash on click", () => {
     const workerId = "worker_1";


### PR DESCRIPTION
## Summary
- let `ActorRef` accept a title override while retaining actor-only fallback behavior
- pass lifecycle actor/reason composite titles to nested worker links and static actor text
- cover composite and fallback titles in focused component tests

## Verification
- `cd event-runtime/web && bun test src/components/RunDetailBlocks.test.tsx src/isWorkerId.test.ts` — 30 pass, 0 fail

UX critique: required — SHIP; evidence: http://127.0.0.1:7795/#/runs/run_30769060-5b42-4a6e-a94a-417067a23900

Follow-up mobile-width finding filed as WM-462.

Fixes WM-167