### PR TITLE
feat(event-runtime): cause-typed environment retries

### DIFF
--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -76,13 +76,13 @@ describe("reaper (OPS-416)", () => {
       .query(`SELECT from_state, to_state, reason FROM lifecycle_events WHERE run_id = ? ORDER BY seq`)
       .all(spec.runId);
     const lastTwo = events.slice(-2);
-    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "lease_expired" });
-    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "retry" });
+    expect(lastTwo[0]).toEqual({ from_state: "VERIFYING", to_state: "FAILED", reason: "failure:environment:lease_expired" });
+    expect(lastTwo[1]).toEqual({ from_state: "FAILED", to_state: "QUEUED", reason: "retry:environment" });
   });
 
   test("reaps stranded VERIFYING run and dead-letters to FAILED when maxAttempts reached", () => {
     const db = openDb(":memory:");
-    const spec = makeSpec({ maxAttempts: 1 });
+    const spec = makeSpec({ maxAttempts: 1, maxEnvironmentRetries: 0 });
     setupVerifyingRun(db, spec, { now: T0, expired: true });
 
     expect(runState(db, spec.runId)).toBe("VERIFYING");

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -40,6 +40,60 @@ const RUNTIME_ARTIFACTS = [{ kind: "transcript", path: ".transcript.json" }];
 /** Grace added to the spec timeout before a lease is considered abandoned. */
 const LEASE_GRACE_SECONDS = 120;
 
+/** Infrastructure retries are independent from the agent-error attempt budget. */
+export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
+
+const ENVIRONMENT_FAILURES = new Set(["adapter_error", "lease_expired"]);
+const AGENT_FAILURES = new Set(["contract_violation"]);
+const FATAL_FAILURES = new Set([
+  "cli_not_found",
+  "unknown_adapter",
+  "agent_definition_mismatch",
+  "workspace_integrity_violation",
+]);
+
+/** Closed failure taxonomy: unknown reasons fail safe as fatal and never retry. */
+export function classifyFailureCause(reasonCode) {
+  if (ENVIRONMENT_FAILURES.has(reasonCode)) return "environment";
+  if (AGENT_FAILURES.has(reasonCode) || String(reasonCode).startsWith("agent_exit_")) {
+    return "agent_error";
+  }
+  if (FATAL_FAILURES.has(reasonCode) || String(reasonCode).startsWith("policy_denied:")) {
+    return "fatal";
+  }
+  return "fatal";
+}
+
+function maxEnvironmentRetries(spec) {
+  return Number.isInteger(spec.maxEnvironmentRetries) && spec.maxEnvironmentRetries >= 0
+    ? spec.maxEnvironmentRetries
+    : DEFAULT_MAX_ENVIRONMENT_RETRIES;
+}
+
+function failureCount(db, runId, cause) {
+  return db
+    .query(`SELECT reason_code FROM attempts WHERE run_id = ? AND finished_at IS NOT NULL`)
+    .all(runId)
+    .filter((row) => classifyFailureCause(row.reason_code) === cause)
+    .length;
+}
+
+/** Called after the current attempt is finalized, so counts include this failure. */
+function retryDecision(db, runId, spec, reasonCode) {
+  const cause = classifyFailureCause(reasonCode);
+  if (cause === "environment") {
+    return { cause, retry: failureCount(db, runId, cause) <= maxEnvironmentRetries(spec) };
+  }
+  if (cause === "agent_error") {
+    return { cause, retry: failureCount(db, runId, cause) < spec.maxAttempts };
+  }
+  return { cause, retry: false };
+}
+
+function typedFailureReason(reasonCode, detail = reasonCode) {
+  return `failure:${classifyFailureCause(reasonCode)}:${detail}`;
+}
+
 function resolveNow(now) {
   return typeof now === "function" ? now() : (now ?? Date.now());
 }
@@ -512,8 +566,8 @@ export async function executeClaimed(db, registry, adapters, claim, {
   }, 250);
   cancelPoll?.unref?.();
 
-  /** Terminal failure-shaped write: transition + attempts row, one tx. */
-  const failTerminal = (to, journalReason, reasonCode, { requeue = false } = {}) =>
+  /** Terminal failure-shaped write: classify, finalize, and budget any retry atomically. */
+  const failTerminal = (to, journalReason, reasonCode) =>
     txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
@@ -523,16 +577,17 @@ export async function executeClaimed(db, registry, adapters, claim, {
       const expectFrom = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
       transition(db, {
         runId, to, expectFrom,
-        actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
+        actor: owner, reason: typedFailureReason(reasonCode, journalReason), attempt, policyVersion, now: currentNow,
       });
       finishAttempt(db, runId, attempt, to, reasonCode, currentNow, attemptUsage);
-      if (requeue && attempt < spec.maxAttempts) {
+      const decision = retryDecision(db, runId, spec, reasonCode);
+      if (decision.retry) {
         transition(db, {
           runId, to: "QUEUED", expectFrom: "FAILED",
-          actor: owner, reason: "retry", attempt, policyVersion, now: nowFn(),
+          actor: owner, reason: `retry:${decision.cause}`, attempt, policyVersion, now: nowFn(),
         });
       }
-      return { ok: true };
+      return { ok: true, cause: decision.cause, requeued: decision.retry };
     });
 
   let def = null;
@@ -540,20 +595,21 @@ export async function executeClaimed(db, registry, adapters, claim, {
     def = getAgent(registry, spec.agent);
   } catch {}
 
-  const refuseTerminal = (reasonCode, checks = ["dispatch_gate"]) =>
+  const refuseTerminal = (reasonCode, checks = ["dispatch_gate"], { causeTyped = false } = {}) =>
     txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
         recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
         return { fenced: true };
       }
+      const journalReason = causeTyped ? typedFailureReason(reasonCode) : reasonCode;
       transition(db, {
         runId, to: "VERIFYING", expectFrom: "RUNNING",
-        actor: owner, reason: reasonCode, attempt, policyVersion, now: currentNow,
+        actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
       });
       transition(db, {
         runId, to: "REFUSED", expectFrom: "VERIFYING",
-        actor: owner, reason: reasonCode, attempt, policyVersion, now: currentNow,
+        actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
       });
       const receipt = createReceipt({
         runId,
@@ -673,7 +729,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     if (!def) def = getAgent(registry, spec.agent);
 
     if (!verifyDefHash(spec, def)) {
-      const refusedRes = refuseTerminal("agent_definition_mismatch", ["def_hash_mismatch"]);
+      const refusedRes = refuseTerminal("agent_definition_mismatch", ["def_hash_mismatch"], { causeTyped: true });
       destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
       if (refusedRes?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "REFUSED", reasonCode: "agent_definition_mismatch", receipt: refusedRes.receipt };
@@ -759,7 +815,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `agent_exit_${exitCode}`, log: null }); } catch {}
       }
       const reasonCode = `agent_exit_${exitCode}`;
-      const res = failTerminal("FAILED", reasonCode, reasonCode, { requeue: true });
+      const res = failTerminal("FAILED", reasonCode, reasonCode);
       destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
@@ -829,14 +885,15 @@ export async function executeClaimed(db, registry, adapters, claim, {
         }
         transition(db, {
           runId, to: "FAILED", expectFrom: "VERIFYING",
-          actor: owner, reason: failureReason,
+          actor: owner, reason: typedFailureReason(reasonCode, failureReason),
           attempt, policyVersion, now: currentNow,
         });
         finishAttempt(db, runId, attempt, "FAILED", reasonCode, currentNow, attemptUsage);
-        if (reasonCode !== "baseline_red" && attempt < spec.maxAttempts) {
+        const decision = retryDecision(db, runId, spec, reasonCode);
+        if (decision.retry) {
           transition(db, {
             runId, to: "QUEUED", expectFrom: "FAILED",
-            actor: owner, reason: "retry", attempt, policyVersion, now: nowFn(),
+            actor: owner, reason: `retry:${decision.cause}`, attempt, policyVersion, now: nowFn(),
           });
         }
         return { ok: true };
@@ -1001,7 +1058,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     const journalReason = `${reasonCode}: ${err?.message ?? String(err)}`;
     let res;
     try {
-      res = failTerminal("FAILED", journalReason, reasonCode, { requeue: !isCliNotFound && !isWorkspaceProvisioning });
+      res = failTerminal("FAILED", journalReason, reasonCode);
     } catch {
       // if failTerminal could not transition, continue
     }
@@ -1021,7 +1078,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
 /**
  * Re-queue LEASED/RUNNING/VERIFYING runs whose current attempt's lease expired.
  * The stale attempt keeps its (now lower) fencing token, so a late publish from
- * it is fenced out. Respects maxAttempts and dead-letters beyond it.
+ * it is fenced out. Lease loss spends only the dedicated environment budget.
  */
 export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = "unknown" } = {}) {
   const currentNow = resolveNow(now);
@@ -1035,34 +1092,39 @@ export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = 
       .all(iso(currentNow));
     for (const row of rows) {
       const spec = JSON.parse(row.spec_json);
-      if (row.attempts < spec.maxAttempts) {
-        if (row.state === "VERIFYING") {
-          transition(db, {
-            runId: row.run_id, to: "FAILED",
-            actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now: currentNow,
-          });
-          transition(db, {
-            runId: row.run_id, to: "QUEUED",
-            actor: "reaper", reason: "retry", attempt: row.attempts, policyVersion, now: currentNow,
-          });
-        } else {
-          transition(db, {
-            runId: row.run_id, to: "QUEUED",
-            actor: "reaper", reason: "lease_expired", attempt: row.attempts, policyVersion, now: currentNow,
-          });
-        }
-      } else {
-        if (row.state === "LEASED") {
-          transition(db, {
-            runId: row.run_id, to: "RUNNING",
-            actor: "reaper", reason: "lease_expired_attempts_exhausted", attempt: row.attempts, policyVersion, now: currentNow,
-          });
-        }
+      const failureReason = typedFailureReason("lease_expired");
+
+      // VERIFYING cannot transition directly to QUEUED; record its failure first.
+      if (row.state === "VERIFYING") {
         transition(db, {
           runId: row.run_id, to: "FAILED",
-          actor: "reaper", reason: "lease_expired_attempts_exhausted", attempt: row.attempts, policyVersion, now: currentNow,
+          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
         });
-        finishAttempt(db, row.run_id, row.attempts, "FAILED", "lease_expired", currentNow);
+      }
+      finishAttempt(db, row.run_id, row.attempts, "FAILED", "lease_expired", currentNow);
+      const decision = retryDecision(db, row.run_id, spec, "lease_expired");
+
+      if (decision.retry) {
+        transition(db, {
+          runId: row.run_id, to: "QUEUED",
+          actor: "reaper", reason: `retry:${decision.cause}`, attempt: row.attempts, policyVersion, now: currentNow,
+        });
+        continue;
+      }
+
+      // LEASED has no direct FAILED edge; advance through RUNNING only when
+      // the environment retry ceiling is exhausted and the run must terminate.
+      if (row.state === "LEASED") {
+        transition(db, {
+          runId: row.run_id, to: "RUNNING",
+          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
+        });
+      }
+      if (row.state !== "VERIFYING") {
+        transition(db, {
+          runId: row.run_id, to: "FAILED",
+          actor: "reaper", reason: failureReason, attempt: row.attempts, policyVersion, now: currentNow,
+        });
       }
     }
     return rows.length;
@@ -1132,15 +1194,18 @@ export function forceFailRun(db, runId, { actor = "operator", reason = "operator
 }
 
 /**
- * Operator retry (§13): FAILED → QUEUED, or recovery from VERIFYING. Retrying past maxAttempts requires
- * the explicit force override, which is recorded in the journal reason.
+ * Operator retry (§13): FAILED → QUEUED, or recovery from VERIFYING. Only
+ * agent-caused failures spend maxAttempts; environment attempts remain retryable.
+ * Retrying past the agent budget requires the explicit force override.
  */
 export function retryRun(db, runId, { actor, force = false, now = () => Date.now(), policyVersion } = {}) {
   const currentNow = resolveNow(now);
   const row = db.query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
   if (!row) throw new Error(`unknown run ${runId}`);
   const spec = JSON.parse(row.spec_json);
-  if (!force && row.attempts >= spec.maxAttempts) throw new Error("attempts_exhausted");
+  if (!force && failureCount(db, runId, "agent_error") >= spec.maxAttempts) {
+    throw new Error("attempts_exhausted");
+  }
   if (row.state === "VERIFYING") {
     return txImmediate(db, () => {
       transition(db, { runId, to: "FAILED", actor, reason: "operator_retry_verifying", policyVersion, now: currentNow });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1203,7 +1203,7 @@ export function retryRun(db, runId, { actor, force = false, now = () => Date.now
   const row = db.query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
   if (!row) throw new Error(`unknown run ${runId}`);
   const spec = JSON.parse(row.spec_json);
-  if (!force && failureCount(db, runId, "agent_error") >= spec.maxAttempts) {
+  if (!force && (failureCount(db, runId, "agent_error") >= spec.maxAttempts || failureCount(db, runId, "fatal") > 0)) {
     throw new Error("attempts_exhausted");
   }
   if (row.state === "VERIFYING") {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -16,8 +16,9 @@ import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import {
   acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
-  createReloadWatcher, defaultLocksDir, dispatchLockPath, executeClaimed, reapExpiredLeases,
-  releaseClaimLock, repositoryIsClean, repositoryStatus, retryRun, runOnce,
+  createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
+  executeClaimed, classifyFailureCause, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
+  repositoryStatus, retryRun, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
 
@@ -269,7 +270,7 @@ describe("worker", () => {
 
   test("policy denial is terminal and is never retried as an opaque agent exit", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ adapter: "policy" }));
+    const spec = queueRun(db, makeSpec({ adapter: "policy", maxAttempts: 5 }));
     const policyAdapter = {
       execute: async () => ({
         // Adapters report policyDenials only when they are the verdict — the
@@ -287,6 +288,7 @@ describe("worker", () => {
     expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("policy_denied:Bash");
     expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
     expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(0);
+    expect(claimNext(db, opts())).toBeNull();
   });
 
   test("refuse: REFUSED, results row stored, no outbox row, workspace destroyed", async () => {
@@ -521,12 +523,11 @@ describe("worker", () => {
     expect(db.query(`SELECT status FROM proposals WHERE id = 'p2'`).get().status).toBe("open");
   });
 
-  test("retryRun: exhausted attempts throw without force, re-queue with force", () => {
+  test("retryRun: exhausted agent attempts throw without force, re-queue with force", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ maxAttempts: 1 }));
-    claimNext(db, opts());
-    transition(db, { runId: spec.runId, to: "RUNNING", expectFrom: "LEASED", actor: "test", now: T0 });
-    transition(db, { runId: spec.runId, to: "FAILED", expectFrom: "RUNNING", actor: "test", now: T0 });
+    const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] }, maxAttempts: 1 }));
+    await runOnce(db, registry, adapters, opts());
+    expect(runState(db, spec.runId)).toBe("FAILED");
 
     expect(() => retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 }))
       .toThrow("attempts_exhausted");
@@ -536,45 +537,144 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("QUEUED");
   });
 
-  test("adapter exception: FAILED/adapter_error, workspace destroyed, not wedged in RUNNING (OPS-405)", async () => {
+  test("retryRun does not treat environment attempts as exhausted agent attempts", async () => {
     const db = openDb(":memory:");
-    const throwingAdapter = {
-      execute: async () => {
-        throw new Error("simulated transport explosion");
-      },
-    };
-    const throwingAdapters = { throwing: throwingAdapter };
-    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 1, workspace: { type: "ephemeral", retainOnFailure: false } }));
-    const o = opts();
-
-    const summary = await runOnce(db, registry, throwingAdapters, o);
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("adapter_error");
+    const throwingAdapter = { execute: async () => { throw new Error("network dropped"); } };
+    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 1, maxEnvironmentRetries: 0 }));
+    await runOnce(db, registry, { throwing: throwingAdapter }, opts());
     expect(runState(db, spec.runId)).toBe("FAILED");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
-    expect(attempt.terminal_state).toBe("FAILED");
-    expect(attempt.reason_code).toBe("adapter_error");
-    expect(attempt.finished_at).toBeTruthy();
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    const retried = retryRun(db, spec.runId, { actor: "operator", policyVersion: "test", now: T0 });
+    expect(retried.to).toBe("QUEUED");
   });
 
-  test("adapter exception with retries: auto re-QUEUED, workspace cleaned (OPS-405)", async () => {
+  test("failure cause taxonomy classifies retryable and fatal worker failures", () => {
+    expect(classifyFailureCause("adapter_error")).toBe("environment");
+    expect(classifyFailureCause("lease_expired")).toBe("environment");
+    expect(classifyFailureCause("agent_exit_1")).toBe("agent_error");
+    expect(classifyFailureCause("contract_violation")).toBe("agent_error");
+    for (const reason of [
+      "cli_not_found",
+      "unknown_adapter",
+      "agent_definition_mismatch",
+      "policy_denied:Bash",
+      "workspace_integrity_violation",
+    ]) {
+      expect(classifyFailureCause(reason)).toBe("fatal");
+    }
+    expect(DEFAULT_MAX_ENVIRONMENT_RETRIES).toBe(3);
+  });
+
+  test("adapter_error with maxAttempts 1 requeues and succeeds without consuming the agent budget", async () => {
+    const db = openDb(":memory:");
+    let calls = 0;
+    const flakyAdapter = {
+      async execute(args) {
+        calls += 1;
+        if (calls === 1) throw new Error("simulated transport explosion");
+        return fake.execute(args);
+      },
+    };
+    const spec = queueRun(db, makeSpec({
+      adapter: "flaky",
+      maxAttempts: 1,
+      maxEnvironmentRetries: 1,
+      workspace: { type: "ephemeral", retainOnFailure: false },
+    }));
+    const o = opts();
+
+    const first = await runOnce(db, registry, { flaky: flakyAdapter }, o);
+    expect(first).toMatchObject({ terminalState: "FAILED", reasonCode: "adapter_error" });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:environment");
+
+    const second = await runOnce(db, registry, { flaky: flakyAdapter }, o);
+    expect(second.terminalState).toBe("COMPLETED");
+    expect(runState(db, spec.runId)).toBe("COMPLETED");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
+      .toEqual([{ reason_code: "adapter_error" }, { reason_code: "ok" }]);
+  });
+
+  test("repeated environment failures dead-letter after the dedicated retry ceiling", async () => {
     const db = openDb(":memory:");
     const throwingAdapter = {
       execute: async () => {
         throw new Error("simulated transport explosion");
       },
     };
-    const throwingAdapters = { throwing: throwingAdapter };
-    const spec = queueRun(db, makeSpec({ adapter: "throwing", maxAttempts: 2, workspace: { type: "ephemeral", retainOnFailure: false } }));
+    const spec = queueRun(db, makeSpec({
+      adapter: "throwing",
+      maxAttempts: 1,
+      maxEnvironmentRetries: 2,
+      workspace: { type: "ephemeral", retainOnFailure: false },
+    }));
     const o = opts();
 
-    const summary = await runOnce(db, registry, throwingAdapters, o);
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("adapter_error");
+    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
     expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
+    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect((await runOnce(db, registry, { throwing: throwingAdapter }, o)).reasonCode).toBe("adapter_error");
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(db.query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`).get(spec.runId).n).toBe(3);
+    expect(lifecycleOf(db, spec.runId).filter((event) => event.reason === "retry:environment")).toHaveLength(2);
+  });
+
+  test("environment failures do not consume agent_exit retry attempts", async () => {
+    const db = openDb(":memory:");
+    let calls = 0;
+    const mixedAdapter = {
+      async execute() {
+        calls += 1;
+        if (calls === 1) throw new Error("network dropped");
+        return { exitCode: 1, timedOut: false };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "mixed", maxAttempts: 2, maxEnvironmentRetries: 1 }));
+    const o = opts();
+
+    await runOnce(db, registry, { mixed: mixedAdapter }, o);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    await runOnce(db, registry, { mixed: mixedAdapter }, o);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:agent_error");
+    await runOnce(db, registry, { mixed: mixedAdapter }, o);
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
+      .toEqual([
+        { reason_code: "adapter_error" },
+        { reason_code: "agent_exit_1" },
+        { reason_code: "agent_exit_1" },
+      ]);
+  });
+
+  test("contract violations consume maxAttempts independently of environment failures", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ input: { repos: ["invalid-artifact"] }, maxAttempts: 2 }));
+    const o = opts();
+
+    await runOnce(db, registry, adapters, o);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:agent_error");
+    await runOnce(db, registry, adapters, o);
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
+      .toEqual([{ reason_code: "contract_violation" }, { reason_code: "contract_violation" }]);
+  });
+
+  test("fatal errors never requeue regardless of either retry budget", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({
+      adapter: "nonexistent",
+      maxAttempts: 5,
+      maxEnvironmentRetries: 5,
+    }));
+
+    const summary = await runOnce(db, registry, adapters, opts());
+    expect(summary).toMatchObject({ terminalState: "FAILED", reasonCode: "unknown_adapter" });
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(claimNext(db, opts())).toBeNull();
+    expect(lifecycleOf(db, spec.runId).some((event) => event.reason?.startsWith("retry:"))).toBe(false);
   });
 
   test("post-VERIFYING exception finalizes the attempt and re-queues instead of stranding it (WM-261)", async () => {
@@ -601,22 +701,25 @@ describe("worker", () => {
     expect(existsSync(path.join(o.workspacesRoot, `${spec.runId}-a1`))).toBe(false);
   });
 
-  test("reapExpiredLeases dead-letters when maxAttempts is reached (OPS-405)", () => {
+  test("lease_expired uses the environment retry ceiling instead of maxAttempts", () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ maxAttempts: 1 }));
+    const spec = queueRun(db, makeSpec({ maxAttempts: 1, maxEnvironmentRetries: 1 }));
     const o = opts();
-    const claim = claimNext(db, o);
+    claimNext(db, o);
     expect(runState(db, spec.runId)).toBe("LEASED");
 
-    const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
-    expect(runState(db, spec.runId)).toBe("FAILED");
+    const firstExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+    expect(reapExpiredLeases(db, { now: firstExpiry, policyVersion: "test" })).toBe(1);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, spec.runId).at(-1).reason).toBe("retry:environment");
 
-    const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
-    expect(attempt.terminal_state).toBe("FAILED");
-    expect(attempt.reason_code).toBe("lease_expired");
-    // Does not re-queue again
-    expect(reapExpiredLeases(db, { now: afterExpiry + 1000, policyVersion: "test" })).toBe(0);
+    const secondClaim = claimNext(db, { ...o, now: firstExpiry });
+    const secondExpiry = firstExpiry + (spec.timeoutSeconds + 120) * 1000 + 1;
+    expect(secondClaim.attempt).toBe(2);
+    expect(reapExpiredLeases(db, { now: secondExpiry, policyVersion: "test" })).toBe(1);
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
+      .toEqual([{ reason_code: "lease_expired" }, { reason_code: "lease_expired" }]);
     expect(claimNext(db, opts())).toBeNull();
   });
 
@@ -835,6 +938,10 @@ describe("worker", () => {
     const attempt = db.query(`SELECT * FROM attempts WHERE run_id = ?`).get(spec.runId);
     expect(attempt.terminal_state).toBe("REFUSED");
     expect(attempt.reason_code).toBe("agent_definition_mismatch");
+    expect(lifecycleOf(db, spec.runId).slice(-2).map((event) => event.reason)).toEqual([
+      "failure:fatal:agent_definition_mismatch",
+      "failure:fatal:agent_definition_mismatch",
+    ]);
   });
 
   test("fencing on contract violation: stale worker cannot overwrite newer attempt (OPS-413)", async () => {


### PR DESCRIPTION
## Summary
- classify worker failures as environment, agent_error, or fatal
- retry adapter and lease environment failures under an independent ceiling
- preserve agent maxAttempts across environment failures and journal typed retry causes
- cover environment success/exhaustion, agent budgets, fatal failures, and lease reaping

## Verification
- `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/verify.test.mjs` — 86 pass, 0 fail

UX critique: skipped — backend event-runtime behavior with no user-facing surface

Fixes WM-224