### PR TITLE
fix(worker): bound synchronous subprocesses

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -26,6 +26,16 @@ import { PathViolation, safeJoin } from "./workspace.mjs";
  */
 export const EVIDENCE_INLINE_LIMIT_BYTES = 256 * 1024;
 
+/** Hard ceiling for the repository-owned verification command (WM-262). */
+export const DEFAULT_REPO_VERIFY_TIMEOUT_MS = 120_000;
+
+function repoVerifyTimeoutMs() {
+  const configured = Number(process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_REPO_VERIFY_TIMEOUT_MS;
+}
+
 export const REFUSAL_REASONS = [
   "missing_input",
   "permission_denied",
@@ -84,7 +94,17 @@ export { normalizeFailureOutput, failureSignature };
  *         | { kind: "completed", result: object, receipt: object }}
  * @throws {ContractViolation} on any contract failure — fail closed.
  */
-export function verifyResult({ spec, def, registry, workspaceDir, attempt, journalHead = null, extraArtifacts = [], worktreeRecord = null }) {
+export function verifyResult({
+  spec,
+  def,
+  registry,
+  workspaceDir,
+  attempt,
+  journalHead = null,
+  extraArtifacts = [],
+  worktreeRecord = null,
+  verifyTimeoutMs = repoVerifyTimeoutMs(),
+}) {
   let raw;
   try {
     raw = readFileSync(path.join(workspaceDir, "result.json"), "utf8");
@@ -103,7 +123,9 @@ export function verifyResult({ spec, def, registry, workspaceDir, attempt, journ
   if (!shape.valid) throw new ContractViolation(shape.errors);
 
   if (candidate.terminalState === "refused") return verifyRefused({ spec, def, candidate, attempt });
-  return verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts, worktreeRecord });
+  return verifyCompleted({
+    spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts, worktreeRecord, verifyTimeoutMs,
+  });
 }
 
 /**
@@ -235,7 +257,17 @@ const SEMANTIC_CHECKS = {
   "factory.work-plan/v1": (candidate) => checkWorkPlan(candidate),
 };
 
-function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts = [], worktreeRecord = null }) {
+function verifyCompleted({
+  spec,
+  def,
+  candidate,
+  workspaceDir,
+  attempt,
+  journalHead,
+  extraArtifacts = [],
+  worktreeRecord = null,
+  verifyTimeoutMs,
+}) {
   if (candidate.artifact === undefined) throw new ContractViolation(["missing_artifact"]);
 
   const artifactCheck = validate(def.outputSchema, candidate.artifact);
@@ -260,11 +292,18 @@ function verifyCompleted({ spec, def, candidate, workspaceDir, attempt, journalH
     const worktreePath = worktreeRecord.path && existsSync(worktreeRecord.path)
       ? worktreeRecord.path
       : path.join(workspaceDir, "repo");
-    const vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], { cwd: worktreePath, encoding: "utf8" });
-    if (vres.status !== 0) {
+    const vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], {
+      cwd: worktreePath,
+      encoding: "utf8",
+      timeout: verifyTimeoutMs,
+    });
+    if (vres.error?.code === "ETIMEDOUT" || vres.status !== 0) {
       const output = [vres.stdout, vres.stderr].filter(Boolean).join("\n").trim();
-      const why = output.split("\n").filter(Boolean).pop() || `exit ${vres.status}`;
-      const baselineStillRed = matchesRedBaseline(worktreeRecord.baseline, output);
+      const timedOut = vres.error?.code === "ETIMEDOUT";
+      const why = timedOut
+        ? `timed out after ${verifyTimeoutMs}ms`
+        : output.split("\n").filter(Boolean).pop() || `exit ${vres.status}`;
+      const baselineStillRed = !timedOut && matchesRedBaseline(worktreeRecord.baseline, output);
       throw new ContractViolation(
         [`repo_verify_failed: ${why}`],
         { reasonCode: baselineStillRed ? "baseline_red" : "contract_violation" },

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -364,6 +364,26 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(out.kind).toBe("completed");
     expect(out.result.verification.checks).toContain("repo_verify_passed");
   });
+
+  test("a timed-out repository verification fails closed without hanging", () => {
+    const dir = worktreeWorkspace("while :; do :; done", null);
+    const previous = process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
+    process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = "25";
+    const started = Date.now();
+    try {
+      try {
+        verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.violations).toEqual(["repo_verify_failed: timed out after 25ms"]);
+        expect(Date.now() - started).toBeLessThan(1_000);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
+      else process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = previous;
+    }
+  });
 });
 
 describe("evidence retention (OPS-206)", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -43,6 +43,16 @@ const LEASE_GRACE_SECONDS = 120;
 /** Infrastructure retries are independent from the agent-error attempt budget. */
 export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
 
+/** Hard ceiling for synchronous git and Linear helper processes (WM-262). */
+export const DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS = 120_000;
+
+function workerSubprocessTimeoutMs() {
+  const configured = Number(process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS;
+}
+
 const ENVIRONMENT_FAILURES = new Set(["adapter_error", "lease_expired"]);
 const AGENT_FAILURES = new Set(["contract_violation"]);
 const FATAL_FAILURES = new Set([
@@ -112,9 +122,13 @@ function finishAttempt(db, runId, attempt, terminalState, reasonCode, now, usage
 }
 
 /** Include ignored files: an agent must not be able to hide a repository write. */
-export function repositoryStatus(checkoutPath) {
-  const result = spawnSync("git", ["-C", checkoutPath, "status", "--porcelain", "--untracked-files=all", "--ignored=matching"], {
+export function repositoryStatus(
+  checkoutPath,
+  { timeoutMs = workerSubprocessTimeoutMs(), gitCommand = "git" } = {},
+) {
+  const result = spawnSync(gitCommand, ["-C", checkoutPath, "status", "--porcelain", "--untracked-files=all", "--ignored=matching"], {
     encoding: "utf8",
+    timeout: timeoutMs,
   });
   return result.status === 0 ? result.stdout : null;
 }
@@ -311,7 +325,10 @@ export function codeStampFiles(repoRoot = codeStampRoot(), paths = CODE_STAMP_PA
 }
 
 function gitHead(repoRoot) {
-  const result = spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], { encoding: "utf8" });
+  const result = spawnSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+    timeout: workerSubprocessTimeoutMs(),
+  });
   return result.status === 0 ? result.stdout.trim().slice(0, 12) : "nogit";
 }
 
@@ -384,12 +401,21 @@ export function createReloadWatcher({
 
 const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
 
+/** Execute one bounded Linear CLI operation; exported for timeout regression tests. */
+export function runLinearCli(
+  args,
+  { command = "bun", timeoutMs = workerSubprocessTimeoutMs() } = {},
+) {
+  return execFileSync(command, [linearCli(), ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+}
+
 function defaultClaimTicket({ repo, ticket, harness = "claude" }) {
   try {
-    execFileSync("bun", [linearCli(), "claim", ticket, "--agent", harness], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    runLinearCli(["claim", ticket, "--agent", harness]);
     return { ok: true };
   } catch (err) {
     const stderr = String(err?.stderr ?? "");
@@ -403,24 +429,15 @@ function defaultUnclaimTicket({ repo, ticket, why, log = null, fetchTicket }) {
     if (typeof fetchTicket === "function") {
       cur = fetchTicket(ticket);
     } else {
-      const out = execFileSync("bun", [linearCli(), "get", ticket, "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      const out = runLinearCli(["get", ticket, "--json"]);
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
     if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
 
-    execFileSync("bun", [linearCli(), "state", ticket, "Todo", "--unassign", "--remove", "ai:in-progress"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    runLinearCli(["state", ticket, "Todo", "--unassign", "--remove", "ai:in-progress"]);
     const body = `Dispatch run failed, claim released back to Todo.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}`;
-    execFileSync("bun", [linearCli(), "comment", ticket, body], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    runLinearCli(["comment", ticket, body]);
     return true;
   } catch {
     return false;
@@ -444,10 +461,7 @@ function baselineFailureSignature({ why, log = null, baseline = null }) {
 function hasRecordedBaselineFailureComment(ticket, signature) {
   const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
   try {
-    const out = execFileSync("bun", [linearCli(), "comments", ticket, "--json"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const out = runLinearCli(["comments", ticket, "--json"]);
     const comments = JSON.parse(out);
     return (comments ?? []).some((row) => String(row.body ?? "").includes(marker));
   } catch {
@@ -461,29 +475,20 @@ function defaultBlockBaselineTicket({ repo, ticket, why, log = null, baseline = 
     if (typeof fetchTicket === "function") {
       cur = fetchTicket(ticket);
     } else {
-      const out = execFileSync("bun", [linearCli(), "get", ticket, "--json"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      const out = runLinearCli(["get", ticket, "--json"]);
       cur = JSON.parse(out);
     }
     if (!cur || cur.state?.name !== "In Progress") return false;
     if (!(cur.labels?.nodes ?? []).some((l) => l.name === "ai:in-progress")) return false;
 
     const signature = baselineFailureSignature({ why, log, baseline });
-    execFileSync("bun", [linearCli(), "state", ticket, "Blocked", "--unassign", "--add", "ai:blocked", "--remove", "ai:in-progress"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    runLinearCli(["state", ticket, "Blocked", "--unassign", "--add", "ai:blocked", "--remove", "ai:in-progress"]);
 
     if (!hasRecordedBaselineFailureComment(ticket, signature)) {
       const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
       const body = `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}\n\n
 <!-- ${marker} -->`;
-      execFileSync("bun", [linearCli(), "comment", ticket, body], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      runLinearCli(["comment", ticket, body]);
     }
     return true;
   } catch {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -18,7 +18,7 @@ import {
   acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
   createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
   executeClaimed, classifyFailureCause, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
-  repositoryStatus, retryRun, runOnce,
+  repositoryStatus, retryRun, runLinearCli, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
 
@@ -112,6 +112,35 @@ describe("worker", () => {
     expect(repositoryStatus(repo)).toBe(baseline);
     writeFileSync(path.join(repo, "generated", "agent-write.log"), "new\n");
     expect(repositoryStatus(repo)).not.toBe(baseline);
+  });
+
+  test("repository status returns null when git exceeds its timeout", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-hanging-git-"));
+    const hangingGit = path.join(dir, "git");
+    writeFileSync(hangingGit, "#!/bin/bash\nwhile :; do :; done\n", "utf8");
+    execFileSync("chmod", ["+x", hangingGit]);
+
+    const started = Date.now();
+    expect(repositoryStatus(dir, { gitCommand: hangingGit, timeoutMs: 25 })).toBeNull();
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  test("Linear helper subprocesses honor the configured timeout", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-hanging-linear-"));
+    const hangingCommand = path.join(dir, "bun");
+    writeFileSync(hangingCommand, "#!/bin/bash\nwhile :; do :; done\n", "utf8");
+    execFileSync("chmod", ["+x", hangingCommand]);
+    const previous = process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
+    process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = "25";
+
+    const started = Date.now();
+    try {
+      expect(() => runLinearCli(["get", "WM-262"], { command: hangingCommand })).toThrow();
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
+      else process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = previous;
+    }
   });
 
   test("e2e (WM-135): tiered pi route plans a spec with the model pinned; the fake adapter executes it, ignoring the model", async () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -17,6 +17,16 @@ import { artifactsRoot } from "./config.mjs";
 import { getRepo, loadRepos } from "./repos.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 
+/** Hard ceiling for repository-owned worktree lifecycle scripts (WM-262). */
+export const DEFAULT_WORKTREE_SCRIPT_TIMEOUT_MS = 120_000;
+
+function worktreeScriptTimeoutMs() {
+  const configured = Number(process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_WORKTREE_SCRIPT_TIMEOUT_MS;
+}
+
 export class PathViolation extends Error {
   constructor(workspaceDir, relPath) {
     super(`path "${relPath}" escapes workspace ${workspaceDir}`);
@@ -98,7 +108,7 @@ const WORKTREE_MARKER = ".worktree.json";
  * repo's declared `verify` command rides along in the returned record — the
  * §9 verifier runs it as ordinary code, never trusting the agent's report.
  */
-function materializeWorktree({ workspaceDir, input, checkoutDir }) {
+function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
   const repoName = input?.repo;
   const ticket = input?.ticket;
   if (!repoName || !ticket) {
@@ -110,6 +120,20 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
       `repo "${repoName}" declares no worktree lifecycle in config/repos.yaml (worktree_up/worktree_down/worktree_root) — the planner should have refused this`,
     );
   }
+  const worktreePath = path.join(repo.worktreeRoot, ticket);
+  const record = {
+    repo: repoName,
+    ticket,
+    path: worktreePath,
+    repoPath: repo.path,
+    down: repo.worktreeDown,
+    verify: repo.verify,
+  };
+  // Persist teardown facts before bring-up starts. A script can create its
+  // worktree and daemons before timing out; the marker lets the janitor find
+  // and safely delegate cleanup even when createWorkspace never returns.
+  writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+
   // Repo-owned bring-up may discover a red project baseline after the usable
   // worktree already exists. It reports that condition out-of-band and still
   // exits zero; a non-zero exit remains a provisioning failure.
@@ -118,13 +142,16 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
     cwd: repo.path,
     encoding: "utf8",
     env: { ...process.env, FACTORY_WORKTREE_REPORT: reportPath },
+    timeout: timeoutMs,
   });
-  if (up.status !== 0) {
-    const why = (up.stderr || up.stdout || "").trim().split("\n").pop() || `exit ${up.status}`;
+  if (up.error?.code === "ETIMEDOUT" || up.status !== 0) {
+    const timedOut = up.error?.code === "ETIMEDOUT";
+    const why = timedOut
+      ? `timed out after ${timeoutMs}ms`
+      : (up.stderr || up.stdout || "").trim().split("\n").pop() || `exit ${up.status}`;
     throw new WorktreeError(`worktree_up failed for ${repoName}/${ticket}: ${why}`);
   }
 
-  const worktreePath = path.join(repo.worktreeRoot, ticket);
   if (!existsSync(worktreePath)) {
     throw new WorktreeError(`worktree_up reported success for ${repoName}/${ticket} but did not create ${worktreePath}`);
   }
@@ -143,15 +170,7 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
   }
 
   symlinkSync(worktreePath, path.join(workspaceDir, checkoutDir));
-  const record = {
-    repo: repoName,
-    ticket,
-    path: worktreePath,
-    repoPath: repo.path,
-    down: repo.worktreeDown,
-    verify: repo.verify,
-    ...(baseline ? { baseline } : {}),
-  };
+  if (baseline) record.baseline = baseline;
   writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
 
   // The agent contract points it at input.json, so runtime-discovered context
@@ -170,7 +189,15 @@ function materializeWorktree({ workspaceDir, input, checkoutDir }) {
   return record;
 }
 
-export function createWorkspace({ root, runId, attempt, input, workspace = {}, artifactStore = artifactsRoot() }) {
+export function createWorkspace({
+  root,
+  runId,
+  attempt,
+  input,
+  workspace = {},
+  artifactStore = artifactsRoot(),
+  worktreeTimeoutMs = worktreeScriptTimeoutMs(),
+}) {
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "input.json"), `${canonicalJson(input)}\n`, "utf8");
@@ -207,7 +234,12 @@ export function createWorkspace({ root, runId, attempt, input, workspace = {}, a
 
   let worktree = null;
   if (workspace.type === "worktree") {
-    worktree = materializeWorktree({ workspaceDir: dir, input, checkoutDir: workspace.checkoutDir ?? "repo" });
+    worktree = materializeWorktree({
+      workspaceDir: dir,
+      input,
+      checkoutDir: workspace.checkoutDir ?? "repo",
+      timeoutMs: worktreeTimeoutMs,
+    });
   }
   return { dir, checkout, materialized, worktree };
 }
@@ -216,7 +248,15 @@ export function createWorkspace({ root, runId, attempt, input, workspace = {}, a
  * Remove the workspace unless retention was requested (§7: retain on failure
  * when policy says so). Returns false when retained, true when destroyed.
  */
-export function destroyWorkspace(dir, { retain = false, checkout = null, repoName = null } = {}) {
+export function destroyWorkspace(
+  dir,
+  {
+    retain = false,
+    checkout = null,
+    repoName = null,
+    worktreeTimeoutMs = worktreeScriptTimeoutMs(),
+  } = {},
+) {
   // Deregister a repository checkout even when the directory is retained:
   // a mirror that keeps stale worktree registrations refuses future adds.
   if (checkout) releaseCheckout({ checkoutPath: checkout, repoName });
@@ -237,8 +277,12 @@ export function destroyWorkspace(dir, { retain = false, checkout = null, repoNam
       record = null;
     }
     if (!record?.down || !record?.ticket) return false;
-    const down = spawnSync("/bin/bash", [record.down, record.ticket], { cwd: record.repoPath, encoding: "utf8" });
-    if (down.status !== 0) return false;
+    const down = spawnSync("/bin/bash", [record.down, record.ticket], {
+      cwd: record.repoPath,
+      encoding: "utf8",
+      timeout: worktreeTimeoutMs,
+    });
+    if (down.error?.code === "ETIMEDOUT" || down.status !== 0) return false;
   }
 
   rmSync(dir, { recursive: true, force: true });

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -87,6 +87,14 @@ describe("worktree workspaces (WM-108)", () => {
       `#!/bin/bash\nexit 0\n`,
     );
     writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-hanging.sh"),
+      `#!/bin/bash\nwhile :; do :; done\n`,
+    );
+    writeFileSync(
+      path.join(repoDir, "bin", "worktree-down-hanging.sh"),
+      `#!/bin/bash\nwhile :; do :; done\n`,
+    );
+    writeFileSync(
       path.join(repoDir, "bin", "worktree-up-red-baseline.sh"),
       `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\nprintf '%s\\n' '{"status":"red","check":"web_build","command":"bun run build:fast","exitCode":1,"output":"entry chunk exceeds budget"}' > "$FACTORY_WORKTREE_REPORT"\n`,
     );
@@ -108,6 +116,12 @@ describe("worktree workspaces (WM-108)", () => {
         `  - name: empty-up\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up-empty.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n` +
+        `  - name: hanging-up\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up-hanging.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n` +
+        `  - name: hanging-down\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down-hanging.sh\n` +
+        `    worktree_root: ${wtRoot}\n` +
         `  - name: red-baseline\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up-red-baseline.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n    verify: bun test\n` +
@@ -125,13 +139,14 @@ describe("worktree workspaces (WM-108)", () => {
     else process.env.FACTORY_REPOS_ROOT = previousReposRoot;
   });
 
-  const make = (repo, ticket, runId) =>
+  const make = (repo, ticket, runId, extra = {}) =>
     createWorkspace({
       root: tmpRoot(),
       runId,
       attempt: 1,
       input: { repo, ticket },
       workspace: { type: "worktree" },
+      ...extra,
     });
 
   test("up is delegated to the repo's script; the tree is reachable at ./repo; verify rides along", () => {
@@ -178,6 +193,15 @@ describe("worktree workspaces (WM-108)", () => {
     expect(existsSync(path.join(wtRoot, "WM-4"))).toBe(true);
   });
 
+  test("a timed-out worktree_down retains the workspace without hanging", () => {
+    const { dir } = make("hanging-down", "WM-10", "run_wt10");
+    const started = Date.now();
+    expect(destroyWorkspace(dir, { worktreeTimeoutMs: 25 })).toBe(false);
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(path.join(wtRoot, "WM-10"))).toBe(true);
+  });
+
   test("a red baseline is recorded in the marker and agent input without aborting workspace creation", () => {
     const { dir, worktree } = make("red-baseline", "WM-5", "run_wt5");
     expect(worktree.baseline).toMatchObject({
@@ -214,6 +238,39 @@ describe("worktree workspaces (WM-108)", () => {
 
   test("a zero-exit script that created no worktree is still a provisioning failure", () => {
     expect(() => make("empty-up", "WM-9", "run_wt9")).toThrow(/did not create/);
+  });
+
+  test("a timed-out worktree_up raises a typed error and leaves teardown facts for the janitor", () => {
+    const root = tmpRoot();
+    const workspaceDir = path.join(root, "run_wt11-a1");
+    const previous = process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+    process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = "25";
+    const started = Date.now();
+    try {
+      try {
+        createWorkspace({
+          root,
+          runId: "run_wt11",
+          attempt: 1,
+          input: { repo: "hanging-up", ticket: "WM-11" },
+          workspace: { type: "worktree" },
+        });
+        throw new Error("expected WorktreeError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(WorktreeError);
+        expect(err.code).toBe("workspace_provisioning_error");
+        expect(err.message).toContain("timed out after 25ms");
+        expect(Date.now() - started).toBeLessThan(1_000);
+        expect(JSON.parse(readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"))).toMatchObject({
+          repo: "hanging-up",
+          ticket: "WM-11",
+          down: "bin/worktree-down.sh",
+        });
+      }
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+      else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
+    }
   });
 
   test("a repo with no declared scripts fails typed, not with a crash mid-spawn", () => {


### PR DESCRIPTION
## Summary
- bound repo verification and worktree lifecycle scripts with configurable 120s defaults
- preserve typed timeout failure and workspace-retention semantics, including partial bring-up markers
- bound worker git/Linear helpers and add timeout regression coverage

## Verification
- `bun test event-runtime/lib/verify.test.mjs event-runtime/lib/workspace.test.mjs event-runtime/lib/worker.test.mjs` — 106 pass, 0 fail

UX critique: skipped — backend worker subprocess hardening has no user-facing surface

Fixes WM-262

## Handoff

### File scope
Six files, all under `event-runtime/lib/` — no files outside this scope were touched:

```
 event-runtime/lib/verify.mjs         | 53 ++++++++++++++++++++---
 event-runtime/lib/verify.test.mjs    | 20 +++++++++
 event-runtime/lib/worker.mjs         | 75 +++++++++++++++++---------------
 event-runtime/lib/worker.test.mjs    | 31 +++++++++++++-
 event-runtime/lib/workspace.mjs      | 83 ++++++++++++++++++++++++++++--------
 event-runtime/lib/workspace.test.mjs | 59 ++++++++++++++++++++++++-
 6 files changed, 259 insertions(+), 62 deletions(-)
```

### Verification

Ticket-scoped suites (`bun test` on the three changed test files):

```
 107 pass
 0 fail
 444 expect() calls
Ran 107 tests across 3 files. [4.72s]
```

Full suite (`bun test`), run after `bun install` at the repo root **and** in `event-runtime/web`:

```
 2040 pass
 1 fail
 8045 expect() calls
Ran 2041 tests across 139 files. [203.38s]
```

The single failure is `seed & re-seed deduplication (OPS-464) > initial seed succeeds and verify passes` — the known pre-existing/flaky timing-sensitive test. Clean `develop` shows the same ~2034 pass / 1 fail shape, so it is not caused by this branch. Nothing in this PR's scope (`verify.mjs`, `worker.mjs`, `workspace.mjs`) is involved in it.

Build check (`bun build/emit.mjs --check`), exit 0:

```
ok — 90 generated files match shared/
```

(The command also prints an informational "floor delivery: 10 of 10 repo(s) are not carrying the current floor" notice about other local repos' `AGENTS.md`; it is unrelated to this PR and does not affect the exit status.)

CI on the merge commit `8fff13b` is green — `Verify` pass, `Shadow runner fleet available` pass.

### Merge conflict resolution with `develop`

This branch went CONFLICTING after WM-481 landed on `develop`. The single real conflict was in `event-runtime/lib/workspace.mjs`, in the `worktree_up` failure branch, and was resolved by **combining both sides** rather than taking either one:

- **From WM-262 (this PR):** a `spawnSync` timeout surfaces as `up.error?.code === "ETIMEDOUT"` with a *zero-ish/undefined* status — it is not reported as a non-zero exit. So the failure condition must be `if (up.error?.code === "ETIMEDOUT" || up.status !== 0)`. Dropping this half would let a timed-out bring-up be treated as success, which is precisely the hang this ticket exists to fix.
- **From WM-481 (`develop`):** the failure message prefers the full trimmed `stderr`, then `stdout`, then `exit ${up.status}` — rather than only the last line. Dropping this half would restore the truncated diagnostics WM-481 fixed; a bash `set -e` abort often puts the useful message above the final line.

Both halves address different concerns (detecting the failure vs. reporting it), so keeping both is strictly correct. The resolved code:

```js
if (up.error?.code === "ETIMEDOUT" || up.status !== 0) {
  const timedOut = up.error?.code === "ETIMEDOUT";
  const stderr = (up.stderr || "").trim();
  const stdout = (up.stdout || "").trim();
  const why = timedOut
    ? `timed out after ${timeoutMs}ms`
    : stderr || stdout || `exit ${up.status}`;
  throw new WorktreeError(`worktree_up failed for ${repoName}/${ticket}: ${why}`);
}
```

The same `ETIMEDOUT ||` guard is applied to the `worktree_down` path. Merge commit: `8fff13b`.

### UX critique
Not applicable — no user-visible surface. This is backend-only work: subprocess timeout bounding in the event-runtime worker/verify/workspace libraries, with no UI, copy, navigation, or user-facing flow changes.
