### PR TITLE
fix(orchestrator): stop active children on supervisor shutdown

### DIFF
--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -29,209 +29,308 @@ import { spawn } from "node:child_process";
 import { loadSchedule, toSeconds, ROOT } from "../lib/schedule.mjs";
 import { latestReaperRunMs } from "./reaper.mjs";
 
-const argv = process.argv.slice(2);
-const has = (f) => argv.includes(f);
-const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
+/**
+ * Keep spawned processes reachable until their stdio has closed. Shutdown can
+ * then signal every active child and await settlement without polling.
+ */
+export function createChildTracker({ setTimeoutFn = setTimeout, clearTimeoutFn = clearTimeout } = {}) {
+  const active = new Set();
+  const waiters = new Set();
 
-const APPLY = has("--apply");
-const ONCE = has("--once");
-const ALL = has("--all");
-const ONLY = (val("--only") || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const resolveWaiters = () => {
+    if (active.size) return;
+    for (const resolve of [...waiters]) resolve(true);
+  };
 
-// One supervisor per repo. Run two of these side by side to work two repos at
-// once — they share nothing but the machine, and either can be stopped alone.
-const REPO = val("--repo");
-const HARNESS = val("--harness");
-const { jobs, repo: TARGET, harness: AGENT } = loadSchedule(REPO, HARNESS);
+  return {
+    active,
+    get size() { return active.size; },
 
-const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`,
-  bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
-  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
-};
-const clock = () => new Date().toTimeString().slice(0, 8);
+    track(child) {
+      active.add(child);
+      let settled = false;
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        active.delete(child);
+        resolveWaiters();
+      };
+      child.once("close", cleanup);
+      return child;
+    },
 
-// Terminal tab title (OSC 0) — so a wall of tabs reads "which repo, which
-// mode, what's running right now" without focusing any of them.
-const setTitle = (s) => { if (process.stdout.isTTY) process.stdout.write(`\x1b]0;${s}\x07`); };
-const baseTitle = () => `factory ${TARGET} — ${APPLY ? "APPLY" : "dry"}`;
-const refreshTitle = () => setTitle(running.size ? `${baseTitle()} ▸ ${[...running].join(",")}` : baseTitle());
+    terminateAll(signal = "SIGTERM") {
+      for (const child of [...active]) {
+        try { child.kill(signal); } catch {}
+      }
+    },
 
-if (has("--list") || (!ALL && ONLY.length === 0)) {
-  console.log(c.bold("\njobs in config/schedule.yaml\n"));
-  for (const j of jobs) {
-    const timer = j.enabled === false ? c.dim("no timer") : c.green("timer eligible");
-    console.log(`  ${c.bold(j.name.padEnd(18))} every ${String(j.every).padEnd(5)} ${timer}`);
-    if (j.dry_command) console.log(c.dim(`    dry:   ${j.dry_command}`));
-    console.log(c.dim(`    apply: ${j.command}`));
-  }
-  console.log(`
+    waitForEmpty(timeoutMs) {
+      if (!active.size) return Promise.resolve(true);
+      return new Promise((resolve) => {
+        let timer;
+        const done = (drained) => {
+          clearTimeoutFn(timer);
+          waiters.delete(done);
+          resolve(drained);
+        };
+        waiters.add(done);
+        timer = setTimeoutFn(() => done(false), timeoutMs);
+      });
+    },
+  };
+}
+
+/**
+ * Build the signal handler separately from the scheduler so forwarding,
+ * bounded settlement, and the double-interrupt escape hatch are unit-testable.
+ */
+export function createShutdownController({
+  childTracker,
+  clearTimers,
+  setTitle = () => {},
+  getCounts = () => ({ completed: 0, failed: 0 }),
+  getRunningNames = () => [],
+  log = console.log,
+  exit = (code) => process.exit(code),
+  timeoutMs = 10_000,
+}) {
+  let shuttingDown = false;
+
+  return async function shutdown(signal) {
+    if (shuttingDown) {
+      exit(130);
+      return { forced: true, drained: false };
+    }
+    shuttingDown = true;
+
+    clearTimers();
+    setTitle("");
+    const names = getRunningNames();
+    if (childTracker.size) {
+      const detail = names.length ? ` (${names.join(", ")})` : "";
+      log(`\n${signal} — stopping ${childTracker.size} active child process(es)${detail}. Signal again to exit immediately.`);
+    }
+
+    childTracker.terminateAll("SIGTERM");
+    const drained = await childTracker.waitForEmpty(timeoutMs);
+    const { completed, failed } = getCounts();
+
+    setTitle("");
+    log(`\nstopped. ${completed} run(s) ok, ${failed} failed.`);
+    if (!drained) log(`  shutdown deadline reached; exiting with child process(es) still active.`);
+    log("nothing is scheduled; nothing runs until you start this again.\n");
+    exit(failed ? 1 : 0);
+    return { forced: false, drained };
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const has = (flag) => argv.includes(flag);
+  const val = (flag) => { const i = argv.indexOf(flag); return i === -1 ? null : argv[i + 1]; };
+
+  const APPLY = has("--apply");
+  const ONCE = has("--once");
+  const ALL = has("--all");
+  const ONLY = (val("--only") || "").split(",").map((s) => s.trim()).filter(Boolean);
+
+  // One supervisor per repo. Run two of these side by side to work two repos at
+  // once — they share nothing but the machine, and either can be stopped alone.
+  const REPO = val("--repo");
+  const HARNESS = val("--harness");
+  const { jobs, repo: TARGET, harness: AGENT } = loadSchedule(REPO, HARNESS);
+
+  const c = {
+    dim: (s) => `\x1b[2m${s}\x1b[0m`,
+    bold: (s) => `\x1b[1m${s}\x1b[0m`,
+    red: (s) => `\x1b[31m${s}\x1b[0m`,
+    green: (s) => `\x1b[32m${s}\x1b[0m`,
+    yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+    cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  };
+  const clock = () => new Date().toTimeString().slice(0, 8);
+  const running = new Set();
+
+  // Terminal tab title (OSC 0) — so a wall of tabs reads "which repo, which
+  // mode, what's running right now" without focusing any of them.
+  const setTitle = (s) => { if (process.stdout.isTTY) process.stdout.write(`\x1b]0;${s}\x07`); };
+  const baseTitle = () => `factory ${TARGET} — ${APPLY ? "APPLY" : "dry"}`;
+  const refreshTitle = () => setTitle(running.size ? `${baseTitle()} ▸ ${[...running].join(",")}` : baseTitle());
+
+  if (has("--list") || (!ALL && ONLY.length === 0)) {
+    console.log(c.bold("\njobs in config/schedule.yaml\n"));
+    for (const job of jobs) {
+      const timer = job.enabled === false ? c.dim("no timer") : c.green("timer eligible");
+      console.log(`  ${c.bold(job.name.padEnd(18))} every ${String(job.every).padEnd(5)} ${timer}`);
+      if (job.dry_command) console.log(c.dim(`    dry:   ${job.dry_command}`));
+      console.log(c.dim(`    apply: ${job.command}`));
+    }
+    console.log(`
 ${c.bold("run one:")}  bun orchestrator/run.mjs --only ${jobs[0]?.name ?? "<job>"} --once
 ${c.bold("for real:")} add --apply     ${c.dim("(without it you get the dry command)")}
 
 ${c.dim("Nothing runs unless you name it. `enabled:` governs launchd installation,")}
 ${c.dim("not this supervisor — see deploy/gen.mjs.")}
 `);
-  process.exit(0);
-}
-
-const selected = ALL ? jobs : jobs.filter((j) => ONLY.includes(j.name));
-const unknown = ONLY.filter((n) => !jobs.some((j) => j.name === n));
-if (unknown.length) {
-  console.error(c.red(`unknown job(s): ${unknown.join(", ")}`));
-  console.error(`known: ${jobs.map((j) => j.name).join(", ")}`);
-  process.exit(2);
-}
-if (!selected.length) { console.error(c.red("nothing selected")); process.exit(2); }
-
-for (const j of selected) {
-  if (!APPLY && !j.dry_command) {
-    console.error(c.red(`\n${j.name} has no dry_command, so there is no safe way to preview it.`));
-    console.error(`Add one to config/schedule.yaml, or run with --apply if you mean it.\n`);
-    process.exit(2);
-  }
-}
-
-const commandFor = (j) => (APPLY ? j.command : j.dry_command);
-
-console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} · ${c.cyan(AGENT)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
-console.log(c.dim(`${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`));
-for (const j of selected) console.log(`  ${c.cyan(j.name)}  every ${j.every}  ${c.dim(commandFor(j))}`);
-console.log();
-
-const running = new Set();
-let completed = 0;
-let failed = 0;
-refreshTitle();
-
-/**
- * Run a command, return its exit code. Used for gates, where we want the code
- * rather than the streaming behaviour of a real job.
- */
-function probe(cmd) {
-  return new Promise((resolve) => {
-    const child = spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] });
-    let out = "";
-    child.stdout.on("data", (d) => (out += d));
-    child.stderr.on("data", (d) => (out += d));
-    child.on("close", (code) => resolve({ code, out: out.trim() }));
-  });
-}
-
-async function runJob(job) {
-  if (running.has(job.name)) {
-    console.log(`${c.dim(clock())} ${c.yellow("skip")}  ${job.name} — previous run still going`);
-    return;
+    return 0;
   }
 
-  // A gate is what makes frequent polling affordable: checking costs one cheap
-  // query, spawning an agent costs budget. Exit 0 = work exists, 1 = idle,
-  // anything else = a real error worth surfacing rather than silently skipping.
-  if (job.gate_command && APPLY) {
-    const { code, out } = await probe(job.gate_command);
-    if (code === 1) {
-      console.log(`${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`);
-      return;
+  const selected = ALL ? jobs : jobs.filter((job) => ONLY.includes(job.name));
+  const unknown = ONLY.filter((name) => !jobs.some((job) => job.name === name));
+  if (unknown.length) {
+    console.error(c.red(`unknown job(s): ${unknown.join(", ")}`));
+    console.error(`known: ${jobs.map((job) => job.name).join(", ")}`);
+    return 2;
+  }
+  if (!selected.length) {
+    console.error(c.red("nothing selected"));
+    return 2;
+  }
+
+  for (const job of selected) {
+    if (!APPLY && !job.dry_command) {
+      console.error(c.red(`\n${job.name} has no dry_command, so there is no safe way to preview it.`));
+      console.error("Add one to config/schedule.yaml, or run with --apply if you mean it.\n");
+      return 2;
     }
-    if (code !== 0) {
-      failed++;
-      console.log(`${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`);
-      return;
-    }
-    console.log(`${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`);
   }
 
-  running.add(job.name);
+  const commandFor = (job) => (APPLY ? job.command : job.dry_command);
+
+  console.log(c.bold(`\nfactory supervisor — ${c.cyan(TARGET)} · ${c.cyan(AGENT)} — ${APPLY ? c.yellow("APPLY (changes will be made)") : c.green("DRY RUN")}`));
+  console.log(c.dim(`${selected.length} job(s); Ctrl-C to stop. Nothing runs after you exit.\n`));
+  for (const job of selected) console.log(`  ${c.cyan(job.name)}  every ${job.every}  ${c.dim(commandFor(job))}`);
+  console.log();
+
+  const children = createChildTracker();
+  let completed = 0;
+  let failed = 0;
   refreshTitle();
-  const cmd = commandFor(job);
-  const started = Date.now();
-  console.log(`${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`);
 
-  return new Promise((resolve) => {
-    const child = spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] });
-    const prefix = c.dim(`  │ `);
-    const pipe = (stream, color) => {
-      let buf = "";
-      stream.on("data", (d) => {
-        buf += d.toString();
-        const lines = buf.split("\n");
-        buf = lines.pop();
-        for (const l of lines) console.log(prefix + (color ? color(l) : l));
-      });
-      stream.on("end", () => { if (buf.trim()) console.log(prefix + (color ? color(buf) : buf)); });
-    };
-    pipe(child.stdout);
-    pipe(child.stderr, c.red);
-
-    child.on("close", (code) => {
-      running.delete(job.name);
-      refreshTitle();
-      const secs = ((Date.now() - started) / 1000).toFixed(1);
-      if (code === 0) { completed++; console.log(`${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`); }
-      else { failed++; console.log(`${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`); }
-      resolve();
+  /**
+   * Run a command, return its exit code. Used for gates, where we want the code
+   * rather than the streaming behaviour of a real job.
+   */
+  function probe(cmd) {
+    return new Promise((resolve) => {
+      const child = children.track(spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] }));
+      let out = "";
+      child.stdout.on("data", (data) => (out += data));
+      child.stderr.on("data", (data) => (out += data));
+      child.on("close", (code) => resolve({ code, out: out.trim() }));
     });
-  });
-}
-
-const timers = [];
-function shutdown() {
-  for (const t of timers) clearInterval(t);
-  setTitle("");
-  console.log(`\n${c.bold("stopped.")} ${completed} run(s) ok, ${failed} failed.`);
-  if (running.size) console.log(c.yellow(`  ${[...running].join(", ")} still finishing — they are child processes and will exit on their own.`));
-  console.log(c.dim("nothing is scheduled; nothing runs until you start this again.\n"));
-  process.exit(failed ? 1 : 0);
-}
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-
-// Startup backstop: the reaper matters most at exactly the moment the factory
-// comes back up — agents crash while the supervisor is down, and their stale
-// claims sit unreaped until something runs it. If this session doesn't include
-// the linear-reaper job and no reaper has run anywhere in the last hour
-// (known from its own logs in ~/.factory/logs/reaper-*.log), run one pass
-// before the first job pass. Dry unless the supervisor itself is --apply —
-// starting a watched dry session must not silently unassign tickets.
-const REAPER_BACKSTOP_MIN = 60;
-if (!selected.some((j) => j.name === "linear-reaper")) {
-  const last = latestReaperRunMs();
-  const ageMin = last === null ? Infinity : (Date.now() - last) / 60_000;
-  if (ageMin > REAPER_BACKSTOP_MIN) {
-    const ageStr = last === null ? "never" : `${Math.round(ageMin)}m ago`;
-    console.log(`${c.dim(clock())} ${c.yellow("reaper")} last ran ${ageStr} — backstop ${APPLY ? "apply" : "dry"} pass first`);
-    const { code, out } = await probe(`bun orchestrator/reaper.mjs${APPLY ? " --apply" : ""}`);
-    for (const l of out.split("\n")) if (l.trim()) console.log(c.dim(`  │ ${l}`));
-    if (code !== 0) console.log(`${c.dim(clock())} ${c.red("reaper backstop failed")} ${c.dim(`exit ${code}`)}`);
   }
+
+  async function runJob(job) {
+    if (running.has(job.name)) {
+      console.log(`${c.dim(clock())} ${c.yellow("skip")}  ${job.name} — previous run still going`);
+      return;
+    }
+
+    // A gate is what makes frequent polling affordable: checking costs one cheap
+    // query, spawning an agent costs budget. Exit 0 = work exists, 1 = idle,
+    // anything else = a real error worth surfacing rather than silently skipping.
+    if (job.gate_command && APPLY) {
+      const { code, out } = await probe(job.gate_command);
+      if (code === 1) {
+        console.log(`${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`);
+        return;
+      }
+      if (code !== 0) {
+        failed++;
+        console.log(`${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`);
+        return;
+      }
+      console.log(`${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`);
+    }
+
+    running.add(job.name);
+    refreshTitle();
+    const cmd = commandFor(job);
+    const started = Date.now();
+    console.log(`${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`);
+
+    return new Promise((resolve) => {
+      const child = children.track(spawn("/bin/bash", ["-lc", cmd], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] }));
+      const prefix = c.dim("  │ ");
+      const pipe = (stream, color) => {
+        let buf = "";
+        stream.on("data", (data) => {
+          buf += data.toString();
+          const lines = buf.split("\n");
+          buf = lines.pop();
+          for (const line of lines) console.log(prefix + (color ? color(line) : line));
+        });
+        stream.on("end", () => { if (buf.trim()) console.log(prefix + (color ? color(buf) : buf)); });
+      };
+      pipe(child.stdout);
+      pipe(child.stderr, c.red);
+
+      child.on("close", (code) => {
+        running.delete(job.name);
+        refreshTitle();
+        const secs = ((Date.now() - started) / 1000).toFixed(1);
+        if (code === 0) {
+          completed++;
+          console.log(`${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`);
+        } else {
+          failed++;
+          console.log(`${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`);
+        }
+        resolve();
+      });
+    });
+  }
+
+  const timers = [];
+  const shutdown = createShutdownController({
+    childTracker: children,
+    clearTimers: () => { for (const timer of timers) clearInterval(timer); },
+    setTitle,
+    getCounts: () => ({ completed, failed }),
+    getRunningNames: () => [...running],
+  });
+  process.on("SIGINT", () => { void shutdown("SIGINT"); });
+  process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
+
+  // Startup backstop: the reaper matters most at exactly the moment the factory
+  // comes back up — agents crash while the supervisor is down, and their stale
+  // claims sit unreaped until something runs it. If this session doesn't include
+  // the linear-reaper job and no reaper has run anywhere in the last hour
+  // (known from its own logs in ~/.factory/logs/reaper-*.log), run one pass
+  // before the first job pass. Dry unless the supervisor itself is --apply —
+  // starting a watched dry session must not silently unassign tickets.
+  const REAPER_BACKSTOP_MIN = 60;
+  if (!selected.some((job) => job.name === "linear-reaper")) {
+    const last = latestReaperRunMs();
+    const ageMin = last === null ? Infinity : (Date.now() - last) / 60_000;
+    if (ageMin > REAPER_BACKSTOP_MIN) {
+      const ageStr = last === null ? "never" : `${Math.round(ageMin)}m ago`;
+      console.log(`${c.dim(clock())} ${c.yellow("reaper")} last ran ${ageStr} — backstop ${APPLY ? "apply" : "dry"} pass first`);
+      const { code, out } = await probe(`bun orchestrator/reaper.mjs${APPLY ? " --apply" : ""}`);
+      for (const line of out.split("\n")) if (line.trim()) console.log(c.dim(`  │ ${line}`));
+      if (code !== 0) console.log(`${c.dim(clock())} ${c.red("reaper backstop failed")} ${c.dim(`exit ${code}`)}`);
+    }
+  }
+
+  // Start the first pass, but DO NOT await it before scheduling. Long-running
+  // dispatch jobs must not prevent timers for the other jobs from being set.
+  // Overlap is handled per job by the `running` set.
+  const firstPass = Promise.all(selected.map(runJob)).catch(() => {});
+
+  if (ONCE) {
+    await firstPass;
+    console.log(`\n${c.bold("one pass complete.")} ${completed} ok, ${failed} failed.`);
+    return failed ? 1 : 0;
+  }
+
+  for (const job of selected) {
+    const ms = toSeconds(job.every) * 1000;
+    console.log(c.dim(`  ${job.name}: next in ${job.every}`));
+    timers.push(setInterval(() => runJob(job), ms));
+  }
+  console.log(c.dim("\nwatching — Ctrl-C to stop.\n"));
+  return 0;
 }
 
