### PR TITLE
feat(event-runtime-web): adopt @radix-ui/react-icons, group the agent Definition panel with attribute icons (WM-482)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -30,9 +30,11 @@ Made by the operator, recorded here so nobody relitigates them mid-build:
   `src/components/ui.tsx` — `StateBadge`, `StatTile`, `ListPane`,
   `DetailPane`, `ListEmpty`, `FilterInput`, `Section`, `KV`, `Disclosure`,
   `JsonBlock`, `Button`, `Dialog` (with its own focus trap and Tab cycle),
-  `Countdown`, `Ago`, `JumpLink`, and the toast region. Radix is still in the
-  lockfile, but only transitively beneath `cmdk`. Two later additions round
-  the stack out: `@xyflow/react` + `elkjs` for the graph canvas (§10.13,
+  `Countdown`, `Ago`, `JumpLink`, and the toast region. Radix _primitives_
+  are still in the lockfile only transitively beneath `cmdk`; the one direct
+  Radix dependency is `@radix-ui/react-icons`, the attribute-icon set (§5.2
+  tier 4, WM-482) — icons, not components. Two later additions round the
+  stack out: `@xyflow/react` + `elkjs` for the graph canvas (§10.13,
   code-split off the entry chunk) and `@fontsource-variable/inter` for
   §5.1's typeface.
 - **No authentication.** This narrows §14's "the web-app step requires real
@@ -330,15 +332,45 @@ no shared set. Every rule below is checkable in review.
    `title` + `aria-label`; **no emoji anywhere** in the UI. Adding a glyph to
    this table is a spec change, not a local decision.
 
-3. **Inline SVG icons.** The only tier for _state_ iconography, per OPS-498:
-   14px viewBox, 1.5px stroke (matches the app's hairline weight),
+3. **State icons — inline SVG.** The only tier for _state_ iconography, per
+   OPS-498: 14px viewBox, 1.5px stroke (matches the app's hairline weight),
    `currentColor` fill/stroke so the hue system does the coloring,
    shape-coded per lifecycle state (dashed circle = proposed, half-disc =
    running, disc+check = completed, disc+× = failed, …). Icons sit **left of
    the text label at `gap-1.5` and never replace it** — shape is redundancy
-   for color-blind and peripheral reading, not a substitute for words. No
-   icon font, no icon npm package: hand-rolled inline SVG keeps the bundle
-   honest and the set closed.
+   for color-blind and peripheral reading, not a substitute for words. State
+   shapes stay hand-rolled in `StateIcon` (`ui.tsx`): the set is closed and
+   each shape encodes one lifecycle meaning; a library glyph would not.
+
+4. **Attribute icons — `@radix-ui/react-icons`** (WM-482, 2026-08-17). For
+   _what a thing is_, not _what state it is in_: the workspace, model tier,
+   timeout, adapter, capabilities of a definition. Radix Icons is the one
+   sanctioned package — 15×15 viewBox, ~1px optical weight, `currentColor`,
+   tree-shaken per-icon imports (`import { TimerIcon } from
+   "@radix-ui/react-icons"`). Rendered at **14px** (`size-3.5`) next to
+   12–13px body text — the 15-grid glyph at 14px sits at the label's own
+   optical weight, which is the point: it must not out-shout the word. Rules:
+
+   - An attribute icon **leads its label** (`KV icon=`, `gap-1.5`) and the
+     label is always present. Icon-only attribute rows do not exist.
+   - It takes the label's color (`--text-faint` in `KV`), never a state hue.
+     Hue still means state (below); an attribute icon in `--hue-err` is a
+     state claim it cannot back.
+   - **One glyph, one meaning, app-wide.** The mapping lives with the first
+     use and later uses import the same glyph: `Pencil1Icon` = mutating,
+     `CubeIcon` = workspace, `LockClosedIcon` = capabilities,
+     `Component1Icon` = adapter, `DesktopIcon` = hosts, `CodeIcon` =
+     command, `ListBulletIcon` = action registry, `LightningBoltIcon` =
+     model tier, `Crosshair2Icon` = exact model override, `TimerIcon` =
+     timeout, `ReloadIcon` = attempts. Add to this list in the same PR that
+     adds the glyph.
+   - Identity rows (`id`, `version`, contract) carry **no** icon — an
+     identifier is text, and a word already fits. Within one `KVGroup`
+     either every row has an icon or none does; `icon={null}` reserves the
+     slot when a group is mixed so labels stay aligned.
+   - `aria-hidden` on the slot; the label carries the name.
+   - Still no icon font, and no second icon package: one library keeps the
+     stroke weight and the visual language uniform.
 
    The nav rail stays **text-only** deliberately. An icon rail is deferred
    until the label list outgrows the 52-width rail — icons there would be
@@ -393,6 +425,7 @@ not in this table is not a placement.
 | Context                    | Position                  | Rule                                                                                                           |
 | -------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | State badge / status label | leading, `gap-1.5`        | Icon then word. Never trailing, never alone.                                                                   |
+| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. `KVGroup` rows are all-icon or no-icon; `icon={null}` reserves the slot. |
 | Button                     | leading only              | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                     |
 | Table cell                 | leading, baseline-aligned | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it. |
 | Section / group header     | between chevron and label | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                          |
@@ -410,7 +443,7 @@ Icon size follows the type size next to it — it is never set independently:
 | Text size        | Icon | Where                                            |
 | ---------------- | ---- | ------------------------------------------------ |
 | 11px (badges)    | 12px | `StateBadge`, table cells, chips                 |
-| 12–13px (body)   | 14px | Default. Buttons, list rows, KV values           |
+| 12–13px (body)   | 14px | Default. Buttons, list rows, KV labels and values (Radix attribute icons render at 14px too) |
 | 14–15px (titles) | 16px | `DetailPane` title, `Dialog` title, empty states |
 
 Chevrons and sort arrows are the exception: 9px, because they are affordance
@@ -474,8 +507,10 @@ Before a PR introduces one, in this order:
 
 1. Would a word do? Then use the word.
 2. Is it in the approved glyph table? Use exactly that glyph for exactly that
-   meaning. If not, and it is a state, it is an OPS-498 SVG icon. If neither,
-   this section changes first (own PR), then the code.
+   meaning. If not, and it is a state, it is an OPS-498 SVG icon. If it names
+   an attribute, it is a Radix icon from the tier-4 mapping (or a new entry
+   added to that mapping in the same PR). If none of these, this section
+   changes first (own PR), then the code.
 3. Does it appear in at least two places, or is it a one-off decoration? A
    one-off is not added.
 4. Placement matches the grammar table; size matches the scale table.

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -365,9 +365,10 @@ no shared set. Every rule below is checkable in review.
      timeout, `ReloadIcon` = attempts. Add to this list in the same PR that
      adds the glyph.
    - Identity rows (`id`, `version`, contract) carry **no** icon — an
-     identifier is text, and a word already fits. Within one `KVGroup`
-     either every row has an icon or none does; `icon={null}` reserves the
-     slot when a group is mixed so labels stay aligned.
+     identifier is text, and a word already fits — but they pass
+     `icon={null}` so the slot is reserved and label text starts at one x
+     down the whole panel. Rule: once any row in a `Section` has an icon,
+     every `KV` in that section reserves the slot (real icon or `null`).
    - `aria-hidden` on the slot; the label carries the name.
    - Still no icon font, and no second icon package: one library keeps the
      stroke weight and the visual language uniform.
@@ -425,7 +426,7 @@ not in this table is not a placement.
 | Context                    | Position                  | Rule                                                                                                           |
 | -------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | State badge / status label | leading, `gap-1.5`        | Icon then word. Never trailing, never alone.                                                                   |
-| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. `KVGroup` rows are all-icon or no-icon; `icon={null}` reserves the slot. |
+| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. Once a section has one icon, every row reserves the slot (`icon={null}` for icon-less rows). |
 | Button                     | leading only              | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                     |
 | Table cell                 | leading, baseline-aligned | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it. |
 | Section / group header     | between chevron and label | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                          |

--- a/event-runtime/web/bun.lock
+++ b/event-runtime/web/bun.lock
@@ -6,6 +6,7 @@
       "name": "event-runtime-web",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.5",
+        "@radix-ui/react-icons": "^1.3.2",
         "@tanstack/react-query": "^5.62.0",
         "@xyflow/react": "^12.11.3",
         "cmdk": "^1.0.4",
@@ -149,6 +150,8 @@
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.6", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ=="],
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.16", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ=="],
+
+    "@radix-ui/react-icons": ["@radix-ui/react-icons@1.3.2", "", { "peerDependencies": { "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc" } }, "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
 

--- a/event-runtime/web/package.json
+++ b/event-runtime/web/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.5",
+    "@radix-ui/react-icons": "^1.3.2",
     "@tanstack/react-query": "^5.62.0",
     "@xyflow/react": "^12.11.3",
     "cmdk": "^1.0.4",

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { Button, ChipInput, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
+import { Button, ChipInput, clearToasts, CopyActions, Countdown, DetailPane, Dialog, FilterInput, getValueHue, KV, KVGroup, notify, Section, shortId, StateBadge, SuggestInput, ToastContainer } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { modal } from "../hooks";
 import { changeInput, typeText } from "../test-render";
@@ -409,6 +409,60 @@ describe("KV mono discipline (WM-136)", () => {
     const value = r.getByTitle("sha256:abcdef");
     expect(value.tagName).toBe("BUTTON");
     expect(classes(value)).toContain("truncate");
+  });
+});
+
+describe("KV attribute icons and unset values (WM-482)", () => {
+  test("renders a leading aria-hidden icon slot only when an icon is passed", () => {
+    const r = render(
+      <>
+        <KV k="timeout" v="120s" icon={<svg data-testid="icon" viewBox="0 0 15 15" />} />
+        <KV k="version" v="1" />
+      </>,
+    );
+    const slot = r.getByTestId("icon").parentElement!;
+    expect(slot.getAttribute("aria-hidden")).toBe("true");
+    // Icon precedes the label inside the same label cell (§5.2 placement grammar).
+    const labelCell = slot.parentElement!;
+    expect(labelCell.getAttribute("title")).toBe("timeout");
+    expect(labelCell.firstElementChild).toBe(slot);
+    // A row without `icon` renders no slot at all — groups without icons stay flush.
+    expect(r.getByTitle("version").querySelector("[aria-hidden]")).toBeNull();
+  });
+
+  test("a null icon reserves the slot so labels in the same group align", () => {
+    const r = render(<KV k="model override" v="-" icon={null} />);
+    expect(r.getByTitle("model override").querySelector("[aria-hidden]")).toBeTruthy();
+  });
+
+  test("renders the unset marker fainter than a set value", () => {
+    const r = render(
+      <>
+        <KV k="hosts" v="-" />
+        <KV k="adapter" v={<span>agy</span>} />
+      </>,
+    );
+    const unset = r.getByText("-");
+    expect(classes(unset)).toContain("text-(--text-faint)");
+    expect(unset.tagName).toBe("SPAN"); // never copyable
+    const set = r.getByText("agy").parentElement!;
+    expect(classes(set)).toContain("text-(--text-dim)");
+  });
+
+  test("KVGroup titles the group and separates consecutive groups with a hairline", () => {
+    const r = render(
+      <>
+        <KVGroup title="Identity">
+          <KV k="id" v="a" />
+        </KVGroup>
+        <KVGroup title="Limits">
+          <KV k="timeout" v="1s" />
+        </KVGroup>
+      </>,
+    );
+    expect(r.getByText("Identity")).toBeTruthy();
+    const limits = r.getByText("Limits").parentElement!;
+    expect(classes(limits)).toContain("not-first:border-t");
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1316,18 +1316,47 @@ export function Section({
  */
 const looksLikeIdentifier = (text: string) => !/\s/.test(text);
 
-export function KV({ k, v, mono }: { k: string; v: ReactNode; mono?: boolean }) {
+/**
+ * `-` is the app-wide "unset" value. It is not copyable and it is not
+ * information; render it fainter than the label so a panel with five unset
+ * rows still lets the eye land on the five that are set (WM-482).
+ */
+const isUnset = (v: ReactNode) => v == null || v === "-";
+
+export function KV({
+  k,
+  v,
+  mono,
+  icon,
+}: {
+  k: string;
+  v: ReactNode;
+  mono?: boolean;
+  /**
+   * Attribute icon per §5.2 tier 3b (WM-482): a Radix icon at 14px,
+   * `currentColor`, leading the label at `gap-1.5`. Pass `null` to reserve
+   * the slot on a row without an icon so labels in the same group stay
+   * aligned; omit it entirely in groups that carry no icons.
+   */
+  icon?: ReactNode;
+}) {
   const text = typeof v === "string" ? v : null;
   const copyable = !!text && text !== "-";
   const isMono = mono ?? (text !== null && looksLikeIdentifier(text));
+  const unset = isUnset(v);
   // Fixed label column with the value left-aligned beside it: right-aligning
   // values left a ragged edge (`1/1` next to `multi-dispatch-WM-127`) that the
   // eye had to re-find on every row (WM-136).
   return (
     <div className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
-      <span className="truncate text-(--text-faint)" title={k}>
-        {k}
-      </span>
+      <div className="flex min-w-0 items-center gap-1.5 text-(--text-faint)" title={k}>
+        {icon !== undefined && (
+          <i className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5" aria-hidden="true">
+            {icon}
+          </i>
+        )}
+        <span className="truncate">{k}</span>
+      </div>
       {copyable ? (
         <button
           type="button"
@@ -1341,12 +1370,26 @@ export function KV({ k, v, mono }: { k: string; v: ReactNode; mono?: boolean }) 
         </button>
       ) : (
         <span
-          className={`truncate text-left text-(--text-dim) ${isMono ? "mono" : ""}`}
+          className={`truncate text-left ${unset ? "text-(--text-faint)" : "text-(--text-dim)"} ${isMono ? "mono" : ""}`}
           title={text ?? undefined}
         >
           {v ?? "-"}
         </span>
       )}
+    </div>
+  );
+}
+
+/**
+ * Sub-grouping inside a `Section` of `KV` rows (WM-482). A flat run of
+ * fifteen rows has no landmarks; a faint title plus a hairline every four or
+ * five rows gives the eye somewhere to land without adding a second card.
+ */
+export function KVGroup({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="not-first:mt-2 not-first:border-t not-first:border-(--border) not-first:pt-2">
+      <div className="pb-0.5 text-[11px] font-medium text-(--text-faint)">{title}</div>
+      {children}
     </div>
   );
 }

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1333,10 +1333,10 @@ export function KV({
   v: ReactNode;
   mono?: boolean;
   /**
-   * Attribute icon per §5.2 tier 3b (WM-482): a Radix icon at 14px,
+   * Attribute icon per §5.2 tier 4 (WM-482): a Radix icon at 14px,
    * `currentColor`, leading the label at `gap-1.5`. Pass `null` to reserve
-   * the slot on a row without an icon so labels in the same group stay
-   * aligned; omit it entirely in groups that carry no icons.
+   * the slot on a row without an icon so label text starts at one x across
+   * the section; omit it entirely in sections that carry no icons at all.
    */
   icon?: ReactNode;
 }) {

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -1,4 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
+import {
+  CodeIcon,
+  Component1Icon,
+  Crosshair2Icon,
+  CubeIcon,
+  DesktopIcon,
+  LightningBoltIcon,
+  ListBulletIcon,
+  LockClosedIcon,
+  Pencil1Icon,
+  ReloadIcon,
+  TimerIcon,
+} from "@radix-ui/react-icons";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { useDisplayOptions, useListKeys } from "../hooks";
@@ -25,6 +38,7 @@ import {
   GroupHeaderRow,
   JsonBlock,
   KV,
+  KVGroup,
   ListEmpty,
   ListPane,
   Section,
@@ -447,49 +461,67 @@ export function Agents({
         >
 
           <Section title="Definition">
-            <KV k="id" v={sel.id} />
-            <KV k="version" v={String(sel.version)} />
-            <KV k="outputContract" v={sel.outputContract} />
-            <KV
-              k="mutating"
-              v={
-                <span style={{ color: sel.mutating ? "var(--hue-err)" : "var(--text-faint)" }}>
-                  {sel.mutating ? "yes" : "no"}
-                </span>
-              }
-            />
-            <KV
-              k="workspace"
-              v={`${sel.workspace.type}${sel.workspace.retainOnFailure ? " · retain on failure" : ""}`}
-            />
-            <KV k="capabilities" v={caps(sel)} />
-            <KV k="adapter" v={adapterText(sel)} />
+            {/* Grouped + attribute icons per §5.2 tier 3b (WM-482). Identity
+                rows carry no icon: an id is text and a word already fits. */}
+            <KVGroup title="Identity">
+              <KV k="id" v={sel.id} />
+              <KV k="version" v={String(sel.version)} />
+              <KV k="outputContract" v={sel.outputContract} />
+            </KVGroup>
+            <KVGroup title="Execution">
+              <KV
+                k="mutating"
+                icon={<Pencil1Icon />}
+                v={
+                  <span style={{ color: sel.mutating ? "var(--hue-err)" : "var(--text-faint)" }}>
+                    {sel.mutating ? "yes" : "no"}
+                  </span>
+                }
+              />
+              <KV
+                k="workspace"
+                icon={<CubeIcon />}
+                v={`${sel.workspace.type}${sel.workspace.retainOnFailure ? " · retain on failure" : ""}`}
+              />
+              <KV k="capabilities" icon={<LockClosedIcon />} v={caps(sel)} />
+              <KV k="adapter" icon={<Component1Icon />} v={adapterText(sel)} />
+              <KV k="hosts" icon={<DesktopIcon />} v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : "-"} />
+              <KV k="command" icon={<CodeIcon />} v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : "-"} />
+              <KV
+                k="actionRegistry"
+                icon={<ListBulletIcon />}
+                v={
+                  sel.actionRegistry && Object.keys(sel.actionRegistry).length > 0
+                    ? Object.keys(sel.actionRegistry).join(", ")
+                    : "-"
+                }
+              />
+            </KVGroup>
             {/* Declared intent and the exact-id escape hatch (WM-135). What each
                 route actually resolves to is per adapter, and lives on the
                 Event routing lines below — the same split `cli.mjs agents` prints. */}
-            <KV k="modelTier" v={sel.modelTier ?? "-"} />
-            <KV
-              k="model override"
-              v={
-                sel.model ? (
-                  <span title="Exact model id — resolved verbatim, whatever the tier says.">{sel.model}</span>
-                ) : (
-                  "-"
-                )
-              }
-            />
-            <KV k="hosts" v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : "-"} />
-            <KV k="command" v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : "-"} />
-            <KV
-              k="actionRegistry"
-              v={
-                sel.actionRegistry && Object.keys(sel.actionRegistry).length > 0
-                  ? Object.keys(sel.actionRegistry).join(", ")
-                  : "-"
-              }
-            />
-            <KV k="timeout" v={sel.limits.timeout_seconds != null ? `${sel.limits.timeout_seconds}s` : "-"} />
-            <KV k="attempts" v={String(sel.limits.attempts ?? "-")} />
+            <KVGroup title="Model">
+              <KV k="modelTier" icon={<LightningBoltIcon />} v={sel.modelTier ?? "-"} />
+              <KV
+                k="model override"
+                icon={<Crosshair2Icon />}
+                v={
+                  sel.model ? (
+                    <span title="Exact model id — resolved verbatim, whatever the tier says.">{sel.model}</span>
+                  ) : (
+                    "-"
+                  )
+                }
+              />
+            </KVGroup>
+            <KVGroup title="Limits">
+              <KV
+                k="timeout"
+                icon={<TimerIcon />}
+                v={sel.limits.timeout_seconds != null ? `${sel.limits.timeout_seconds}s` : "-"}
+              />
+              <KV k="attempts" icon={<ReloadIcon />} v={String(sel.limits.attempts ?? "-")} />
+            </KVGroup>
           </Section>
 
           {sel.command && (

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -461,12 +461,14 @@ export function Agents({
         >
 
           <Section title="Definition">
-            {/* Grouped + attribute icons per §5.2 tier 3b (WM-482). Identity
-                rows carry no icon: an id is text and a word already fits. */}
+            {/* Grouped + attribute icons per §5.2 tier 4 (WM-482). Identity
+                rows carry no icon — an id is text and a word already fits —
+                but reserve the slot so label text starts at one x across the
+                whole panel (ux-critic finding, WM-482). */}
             <KVGroup title="Identity">
-              <KV k="id" v={sel.id} />
-              <KV k="version" v={String(sel.version)} />
-              <KV k="outputContract" v={sel.outputContract} />
+              <KV k="id" icon={null} v={sel.id} />
+              <KV k="version" icon={null} v={String(sel.version)} />
+              <KV k="outputContract" icon={null} v={sel.outputContract} />
             </KVGroup>
             <KVGroup title="Execution">
               <KV

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -734,9 +734,9 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     expect(dialog.textContent).toMatch(/net/);
     expect(dialog.textContent).toMatch(/600s/);
     expect(dialog.textContent).toMatch(/120s/);
-    expect(dialog.querySelectorAll('span[title="adapter"]')).toHaveLength(2);
-    expect(dialog.querySelectorAll('span[title="attempts"]')).toHaveLength(2);
-    expect(dialog.querySelectorAll('span[title="ttl"]')).toHaveLength(2);
+    expect(dialog.querySelectorAll('[title="adapter"]')).toHaveLength(2);
+    expect(dialog.querySelectorAll('[title="attempts"]')).toHaveLength(2);
+    expect(dialog.querySelectorAll('[title="ttl"]')).toHaveLength(2);
     expect(dialog.textContent).toContain("timeoutSeconds");
     expect(dialog.textContent).not.toMatch(/stale-agent/);
 


### PR DESCRIPTION
Fixes WM-482

## What
- Adds `@radix-ui/react-icons` (tree-shaken per-icon imports) as the sanctioned *attribute* icon set — §5.2 tier 4 in `docs/event-runtime-webui.md` (glyph→meaning map, placement/sizing rows, checklist step, stack note). OPS-498 state icons stay hand-rolled.
- `KV` gains an optional leading `icon` slot (14px, `currentColor`, `aria-hidden`; `icon={null}` reserves the slot) and renders the unset `-` at `--text-faint`.
- New `KVGroup` (faint sub-title + hairline) for sub-grouping rows inside a `Section`.
- Agent Definition panel grouped into Identity / Execution / Model / Limits with attribute icons on Execution/Model/Limits rows.

## Verification
- `cd event-runtime/web && bun test` → 645 pass / 0 fail
- `bun run build` → ✓
- Visual check dark + light + contrast on agy-smoke@1, dispatch@1, merge-apply@2, disk-remediate@1
- ux-critic: SHIP; its one in-scope finding (label stagger between groups) fixed in the second commit

## Follow-ups
- WM-483 — spread attribute icons + `KVGroup` to Runs/Workers/Schedules panels; also notes the filled-Radix vs stroke-utility-icon family difference the critic flagged.