### PR TITLE
fix(worker): recover failures from verifying

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -454,8 +454,9 @@ export async function executeClaimed(db, registry, adapters, claim, {
         recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
         return { fenced: true };
       }
+      const expectFrom = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
       transition(db, {
-        runId, to, expectFrom: "RUNNING",
+        runId, to, expectFrom,
         actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
       });
       finishAttempt(db, runId, attempt, to, reasonCode, currentNow, attemptUsage);

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -576,6 +576,30 @@ describe("worker", () => {
     expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
   });
 
+  test("post-VERIFYING exception finalizes the attempt and re-queues instead of stranding it (WM-261)", async () => {
+    const db = openDb(":memory:");
+    const blockedStoreParent = path.join(freshRoot(), "not-a-directory");
+    writeFileSync(blockedStoreParent, "blocks artifact store creation\n");
+    const spec = queueRun(db, makeSpec({
+      maxAttempts: 2,
+      workspace: { type: "ephemeral", retainOnFailure: false },
+    }));
+    const o = opts({ artifactStore: path.join(blockedStoreParent, "artifacts") });
+
+    const summary = await runOnce(db, registry, adapters, o);
+
+    expect(summary).toMatchObject({ terminalState: "FAILED", reasonCode: "adapter_error" });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, spec.runId).slice(-3).map((event) => event.to_state)).toEqual([
+      "VERIFYING", "FAILED", "QUEUED",
+    ]);
+    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
+    expect(attempt.terminal_state).toBe("FAILED");
+    expect(attempt.reason_code).toBe("adapter_error");
+    expect(attempt.finished_at).toBeTruthy();
+    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+  });
+
   test("reapExpiredLeases dead-letters when maxAttempts is reached (OPS-405)", () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ maxAttempts: 1 }));


### PR DESCRIPTION
## Summary
- derive `failTerminal`\u2019s expected source from the current run state
- finalize and requeue failures raised after entering `VERIFYING`
- add a regression test covering artifact-processing failure and workspace cleanup

## Verification
- `bun test event-runtime/lib/worker.test.mjs` \u2014 58 pass, 0 fail

UX critique: skipped \u2014 backend-only worker lifecycle change

Fixes WM-261