-// Start the first pass, but DO NOT await it before scheduling.
-//
-// `dispatch` is deliberately long-running: rolling refill keeps tick.mjs alive
-// for as long as tickets are in flight, which is hours. Awaiting the first pass
-// before installing timers therefore meant the timers were never installed at
-// all — the supervisor silently degraded into a one-shot the moment dispatch
-// picked up a ticket. legalease ran merge exactly once, at 08:54, and never
-// again while twelve green PRs piled up behind it; the loop looked alive
-// because dispatch's agents kept printing.
-//
-// Overlap is already handled per job by the `running` set, so a timer that
-// fires while its own job is still going skips rather than stacks.
-const firstPass = Promise.all(selected.map(runJob)).catch(() => {});
-
-if (ONCE) {
-  await firstPass;
-  console.log(`\n${c.bold("one pass complete.")} ${completed} ok, ${failed} failed.`);
-  process.exit(failed ? 1 : 0);
-}
-
-for (const job of selected) {
-  const ms = toSeconds(job.every) * 1000;
-  console.log(c.dim(`  ${job.name}: next in ${job.every}`));
-  timers.push(setInterval(() => runJob(job), ms));
-}
-console.log(c.dim("\nwatching — Ctrl-C to stop.\n"));
+if (import.meta.main) process.exitCode = await main();

