### PR TITLE
Stabilize graph search input (WM-166)

### DIFF
--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -376,6 +376,50 @@ describe("Graph view inspect loop", () => {
     );
   });
 
+  test("match counter follows the input without participating in toolbar layout", async () => {
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByLabelText, getByText } = renderGraph();
+        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+
+        changeInput(input, "agent:");
+        const counter = await waitFor(() => getByText("1 / 2"));
+        expect(input.nextElementSibling).toBe(counter);
+        expect(counter.className).toContain("absolute");
+        expect(input.parentElement?.className).toContain("w-52");
+
+        changeInput(input, "missing");
+        await waitFor(() => expect(getByText("no matches")).toBe(counter));
+      },
+    );
+  });
+
+  test("Escape clears a search before blurring an empty input", async () => {
+    await withApi(
+      {
+        agents: async () => graphAgents(),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { getByLabelText } = renderGraph();
+        const input = (await waitFor(() => getByLabelText("Search graph nodes"))) as HTMLInputElement;
+        input.focus();
+        changeInput(input, "agent:");
+
+        fireEvent.keyDown(input, { key: "Escape" });
+        expect(input.value).toBe("");
+        expect(document.activeElement).toBe(input);
+
+        fireEvent.keyDown(input, { key: "Escape" });
+        expect(document.activeElement).not.toBe(input);
+      },
+    );
+  });
+
   test("Enter selects match 1 of N instead of skipping to match 2", async () => {
     const onSelectNode = mock(() => {});
     await withApi(

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -366,35 +366,40 @@ export function Graph({
         </div>
         <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
           <div className="flex items-center gap-2">
-            {query.trim() && (
-              <span className="text-[11px] text-(--text-faint)">
-                {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
-              </span>
-            )}
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  const result = searchEnter(matches, safeMatchIdx, focusNodeId);
-                  if (result) {
+            <div className="relative w-52">
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    const result = searchEnter(matches, safeMatchIdx, focusNodeId);
+                    if (result) {
+                      e.preventDefault();
+                      setMatchIdx(result.nextIdx);
+                      onSelectNode(result.selectId);
+                    }
+                  } else if (e.key === "Escape") {
                     e.preventDefault();
-                    setMatchIdx(result.nextIdx);
-                    onSelectNode(result.selectId);
+                    if (query) setQuery("");
+                    else e.currentTarget.blur();
                   }
-                } else if (e.key === "Escape") {
-                  e.preventDefault();
-                  if (query) setQuery("");
-                  else e.currentTarget.blur();
-                }
-              }}
-              placeholder="Search nodes…"
-              aria-label="Search graph nodes"
-              data-view-filter
-              spellCheck={false}
-              className="w-52 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
-            />
+                }}
+                placeholder="Search nodes…"
+                aria-label="Search graph nodes"
+                data-view-filter
+                spellCheck={false}
+                className="w-full rounded-md border border-(--border) bg-(--surface-1) py-1 pr-20 pl-2.5 text-[12px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--accent)"
+              />
+              {query.trim() && (
+                <span
+                  className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-[11px] tabular-nums text-(--text-faint)"
+                  aria-live="polite"
+                >
+                  {matches.length ? `${safeMatchIdx + 1} / ${matches.length}` : "no matches"}
+                </span>
+              )}
+            </div>
             {positioned && graph && graph.nodes.length > 0 && (
               <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
             )}


### PR DESCRIPTION
## Summary
- keep the Graph search input fixed in a 208px wrapper
- render the variable-width match counter as an absolute right-side adornment
- cover counter layout order plus Escape clear/blur behavior

## Verification
- `cd event-runtime/web && bun test src/graph/nodes.test.tsx src/graph/search.test.ts` — 32 pass, 0 fail
- UX critique: required — SHIP after 2 rounds; observed `http://127.0.0.1:7467/#/graph`

Fixes WM-166