### PR TITLE
fix(dispatch): use standard event-runtime port

### DIFF
--- a/tools/dispatch.mjs
+++ b/tools/dispatch.mjs
@@ -13,8 +13,13 @@
  */
 import { parseArgs } from "node:util";
 
-const DEFAULT_PORT = 7391;
-const port = process.env.FACTORY_EVENT_PORT ? Number(process.env.FACTORY_EVENT_PORT) : DEFAULT_PORT;
+export const DEFAULT_PORT = 7381;
+
+export function resolvePort(env = process.env) {
+  return env.FACTORY_EVENT_PORT ? Number(env.FACTORY_EVENT_PORT) : DEFAULT_PORT;
+}
+
+const port = resolvePort();
 const BASE_URL = `http://127.0.0.1:${port}`;
 
 const HELP = `factory dispatch — swift event-runtime task dispatcher
@@ -208,4 +213,6 @@ async function main() {
   }
 }
 
-main().catch((e) => die(e.message));
+if (import.meta.main) {
+  main().catch((e) => die(e.message));
+}

--- a/tools/dispatch.test.mjs
+++ b/tools/dispatch.test.mjs
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { DEFAULT_PORT, resolvePort } from "./dispatch.mjs";
+
+test("defaults to the standard event-runtime port", () => {
+  expect(DEFAULT_PORT).toBe(7381);
+  expect(resolvePort({})).toBe(7381);
+});
+
+test("FACTORY_EVENT_PORT overrides the default port", () => {
+  expect(resolvePort({ FACTORY_EVENT_PORT: "8123" })).toBe(8123);
+});


### PR DESCRIPTION
## Summary
- default Factory dispatch to the live event-runtime port 7381
- export the default and port resolver for focused unit coverage
- verify FACTORY_EVENT_PORT overrides are parsed numerically

## Verification
- `bun test tools/dispatch.test.mjs`

UX critique: skipped — internal infrastructure CLI port-resolution fix with no browser or user-completable flow.

Fixes WM-251