### PR TITLE
test(web): lock RunTrace live states

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -1,9 +1,9 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import type { TraceEntry } from "../types";
+import type { RunState, TraceEntry } from "../types";
 import { changeInput, renderWithClient, restoreApi } from "../test-render";
-import { RunTrace } from "./RunTrace";
+import { LIVE_STATES, RunTrace } from "./RunTrace";
 
 afterEach(() => {
   cleanup();
@@ -26,7 +26,7 @@ const TRACE: TraceEntry[] = [
   }),
 ];
 
-function renderTrace(overrides?: { state?: "RUNNING" | "COMPLETED" }) {
+function renderTrace(overrides?: { state?: RunState }) {
   return renderWithClient(
     <RunTrace
       runId="run_trace_a11y"
@@ -49,6 +49,26 @@ async function waitForChrome(r: ReturnType<typeof renderTrace>) {
 }
 
 describe("RunTrace a11y (WM-143)", () => {
+  test("locks live trace behavior across every RunState (WM-174)", () => {
+    const expectedLiveness: Record<RunState, boolean> = {
+      PROPOSED: false,
+      APPROVED: false,
+      QUEUED: false,
+      LEASED: true,
+      RUNNING: true,
+      VERIFYING: true,
+      COMPLETED: false,
+      REFUSED: false,
+      FAILED: false,
+      TIMED_OUT: false,
+      CANCELLED: false,
+    };
+
+    for (const state of Object.keys(expectedLiveness) as RunState[]) {
+      expect(LIVE_STATES.includes(state)).toBe(expectedLiveness[state]);
+    }
+  });
+
   test("renders no emoji in trace chrome (tools, tokens, errors, jump, clear)", async () => {
     const r = renderTrace();
     const tablist = await waitForChrome(r);
@@ -112,49 +132,52 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(r.getByRole("tab", { name: /^Usage/ }).getAttribute("aria-selected")).toBe("true");
   });
 
-  test("typing words with x in search input does not trigger cancellation or blur (WM-267)", async () => {
-    let cancelKeyDownDispatchedToBody = false;
-    const bodyListener = (e: KeyboardEvent) => {
-      if (e.key === "x" && e.target === document.body) {
-        cancelKeyDownDispatchedToBody = true;
+  test.each(["LEASED", "RUNNING", "VERIFYING"] as const)(
+    "typing words with x in search input does not trigger cancellation or blur while %s (WM-267, WM-174)",
+    async (state) => {
+      let cancelKeyDownDispatchedToBody = false;
+      const bodyListener = (e: KeyboardEvent) => {
+        if (e.key === "x" && e.target === document.body) {
+          cancelKeyDownDispatchedToBody = true;
+        }
+      };
+      document.body.addEventListener("keydown", bodyListener);
+
+      try {
+        const r = renderTrace({ state });
+        await waitForChrome(r);
+
+        const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
+        search.focus();
+        expect(document.activeElement).toBe(search);
+
+        // Type words containing 'x' (exec, regex, context)
+        act(() => {
+          changeInput(search, "exec");
+        });
+        expect(search.value).toBe("exec");
+
+        // Press 'x' key directly while search input is focused
+        fireEvent.keyDown(search, { key: "x" });
+
+        // Search input must remain focused (not blurred)
+        expect(document.activeElement).toBe(search);
+        // No synthetic x event redispatched to document.body
+        expect(cancelKeyDownDispatchedToBody).toBe(false);
+
+        // Typing more words containing 'x'
+        act(() => {
+          changeInput(search, "regex context");
+        });
+        expect(search.value).toBe("regex context");
+        fireEvent.keyDown(search, { key: "x" });
+        expect(document.activeElement).toBe(search);
+        expect(cancelKeyDownDispatchedToBody).toBe(false);
+      } finally {
+        document.body.removeEventListener("keydown", bodyListener);
       }
-    };
-    document.body.addEventListener("keydown", bodyListener);
-
-    try {
-      const r = renderTrace({ state: "RUNNING" });
-      await waitForChrome(r);
-
-      const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
-      search.focus();
-      expect(document.activeElement).toBe(search);
-
-      // Type words containing 'x' (exec, regex, context)
-      act(() => {
-        changeInput(search, "exec");
-      });
-      expect(search.value).toBe("exec");
-
-      // Press 'x' key directly while search input is focused
-      fireEvent.keyDown(search, { key: "x" });
-
-      // Search input must remain focused (not blurred)
-      expect(document.activeElement).toBe(search);
-      // No synthetic x event redispatched to document.body
-      expect(cancelKeyDownDispatchedToBody).toBe(false);
-
-      // Typing more words containing 'x'
-      act(() => {
-        changeInput(search, "regex context");
-      });
-      expect(search.value).toBe("regex context");
-      fireEvent.keyDown(search, { key: "x" });
-      expect(document.activeElement).toBe(search);
-      expect(cancelKeyDownDispatchedToBody).toBe(false);
-    } finally {
-      document.body.removeEventListener("keydown", bodyListener);
-    }
-  });
+    },
+  );
 
   test("single-key shortcuts 1-5 and [ / ] switch filter tabs (WM-217)", async () => {
     const r = renderTrace();

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -12,7 +12,7 @@ function copyText(text: string, label: string = "text") {
 }
 
 /** States in which the trace is still being written — poll incrementally. */
-const LIVE_STATES: RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
+export const LIVE_STATES: readonly RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
 
 /** Server page cap; the recorder's row cap (2000 + 1 marker) is ≤ 5 pages. */
 const PAGE = 500;


### PR DESCRIPTION
## Summary
- export the RunTrace live-state set for direct regression coverage
- exhaustively lock liveness for every RunState variant
- exercise x-containing search input across LEASED, RUNNING, and VERIFYING

## Verification
- `bun test event-runtime/web/src/components/RunTrace.test.tsx` — 11 pass, 0 fail

UX critique: skipped — regression-test coverage and const export only; runtime UI behavior is unchanged.

Fixes WM-174