### PR TITLE
fix(event-runtime-web): omit GET and HEAD proxy bodies

### DIFF
--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -33,7 +33,22 @@ Bun.serve({
     if (url.pathname === "/api" || url.pathname.startsWith("/api/")) {
       const target = `http://127.0.0.1:${API_PORT}${url.pathname.slice(4) || "/"}${url.search}`;
       // Pass-through, nothing added: the proxy exists only for same-origin.
-      return fetch(target, { method: req.method, headers: req.headers, body: req.body });
+      // WHATWG fetch rejects GET/HEAD when a body option is present, even when
+      // the incoming client supplied one, so omit the option for those methods.
+      const bodyless = req.method === "GET" || req.method === "HEAD";
+      const headers = bodyless ? new Headers(req.headers) : req.headers;
+      const init = { method: req.method, headers };
+      if (bodyless) {
+        // Drain any non-standard incoming payload so a keep-alive connection
+        // remains aligned for the client's next request. Its framing headers
+        // must not describe a body that the upstream request intentionally omits.
+        await req.arrayBuffer();
+        headers.delete("content-length");
+        headers.delete("transfer-encoding");
+      } else {
+        init.body = req.body;
+      }
+      return fetch(target, init);
     }
 
     // Static, confined to dist/ — reject traversal rather than resolving it.

--- a/event-runtime/web/serve.test.mjs
+++ b/event-runtime/web/serve.test.mjs
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WEB_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DIST_INDEX = path.join(WEB_DIR, "dist", "index.html");
+
+let api;
+let proxy;
+let webPort;
+let createdDistIndex = false;
+const received = [];
+
+function reservePort() {
+  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response() });
+  const port = probe.port;
+  probe.stop(true);
+  return port;
+}
+
+function requestProxy(method, pathname, body) {
+  return new Promise((resolve, reject) => {
+    const headers = { "x-proxy-test": `${method.toLowerCase()}-marker` };
+    if (body !== undefined) {
+      headers["content-type"] = "text/plain";
+      headers["content-length"] = String(Buffer.byteLength(body));
+    }
+
+    const req = http.request(
+      { hostname: "127.0.0.1", port: webPort, method, path: `/api${pathname}`, headers },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => resolve({
+          status: res.statusCode,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString("utf8"),
+        }));
+      },
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+beforeAll(async () => {
+  if (!existsSync(DIST_INDEX)) {
+    mkdirSync(path.dirname(DIST_INDEX), { recursive: true });
+    writeFileSync(DIST_INDEX, "<!doctype html><title>proxy test</title>");
+    createdDistIndex = true;
+  }
+
+  api = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      received.push({
+        method: req.method,
+        pathname: url.pathname,
+        body: await req.text(),
+        marker: req.headers.get("x-proxy-test"),
+      });
+      return new Response("forwarded", {
+        status: 201,
+        headers: { "x-upstream-method": req.method },
+      });
+    },
+  });
+
+  webPort = reservePort();
+  proxy = Bun.spawn(["bun", path.join(WEB_DIR, "serve.mjs")], {
+    cwd: WEB_DIR,
+    env: {
+      ...process.env,
+      FACTORY_EVENT_PORT: String(api.port),
+      FACTORY_EVENT_WEB_PORT: String(webPort),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const reader = proxy.stdout.getReader();
+  const startup = await reader.read();
+  reader.releaseLock();
+  if (startup.done) {
+    throw new Error(`proxy exited during startup: ${await new Response(proxy.stderr).text()}`);
+  }
+  expect(new TextDecoder().decode(startup.value)).toContain(`http://127.0.0.1:${webPort}`);
+});
+
+afterAll(async () => {
+  proxy?.kill();
+  await proxy?.exited;
+  api?.stop(true);
+  if (createdDistIndex) {
+    unlinkSync(DIST_INDEX);
+    try {
+      rmdirSync(path.dirname(DIST_INDEX));
+    } catch {
+      // Keep a non-empty dist directory created by another process.
+    }
+  }
+});
+
+describe("event-runtime web API proxy", () => {
+  test.each([
+    ["GET", undefined],
+    ["GET", "ignored get payload"],
+    ["HEAD", undefined],
+    ["HEAD", "ignored head payload"],
+  ])("forwards %s without a request body even when the client sends one", async (method, body) => {
+    const pathname = `/bodyless-${method.toLowerCase()}-${body === undefined ? "empty" : "supplied"}`;
+    const response = await requestProxy(method, pathname, body);
+
+    expect(response.status).toBe(201);
+    expect(response.headers["x-upstream-method"]).toBe(method);
+    const forwarded = received.find((entry) => entry.pathname === pathname);
+    expect(forwarded).toEqual({
+      method,
+      pathname,
+      body: "",
+      marker: `${method.toLowerCase()}-marker`,
+    });
+  });
+
+  test.each([
+    ["POST", "post payload"],
+    ["PUT", "put payload"],
+  ])("forwards the %s payload and headers intact", async (method, body) => {
+    const pathname = `/payload-${method.toLowerCase()}`;
+    const response = await requestProxy(method, pathname, body);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toBe("forwarded");
+    expect(received.find((entry) => entry.pathname === pathname)).toEqual({
+      method,
+      pathname,
+      body,
+      marker: `${method.toLowerCase()}-marker`,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- omit request bodies from GET/HEAD upstream fetch options
- drain non-standard GET/HEAD payloads and clear body framing headers to preserve keep-alive connections
- add end-to-end proxy regressions for GET, HEAD, POST, and PUT

## Verification
- `bun test event-runtime/web/serve.test.mjs` — 6 pass, 0 fail

UX critique: skipped — backend reverse-proxy behavior only; no user-facing flow or layout change

Fixes WM-248