### PR TITLE
fix(deploy): make launchd generation fresh-machine safe

### DIFF
--- a/deploy/gen.mjs
+++ b/deploy/gen.mjs
@@ -18,14 +18,21 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { loadSchedule, toSeconds, ROOT } from "../lib/schedule.mjs";
 const OUT = path.join(ROOT, "deploy", "launchd");
-const INSTALL = process.argv.includes("--install");
+const DEFAULT_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 
 const expand = (p) => p.replace(/^~/, homedir());
 
-
 const xml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-function plist(job, defaults) {
+export function launchdPath(environmentPath = process.env.PATH, home = homedir()) {
+  const entries = (environmentPath || DEFAULT_PATH).split(":").filter(Boolean);
+  for (const entry of [path.join(home, ".bun", "bin"), path.join(home, ".local", "bin")]) {
+    if (!entries.includes(entry)) entries.push(entry);
+  }
+  return entries.join(":");
+}
+
+export function plist(job, defaults, environmentPath = launchdPath()) {
   const label = `${defaults.label_prefix}.${job.name}`;
   const logDir = expand(defaults.log_dir || "~/Library/Logs");
   const args = ["/bin/bash", "-lc", `cd ${ROOT} && ${job.command}`];
@@ -48,6 +55,12 @@ ${args.map((a) => `        <string>${xml(a)}</string>`).join("\n")}
     <key>RunAtLoad</key>
     <${defaults.run_at_load === true ? "true" : "false"}/>
 
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${xml(environmentPath)}</string>
+    </dict>
+
     <!-- .out.log, not .log: a job whose wrapper already writes its own
          structured log would otherwise have two writers on one file. -->
     <key>StandardOutPath</key>
@@ -64,34 +77,46 @@ ${args.map((a) => `        <string>${xml(a)}</string>`).join("\n")}
 `;
 }
 
-const { defaults, jobs } = loadSchedule();
-mkdirSync(OUT, { recursive: true });
-
-const enabled = jobs.filter((j) => j.enabled !== false);
-const skipped = jobs.filter((j) => j.enabled === false);
-
-for (const job of enabled) {
-  const file = path.join(OUT, `${defaults.label_prefix}.${job.name}.plist`);
-  const next = plist(job, defaults);
-  const prev = existsSync(file) ? readFileSync(file, "utf8") : null;
-  writeFileSync(file, next);
-  console.log(`${prev === next ? "  unchanged" : prev ? "  updated  " : "  created  "} ${path.basename(file)}  (every ${job.every})`);
-}
-for (const job of skipped) console.log(`  disabled  ${job.name}  — ${String(job.why || "").slice(0, 60)}`);
-
-if (!INSTALL) {
-  console.log(`\n${enabled.length} job(s) rendered to deploy/launchd/. Re-run with --install to load them.`);
-  process.exit(0);
+export function installPlists(enabled, defaults, {
+  outDir = OUT,
+  agentsDir = path.join(homedir(), "Library/LaunchAgents"),
+  run = execFileSync,
+  uid = process.getuid(),
+} = {}) {
+  mkdirSync(agentsDir, { recursive: true });
+  for (const job of enabled) {
+    const label = `${defaults.label_prefix}.${job.name}`;
+    const src = path.join(outDir, `${label}.plist`);
+    const dst = path.join(agentsDir, `${label}.plist`);
+    writeFileSync(dst, readFileSync(src));
+    try { run("launchctl", ["bootout", `gui/${uid}/${label}`], { stdio: "ignore" }); } catch {}
+    run("launchctl", ["bootstrap", `gui/${uid}`, dst]);
+    console.log(`  loaded    ${label}`);
+  }
 }
 
-const AGENTS = path.join(homedir(), "Library/LaunchAgents");
-for (const job of enabled) {
-  const label = `${defaults.label_prefix}.${job.name}`;
-  const src = path.join(OUT, `${label}.plist`);
-  const dst = path.join(AGENTS, `${label}.plist`);
-  writeFileSync(dst, readFileSync(src));
-  const uid = process.getuid();
-  try { execFileSync("launchctl", ["bootout", `gui/${uid}/${label}`], { stdio: "ignore" }); } catch {}
-  execFileSync("launchctl", ["bootstrap", `gui/${uid}`, dst]);
-  console.log(`  loaded    ${label}`);
+export function main({ install = process.argv.includes("--install") } = {}) {
+  const { defaults, jobs } = loadSchedule();
+  mkdirSync(OUT, { recursive: true });
+
+  const enabled = jobs.filter((j) => j.enabled !== false);
+  const skipped = jobs.filter((j) => j.enabled === false);
+
+  for (const job of enabled) {
+    const file = path.join(OUT, `${defaults.label_prefix}.${job.name}.plist`);
+    const next = plist(job, defaults);
+    const prev = existsSync(file) ? readFileSync(file, "utf8") : null;
+    writeFileSync(file, next);
+    console.log(`${prev === next ? "  unchanged" : prev ? "  updated  " : "  created  "} ${path.basename(file)}  (every ${job.every})`);
+  }
+  for (const job of skipped) console.log(`  disabled  ${job.name}  — ${String(job.why || "").slice(0, 60)}`);
+
+  if (!install) {
+    console.log(`\n${enabled.length} job(s) rendered to deploy/launchd/. Re-run with --install to load them.`);
+    return;
+  }
+
+  installPlists(enabled, defaults);
 }
+
+if (import.meta.main) main();

--- a/deploy/gen.test.mjs
+++ b/deploy/gen.test.mjs
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { installPlists, launchdPath, plist } from "./gen.mjs";
+
+const defaults = {
+  label_prefix: "com.wattmind",
+  log_dir: "~/Library/Logs",
+  run_at_load: false,
+};
+const job = {
+  name: "triage",
+  every: "5m",
+  command: "bun orchestrator/run.mjs --only triage",
+};
+
+test("plist includes EnvironmentVariables with a launchd-safe PATH", () => {
+  const home = "/Users/factory";
+  const environmentPath = launchdPath("/custom/bin:/usr/bin", home);
+  const rendered = plist(job, defaults, environmentPath);
+
+  expect(environmentPath).toBe(
+    "/custom/bin:/usr/bin:/Users/factory/.bun/bin:/Users/factory/.local/bin",
+  );
+  expect(rendered).toContain(`    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${environmentPath}</string>
+    </dict>`);
+  expect((rendered.match(/<key>EnvironmentVariables<\/key>/g) ?? []).length).toBe(1);
+  expect((rendered.match(/<key>PATH<\/key>/g) ?? []).length).toBe(1);
+});
+
+test("launchdPath uses the macOS toolchain fallback when PATH is missing", () => {
+  expect(launchdPath("", "/Users/factory")).toBe(
+    "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/factory/.bun/bin:/Users/factory/.local/bin",
+  );
+});
+
+test("installPlists creates a missing LaunchAgents directory before copying", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-launchd-"));
+  const outDir = path.join(root, "rendered");
+  const agentsDir = path.join(root, "home", "Library", "LaunchAgents");
+  const label = `${defaults.label_prefix}.${job.name}`;
+  const source = path.join(outDir, `${label}.plist`);
+  const calls = [];
+
+  try {
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(source, "<plist>generated</plist>\n");
+    expect(existsSync(agentsDir)).toBe(false);
+
+    installPlists([job], defaults, {
+      outDir,
+      agentsDir,
+      uid: 501,
+      run(command, args) {
+        calls.push([command, args]);
+      },
+    });
+
+    expect(readFileSync(path.join(agentsDir, `${label}.plist`), "utf8")).toBe(
+      "<plist>generated</plist>\n",
+    );
+    expect(calls).toEqual([
+      ["launchctl", ["bootout", `gui/501/${label}`]],
+      ["launchctl", ["bootstrap", "gui/501", path.join(agentsDir, `${label}.plist`)]],
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- create the LaunchAgents directory before installing generated plists
- emit a launchd-safe PATH under EnvironmentVariables
- cover PATH generation and fresh-directory installation with unit tests

## Verification
- `bun test deploy/gen.test.mjs`

UX critique: skipped — local infrastructure tooling has no user-facing flow.

Fixes WM-278