### PR TITLE
fix(schedule): stabilize launchd deploy root (WM-339)

### DIFF
--- a/deploy/gen.mjs
+++ b/deploy/gen.mjs
@@ -19,6 +19,9 @@ import path from "node:path";
 import { loadSchedule, toSeconds, ROOT } from "../lib/schedule.mjs";
 const OUT = path.join(ROOT, "deploy", "launchd");
 const DEFAULT_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+// Resolve at job runtime so committed plists are identical whether rendered from
+// the deployed checkout, a disposable ticket worktree, or a CI checkout.
+const DEPLOY_ROOT = '"${FACTORY_ROOT:-$HOME/Develop/factory}"';
 
 const expand = (p) => p.replace(/^~/, homedir());
 
@@ -35,7 +38,7 @@ export function launchdPath(environmentPath = process.env.PATH, home = homedir()
 export function plist(job, defaults, environmentPath = launchdPath()) {
   const label = `${defaults.label_prefix}.${job.name}`;
   const logDir = expand(defaults.log_dir || "~/Library/Logs");
-  const args = ["/bin/bash", "-lc", `cd ${ROOT} && ${job.command}`];
+  const args = ["/bin/bash", "-lc", `cd ${DEPLOY_ROOT} && ${job.command}`];
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/deploy/gen.test.mjs
+++ b/deploy/gen.test.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { installPlists, launchdPath, plist } from "./gen.mjs";
+import { ROOT } from "../lib/schedule.mjs";
 
 const defaults = {
   label_prefix: "com.wattmind",
@@ -30,6 +31,15 @@ test("plist includes EnvironmentVariables with a launchd-safe PATH", () => {
     </dict>`);
   expect((rendered.match(/<key>EnvironmentVariables<\/key>/g) ?? []).length).toBe(1);
   expect((rendered.match(/<key>PATH<\/key>/g) ?? []).length).toBe(1);
+});
+
+test("plist does not leak the renderer worktree into ProgramArguments", () => {
+  const rendered = plist(job, defaults, "/usr/bin");
+
+  expect(rendered).toContain(
+    '<string>cd "${FACTORY_ROOT:-$HOME/Develop/factory}" &amp;&amp; bun orchestrator/run.mjs --only triage</string>',
+  );
+  expect(rendered).not.toContain(ROOT);
 });
 
 test("launchdPath uses the macOS toolchain fallback when PATH is missing", () => {


### PR DESCRIPTION
## Summary
- resolve the launchd working directory at job runtime via `${FACTORY_ROOT:-$HOME/Develop/factory}`
- prevent disposable ticket-worktree paths from entering committed plists
- add regression coverage for the rendered ProgramArguments

## Verification
- `bun test deploy/gen.test.mjs && bun deploy/gen.mjs && bun build/emit.mjs --check`

UX critique: skipped — internal launchd renderer change with no user-facing flow

Fixes WM-339

## Handoff

- PR: https://github.com/watt-mind/factory/pull/459
- Head verified: `28e6ec92150aba9970993cda5f8fa6c1d9f72346` (matches PR head)

### File scope

Both files are inside the ticket's Owned Paths (`deploy/gen.mjs`, `deploy/gen.test.mjs`,
`lib/schedule.mjs`, `deploy/launchd/**`). `lib/schedule.mjs` and `deploy/launchd/**`
were in scope but needed no change — see risk 2.

| File | +/- |
|---|---|
| `deploy/gen.mjs` | +4 / -1 |
| `deploy/gen.test.mjs` | +10 / -0 |

2 files changed, +14 / -1.

### Verification

Ticket verification command — **pass** (exit 0, all three stages):

```
$ bun test deploy/gen.test.mjs && bun deploy/gen.mjs && bun build/emit.mjs --check
bun test v1.3.14 (0d9b296a)

deploy/gen.test.mjs:
  loaded    com.wattmind.triage

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [21.00ms]

  disabled  linear-reaper / label-guard / triage / warm / unblock-digest /
            unblock / dispatch / reconcile / merge / retro / janitor
0 job(s) rendered to deploy/launchd/. Re-run with --install to load them.

ok — 90 generated files match shared/
EXIT=0
```

`git status --short` after `bun deploy/gen.mjs` is **empty** — regeneration is a
no-op against the committed tree, which is the AC #2 property (identical render
from the main checkout, a ticket worktree, and CI). Note this run rendered 0 jobs
because all 11 schedules are currently `disabled`, so it does not by itself exercise
plist content across environments; the new unit test is what actually pins that (see
risk 1).

Repo gate — `bun test && bun build/emit.mjs --check`:

```
 2036 pass
 1 fail
Ran 2037 tests across 139 files. [198.56s]

(fail) seed & re-seed deduplication (OPS-464) > initial seed succeeds and verify passes [10385.80ms]

$ bun build/emit.mjs --check
ok — 90 generated files match shared/     (exit 0)
```

**The single failure is pre-existing and not caused by this branch.** It is the
`SEED_TIMEOUT_MS = 10_000` liveness bound in `event-runtime/demo/seed.test.mjs`
measuring against a seed that really costs 10.1–10.4s on this workstation. It is
tracked as **WM-503** and already fixed on `develop` by `4105ade` (PR #462, merged
2026-08-17T10:47Z), which raised the bound to 20s. This branch was cut before that
merge and is exactly 1 commit behind `develop` — that one commit *is* WM-503 — so
this run reproduces the documented pre-WM-503 develop baseline (1 fail, that fail
being OPS-464) rather than a regression. GitHub CI is green on this exact head,
since the bound is only exceeded on slower/loaded hosts.

`emit.mjs --check` exits 0. Its `! floor delivery: 10 of 10 repo(s) are not carrying
the current floor` line is a non-failing advisory and is present on `develop` too.

### UX critique

**Not applicable — no user-visible surface.** The change substitutes one string into
the `ProgramArguments` of a generated launchd plist: `cd ${ROOT}` becomes
`cd "${FACTORY_ROOT:-$HOME/Develop/factory}"`. There is no UI, no command a person
invokes differently, and no user-completable flow introduced or changed — the only
consumer is `launchd`. There is nothing for a critic to drive, so no critique was
run and none is being claimed.

### Risks — read these first

1. **The deferral is the whole fix, and it moves resolution from render time to job
   run time.** `ROOT` was interpolated by Node when the plist was written; the path
   is now a literal shell expansion evaluated by `/bin/bash -lc` when launchd fires
   the job. Two consequences to check: the plist must keep going through
   `/bin/bash -lc` (it does — `args` is unchanged in shape), and `FACTORY_ROOT` /
   `HOME` must be right in the launchd environment. `HOME` is set by launchd for
   user agents; `FACTORY_ROOT` is not exported in the plist's
   `EnvironmentVariables`, so it will normally be unset and the `$HOME/Develop/factory`
   default is what actually runs. Confirm that default is the deployed checkout.
2. **No committed plists changed, because there are none to change** — all 11
   schedules are `disabled`, so `deploy/launchd/` renders empty. The fix is therefore
   proven by the unit test rather than by a diff in generated output. That is the
   correct order (it lands *before* the first schedule is enabled, which is exactly
   the WM-328 discovery), but it means the cross-environment identity claim rests on
   the test, not on an observed byte-identical regeneration of real plists.
3. **The regression test is the falsifiability evidence and it is genuinely
   two-sided**: it asserts the literal expected `<string>cd "${FACTORY_ROOT:-...}"
   &amp;&amp; ...</string>` *and* `expect(rendered).not.toContain(ROOT)`. The second
   assertion is what fails on the old code from any checkout, including CI's. Worth
   noting the test imports `ROOT` from `lib/schedule.mjs` so it is self-referential to
   wherever it runs — which is the point.
4. **XML escaping**: the rendered string contains `&amp;&amp;` for `&&` but the new
   double quotes around the expansion are emitted raw. That is valid XML in a
   `<string>` body (only `<` and `&` require escaping), and the test pins the exact
   literal, so this is correct — flagging it only because it is the kind of thing
   worth a second look in a plist generator.
