### PR TITLE
fix(worktree): allocate dynamic ports for --here

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -215,32 +215,114 @@ health_field() { # <json> <field>
   '
 }
 
-# First even port at or after preferred in the ticket band that is free or
-# already serving expected_home. Dies if the whole band is someone else's.
-allocate_api_port() { # <preferred> <expected_home>
-  local preferred="$1" expected="$2"
-  local port="$preferred" i=0 json occupant=""
+# First API port at or after preferred that is free or already serving
+# expected_home. When worktree is supplied, its adjacent web port must also
+# be free or owned by that worktree's recorded web daemon.
+allocate_api_port() { # <preferred> <expected_home> [worktree]
+  local preferred="$1" expected="$2" wt="${3:-}"
+  local port="$preferred" i=0 json occupant="" api_available web_port web_pid_port
   [[ "$preferred" =~ ^[0-9]+$ ]] || die "invalid preferred port '$preferred'"
   while [[ $i -lt $PORT_SPAN ]]; do
+    api_available=0
     if port_listening "$port"; then
       json=$(health_json "$port")
       occupant=$(health_field "$json" home)
       if [[ -n "$occupant" && "$occupant" == "$expected" ]]; then
+        api_available=1
+      else
+        warn "port $port is owned by ${occupant:-unknown process} — trying next"
+      fi
+    else
+      api_available=1
+    fi
+
+    if [[ "$api_available" -eq 1 ]]; then
+      if [[ -z "$wt" ]]; then
         printf '%s' "$port"
         return 0
       fi
-      warn "port $port is owned by ${occupant:-unknown process} — trying next"
-    else
-      printf '%s' "$port"
-      return 0
+      web_port=$((port + 1))
+      if ! port_listening "$web_port"; then
+        printf '%s' "$port"
+        return 0
+      fi
+      web_pid_port=""
+      if pid_alive "$(run_dir "$wt")/web.pid"; then
+        web_pid_port=$(listen_tcp_port "$(run_dir "$wt")/web.pid" || true)
+      fi
+      if [[ "$web_pid_port" == "$web_port" ]]; then
+        printf '%s' "$port"
+        return 0
+      fi
+      warn "web port $web_port is owned by another process — trying next pair"
     fi
+
     port=$((port + 2))
     if [[ $port -ge $((PORT_BASE + 2 * PORT_SPAN)) ]]; then
       port=$PORT_BASE
     fi
     i=$((i + 1))
   done
-  die "no free API port in $PORT_BASE–$((PORT_BASE + 2 * PORT_SPAN - 2)); $preferred is owned by ${occupant:-unknown}"
+  die "no free API/web port pair in $PORT_BASE–$((PORT_BASE + 2 * PORT_SPAN - 1)); $preferred is unavailable"
+}
+
+# Resolve and persist a checkout's API/web pair. Recorded ports win when the
+# API slot is free or already serves this checkout. Otherwise recover a live
+# daemon's ports when possible, then walk from the preferred API slot.
+# Sets API_PORT and WEB_PORT for the caller.
+resolve_worktree_ports() { # <worktree> <preferred-api-port> <expected-home>
+  local wt="$1" preferred="$2" expected="$3"
+  local rdir resolved=0 recorded occupant sp wp recorded_web_pid_port api_reusable web_reusable
+  rdir="$(run_dir "$wt")"
+
+  if recorded=$(read_ports "$wt"); then
+    API_PORT="${recorded%% *}"
+    WEB_PORT="${recorded##* }"
+    api_reusable=0
+    web_reusable=0
+
+    if port_listening "$API_PORT"; then
+      occupant=$(health_field "$(health_json "$API_PORT")" home)
+      [[ "$occupant" == "$expected" ]] && api_reusable=1
+    else
+      api_reusable=1
+    fi
+
+    if ! port_listening "$WEB_PORT"; then
+      web_reusable=1
+    elif pid_alive "$rdir/web.pid"; then
+      recorded_web_pid_port=$(listen_tcp_port "$rdir/web.pid" || true)
+      [[ "$recorded_web_pid_port" == "$WEB_PORT" ]] && web_reusable=1
+    fi
+
+    if [[ "$api_reusable" -eq 1 && "$web_reusable" -eq 1 ]]; then
+      info "reusing recorded ports $API_PORT / $WEB_PORT"
+      resolved=1
+    else
+      warn "recorded ports $API_PORT / $WEB_PORT are occupied by another process — allocating a free pair"
+    fi
+  fi
+
+  if [[ "$resolved" -eq 0 ]] && pid_alive "$rdir/serve.pid"; then
+    if sp=$(listen_tcp_port "$rdir/serve.pid"); then
+      API_PORT="$sp"
+      if pid_alive "$rdir/web.pid" && wp=$(listen_tcp_port "$rdir/web.pid"); then
+        WEB_PORT="$wp"
+      else
+        WEB_PORT=$((API_PORT + 1))
+      fi
+      info "reusing live daemon ports $API_PORT / $WEB_PORT"
+      write_ports "$wt" "$API_PORT" "$WEB_PORT"
+      resolved=1
+    fi
+  fi
+
+  if [[ "$resolved" -eq 0 ]]; then
+    API_PORT="$(allocate_api_port "$preferred" "$expected" "$wt")"
+    WEB_PORT=$((API_PORT + 1))
+    write_ports "$wt" "$API_PORT" "$WEB_PORT"
+    info "allocated ports $API_PORT / $WEB_PORT (preferred $preferred)"
+  fi
 }
 
 # Refuse to proceed (and never seed) when /health is a different event home.

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -12,7 +12,7 @@ const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
 // fixtures bind is free, and pass the band to the scripts via
 // FACTORY_PORT_BASE / FACTORY_PORT_SPAN. No absolute ports below.
 const PORT_SPAN = 200;
-const FIXTURE_OFFSETS = [352, 360, 362, 364, 366, 372, 374, 396];
+const FIXTURE_OFFSETS = [352, 353, 360, 361, 362, 363, 364, 365, 366, 367, 372, 373, 374, 375, 396, 397];
 
 function offsetsBindable(base) {
   for (const off of FIXTURE_OFFSETS) {
@@ -104,6 +104,123 @@ test("write_ports / read_ports round-trip", () => {
     expect(written.status).toBe(0);
     expect(written.stdout.trim()).toBe(`${P(352)} ${P(353)}`);
   } finally {
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("resolve_worktree_ports reuses free recorded ports for --here", () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-recorded-"));
+  try {
+    const r = sh([
+      `write_ports "${wt}" ${P(352)} ${P(353)}`,
+      `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
+      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`resolved=${P(352)} ${P(353)}`);
+    expect(r.stdout).toContain(`recorded=${P(352)} ${P(353)}`);
+  } finally {
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("resolve_worktree_ports falls back when the preferred --here port is occupied", async () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-collision-"));
+  const preferred = P(360);
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: preferred,
+    fetch(req) {
+      if (new URL(req.url).pathname === "/health") {
+        return Response.json({ ok: true, env: { home: "/other/checkout/.factory/event-runtime" } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const r = await shAsync([
+      `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`resolved=${P(362)} ${P(363)}`);
+    expect(r.stdout).toContain(`recorded=${P(362)} ${P(363)}`);
+  } finally {
+    server.stop(true);
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("resolve_worktree_ports skips a preferred pair whose web port is occupied", async () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-web-collision-"));
+  const preferred = P(360);
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: P(361),
+    socket: { data() {} },
+  });
+  try {
+    const r = await shAsync([
+      `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`resolved=${P(362)} ${P(363)}`);
+  } finally {
+    listener.stop(true);
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("resolve_worktree_ports replaces recorded ports when the web port is occupied", async () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-recorded-web-collision-"));
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: P(365),
+    socket: { data() {} },
+  });
+  try {
+    const r = await shAsync([
+      `write_ports "${wt}" ${P(364)} ${P(365)}`,
+      `resolve_worktree_ports "${wt}" ${P(372)} "${wt}/.factory/event-runtime"`,
+      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+      `printf "recorded=%s\\n" "$(read_ports "${wt}")"`,
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`resolved=${P(372)} ${P(373)}`);
+    expect(r.stdout).toContain(`recorded=${P(372)} ${P(373)}`);
+  } finally {
+    listener.stop(true);
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("resolve_worktree_ports reuses recorded ports owned by this checkout", async () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-owned-"));
+  const home = `${wt}/.factory/event-runtime`;
+  const api = P(374);
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: api,
+    fetch(req) {
+      if (new URL(req.url).pathname === "/health") {
+        return Response.json({ ok: true, env: { home } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const r = await shAsync([
+      `write_ports "${wt}" ${api} ${P(375)}`,
+      `resolve_worktree_ports "${wt}" ${P(360)} "${home}"`,
+      'printf "resolved=%s %s\\n" "$API_PORT" "$WEB_PORT"',
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`resolved=${api} ${P(375)}`);
+  } finally {
+    server.stop(true);
     rmSync(wt, { recursive: true, force: true });
   }
 });
@@ -226,6 +343,39 @@ test("allocate_api_port reuses port when /health reports matching expected home"
     expect(r.stdout.trim()).toBe(String(P(374)));
   } finally {
     server.stop(true);
+  }
+});
+
+test("daemon health reads the recorded API/web pair", async () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-176-daemon-ports-"));
+  const home = `${wt}/.factory/event-runtime`;
+  const runDir = path.join(wt, ".factory", "run");
+  mkdirSync(runDir, { recursive: true });
+  for (const daemon of ["serve", "worker", "web"]) {
+    writeFileSync(path.join(runDir, `${daemon}.pid`), String(process.pid));
+  }
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: P(396),
+    fetch(req) {
+      if (new URL(req.url).pathname === "/health") {
+        return Response.json({ ok: true, env: { home } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const r = await shAsync([
+      `write_ports "${wt}" ${P(396)} ${P(397)}`,
+      `check_daemon_health "${wt}"`,
+    ].join("\n"));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(`serve:   running (pid ${process.pid}, port ${P(396)})`);
+    expect(r.stdout).toContain(`web:     running (pid ${process.pid}, port ${P(397)})`);
+    expect(r.stdout).toContain("anomalies: none");
+  } finally {
+    server.stop(true);
+    rmSync(wt, { recursive: true, force: true });
   }
 });
 

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -98,54 +98,15 @@ RUN_DIR="$(run_dir "$WT")"
 HOME_DIR="$(event_home "$WT")"
 mkdir -p "$RUN_DIR"
 
-# Resolve API/web ports only after the checkout exists so we can persist them
-# under .factory/run/ports and refuse a stranger already bound on the slot.
+# Resolve API/web ports only after the checkout exists so we can persist them.
+# --here prefers 7391/7392 but follows the same recorded-port reuse and
+# collision fallback path as named ticket worktrees.
 if [[ "$HERE" -eq 1 ]]; then
-  API_PORT="$HERE_API_PORT"
-  WEB_PORT="$HERE_WEB_PORT"
-  write_ports "$WT" "$API_PORT" "$WEB_PORT"
+  preferred="$HERE_API_PORT"
 else
-  resolved=0
-  if recorded=$(read_ports "$WT"); then
-    API_PORT="${recorded%% *}"
-    WEB_PORT="${recorded##* }"
-    if port_listening "$API_PORT"; then
-      occupant=$(health_field "$(health_json "$API_PORT")" home)
-      if [[ "$occupant" == "$HOME_DIR" ]]; then
-        info "reusing recorded ports $API_PORT / $WEB_PORT"
-        resolved=1
-      else
-        if pid_alive "$RUN_DIR/serve.pid" && [[ -n "$occupant" ]]; then
-          die "port $API_PORT is owned by another runtime (env.home=$occupant, this worktree=$HOME_DIR) — refusing to seed"
-        fi
-        warn "recorded port $API_PORT is owned by ${occupant:-unknown process} — allocating a free port"
-      fi
-    else
-      info "reusing recorded ports $API_PORT / $WEB_PORT"
-      resolved=1
-    fi
-  fi
-  if [[ "$resolved" -eq 0 ]] && pid_alive "$RUN_DIR/serve.pid"; then
-    if sp=$(listen_tcp_port "$RUN_DIR/serve.pid"); then
-      API_PORT="$sp"
-      if pid_alive "$RUN_DIR/web.pid" && wp=$(listen_tcp_port "$RUN_DIR/web.pid"); then
-        WEB_PORT="$wp"
-      else
-        WEB_PORT=$((API_PORT + 1))
-      fi
-      info "reusing live daemon ports $API_PORT / $WEB_PORT"
-      write_ports "$WT" "$API_PORT" "$WEB_PORT"
-      resolved=1
-    fi
-  fi
-  if [[ "$resolved" -eq 0 ]]; then
-    preferred="$(ticket_api_port "$TICKET")"
-    API_PORT="$(allocate_api_port "$preferred" "$HOME_DIR")"
-    WEB_PORT=$((API_PORT + 1))
-    write_ports "$WT" "$API_PORT" "$WEB_PORT"
-    info "allocated ports $API_PORT / $WEB_PORT (preferred $preferred)"
-  fi
+  preferred="$(ticket_api_port "$TICKET")"
 fi
+resolve_worktree_ports "$WT" "$preferred" "$HOME_DIR"
 
 # ------------------------------------------------------------ dependencies ---
 info "installing dependencies (bun install, root + web)"


### PR DESCRIPTION
## Summary
- route `worktree-up.sh --here` through shared recorded-port resolution
- fall back from occupied API or web slots and persist the selected pair
- cover collision, recorded reuse, ownership, and daemon port consumption

## Verification
- `bun test bin/worktree-common.test.mjs bin/worktree-checkout.test.mjs` — 34 pass, 0 fail

UX critique: skipped — internal infrastructure tooling with no user-facing flow

Fixes WM-176