--- a/orchestrator/run.test.mjs
+++ b/orchestrator/run.test.mjs
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { createChildTracker, createShutdownController } from "./run.mjs";
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.signals = [];
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    return true;
+  };
+  return child;
+}
+
+function shutdownHarness(childTracker, overrides = {}) {
+  const exits = [];
+  const logs = [];
+  let timersCleared = 0;
+  const shutdown = createShutdownController({
+    childTracker,
+    clearTimers: () => { timersCleared++; },
+    getCounts: () => ({ completed: 2, failed: 0 }),
+    getRunningNames: () => ["dispatch"],
+    log: (message) => logs.push(message),
+    exit: (code) => exits.push(code),
+    ...overrides,
+  });
+  return { shutdown, exits, logs, get timersCleared() { return timersCleared; } };
+}
+
+test("active child processes are tracked and removed when they close", async () => {
+  const tracker = createChildTracker();
+  const first = fakeChild();
+  const second = fakeChild();
+
+  expect(tracker.track(first)).toBe(first);
+  tracker.track(second);
+  expect(tracker.size).toBe(2);
+  expect(tracker.active.has(first)).toBe(true);
+
+  first.emit("close", 0);
+  expect(tracker.size).toBe(1);
+  expect(tracker.active.has(first)).toBe(false);
+
+  second.emit("close", 0);
+  expect(tracker.size).toBe(0);
+  expect(await tracker.waitForEmpty(20)).toBe(true);
+});
+
+test("shutdown forwards SIGTERM and waits for active children to settle", async () => {
+  const tracker = createChildTracker();
+  const child = fakeChild();
+  tracker.track(child);
+  const harness = shutdownHarness(tracker);
+  let settled = false;
+
+  const pending = harness.shutdown("SIGINT").then((result) => {
+    settled = true;
+    return result;
+  });
+  await Promise.resolve();
+
+  expect(harness.timersCleared).toBe(1);
+  expect(child.signals).toEqual(["SIGTERM"]);
+  expect(settled).toBe(false);
+  expect(harness.exits).toEqual([]);
+
+  child.emit("close", 0);
+  const result = await pending;
+  expect(result).toEqual({ forced: false, drained: true });
+  expect(harness.exits).toEqual([0]);
+});
+
+test("shutdown stops waiting at its deadline", async () => {
+  const tracker = createChildTracker();
+  tracker.track(fakeChild());
+  const harness = shutdownHarness(tracker, { timeoutMs: 10 });
+
+  const result = await harness.shutdown("SIGTERM");
+
+  expect(result).toEqual({ forced: false, drained: false });
+  expect(harness.exits).toEqual([0]);
+  expect(harness.logs.some((line) => line.includes("deadline reached"))).toBe(true);
+});
+
+test("a second interrupt exits immediately with code 130", async () => {
+  let terminateCalls = 0;
+  const childTracker = {
+    size: 1,
+    terminateAll: () => { terminateCalls++; },
+    waitForEmpty: () => new Promise(() => {}),
+  };
+  const harness = shutdownHarness(childTracker);
+
+  void harness.shutdown("SIGINT");
+  const result = await harness.shutdown("SIGTERM");
+
+  expect(terminateCalls).toBe(1);
+  expect(harness.timersCleared).toBe(1);
+  expect(result).toEqual({ forced: true, drained: false });
+  expect(harness.exits).toEqual([130]);
+});


### PR DESCRIPTION
## Summary
- track every child spawned by supervisor jobs and probes
- forward SIGTERM and await child settlement for up to 10 seconds during shutdown
- expose testable lifecycle helpers and gate scheduler startup behind `import.meta.main`

## Verification
- `bun test orchestrator/run.test.mjs && bun orchestrator/run.mjs --list`

UX critique: skipped — backend/orchestrator process-lifecycle change with no user-facing surface

Fixes WM-242