### PR TITLE
fix(test): raise the seed liveness bound above its real cost (WM-503)

### DIFF
--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -12,7 +12,22 @@ const VERIFY = fileURLToPath(new URL("./verify.mjs", import.meta.url));
 const TRIAGE_SCAN_OUTPUT_SCHEMA = JSON.parse(
   readFileSync(fileURLToPath(new URL("../schemas/triage-scan.output.json", import.meta.url)), "utf8"),
 );
-const SEED_TIMEOUT_MS = 10_000;
+// A liveness bound, not a performance target (WM-503). The two assertions that
+// use it exist to catch a seed that waits on the WRONG causal edge — reusing a
+// prior terminal triage-apply proposal instead of following the new scan's edge
+// — which blocks indefinitely rather than merely running slow.
+//
+// At 10s it was baseline-red on every run: the seed measures 10.1-10.5s on a
+// developer workstation, so the bound sat ~2% under the real cost and failed
+// 3/3 sampled runs (10164ms, 10130ms, 10545ms). That single failure failed the
+// whole-suite verification gate for EVERY dispatched ticket, since the gate is
+// all-or-nothing — the factory could not complete a ticket cleanly, and at
+// least one agent discarded a correct fix because of it.
+//
+// 20s is ~2x the observed cost, so ordinary host load cannot trip it, while a
+// genuine wrong-edge hang still fails here (and, failing that, at the 30s test
+// timeout). Rediscovered as WM-487, WM-492, WM-499 and WM-90 before WM-503.
+const SEED_TIMEOUT_MS = 20_000;
 
 const redact = (text) => String(text ?? "")
   .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")


### PR DESCRIPTION
Fixes WM-503

## Summary

`SEED_TIMEOUT_MS` in `event-runtime/demo/seed.test.mjs` was 10s while the seed actually costs 10.1–10.5s, so the bound sat about 2% *under* the real cost and failed on essentially every run.

## Why this is urgent rather than cosmetic

The verification gate is whole-suite and all-or-nothing, so this one pre-existing failure failed **every dispatched ticket**, regardless of that ticket's own correctness:

```
WM-339  repo_verify_failed: Ran 2037 tests across 139 files   → PR #459 opened, CI green
WM-473  repo_verify_failed: Ran 2038 tests across 139 files   → PR #458 opened, CI green
WM-495  repo_verify_failed: Ran 2034 tests across 139 files   → PR #457 opened, CI green
```

Each of those produced a good PR with green GitHub CI and was still marked `FAILED`. A `FAILED` run also pins its idempotency key, so the ticket then needs `retry --force` before it can be dispatched again. Worse, WM-480's agent *fixed its target defect and then discarded the fix*, rolling the ticket back to Todo because "the exact gate repeatedly fails an unrelated out-of-scope" test.

GitHub CI is green on these same commits, so the defect is invisible from PR checks and only bites the agents' local gate.

## Why raise the number rather than speed up the seed

`SEED_TIMEOUT_MS` is a **liveness bound, not a performance target**. Both assertions using it guard against the seed waiting on the *wrong causal edge* — reusing a prior terminal `triage-apply` proposal instead of following the new scan's edge — as the comment at the second call site says. That failure mode hangs indefinitely; it does not merely run slow. So the guard's job is "did it hang", and 10s was never the meaningful threshold — it was just below the honest cost.

20s is ~2× observed cost, so ordinary host load cannot trip it, while a genuine wrong-edge hang still fails here, and failing that, at the enclosing 30s test timeout. The guard is preserved, not weakened.

## Handoff

**Scope.** One constant in one file: `event-runtime/demo/seed.test.mjs`. No production code, no behaviour change.

**Measurement before the change** — three consecutive runs on clean `develop`, all failing at `seed.test.mjs:172`:

```
Expected: < 10000   Received: 10164
Expected: < 10000   Received: 10130
Expected: < 10000   Received: 10545
```

Independently reproduced at 10640ms and 10090ms. The margin is ~1–6%, which is why it presents as a flake rather than deterministically red — worth noting, because "it passed once" is not evidence of a fix.

**Verification after the change** — three consecutive runs:

```
 5 pass  0 fail
 5 pass  0 fail
 5 pass  0 fail
```

**UX critique.** Not applicable — test-only change, no user-visible surface.

## What this does NOT fix

This removes today's blockage; it does not make the gate robust. WM-503 keeps a second half open: the gate should not attribute a pre-existing base failure to a branch at all. A baseline mechanism already exists (`worktreeRecord.baseline`, `matchesRedBaseline`, `reasonCode: "baseline_red"`) but never engages, for two independent reasons — `bin/worktree-up.sh` never captures a test-suite baseline (its only `record_red_baseline` call site is `web_build`), and `failureSignature` is exact normalized-string equality, so any failure whose output embeds run-varying values (durations, test counts) can never match. Until that is fixed the next flake will do identical damage.

**Duplicates to retire.** This was rediscovered as WM-487, WM-492, WM-499 and WM-90 before WM-503 — five tickets for one unfixed defect.