### PR TITLE
feat(event-runtime-web): attribute-icon registry across all detail panels (WM-483)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -376,7 +376,7 @@ no shared set. Every rule below is checkable in review.
      | `ListBulletIcon`   | actionRegistry                                                      |
      | `PlayIcon`         | execution, execution mode                                           |
      | `SewingPinIcon`    | placement                                                           |
-     | `GearIcon`         | worker, workerId                                                    |
+     | `GearIcon`         | worker (the entity; `workerId` is an id and stays unmapped)          |
      | `TargetIcon`       | target                                                              |
      | `LightningBoltIcon`| model tier                                                          |
      | `Crosshair2Icon`   | model, model override, model (pinned) — an exact model id           |
@@ -385,7 +385,8 @@ no shared set. Every rule below is checkable in review.
      | `ReloadIcon`       | attempts                                                            |
      | `LapTimerIcon`     | ttl, proposal ttl, cadence — an interval, not a moment              |
      | `FileTextIcon`     | input, input.*                                                      |
-     | `PaperPlaneIcon`   | origin event, event type, type, source, planned/admitted events     |
+     | `PaperPlaneIcon`   | origin event, event type, type, planned/admitted events             |
+     | `EnterIcon`        | source — where an event came in from; distinct from its type        |
      | `ChatBubbleIcon`   | reason, proposal reason, planner reason                             |
      | `CheckCircledIcon` | approval                                                            |
      | `ClockIcon`        | created, updated, occurredAt, receivedAt, admittedAt, startedAt, stoppedAt, decided at, last fire, last completed, next due — a moment |

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -356,19 +356,50 @@ no shared set. Every rule below is checkable in review.
    - It takes the label's color (`--text-faint` in `KV`), never a state hue.
      Hue still means state (below); an attribute icon in `--hue-err` is a
      state claim it cannot back.
-   - **One glyph, one meaning, app-wide.** The mapping lives with the first
-     use and later uses import the same glyph: `Pencil1Icon` = mutating,
-     `CubeIcon` = workspace, `LockClosedIcon` = capabilities,
-     `Component1Icon` = adapter, `DesktopIcon` = hosts, `CodeIcon` =
-     command, `ListBulletIcon` = action registry, `LightningBoltIcon` =
-     model tier, `Crosshair2Icon` = exact model override, `TimerIcon` =
-     timeout, `ReloadIcon` = attempts. Add to this list in the same PR that
-     adds the glyph.
-   - Identity rows (`id`, `version`, contract) carry **no** icon — an
-     identifier is text, and a word already fits — but they pass
-     `icon={null}` so the slot is reserved and label text starts at one x
-     down the whole panel. Rule: once any row in a `Section` has an icon,
-     every `KV` in that section reserves the slot (real icon or `null`).
+   - **One glyph, one meaning, app-wide — resolved by label, never by hand.**
+     The registry is `components/attrIcons.tsx`. A `<Section icons>` opts
+     its `KV` rows in; each row looks its glyph up by normalised label
+     (`modelTier` ≡ `model tier` ≡ `model-tier`; `input.<field>` ≡ `input`),
+     so `adapter` wears the same icon on Runs, Workers, Agents, and Proposals
+     by construction (WM-483). Views do not pass `icon=` themselves except to
+     override deliberately. Current map:
+
+     | Glyph              | Attribute(s)                                                        |
+     | ------------------ | ------------------------------------------------------------------- |
+     | `PersonIcon`       | agent, decided by                                                   |
+     | `Component1Icon`   | adapter                                                             |
+     | `Pencil1Icon`      | mutating                                                            |
+     | `CubeIcon`         | workspace                                                           |
+     | `LockClosedIcon`   | capabilities                                                        |
+     | `DesktopIcon`      | host, hosts                                                         |
+     | `CodeIcon`         | command                                                             |
+     | `ListBulletIcon`   | actionRegistry                                                      |
+     | `PlayIcon`         | execution, execution mode                                           |
+     | `SewingPinIcon`    | placement                                                           |
+     | `GearIcon`         | worker, workerId                                                    |
+     | `TargetIcon`       | target                                                              |
+     | `LightningBoltIcon`| model tier                                                          |
+     | `Crosshair2Icon`   | model, model override, model (pinned) — an exact model id           |
+     | `EyeOpenIcon`      | model (observed)                                                    |
+     | `TimerIcon`        | timeout                                                             |
+     | `ReloadIcon`       | attempts                                                            |
+     | `LapTimerIcon`     | ttl, proposal ttl, cadence — an interval, not a moment              |
+     | `FileTextIcon`     | input, input.*                                                      |
+     | `PaperPlaneIcon`   | origin event, event type, type, source, planned/admitted events     |
+     | `ChatBubbleIcon`   | reason, proposal reason, planner reason                             |
+     | `CheckCircledIcon` | approval                                                            |
+     | `ClockIcon`        | created, updated, occurredAt, receivedAt, admittedAt, startedAt, stoppedAt, decided at, last fire, last completed, next due — a moment |
+     | `LoopIcon`         | loop, loop name                                                     |
+     | `UpdateIcon`       | catch-up                                                            |
+     | `ArchiveIcon`      | repository                                                          |
+     | `GitHubLogoIcon`   | GitHub                                                              |
+     | `CommitIcon`       | base branch, deploy branch                                          |
+
+     Add to this table in the same PR that adds the registry row.
+   - Identity rows (`id`, `run`, `version`, hashes, keys, contract) and
+     state rows (`state`, `status`, `decision` — those carry a `StateBadge`)
+     are **not** in the registry. Inside an iconed section they get an empty
+     reserved slot, so label text starts at one x down the whole section.
    - `aria-hidden` on the slot; the label carries the name.
    - Still no icon font, and no second icon package: one library keeps the
      stroke weight and the visual language uniform.
