### PR TITLE
fix(event-runtime-web): include visible null-offset focus targets

### DIFF
--- a/event-runtime/web/src/components/Dialog.test.tsx
+++ b/event-runtime/web/src/components/Dialog.test.tsx
@@ -118,21 +118,70 @@ describe("Dialog", () => {
     expect(document.activeElement).toBe(chip);
   });
 
-  test("Tab cycle ignores a hidden control after the last visible control", () => {
-    const r = render(<OpenDialog onClose={() => {}} />);
+  test("Tab cycle includes a control inside a display: contents container", () => {
+    const r = render(
+      <OpenDialog onClose={() => {}}>
+        <div style={{ display: "contents" }}>
+          <button type="button" data-testid="contents-control">
+            contents control
+          </button>
+        </div>
+      </OpenDialog>,
+    );
     const panel = r.getByRole("dialog");
     const envelope = r.getByTestId("envelope");
     const chip = r.getByTestId("chip");
-    const hidden = document.createElement("button");
-    hidden.type = "button";
-    hidden.hidden = true;
-    panel.appendChild(hidden);
+    const contentsControl = r.getByTestId("contents-control");
 
-    // happy-dom has no layout engine, so offsetParent must be stamped to make
-    // this browser visibility branch falsifiable rather than accidentally green.
+    // happy-dom has no layout engine, so stamp the CSSOM values this browser
+    // case produces and make the regression fail under the old heuristic.
     Object.defineProperty(envelope, "offsetParent", { configurable: true, value: panel });
     Object.defineProperty(chip, "offsetParent", { configurable: true, value: panel });
-    Object.defineProperty(hidden, "offsetParent", { configurable: true, value: null });
+    Object.defineProperty(contentsControl, "offsetParent", { configurable: true, value: null });
+
+    envelope.focus();
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(contentsControl);
+  });
+
+  test("Tab cycle includes a position: fixed control", () => {
+    const r = render(
+      <OpenDialog onClose={() => {}}>
+        <button type="button" data-testid="fixed-control" style={{ position: "fixed" }}>
+          fixed control
+        </button>
+      </OpenDialog>,
+    );
+    const panel = r.getByRole("dialog");
+    const envelope = r.getByTestId("envelope");
+    const chip = r.getByTestId("chip");
+    const fixedControl = r.getByTestId("fixed-control");
+
+    Object.defineProperty(envelope, "offsetParent", { configurable: true, value: panel });
+    Object.defineProperty(chip, "offsetParent", { configurable: true, value: panel });
+    Object.defineProperty(fixedControl, "offsetParent", { configurable: true, value: null });
+
+    envelope.focus();
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(fixedControl);
+  });
+
+  test("Tab cycle ignores hidden, display:none, and visibility:hidden controls", () => {
+    const r = render(
+      <OpenDialog onClose={() => {}}>
+        <button type="button" hidden>
+          hidden attribute
+        </button>
+        <div style={{ display: "none" }}>
+          <button type="button">display none ancestor</button>
+        </div>
+        <button type="button" style={{ visibility: "hidden" }}>
+          visibility hidden
+        </button>
+      </OpenDialog>,
+    );
+    const envelope = r.getByTestId("envelope");
+    const chip = r.getByTestId("chip");
 
     chip.focus();
     expect(fireEvent.keyDown(window, { key: "Tab" })).toBe(false);

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1386,10 +1386,31 @@ export function Button({
 const FOCUSABLE =
   "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
+/** Whether a candidate is rendered without relying on offsetParent layout semantics. */
+function isTabCycleNodeVisible(el: HTMLElement, root: HTMLElement): boolean {
+  if (!el.isConnected) return false;
+
+  // `offsetParent` is also null for visible fixed-position elements and for
+  // descendants of `display: contents`. Walk the rendered ancestor chain
+  // instead, while checking visibility on the candidate because descendants
+  // can override an ancestor's `visibility` value.
+  let current: HTMLElement | null = el;
+  while (current) {
+    if (current.hidden) return false;
+    const style = current.ownerDocument.defaultView?.getComputedStyle(current);
+    if (style?.display === "none") return false;
+    if (current === root) break;
+    current = current.parentElement;
+  }
+
+  const visibility = el.ownerDocument.defaultView?.getComputedStyle(el).visibility;
+  return visibility !== "hidden" && visibility !== "collapse";
+}
+
 /** Keep Tab focus inside a modal while ignoring controls hidden by layout. */
 export function tabCycle(root: HTMLElement, e: KeyboardEvent) {
-  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
-    (el) => el.offsetParent !== null || el === document.activeElement,
+  const nodes = [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((el) =>
+    isTabCycleNodeVisible(el, root),
   );
   if (nodes.length === 0) {
     e.preventDefault();


### PR DESCRIPTION
Fixes WM-246

Replaces the `offsetParent` visibility heuristic with explicit rendered/visibility checks so focus traps include fixed-position controls and descendants of `display: contents` while excluding genuinely hidden controls. Adds Dialog regression coverage for both visible edge cases and hidden controls.

Verification: `bun test event-runtime/web/src/components/Dialog.test.tsx` — 11 pass, 0 fail.

UX critique: required — SHIP; evidence: http://127.0.0.1:7739/