### PR TITLE
fix(event-runtime): make hermetic guard snapshot constant-time (WM-480)

### DIFF
--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync } from "node:fs";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -362,6 +362,10 @@ describe("txImmediate (OPS-233)", () => {
 });
 
 describe("hermetic execution guard (OPS-425)", () => {
+  const expectRealDbUnchanged = (before, after) => {
+    expect(after.dbMtime).toBe(before.dbMtime);
+  };
+
   test("isolated home directories never mutate the operator's real ~/.factory", () => {
     const before = realFactorySnapshot();
     const isolated = createIsolatedHome("evrt-guard-test-");
@@ -371,8 +375,27 @@ describe("hermetic execution guard (OPS-425)", () => {
     expect(db.query(`SELECT value FROM counters WHERE name = 'guard'`).get().value).toBe(42);
     db.close();
     const after = realFactorySnapshot();
-    if (before.exists && after.exists) {
-      expect(after.mtime).toBe(before.mtime);
+    expectRealDbUnchanged(before, after);
+  });
+
+  test("detects a write to runtime.db in a supplied real-home fixture", () => {
+    const factoryHome = mkdtempSync(path.join(os.tmpdir(), "evrt-real-home-"));
+    const eventHome = path.join(factoryHome, "event-runtime");
+    const dbPath = path.join(eventHome, "runtime.db");
+    try {
+      mkdirSync(eventHome);
+      writeFileSync(dbPath, "before");
+      const oldTime = new Date("2000-01-01T00:00:00.000Z");
+      utimesSync(dbPath, oldTime, oldTime);
+
+      const before = realFactorySnapshot(factoryHome);
+      expect(() => expectRealDbUnchanged(before, realFactorySnapshot(factoryHome))).not.toThrow();
+
+      appendFileSync(dbPath, " after");
+      const after = realFactorySnapshot(factoryHome);
+      expect(() => expectRealDbUnchanged(before, after)).toThrow();
+    } finally {
+      rmSync(factoryHome, { recursive: true, force: true });
     }
   });
 });

--- a/event-runtime/test-helpers.mjs
+++ b/event-runtime/test-helpers.mjs
@@ -4,7 +4,7 @@
  * Ensures all test executions run hermetically inside temporary directories
  * and never touch or mutate the operator's real ~/.factory directory.
  */
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import os, { homedir } from "node:os";
 import path from "node:path";
 
@@ -65,15 +65,21 @@ export async function withIsolatedHome(fn, prefix = "evrt-scope-home-") {
 /**
  * Returns snapshot stats of ~/.factory to verify hermeticity (guard test).
  */
-export function realFactorySnapshot() {
-  const realHome = path.join(homedir(), ".factory");
-  const eventHome = path.join(realHome, "event-runtime");
-  if (!existsSync(eventHome)) return { exists: false, mtime: 0, entries: [] };
+export function realFactorySnapshot(factoryHome = path.join(homedir(), ".factory")) {
+  const eventHome = path.join(factoryHome, "event-runtime");
+  let eventStat;
   try {
-    const stat = statSync(eventHome);
-    const entries = readdirSync(eventHome, { recursive: true });
-    return { exists: true, mtime: stat.mtimeMs, entries };
-  } catch {
-    return { exists: true, mtime: 0, entries: [] };
+    eventStat = statSync(eventHome);
+  } catch (error) {
+    if (error?.code === "ENOENT") return { exists: false, mtime: 0, dbMtime: 0 };
+    return { exists: true, mtime: 0, dbMtime: 0 };
   }
+
+  let dbMtime = 0;
+  try {
+    dbMtime = statSync(path.join(eventHome, "runtime.db")).mtimeMs;
+  } catch {
+    // A missing or unreadable database has the same stable sentinel value.
+  }
+  return { exists: true, mtime: eventStat.mtimeMs, dbMtime };
 }


### PR DESCRIPTION
## Summary
- replace the recursive live runtime-home scan with O(1) directory and runtime.db stat calls
- guard the operator runtime by comparing runtime.db mtime instead of the mutable directory mtime
- add a temp-home negative test proving runtime.db writes trip the guard

## Verification
- `bun test && bun build/emit.mjs --check && bun test event-runtime/lib/db.test.mjs -t hermetic 2>&1 | tail -3`

UX critique: skipped — test infrastructure only; no user-facing surface

Fixes WM-480