@@ -426,7 +457,7 @@ not in this table is not a placement.
 | Context                    | Position                  | Rule                                                                                                           |
 | -------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | State badge / status label | leading, `gap-1.5`        | Icon then word. Never trailing, never alone.                                                                   |
-| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. Once a section has one icon, every row reserves the slot (`icon={null}` for icon-less rows). |
+| `KV` label (attribute icon)| leading, `gap-1.5`        | Icon then label, in the label column, label color. `<Section icons>` opts a section in; every row then resolves from `attrIcons.tsx` by label and unmapped rows keep an empty slot. |
 | Button                     | leading only              | A trailing glyph is reserved for one meaning: `…` = "opens a dialog". Nothing else trails.                     |
 | Table cell                 | leading, baseline-aligned | Same column as its text; a cell is never icon-only unless the header names the meaning and `title` repeats it. |
 | Section / group header     | between chevron and label | Chevron → dot/icon → label → count, in that order (`GroupHeaderRow`).                                          |
@@ -509,8 +540,9 @@ Before a PR introduces one, in this order:
 1. Would a word do? Then use the word.
 2. Is it in the approved glyph table? Use exactly that glyph for exactly that
    meaning. If not, and it is a state, it is an OPS-498 SVG icon. If it names
-   an attribute, it is a Radix icon from the tier-4 mapping (or a new entry
-   added to that mapping in the same PR). If none of these, this section
+   an attribute, it comes from the tier-4 registry (`attrIcons.tsx`) via
+   `<Section icons>` — add a registry row + table entry in the same PR rather
+   than passing `icon=` by hand. If none of these, this section
    changes first (own PR), then the code.
 3. Does it appear in at least two places, or is it a one-off decoration? A
    one-off is not added.

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -481,7 +481,7 @@ export function RunDetailBlocks({
 
   return (
     <>
-      <Section title="Run">
+      <Section title="Run" icons>
         <KV
           k="agent"
           v={

--- a/event-runtime/web/src/components/attrIcons.test.tsx
+++ b/event-runtime/web/src/components/attrIcons.test.tsx
@@ -1,0 +1,38 @@
+import "../test-dom";
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ATTR_ICON_KEYS, attrIcon, normalizeAttr } from "./attrIcons";
+
+const svg = (label: string) => renderToStaticMarkup(<>{attrIcon(label)}</>);
+
+describe("attribute icon registry (§5.2 tier 4, WM-483)", () => {
+  test("normalises label spellings so one attribute has one key", () => {
+    expect(normalizeAttr("modelTier")).toBe("modeltier");
+    expect(normalizeAttr("model tier")).toBe("modeltier");
+    expect(normalizeAttr("model-tier")).toBe("modeltier");
+    expect(normalizeAttr("model (pinned)")).toBe("modelpinned");
+    expect(normalizeAttr("input.repoPin")).toBe("input");
+  });
+
+  test("the same attribute resolves to the same glyph regardless of the view's label style", () => {
+    expect(svg("modelTier")).toBe(svg("model tier"));
+    expect(svg("outputContract")).toBe(svg("output contract"));
+    expect(svg("input.repo")).toBe(svg("input"));
+    expect(svg("adapter")).not.toBe("");
+    expect(svg("adapter")).not.toBe(svg("agent"));
+  });
+
+  test("identity and state labels are unmapped so they render an empty, reserved slot", () => {
+    for (const k of ["id", "run", "runId", "version", "specHash", "idempotencyKey", "state", "status", "decision", "pid"]) {
+      expect(attrIcon(k)).toBeNull();
+    }
+  });
+
+  test("every registered glyph is a currentColor svg (hue stays with the label)", () => {
+    for (const key of ATTR_ICON_KEYS) {
+      const out = svg(key);
+      expect(out.startsWith("<svg")).toBe(true);
+      expect(out).toContain('fill="currentColor"');
+    }
+  });
+});

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from "react";
+import {
+  ArchiveIcon,
+  ChatBubbleIcon,
+  CheckCircledIcon,
+  ClockIcon,
+  CodeIcon,
+  CommitIcon,
+  Component1Icon,
+  Crosshair2Icon,
+  CubeIcon,
+  DesktopIcon,
+  EyeOpenIcon,
+  FileTextIcon,
+  GearIcon,
+  GitHubLogoIcon,
+  LapTimerIcon,
+  LightningBoltIcon,
+  ListBulletIcon,
+  LockClosedIcon,
+  LoopIcon,
+  PaperPlaneIcon,
+  Pencil1Icon,
+  PersonIcon,
+  PlayIcon,
+  ReloadIcon,
+  SewingPinIcon,
+  TargetIcon,
+  TimerIcon,
+  UpdateIcon,
+} from "@radix-ui/react-icons";
+
+/**
+ * Attribute icon registry — §5.2 tier 4 (WM-482, WM-483).
+ *
+ * One glyph, one meaning, app-wide: every `KV` row that names an attribute
+ * resolves its icon HERE, by label, so `adapter` on the Runs panel and
+ * `adapter` on the Agents panel cannot drift. Views never pick a glyph.
+ *
+ * Keys are normalised labels (`normalizeAttr`): lower-case, everything but
+ * `[a-z0-9]` dropped, so `modelTier`, `model tier`, and `model-tier` are one
+ * key. `input.<field>` rows share the `input` glyph. Identity rows (ids,
+ * hashes, versions, contracts, keys) are deliberately absent — an identifier
+ * is text and a word already fits; in an iconed section they reserve the
+ * slot and stay blank.
+ *
+ * Adding an attribute: add the row here AND to the tier-4 table in
+ * `docs/event-runtime-webui.md` in the same PR.
+ */
+const REGISTRY: Record<string, () => ReactNode> = {
+  // ── definition / execution ────────────────────────────────────────────
+  agent: () => <PersonIcon />,
+  adapter: () => <Component1Icon />,
+  mutating: () => <Pencil1Icon />,
+  workspace: () => <CubeIcon />,
+  capabilities: () => <LockClosedIcon />,
+  hosts: () => <DesktopIcon />,
+  host: () => <DesktopIcon />,
+  command: () => <CodeIcon />,
+  actionregistry: () => <ListBulletIcon />,
+  execution: () => <PlayIcon />,
+  executionmode: () => <PlayIcon />,
+  placement: () => <SewingPinIcon />,
+  workerid: () => <GearIcon />,
+  worker: () => <GearIcon />,
+  target: () => <TargetIcon />,
+
+  // ── model ─────────────────────────────────────────────────────────────
+  modeltier: () => <LightningBoltIcon />,
+  model: () => <Crosshair2Icon />,
+  modeloverride: () => <Crosshair2Icon />,
+  modelpinned: () => <Crosshair2Icon />,
+  modelobserved: () => <EyeOpenIcon />,
+
+  // ── limits / retries ──────────────────────────────────────────────────
+  timeout: () => <TimerIcon />,
+  attempts: () => <ReloadIcon />,
+  ttl: () => <LapTimerIcon />,
+  proposalttl: () => <LapTimerIcon />,
+  cadence: () => <LapTimerIcon />,
+
+  // ── payload / provenance ──────────────────────────────────────────────
+  input: () => <FileTextIcon />,
+  originevent: () => <PaperPlaneIcon />,
+  eventtype: () => <PaperPlaneIcon />,
+  type: () => <PaperPlaneIcon />,
+  source: () => <PaperPlaneIcon />,
+  plannedevents: () => <PaperPlaneIcon />,
+  admittedevents: () => <PaperPlaneIcon />,
+  reason: () => <ChatBubbleIcon />,
+  proposalreason: () => <ChatBubbleIcon />,
+  plannerreason: () => <ChatBubbleIcon />,
+  decidedby: () => <PersonIcon />,
+  approval: () => <CheckCircledIcon />,
+
+  // ── clocks (points in time — `timeout`/`ttl` are durations, above) ────
+  created: () => <ClockIcon />,
+  updated: () => <ClockIcon />,
+  occurredat: () => <ClockIcon />,
+  receivedat: () => <ClockIcon />,
+  admittedat: () => <ClockIcon />,
+  startedat: () => <ClockIcon />,
+  stoppedat: () => <ClockIcon />,
+  decidedat: () => <ClockIcon />,
+  lastfire: () => <ClockIcon />,
+  lastcompleted: () => <ClockIcon />,
+  nextdue: () => <ClockIcon />,
+
+  // ── schedules ─────────────────────────────────────────────────────────
+  loop: () => <LoopIcon />,
+  loopname: () => <LoopIcon />,
+  catchup: () => <UpdateIcon />,
+
+  // ── projects / repos ──────────────────────────────────────────────────
+  repository: () => <ArchiveIcon />,
+  github: () => <GitHubLogoIcon />,
+  basebranch: () => <CommitIcon />,
+  deploybranch: () => <CommitIcon />,
+};
+
+export const normalizeAttr = (label: string): string => {
+  const base = label.startsWith("input.") ? "input" : label;
+  return base.toLowerCase().replace(/[^a-z0-9]/g, "");
+};
+
+/** The registered glyph for a `KV` label, or `null` when the label is identity/unmapped. */
+export function attrIcon(label: string): ReactNode {
+  const make = REGISTRY[normalizeAttr(label)];
+  return make ? make() : null;
+}
+
+/** For tests and the doc table: the normalised keys this registry knows. */
+export const ATTR_ICON_KEYS: readonly string[] = Object.keys(REGISTRY);

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -10,6 +10,7 @@ import {
   Crosshair2Icon,
   CubeIcon,
   DesktopIcon,
+  EnterIcon,
   EyeOpenIcon,
   FileTextIcon,
   GearIcon,
@@ -61,7 +62,6 @@ const REGISTRY: Record<string, () => ReactNode> = {
   execution: () => <PlayIcon />,
   executionmode: () => <PlayIcon />,
   placement: () => <SewingPinIcon />,
-  workerid: () => <GearIcon />,
   worker: () => <GearIcon />,
   target: () => <TargetIcon />,
 
@@ -84,7 +84,9 @@ const REGISTRY: Record<string, () => ReactNode> = {
   originevent: () => <PaperPlaneIcon />,
   eventtype: () => <PaperPlaneIcon />,
   type: () => <PaperPlaneIcon />,
-  source: () => <PaperPlaneIcon />,
+  // `source` sits next to `type` on Events/Proposals; it must not share the
+  // event glyph — "where it came in from" vs "what it is" (ux-critic, WM-483).
+  source: () => <EnterIcon />,
   plannedevents: () => <PaperPlaneIcon />,
   admittedevents: () => <PaperPlaneIcon />,
   reason: () => <ChatBubbleIcon />,

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -430,6 +430,23 @@ describe("KV attribute icons and unset values (WM-482)", () => {
     expect(r.getByTitle("version").querySelector("[aria-hidden]")).toBeNull();
   });
 
+  test("<Section icons> resolves KV glyphs from the registry and reserves the slot for unmapped labels (WM-483)", () => {
+    const r = render(
+      <Section title="Run" icons>
+        <KV k="adapter" v="pi" />
+        <KV k="runId" v="run_1" />
+      </Section>,
+    );
+    expect(r.getByTitle("adapter").querySelector("i[aria-hidden] svg")).toBeTruthy();
+    const slot = r.getByTitle("runId").querySelector("i[aria-hidden]");
+    expect(slot).toBeTruthy();
+    expect(slot!.querySelector("svg")).toBeNull();
+    cleanup();
+    // Without the opt-in nothing changes for the ~100 existing KV call sites.
+    const bare = render(<Section title="Run"><KV k="adapter" v="pi" /></Section>);
+    expect(bare.getByTitle("adapter").querySelector("i[aria-hidden]")).toBeNull();
+  });
+
   test("a null icon reserves the slot so labels in the same group align", () => {
     const r = render(<KV k="model override" v="-" icon={null} />);
     expect(r.getByTitle("model override").querySelector("[aria-hidden]")).toBeTruthy();

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createContext, type ReactNode, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
+import { attrIcon } from "./attrIcons";
 import { createPortal } from "react-dom";
 import { modal, useFocusReturn, useNow } from "../hooks";
 import type { Section, SortDir } from "../displayOptions";
@@ -1252,18 +1253,29 @@ function saveCollapsedSection(id: string, collapsed: boolean): void {
  * `card={false}` is for sections whose children already draw their own
  * bordered containers — nesting a card inside a card doubles the border.
  */
+/**
+ * "This section carries attribute icons" (§5.2 tier 4, WM-483). Set by
+ * `<Section icons>`; every `KV` beneath it resolves its glyph from the
+ * registry by label and reserves the slot when the label is unmapped, so
+ * label text starts at one x down the whole section.
+ */
+const KVIconsContext = createContext(false);
+
 export function Section({
   title,
   id,
   children,
   card = true,
   collapsible = true,
+  icons = false,
 }: {
   title: string;
   id?: string;
   children: ReactNode;
   card?: boolean;
   collapsible?: boolean;
+  /** Resolve attribute icons for every `KV` in this section (see `attrIcons.tsx`). */
+  icons?: boolean;
 }) {
   const key = id ?? title;
   const [collapsed, setCollapsed] = useState(() => collapsible && loadCollapsedSections().includes(key));
@@ -1279,6 +1291,7 @@ export function Section({
   );
 
   return (
+    <KVIconsContext.Provider value={icons}>
     <div className="mb-5">
       {collapsible ? (
         <button
@@ -1305,6 +1318,7 @@ export function Section({
           children
         ))}
     </div>
+    </KVIconsContext.Provider>
   );
 }
 
@@ -1334,12 +1348,15 @@ export function KV({
   mono?: boolean;
   /**
    * Attribute icon per §5.2 tier 4 (WM-482): a Radix icon at 14px,
-   * `currentColor`, leading the label at `gap-1.5`. Pass `null` to reserve
-   * the slot on a row without an icon so label text starts at one x across
-   * the section; omit it entirely in sections that carry no icons at all.
+   * `currentColor`, leading the label at `gap-1.5`. Normally left unset —
+   * inside `<Section icons>` the glyph resolves from `attrIcons.tsx` by
+   * label (WM-483) so the same attribute wears the same icon everywhere.
+   * `null` reserves an empty slot; an explicit node overrides the registry.
    */
   icon?: ReactNode;
 }) {
+  const autoIcons = useContext(KVIconsContext);
+  const resolvedIcon = icon !== undefined ? icon : autoIcons ? attrIcon(k) : undefined;
   const text = typeof v === "string" ? v : null;
   const copyable = !!text && text !== "-";
   const isMono = mono ?? (text !== null && looksLikeIdentifier(text));
@@ -1350,9 +1367,9 @@ export function KV({
   return (
     <div className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
       <div className="flex min-w-0 items-center gap-1.5 text-(--text-faint)" title={k}>
-        {icon !== undefined && (
+        {resolvedIcon !== undefined && (
           <i className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5" aria-hidden="true">
-            {icon}
+            {resolvedIcon}
           </i>
         )}
         <span className="truncate">{k}</span>

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -1,17 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  CodeIcon,
-  Component1Icon,
-  Crosshair2Icon,
-  CubeIcon,
-  DesktopIcon,
-  LightningBoltIcon,
-  ListBulletIcon,
-  LockClosedIcon,
-  Pencil1Icon,
-  ReloadIcon,
-  TimerIcon,
-} from "@radix-ui/react-icons";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { useDisplayOptions, useListKeys } from "../hooks";
@@ -460,20 +447,19 @@ export function Agents({
           close={<Button onClick={() => onSelectAgent(null)}>Close</Button>}
         >
 
-          <Section title="Definition">
-            {/* Grouped + attribute icons per §5.2 tier 4 (WM-482). Identity
-                rows carry no icon — an id is text and a word already fits —
-                but reserve the slot so label text starts at one x across the
-                whole panel (ux-critic finding, WM-482). */}
+          <Section title="Definition" icons>
+            {/* Grouped + attribute icons per §5.2 tier 4 (WM-482). Glyphs
+                resolve from the registry by label (WM-483); identity rows are
+                unmapped there and reserve an empty slot so label text starts
+                at one x across the whole panel. */}
             <KVGroup title="Identity">
-              <KV k="id" icon={null} v={sel.id} />
-              <KV k="version" icon={null} v={String(sel.version)} />
-              <KV k="outputContract" icon={null} v={sel.outputContract} />
+              <KV k="id" v={sel.id} />
+              <KV k="version" v={String(sel.version)} />
+              <KV k="outputContract" v={sel.outputContract} />
             </KVGroup>
             <KVGroup title="Execution">
               <KV
                 k="mutating"
-                icon={<Pencil1Icon />}
                 v={
                   <span style={{ color: sel.mutating ? "var(--hue-err)" : "var(--text-faint)" }}>
                     {sel.mutating ? "yes" : "no"}
@@ -482,16 +468,14 @@ export function Agents({
               />
               <KV
                 k="workspace"
-                icon={<CubeIcon />}
                 v={`${sel.workspace.type}${sel.workspace.retainOnFailure ? " · retain on failure" : ""}`}
               />
-              <KV k="capabilities" icon={<LockClosedIcon />} v={caps(sel)} />
-              <KV k="adapter" icon={<Component1Icon />} v={adapterText(sel)} />
-              <KV k="hosts" icon={<DesktopIcon />} v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : "-"} />
-              <KV k="command" icon={<CodeIcon />} v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : "-"} />
+              <KV k="capabilities" v={caps(sel)} />
+              <KV k="adapter" v={adapterText(sel)} />
+              <KV k="hosts" v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : "-"} />
+              <KV k="command" v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : "-"} />
               <KV
                 k="actionRegistry"
-                icon={<ListBulletIcon />}
                 v={
                   sel.actionRegistry && Object.keys(sel.actionRegistry).length > 0
                     ? Object.keys(sel.actionRegistry).join(", ")
@@ -503,10 +487,9 @@ export function Agents({
                 route actually resolves to is per adapter, and lives on the
                 Event routing lines below — the same split `cli.mjs agents` prints. */}
             <KVGroup title="Model">
-              <KV k="modelTier" icon={<LightningBoltIcon />} v={sel.modelTier ?? "-"} />
+              <KV k="modelTier" v={sel.modelTier ?? "-"} />
               <KV
                 k="model override"
-                icon={<Crosshair2Icon />}
                 v={
                   sel.model ? (
                     <span title="Exact model id — resolved verbatim, whatever the tier says.">{sel.model}</span>
@@ -519,10 +502,9 @@ export function Agents({
             <KVGroup title="Limits">
               <KV
                 k="timeout"
-                icon={<TimerIcon />}
                 v={sel.limits.timeout_seconds != null ? `${sel.limits.timeout_seconds}s` : "-"}
               />
-              <KV k="attempts" icon={<ReloadIcon />} v={String(sel.limits.attempts ?? "-")} />
+              <KV k="attempts" v={String(sel.limits.attempts ?? "-")} />
             </KVGroup>
           </Section>
 

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -879,7 +879,7 @@ export function Events({
           close={<Button onClick={() => onSelectEvent(null)}>Close</Button>}
         >
 
-          <Section title="Event">
+          <Section title="Event" icons>
             <KV k="source" v={sel.source} />
             <KV k="type" v={sel.type} />
             <KV k="subject" v={sel.subject} />
@@ -916,7 +916,7 @@ export function Events({
             const err = sel.lastPlanError;
             const hue = err ? "var(--hue-err)" : "var(--hue-warn)";
             return (
-              <Section title="Planning">
+              <Section title="Planning" icons>
                 {sel.planFailures > 0 && <KV k="planFailures" v={String(sel.planFailures)} />}
                 {r && <KV k="proposalReason" v={r} />}
                 {(err || r) && (

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -597,7 +597,7 @@ export function Projects({
               </div>
             </Section>
 
-            <Section id="project-configuration" title="Configuration">
+            <Section id="project-configuration" title="Configuration" icons>
               <KV k="Name" v={sel.name} />
               {sel.project && <KV k="Project" v={sel.project} />}
               {sel.team && <KV k="Team" v={sel.team} />}

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1069,7 +1069,7 @@ export function Proposals({
           close={<Button onClick={() => onSelectProposal(null)}>Close</Button>}
         >
 
-          <Section title="Proposal">
+          <Section title="Proposal" icons>
             <KV k="id" v={sel.id} />
             {sel.agent && (
               <KV
@@ -1115,7 +1115,7 @@ export function Proposals({
           </Section>
 
           {sel.eventId && (
-            <Section title="Origin event">
+            <Section title="Origin event" icons>
               <KV
                 k="eventId"
                 v={

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -530,7 +530,7 @@ export function Schedules({
               </div>
             )}
 
-            <Section id="schedule-configuration" title="Configuration">
+            <Section id="schedule-configuration" title="Configuration" icons>
               <KV k="loop name" v={<span className="mono">{sel.loop}</span>} />
               <KV
                 k="cadence"
@@ -596,7 +596,7 @@ export function Schedules({
               />
             </Section>
 
-            <Section title="Timing & Clocks">
+            <Section title="Timing & Clocks" icons>
               <KV
                 k="last fire"
                 v={

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -915,7 +915,7 @@ export function Workers({
           )}
 
           {sel.currentRun && (
-            <Section title="Active Run">
+            <Section title="Active Run" icons>
               <KV
                 k="runId"
                 v={
@@ -957,7 +957,7 @@ export function Workers({
             </div>
           </Section>
 
-          <Section title="Process">
+          <Section title="Process" icons>
             <KV k="workerId" v={sel.workerId} />
             <KV k="host" v={sel.host} />
             <KV k="pid" v={String(sel.pid)} />

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -81,7 +81,16 @@ function vendorChunk(id: string): string | undefined {
 // rather than on a change. A ratchet that trips on noise sends whoever hits it
 // hunting a bug they did not introduce. If a future raise buys less headroom than
 // this, split the entry instead of moving the number again.
-const ENTRY_CHUNK_BUDGET_BYTES = 500 * 1000;
+//
+// WM-483 re-baselined to 550 kB on 2026-08-17. The attribute-icon registry
+// (`components/attrIcons.tsx`, §5.2 tier 4) hangs off `KV` in `ui.tsx`, which
+// every eager view imports, so its ~35 Radix glyphs land in the entry by design:
+// 488.48 kB → 522.66 kB. Tree-shaking was verified first (only the imported
+// glyphs appear in the output; the package is `sideEffects: false`), and the
+// vendor split is unchanged. The operator accepted the larger entry for one
+// consistent icon set over per-route duplication. Slack is ~27 kB (5%), the same
+// proportion as the WM-332 raise.
+const ENTRY_CHUNK_BUDGET_BYTES = 550 * 1000;
 
 function entryChunkBudget(): Plugin {
   return {


### PR DESCRIPTION
Fixes WM-483

## What
- `components/attrIcons.tsx` — one label→glyph registry (§5.2 tier 4). Keys are normalised (`modelTier` ≡ `model tier`; `input.*` ≡ `input`); identity and state labels are unmapped on purpose.
- `<Section icons>` opts a section in; `KV` resolves its glyph from the registry by label and reserves an empty slot for unmapped rows so labels align. Views never pick a glyph by hand.
- Opted in: Runs (`Run`), Workers (`Active Run`, `Process`), Schedules (`Configuration`, `Timing & Clocks`), Events (`Event`, `Planning`), Proposals (`Proposal`, `Origin event`), Projects (`Configuration`), Agents (`Definition` — now registry-driven, hand-picked icons removed).
- Entry chunk 488 → 523 kB because the registry rides `ui.tsx` into the entry by design; budget re-baselined 500 → 550 kB with the operator's OK, tree-shaking verified (28 glyphs in output). Rationale recorded in `vite.config.ts`.
- `docs/event-runtime-webui.md` §5.2: registry table replaces the inline glyph list; grammar row + checklist updated.

## Verification
- `cd event-runtime/web && bun test` → 650 pass / 0 fail
- `bun run build` → ✓ (522.7 kB entry, budget 550)
- Visual: Runs, Workers, Schedules, Events, Proposals, Projects, Agents — dark + light
- ux-critic round: FIX-FIRST → fixed `source`/`type` sharing a glyph (`source` → `EnterIcon`) and the `workerId` identity exception; adapter-vs-model squint note left as a comment on WM-483

## Not in this PR
- Migrating the stroke-style utility icons (`CopyActions`, theme toggle) to Radix — separate visual decision, noted on WM-483.