### PR TITLE
fix(event-runtime-web): template search crashes on unrouted event types (WM-475)

### DIFF
--- a/event-runtime/web/src/components/InjectDialog.test.tsx
+++ b/event-runtime/web/src/components/InjectDialog.test.tsx
@@ -653,6 +653,31 @@ describe("InjectDialog keyboard search (WM-80)", () => {
       });
       expect(document.activeElement === search).toBe(true);
     }));
+
+  test("typing in search filters templates safely when registry contains unrouted event types (WM-475)", async () => {
+    const origAgents = api.agents;
+    const origRepos = api.repos;
+    api.agents = async () => ({
+      ...schemaRegistry(),
+      eventTypes: [
+        ...schemaRegistry().eventTypes,
+        { type: "factory.ticket.dispatched", proposalTtlSeconds: null } as any,
+      ],
+    });
+    api.repos = async () => ({ repos: REPO_ITEMS });
+    try {
+      const r = renderWithClient(<InjectDialog onClose={() => {}} />);
+      await r.findByText("factory.ticket.dispatched");
+      const search = r.getByPlaceholderText(/search event types/i);
+      act(() => {
+        changeInput(search, "smoke");
+      });
+      expect(r.getByText(/no templates or recent payloads matching "smoke"/i)).toBeTruthy();
+    } finally {
+      api.agents = origAgents;
+      api.repos = origRepos;
+    }
+  });
 });
 
 describe("InjectDialog invalid-payload confirm is distinct (WM-85)", () => {

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -375,8 +375,8 @@ export function InjectDialog({
     const q = search.trim().toLowerCase();
     if (!q) return recentEvents;
     return recentEvents.filter((r) => {
-      if (r.type.toLowerCase().includes(q)) return true;
-      if (r.eventId.toLowerCase().includes(q)) return true;
+      if (r.type?.toLowerCase().includes(q)) return true;
+      if (r.eventId?.toLowerCase().includes(q)) return true;
       if (r.envelope && isPlainObject(r.envelope.payload)) {
         try {
           if (JSON.stringify(r.envelope.payload).toLowerCase().includes(q)) return true;
@@ -391,9 +391,9 @@ export function InjectDialog({
     if (!q) return templates;
     return templates.filter(
       (t) =>
-        t.eventType.toLowerCase().includes(q) ||
-        t.agent.toLowerCase().includes(q) ||
-        t.summary.toLowerCase().includes(q),
+        (t.eventType?.toLowerCase().includes(q) ?? false) ||
+        (t.agent?.toLowerCase().includes(q) ?? false) ||
+        (t.summary?.toLowerCase().includes(q) ?? false),
     );
   }, [templates, search]);
 

--- a/event-runtime/web/src/graph/model.ts
+++ b/event-runtime/web/src/graph/model.ts
@@ -106,9 +106,9 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
       id: eventNodeId(route.type),
       kind: "eventType",
       label: route.type,
-      adapter: route.adapter,
+      adapter: route.adapter ?? "—",
       scope: route.idempotencyScope ?? [],
-      ttl: route.proposalTtlSeconds,
+      ttl: route.proposalTtlSeconds ?? null,
       admittedCount,
       plannedCount,
     });
@@ -150,7 +150,7 @@ export function buildCapabilityGraph(view: AgentsView, live?: LiveGraphState): C
 
   // 3. event type → agent (the planner's registered mapping)
   for (const route of routes) {
-    if (!byRef.has(route.agent)) continue; // registry guarantees this, but never draw a dangling edge
+    if (!route.agent || !byRef.has(route.agent)) continue; // registry guarantees this, but never draw a dangling edge
     edges.push({
       id: `routes:${route.type}`,
       source: eventNodeId(route.type),

--- a/event-runtime/web/src/templates.test.ts
+++ b/event-runtime/web/src/templates.test.ts
@@ -217,6 +217,18 @@ describe("buildTemplates", () => {
   ])("returns no templates when the registry response is %s", (_label, response) => {
     expect(buildTemplates(response as unknown as AgentsView, NOW)).toEqual([]);
   });
+
+  test("handles unrouted event types without agent or adapter (WM-475)", () => {
+    const unroutedView = {
+      agents: [],
+      eventTypes: [{ type: "factory.ticket.dispatched", proposalTtlSeconds: null }],
+    };
+    const templates = buildTemplates(unroutedView as unknown as AgentsView, NOW);
+    expect(templates).toHaveLength(1);
+    expect(templates[0]?.eventType).toBe("factory.ticket.dispatched");
+    expect(templates[0]?.agent).toBe("");
+    expect(templates[0]?.adapter).toBe("");
+  });
 });
 
 describe("retriggerEnvelope", () => {

--- a/event-runtime/web/src/templates.ts
+++ b/event-runtime/web/src/templates.ts
@@ -108,17 +108,20 @@ export function buildTemplates(view: unknown, nowMs: number): TriggerTemplate[] 
 
   const byRef = new Map(agents.map((a) => [a.ref, a]));
   return eventTypes.map((route) => {
-    const def = byRef.get(route.agent);
+    const def = route.agent ? byRef.get(route.agent) : undefined;
     const id = triggerId(nowMs);
+    const eventType = route.type ?? "";
+    const agent = route.agent ?? "";
+    const adapter = route.adapter ?? "";
     return {
-      eventType: route.type,
-      agent: route.agent,
-      adapter: route.adapter,
+      eventType,
+      agent,
+      adapter,
       summary: summarize(def?.inputSchema),
       envelope: {
         schemaVersion: "factory.event/v1",
         eventId: id,
-        type: route.type,
+        type: eventType,
         source: "web-trigger",
         subject: "factory",
         occurredAt: new Date(nowMs).toISOString(),

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -310,10 +310,10 @@ export interface RecommendationRule {
 /** Every registered route, independent of which agent mentions it. */
 export interface EventRoute {
   type: string;
-  agent: string;
-  adapter: string;
-  idempotencyScope: string[];
-  proposalTtlSeconds: number | null;
+  agent?: string;
+  adapter?: string;
+  idempotencyScope?: string[];
+  proposalTtlSeconds?: number | null;
 }
 
 export interface AgentsView {


### PR DESCRIPTION
## Summary
Fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')` in `InjectDialog` when typing in the template search input.

### Problem
`/api/agents` returns registered event types that lack an `agent` or `adapter` (e.g. `factory.ticket.dispatched`). When building templates in `buildTemplates`, `route.agent` is `undefined`. Searching in `InjectDialog` triggered `t.agent.toLowerCase()`, throwing a TypeError and crashing the UI.

### Fix
1. Default `agent` and `adapter` to empty strings in `buildTemplates` (`templates.ts`).
2. Add optional chaining when matching `t.eventType`, `t.agent`, `t.summary`, `r.type`, `r.eventId` in `InjectDialog.tsx`.
3. Mark `agent` and `adapter` as optional on `EventRoute` in `types.ts` and handle optional fields in `graph/model.ts`.
4. Add regression tests in `InjectDialog.test.tsx` and `templates.test.ts`.

Fixes WM-475