### PR TITLE
config(repos): give watts-mobile a worktree lifecycle for janitor cleanup (WM-490)

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -182,8 +182,10 @@ repos:
     team: CW
     project: Mobile App
     base: develop
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/watts-mobile
-    report_only: true            # No isolated worktree lifecycle yet.
+    report_only: true            # Command distribution / janitor cleanup enabled; dispatch pending.
     verify: pnpm typecheck && pnpm lint && pnpm test
     escalate_paths:
       - src/features/subscriptions/**


### PR DESCRIPTION
Fixes WM-490

## Summary

Adds `worktree_up` / `worktree_down` to the `watts-mobile` entry in `config/repos.yaml` and updates its `report_only` comment to say why.

```yaml
+    worktree_up: bin/worktree-up.sh
+    worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/watts-mobile
-    report_only: true            # No isolated worktree lifecycle yet.
+    report_only: true            # Command distribution / janitor cleanup enabled; dispatch pending.
```

## Handoff

**Scope.** One file, one entry: `config/repos.yaml`, `watts-mobile`. No code changes.

**This does not enable dispatch.** `report_only: true` is retained and remains authoritative for target selection. The change follows the rule stated in the file's own header — a repo "may still configure its teardown script while remaining `report_only` for dispatch" — and the guidance further down that "a report-only repo may configure `worktree_down` for safe janitor cleanup." Another entry in the same file already carries exactly this shape, with the comment "Dispatch remains disabled; janitor may use the teardown script."

**Effect.** `orchestrator/janitor.mjs` can now reclaim finished `watts-mobile` worktrees rather than leaving them to pile up — the accumulation failure mode documented in WM-476, which on this repo had reached 49 worktrees with 46 of them for already-landed work.

**Verification.**

```
$ bun test event-runtime/lib/repos.test.mjs
 16 pass, 0 fail, 57 expect() calls  [46.00ms]

$ bun event-runtime/cli.mjs repos | grep watts-mobile
watts-mobile  CW  report-only  develop  -  -  yes  /Users/hdkiller/Develop/.worktrees/watts-mobile
```

The `repos` view confirms both halves of the intent: still `report-only`, and now resolving a worktree lifecycle.

**UX critique.** Not applicable — no user-visible surface.