### PR TITLE
fix(merge): expire stale merge barriers (WM-495)

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -296,17 +296,35 @@ function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
   return null;
 }
 
-function mergeBarrierReason(db, candidate) {
-  const active = db
+function mergeBarrierReason(db, candidate, now) {
+  const inFlight = db
     .query(
-      `SELECT run_id FROM runs
+      `SELECT run_id, state, spec_json, created_at FROM runs
      WHERE run_id != ?
-       AND state NOT IN ('PROPOSED','COMPLETED','REFUSED','FAILED','TIMED_OUT','CANCELLED')
+       AND state IN ('QUEUED','LEASED','RUNNING','VERIFYING')
        AND json_extract(spec_json, '$.agent') IN ('merge-apply@2','merge-verify@1')
-     LIMIT 1`,
+     ORDER BY created_at, rowid`,
     )
-    .get(candidate.run_id);
-  if (active) return `merge_barrier_active:${active.run_id}`;
+    .all(candidate.run_id);
+  for (const run of inFlight) {
+    let timeoutSeconds;
+    try {
+      timeoutSeconds = JSON.parse(run.spec_json).timeoutSeconds;
+    } catch {
+      continue;
+    }
+    const createdAt = Date.parse(run.created_at);
+    if (
+      !Number.isFinite(timeoutSeconds) ||
+      timeoutSeconds <= 0 ||
+      !Number.isFinite(createdAt)
+    ) {
+      continue;
+    }
+    const ageSeconds = Math.max(0, Math.floor((now - createdAt) / 1000));
+    if (ageSeconds >= timeoutSeconds) continue;
+    return `merge_barrier_active:${run.run_id}:state=${run.state}:age=${ageSeconds}s`;
+  }
 
   // A landed event owns the global barrier until its exact verifier completes.
   // FAILED verification intentionally remains a hold: CI/smoke red must stop
@@ -324,78 +342,7 @@ function mergeBarrierReason(db, candidate) {
      LIMIT 1`,
     )
     .get();
-  if (unverified) return `merge_barrier_unverified:${unverified.event_id}`;
-
-  // An apply that failed after its last deterministic precheck is uncertain:
-  // the merge may have landed before event admission. A later completed apply
-  // clears only that exact PR/reviewed-head hold, and only after the apply's
-  // causally emitted landing has itself been verified to completion.
-  const uncertain = db
-    .query(
-      `SELECT failed.run_id FROM runs failed
-     WHERE failed.state IN ('FAILED','TIMED_OUT')
-       AND json_extract(failed.spec_json, '$.agent') = 'merge-apply@2'
-       AND NOT EXISTS (
-         SELECT 1
-         FROM runs applied
-         JOIN events landed
-           ON landed.source = 'chain'
-          AND landed.type = 'factory.merge-landed'
-          AND landed.causation_id = applied.run_id
-         JOIN proposals verification_proposal
-           ON verification_proposal.event_source = landed.source
-          AND verification_proposal.event_id = landed.event_id
-         JOIN runs verifier
-           ON verifier.run_id = verification_proposal.run_id
-         WHERE applied.rowid > failed.rowid
-           AND verification_proposal.decision = 'run'
-           AND verification_proposal.status = 'approved'
-           AND applied.state = 'COMPLETED'
-           AND json_extract(applied.spec_json, '$.agent') = 'merge-apply@2'
-           AND json_extract(applied.spec_json, '$.input.github') =
-             json_extract(failed.spec_json, '$.input.github')
-           AND json_extract(applied.spec_json, '$.input.plan[0].pr') =
-             json_extract(failed.spec_json, '$.input.plan[0].pr')
-           AND json_extract(applied.spec_json, '$.input.plan[0].headSha') =
-             json_extract(failed.spec_json, '$.input.plan[0].headSha')
-           AND json_extract(landed.envelope_json, '$.payload.repo') =
-             json_extract(applied.spec_json, '$.input.repo')
-           AND json_extract(landed.envelope_json, '$.payload.github') =
-             json_extract(applied.spec_json, '$.input.github')
-           AND json_extract(landed.envelope_json, '$.payload.base') =
-             json_extract(applied.spec_json, '$.input.base')
-           AND json_extract(landed.envelope_json, '$.payload.pr') =
-             json_extract(applied.spec_json, '$.input.plan[0].pr')
-           AND json_extract(landed.envelope_json, '$.payload.ticket') =
-             json_extract(applied.spec_json, '$.input.plan[0].ticket')
-           AND json_extract(landed.envelope_json, '$.payload.headSha') =
-             json_extract(applied.spec_json, '$.input.plan[0].headSha')
-           AND json_extract(landed.envelope_json, '$.payload.headRef') =
-             json_extract(applied.spec_json, '$.input.plan[0].headRef')
-           AND verifier.state = 'COMPLETED'
-           AND json_extract(verifier.spec_json, '$.agent') = 'merge-verify@1'
-           AND json_extract(verifier.spec_json, '$.input.repo') =
-             json_extract(landed.envelope_json, '$.payload.repo')
-           AND json_extract(verifier.spec_json, '$.input.github') =
-             json_extract(landed.envelope_json, '$.payload.github')
-           AND json_extract(verifier.spec_json, '$.input.base') =
-             json_extract(landed.envelope_json, '$.payload.base')
-           AND json_extract(verifier.spec_json, '$.input.pr') =
-             json_extract(landed.envelope_json, '$.payload.pr')
-           AND json_extract(verifier.spec_json, '$.input.ticket') =
-             json_extract(landed.envelope_json, '$.payload.ticket')
-           AND json_extract(verifier.spec_json, '$.input.headSha') =
-             json_extract(landed.envelope_json, '$.payload.headSha')
-           AND json_extract(verifier.spec_json, '$.input.headRef') =
-             json_extract(landed.envelope_json, '$.payload.headRef')
-           AND json_extract(verifier.spec_json, '$.input.mergeCommitSha') =
-             json_extract(landed.envelope_json, '$.payload.mergeCommitSha')
-       )
-     ORDER BY failed.rowid
-     LIMIT 1`,
-    )
-    .get();
-  return uncertain ? `merge_barrier_uncertain:${uncertain.run_id}` : null;
+  return unverified ? `merge_barrier_unverified:${unverified.event_id}` : null;
 }
 
 const REGISTERED_COMMAND_EDGES = {
@@ -614,7 +561,7 @@ function durableFixRoundReason(db, candidate, input, policy) {
   return null;
 }
 
-function mergeEligibility(db, candidate, envelope, policy) {
+function mergeEligibility(db, candidate, envelope, policy, now) {
   if (!MERGE_EVENT_TYPES.has(envelope.type)) return null;
   const input = envelope.payload ?? {};
 
@@ -668,13 +615,14 @@ function mergeEligibility(db, candidate, envelope, policy) {
       item.ambiguous !== false
     )
       return "merge_review_not_policy_safe";
-    return mergeBarrierReason(db, candidate);
+    return mergeBarrierReason(db, candidate, now);
   }
 
   // merge-landed / merge-verify are allowed only for the exact immutable
   // landing identity; schema validation checks each 40-hex pin.
-  return mergeBarrierReason(db, candidate)?.startsWith("merge_barrier_active:")
-    ? mergeBarrierReason(db, candidate)
+  const barrierReason = mergeBarrierReason(db, candidate, now);
+  return barrierReason?.startsWith("merge_barrier_active:")
+    ? barrierReason
     : null;
 }
 
@@ -683,7 +631,7 @@ function eligible(
   candidate,
   registry,
   policy,
-  { dispatchEligibility, dispatch },
+  { dispatchEligibility, dispatch, now },
 ) {
   if (candidate.event_source !== CHAIN_APPROVAL_SOURCE)
     return "event_source_not_chain";
@@ -722,7 +670,7 @@ function eligible(
   );
   if (predecessorReason) return predecessorReason;
 
-  const mergeReason = mergeEligibility(db, candidate, envelope, policy);
+  const mergeReason = mergeEligibility(db, candidate, envelope, policy, now);
   if (mergeReason) return mergeReason;
 
   const mapping = getEventType(registry, envelope.type);
@@ -797,6 +745,7 @@ export function autoApproveChains(
         : eligible(db, row, registry, policy, {
             dispatchEligibility,
             dispatch,
+            now,
           });
     if (reason) {
       noteOpenReason(db, row.id, reason);

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -41,6 +41,7 @@ function seed(
     predecessorInput = input,
     parentRunId = `parent-${id}`,
     seedPredecessor = true,
+    timeoutSeconds = 600,
   } = {},
 ) {
   const mapping = registry.eventTypes[type];
@@ -130,6 +131,7 @@ function seed(
     runId,
     agent: mapping.agent,
     input,
+    timeoutSeconds,
     ...(defaultApprovalPolicy ? { approvalPolicy: defaultApprovalPolicy } : {}),
     ...(runSpec ?? {}),
   };
@@ -593,106 +595,37 @@ describe("chain auto approval (WM-357)", () => {
     ).toContain("merge_owner_not_allowed");
   });
 
-  test("failed and timed-out merge applies remain global holds without a durable resolution", () => {
-    for (const state of ["FAILED", "TIMED_OUT"]) {
+  test("terminal merge applies never hold the barrier", () => {
+    for (const state of [
+      "FAILED",
+      "CANCELLED",
+      "TIMED_OUT",
+      "REFUSED",
+      "COMPLETED",
+    ]) {
       const db = openDb(":memory:");
-      const historical = seedHistoricalApply(db, {
-        id: `uncertain-${state.toLowerCase()}`,
+      seedHistoricalApply(db, {
+        id: `terminal-${state.toLowerCase()}`,
         state,
       });
-      seed(db, {
+      const input = reviewedMergeInput({ pr: 410 });
+      const candidate = seed(db, {
         id: `candidate-after-${state.toLowerCase()}`,
         type: "factory.merge-apply.requested",
-        input: reviewedMergeInput({ pr: 410 }),
+        input,
         predecessorArtifact: {
           recommendation: "MERGE",
-          ...reviewedMergeInput({ pr: 410 }),
+          ...input,
           fix: [],
           escalate: [],
           summary: "next merge candidate",
         },
       });
 
-      expect(autoMerge(db).approved).toEqual([]);
-      expect(openProposals(db, {})[0].reason).toContain(
-        `merge_barrier_uncertain:${historical.runId}`,
-      );
-    }
-  });
-
-  test("a later exact apply and completed verifier supersede the historical PR 409 failure", () => {
-    const db = openDb(":memory:");
-    const input = reviewedMergeInput({ pr: 409, ticket: "WM-430" });
-    seedHistoricalApply(db, {
-      id: "historical-pr-409-failure",
-      runId: "run_14f89ff8-052c-4119-9e0c-fec9bb626fec",
-      input,
-      state: "FAILED",
-    });
-    seedMergeResolution(db, {
-      id: "successful-pr-409-apply",
-      applyRunId: "run_90c6d727-7c1e-4859-98ab-66774df7eaed",
-      verifyRunId: "run_0fca34e9-7b60-4ccb-ba51-7cea9596b0fe",
-      input,
-    });
-    const nextInput = reviewedMergeInput({ pr: 410, ticket: "WM-446" });
-    const candidate = seed(db, {
-      id: "next-merge-after-pr-409",
-      type: "factory.merge-apply.requested",
-      input: nextInput,
-      predecessorArtifact: {
-        recommendation: "MERGE",
-        ...nextInput,
-        fix: [],
-        escalate: [],
-        summary: "next merge can proceed",
-      },
-    });
-
-    expect(autoMerge(db).approved).toEqual([
-      { proposalId: candidate.id, runId: candidate.runId },
-    ]);
-    expect(runState(db, candidate.runId)).toBe("QUEUED");
-  });
-
-  test("a completed apply for a different PR or reviewed head does not clear the hold", () => {
-    const mismatches = [
-      reviewedMergeInput({ pr: 408, ticket: "WM-408" }),
-      reviewedMergeInput({ pr: 409, headSha: "d".repeat(40) }),
-      {
-        ...reviewedMergeInput({ pr: 409 }),
-        github: "watt-mind/other-factory",
-      },
-    ];
-    for (const [index, resolutionInput] of mismatches.entries()) {
-      const db = openDb(":memory:");
-      const historical = seedHistoricalApply(db, {
-        id: `identity-hold-${index}`,
-        input: reviewedMergeInput({ pr: 409 }),
-        state: "FAILED",
-      });
-      seedMergeResolution(db, {
-        id: `identity-mismatch-${index}`,
-        input: resolutionInput,
-      });
-      const nextInput = reviewedMergeInput({ pr: 410 });
-      seed(db, {
-        id: `identity-candidate-${index}`,
-        type: "factory.merge-apply.requested",
-        input: nextInput,
-        predecessorArtifact: {
-          recommendation: "MERGE",
-          ...nextInput,
-          fix: [],
-          escalate: [],
-          summary: "identity mismatch candidate",
-        },
-      });
-
-      expect(autoMerge(db).approved).toEqual([]);
-      expect(openProposals(db, {})[0].reason).toContain(
-        `merge_barrier_uncertain:${historical.runId}`,
-      );
+      expect(autoMerge(db).approved).toEqual([
+        { proposalId: candidate.id, runId: candidate.runId },
+      ]);
+      expect(runState(db, candidate.runId)).toBe("QUEUED");
     }
   });
 
@@ -731,42 +664,43 @@ describe("chain auto approval (WM-357)", () => {
     }
   });
 
-  test("inexact verifier identity or proposal provenance does not clear the hold", () => {
-    const inexactVerifiers = [
-      { verifierInputOverrides: { repo: "other-factory" } },
-      { verifierInputOverrides: { base: "release" } },
-      { verifierInputOverrides: { ticket: "WM-999" } },
-      { verifierInputOverrides: { headRef: "feat/WM-999" } },
-      { proposalDecision: "watch" },
-    ];
-    for (const [index, options] of inexactVerifiers.entries()) {
+  test("in-flight merge applies hold with state and age until their own timeout", () => {
+    for (const state of ["QUEUED", "LEASED", "RUNNING", "VERIFYING"]) {
       const db = openDb(":memory:");
-      const historical = seedHistoricalApply(db, {
-        id: `inexact-verifier-hold-${index}`,
-        state: "FAILED",
+      const active = seedHistoricalApply(db, {
+        id: `active-${state.toLowerCase()}`,
+        state,
       });
-      seedMergeResolution(db, {
-        id: `inexact-verifier-resolution-${index}`,
-        ...options,
-      });
-      const nextInput = reviewedMergeInput({ pr: 410 });
-      seed(db, {
-        id: `inexact-verifier-candidate-${index}`,
+      db.query(`UPDATE runs SET created_at = ? WHERE run_id = ?`).run(
+        new Date(now - 599_000).toISOString(),
+        active.runId,
+      );
+      const input = reviewedMergeInput({ pr: 410 });
+      const candidate = seed(db, {
+        id: `candidate-during-${state.toLowerCase()}`,
         type: "factory.merge-apply.requested",
-        input: nextInput,
+        input,
         predecessorArtifact: {
           recommendation: "MERGE",
-          ...nextInput,
+          ...input,
           fix: [],
           escalate: [],
-          summary: "inexact verifier candidate",
+          summary: "active barrier candidate",
         },
       });
 
       expect(autoMerge(db).approved).toEqual([]);
       expect(openProposals(db, {})[0].reason).toContain(
-        `merge_barrier_uncertain:${historical.runId}`,
+        `merge_barrier_active:${active.runId}:state=${state}:age=599s`,
       );
+
+      db.query(`UPDATE runs SET created_at = ? WHERE run_id = ?`).run(
+        new Date(now - 600_000).toISOString(),
+        active.runId,
+      );
+      expect(autoMerge(db).approved).toEqual([
+        { proposalId: candidate.id, runId: candidate.runId },
+      ]);
     }
   });
 


### PR DESCRIPTION
## Summary
- ignore terminal merge-apply runs when evaluating the global merge barrier
- expire in-flight blockers at their declared run timeout
- include blocker state and age in operator-visible hold reasons
- cover terminal, in-flight, and expiry behavior

## Verification
- `bun test event-runtime/lib/auto-approval.test.mjs`

UX critique: skipped — backend runtime policy with no user-facing surface.

Fixes WM-495

## Handoff

- PR: https://github.com/watt-mind/factory/pull/457
- Head verified: `ac48af50311995c8ee7b170d4601245999006e2f` (matches PR head)

### File scope

Both files are inside the ticket's Owned Paths; nothing outside them was touched.

| File | +/- |
|---|---|
| `event-runtime/lib/auto-approval.mjs` | +34 / -85 |
| `event-runtime/lib/auto-approval.test.mjs` | +44 / -110 |

2 files changed, +78 / -195.

### Verification

Ticket verification command — **pass**:

```
$ bun test event-runtime/lib/auto-approval.test.mjs
bun test v1.3.14 (0d9b296a)

 23 pass
 0 fail
 94 expect() calls
Ran 23 tests across 1 file. [118.00ms]
```

Repo gate — `bun test && bun build/emit.mjs --check`:

```
 2033 pass
 1 fail
Ran 2034 tests across 139 files. [201.43s]

(fail) seed & re-seed deduplication (OPS-464) > initial seed succeeds and verify passes [11022.97ms]

$ bun build/emit.mjs --check
ok — 90 generated files match shared/     (exit 0)
```

**The single failure is pre-existing and not caused by this branch.** It is the
`SEED_TIMEOUT_MS = 10_000` liveness bound in `event-runtime/demo/seed.test.mjs`
measuring against a seed that really costs 10.1–11.0s on this workstation. It is
tracked as **WM-503** and already fixed on `develop` by `4105ade` (PR #462, merged
2026-08-17T10:47Z), which raised the bound to 20s. This branch was cut before that
merge and is exactly 1 commit behind `develop` — that one commit *is* WM-503 — so
this run reproduces the documented pre-WM-503 develop baseline (2034 total, 1 fail,
that fail being OPS-464) rather than a regression. GitHub CI is green on this exact
head, since the bound is only exceeded on slower/loaded hosts.

`emit.mjs --check` exits 0. Its `! floor delivery: 10 of 10 repo(s) are not carrying
the current floor` line is a non-failing advisory and is present on `develop` too.

### UX critique

**Not applicable — no user-visible surface.** This change is entirely inside the
event-runtime auto-approval policy: a SQLite query over the `runs` table and the
string it returns as a proposal hold reason. There is no page, screen, command
flow, or user-completable journey introduced or changed, so there is nothing for a
critic to drive. No critique was run and none is being claimed.

The one operator-facing artifact is the hold-reason text, which changes from
`merge_barrier_active:<run_id>` to
`merge_barrier_active:<run_id>:state=<STATE>:age=<N>s`. That is a strictly additive
diagnostic string (AC #3), asserted directly in the tests.

### Risks — read these first

1. **This PR deletes the `merge_barrier_uncertain` mechanism outright**, not just
   its terminal-state cases: the ~74-line `NOT EXISTS` correlation query in
   `mergeBarrierReason` is removed, and `merge_barrier_uncertain` no longer exists
   as a reason. The reasoning is sound — that query only ever matched
   `state IN ('FAILED','TIMED_OUT')`, which AC #1 declares must never hold the
   barrier, so it became dead code — but a reviewer should confirm they agree that
   an apply which failed *after* its last deterministic precheck (and may therefore
   have landed the merge before event admission) is adequately covered by the
   surviving `merge_barrier_unverified` hold. This is the judgement call in the PR.
2. **Three tests were deleted** with it (`a later exact apply and completed verifier
   supersede the historical PR 409 failure`, `a completed apply for a different PR or
   reviewed head does not clear the hold`, `inexact verifier identity or proposal
   provenance does not clear the hold`). They asserted the removed mechanism.
3. **The barrier is not "always allow"** — AC #4 is covered in both directions: the
   new `in-flight merge applies hold with state and age until their own timeout` test
   asserts a hold at age 599s and a release at 600s across all four in-flight states,
   and the new `terminal merge applies never hold the barrier` test asserts release
   across all five terminal states.
4. **Expiry is driven by `spec_json.timeoutSeconds`** parsed per run. A run whose
   spec has a missing, non-finite or non-positive `timeoutSeconds`, or an unparseable
   `created_at`, is skipped by `continue` — i.e. it does **not** hold the barrier.
   That is fail-open. Worth a deliberate nod, though the schema pins the field.
5. `eligible()`/`mergeEligibility()` now take `now` as an explicit parameter rather
   than reading the clock internally; confirm every call site threads it (the diff
   updates `autoApproveChains` to pass it).
