### PR TITLE
config(models): point the cursor adapter's tier map at Cursor Grok 4.6 (WM-489)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -111,10 +111,15 @@ models:
     light: gemini-3.7-flash
   # cursor (WM-440), Cursor Agent CLI login/subscription window.
   # IDs from `agent --list-models` on 2026.08.11.
+  # Grok 4.6 rather than Composer (WM-489). Grok ships eight variants —
+  # low/medium/high/xhigh, each with a -fast twin — so the tiers are effort
+  # levels of one model, not three different models. `-high` is the variant
+  # the CLI displays as plain "Cursor Grok 4.6"; `-xhigh` is available if
+  # strong should reach higher.
   cursor:
-    strong: composer-2.5
-    standard: composer-2.5
-    light: composer-2.5-fast
+    strong: cursor-grok-4.6-high
+    standard: cursor-grok-4.6-high
+    light: cursor-grok-4.6-low-fast
 
 limits:
   # Hard wall-clock cap the FACTORY enforces, independent of whatever the


### PR DESCRIPTION
Fixes WM-489

## Summary

Repoints the `cursor` adapter's model-tier map from Composer 2.5 to Cursor Grok 4.6.

```yaml
cursor:
  strong: cursor-grok-4.6-high
  standard: cursor-grok-4.6-high
  light: cursor-grok-4.6-low-fast
```

Grok 4.6 ships as effort variants of a single model (`low`/`medium`/`high`/`xhigh`, each with a `-fast` twin), so unlike the `pi` map — where sol/terra/luna are genuinely different models — these tiers are effort levels. `-high` is the variant the CLI displays as plain "Cursor Grok 4.6"; `-xhigh` is available if `strong` should reach higher later. The existing shape (strong == standard, light on a `-fast` variant) is preserved from the Composer mapping.

## Handoff

**Scope.** One file, one block: `config/policy.yaml`, the `models.cursor` tier map. No code paths change. This does **not** route any work to cursor — `factory.dispatch.requested` stays pinned to `pi` in `event-types.json`. It only changes what the three tiers resolve to *when* something runs on cursor.

**Model IDs verified, not inferred.** Taken from `agent --list-models` against the installed CLI (`2026.08.11-e8db854`), matching how the Composer IDs were originally sourced.

**Verification.**

```
$ bun test event-runtime/lib/registry.test.mjs
 14 pass, 0 fail, 44 expect() calls  [477.00ms]

$ bun event-runtime/cli.mjs agents | grep "adapter cursor"
  event type  factory.cursor-smoke.requested  adapter cursor  ...  model cursor-grok-4.6-low-fast
```

Registry load is the gate that matters here: a tier with no mapping fails closed at load, so all three must resolve.

**End-to-end, not just parsed.** Injected a real `factory.cursor-smoke.requested` and ran it:

```
run_f5342d71-20c3-4809-993f-dbfc3b8bfdcb  COMPLETED  cursor-smoke@1  cursor
  attempt 1  model Cursor Grok 4.6 Low Fast  adapter cursor
  artifact {"echo":"grok-4.6 tier check WM-489"}
  verificationStatus  passed
```

That confirms the Cursor CLI accepts the ID and the round trip works, which a config parse alone would not.

**UX critique.** Not applicable — no user-visible surface.

**Related.** WM-488 filed for per-run adapter override, which is the clean way to send individual work to a chosen harness instead of repointing an event type.