### PR TITLE
fix(dispatch): requeue claim lock contention

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -43,6 +43,11 @@ const LEASE_GRACE_SECONDS = 120;
 /** Infrastructure retries are independent from the agent-error attempt budget. */
 export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
 
+/** Claim-lock contention is deferred independently from execution attempts. */
+export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 8;
+export const CLAIM_LOCK_BACKOFF_BASE_MS = 25;
+export const CLAIM_LOCK_BACKOFF_MAX_MS = 1_000;
+
 /** Hard ceiling for synchronous git and Linear helper processes (WM-262). */
 export const DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS = 120_000;
 
@@ -193,18 +198,28 @@ export function claimNext(db, { owner, now = () => Date.now(), policyVersion = "
   // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
   // not both read the same QUEUED row before either writes (OPS-233).
   return txImmediate(db, () => {
-    // Oldest-first, but skip runs this worker may not take — placement
-    // requirements (§4) and adapters it does not have. Filtering in JS keeps
-    // the rule in one predicate; Postgres can push it into SQL later.
+    const claimNow = resolveNow(now);
+    // Claim-lock backoff is recorded on the latest QUEUED lifecycle event.
+    // updated_at cannot be treated as a generic not-before because tests and
+    // event replay may enqueue rows whose source timestamps are ahead of this
+    // worker's clock.
     const candidates = db
       .query(
-        `SELECT run_id, spec_json, attempts FROM runs
-         WHERE state = 'QUEUED' ORDER BY created_at, run_id`,
+        `SELECT r.run_id, r.spec_json, r.attempts,
+                le.reason AS queue_reason, le.at AS queued_at
+           FROM runs r
+           JOIN lifecycle_events le ON le.seq = (
+             SELECT MAX(latest.seq) FROM lifecycle_events latest WHERE latest.run_id = r.run_id
+           )
+          WHERE r.state = 'QUEUED'
+          ORDER BY r.created_at, r.run_id`,
       )
       .all();
     let row = null;
     let spec = null;
     for (const candidate of candidates) {
+      const backoff = /^claim_lock_contention:\d+:backoff_(\d+)ms$/.exec(candidate.queue_reason ?? "");
+      if (backoff && Date.parse(candidate.queued_at) + Number(backoff[1]) > claimNow) continue;
       const candidateSpec = JSON.parse(candidate.spec_json);
       if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
       if (adapters && !adapterOverride && !adapters.includes(candidateSpec.adapter)) continue;
@@ -215,7 +230,6 @@ export function claimNext(db, { owner, now = () => Date.now(), policyVersion = "
     if (!row) return null;
     const attempt = row.attempts + 1;
     const fencingToken = nextCounter(db, "fencing");
-    const claimNow = resolveNow(now);
     const leaseExpiresAt = iso(claimNow + (spec.timeoutSeconds + LEASE_GRACE_SECONDS) * 1000);
 
     db.query(`UPDATE runs SET attempts = ?, updated_at = ? WHERE run_id = ?`)
@@ -272,6 +286,50 @@ export function acquireClaimLock(lockFile, { pid = process.pid, now = Date.now()
 
 export function releaseClaimLock(lockFile) {
   try { unlinkSync(lockFile); } catch {}
+}
+
+function claimLockBackoffMs(contentionNumber, random = Math.random) {
+  const cap = Math.min(
+    CLAIM_LOCK_BACKOFF_MAX_MS,
+    CLAIM_LOCK_BACKOFF_BASE_MS * (2 ** Math.max(0, contentionNumber - 1)),
+  );
+  const sample = Math.min(1, Math.max(0, Number(random()) || 0));
+  return Math.floor((cap / 2) + (sample * cap / 2));
+}
+
+/**
+ * Put a run that never acquired the claim lock back in the queue without
+ * spending its execution attempt. The lifecycle reason and timestamp form a
+ * durable not-before value consumed by claimNext().
+ */
+function deferClaimLockContention(db, {
+  runId, attempt, fencingToken, owner, policyVersion, now,
+  maxRequeues = DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
+  random = Math.random,
+}) {
+  return txImmediate(db, () => {
+    const currentNow = resolveNow(now);
+    if (!assertCurrentToken(db, runId, fencingToken)) {
+      recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+      return { fenced: true };
+    }
+    const prior = Number(db.query(
+      `SELECT COUNT(*) AS n FROM lifecycle_events
+       WHERE run_id = ? AND reason LIKE 'claim_lock_contention:%'`,
+    ).get(runId)?.n ?? 0);
+    if (prior >= maxRequeues) return { starved: true, contentions: prior };
+
+    const contentionNumber = prior + 1;
+    const backoffMs = claimLockBackoffMs(contentionNumber, random);
+    transition(db, {
+      runId, to: "QUEUED", expectFrom: "RUNNING", actor: owner,
+      reason: `claim_lock_contention:${contentionNumber}:backoff_${backoffMs}ms`,
+      attempt, policyVersion, now: currentNow,
+    });
+    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(runId, attempt);
+    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(attempt - 1, runId);
+    return { requeued: true, contentions: contentionNumber, backoffMs };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -570,6 +628,11 @@ export async function executeClaimed(db, registry, adapters, claim, {
     }
   }, 250);
   cancelPoll?.unref?.();
+  const stopCancellationMonitor = () => {
+    if (cancelPoll) clearInterval(cancelPoll);
+    cancelPoll = null;
+    ACTIVE_EXECUTIONS.delete(runId);
+  };
 
   /** Terminal failure-shaped write: classify, finalize, and budget any retry atomically. */
   const failTerminal = (to, journalReason, reasonCode) =>
@@ -668,9 +731,28 @@ export async function executeClaimed(db, registry, adapters, claim, {
     if (isWorktree && repoName && ticketId) {
       const lockAcquired = acquireClaimLock(lockFile, { pid: process.pid, now: nowFn(), isAlive: isAliveFn });
       if (!lockAcquired) {
-        const res = refuseTerminal("claim_lock_busy", ["dispatch_claim_lock"]);
+        const deferred = deferClaimLockContention(db, {
+          runId, attempt, fencingToken, owner, policyVersion, now: nowFn,
+          maxRequeues: Number.isInteger(dispatchOpts?.maxClaimLockContentionRequeues)
+            ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
+            : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
+          random: dispatchOpts?.random ?? Math.random,
+        });
+        if (deferred?.fenced) {
+          stopCancellationMonitor();
+          return { fenced: true };
+        }
+        if (deferred?.requeued) {
+          stopCancellationMonitor();
+          return {
+            runId, attempt, terminalState: "QUEUED", reasonCode: "claim_lock_contention",
+            requeueAfterMs: deferred.backoffMs,
+          };
+        }
+        const res = refuseTerminal("claim_lock_starvation", ["dispatch_claim_lock"]);
+        stopCancellationMonitor();
         if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode: "claim_lock_busy", receipt: res?.receipt };
+        return { runId, attempt, terminalState: "REFUSED", reasonCode: "claim_lock_starvation", receipt: res?.receipt };
       }
 
       let gateRefusal = null;
@@ -765,8 +847,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         abortSignal: abortController.signal, signal: abortController.signal,
       });
     } finally {
-      clearInterval(cancelPoll);
-      ACTIVE_EXECUTIONS.delete(runId);
+      stopCancellationMonitor();
     }
 
     if (outcome?.usage) attemptUsage = { adapter: adapterKey, ...outcome.usage };

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -269,15 +269,17 @@ export function acquireClaimLock(lockFile, { pid = process.pid, now = Date.now()
       writeFileSync(lockFile, `${pid} ${now}\n`, { flag: "wx" });
       return true;
     } catch {
-      let lockPid = 0, at = 0;
+      let lockPid = 0;
       try {
         const content = readFileSync(lockFile, "utf8").trim();
-        [lockPid, at] = content.split(/\s+/).map(Number);
+        [lockPid] = content.split(/\s+/).map(Number);
       } catch {
         return false;
       }
       const alive = isAlive(lockPid);
-      if (alive && now - at < 120_000) return false;
+      // Age alone is not proof of abandonment: a slow but live Linear claim
+      // must retain mutual exclusion. Only a dead owner makes the lock stale.
+      if (alive) return false;
       try { unlinkSync(lockFile); } catch {}
     }
   }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1289,15 +1289,15 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     releaseClaimLock(lockFile);
   });
 
-  test("acquireClaimLock steals stale lock older than 120s or from dead PID", () => {
+  test("acquireClaimLock preserves old locks from live owners and reclaims dead owners", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-stale-"));
     const lockFile = dispatchLockPath("wt-worker", lockDir);
-    // Write stale lock from 200s ago
+    // Age alone cannot make a live owner's lock safe to steal.
     writeFileSync(lockFile, `${process.pid} 1000\n`, "utf8");
-    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 201_000, isAlive: () => true })).toBe(true);
+    expect(acquireClaimLock(lockFile, { pid: process.pid, now: 201_000, isAlive: () => true })).toBe(false);
     releaseClaimLock(lockFile);
 
-    // Write lock from dead PID
+    // A dead owner's lock is stale and is reclaimed immediately.
     writeFileSync(lockFile, `999999 1000\n`, "utf8");
     expect(acquireClaimLock(lockFile, { pid: process.pid, now: 2000, isAlive: () => false })).toBe(true);
     releaseClaimLock(lockFile);

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1303,17 +1303,19 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     releaseClaimLock(lockFile);
   });
 
-  test("contended claim lock at execute time causes typed refusal claim_lock_busy", async () => {
+  test("contended claim lock requeues with jittered backoff without consuming an attempt, then runs", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-busy-"));
     const lockFile = dispatchLockPath("wt-worker", lockDir);
-    // Hold the lock
     acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
 
     const spec = queueRun(db, makeDispatchSpec());
+    let now = T0;
     const o = opts({
+      now: () => now,
       dispatch: {
         locksDir: lockDir,
+        random: () => 0,
         fetchTicket: () => ({ identifier: "WM-701", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
         fetchInFlight: () => [],
         countLeases: () => 0,
@@ -1321,10 +1323,106 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       },
     });
 
-    const summary = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect(summary.terminalState).toBe("REFUSED");
-    expect(summary.reasonCode).toBe("claim_lock_busy");
+    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "claim_lock_contention" });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
+    expect(db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
+    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
+    expect(claimNext(db, o)).toBeNull();
+
     releaseClaimLock(lockFile);
+    now += deferred.requeueAfterMs;
+    const completed = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(completed).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok", attempt: 1 });
+    expect(runState(db, spec.runId)).toBe("COMPLETED");
+    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(1);
+  });
+
+  test("claim lock starvation refuses with a distinct reason after the requeue ceiling", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-starved-"));
+    const lockFile = dispatchLockPath("wt-worker", lockDir);
+    acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
+
+    const spec = queueRun(db, makeDispatchSpec());
+    let now = T0;
+    const o = opts({
+      now: () => now,
+      dispatch: {
+        locksDir: lockDir,
+        random: () => 0,
+        maxClaimLockContentionRequeues: 1,
+        fetchTicket: () => ({ identifier: "WM-701", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+      },
+    });
+
+    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    now += deferred.requeueAfterMs;
+    const refused = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(refused).toMatchObject({ terminalState: "REFUSED", reasonCode: "claim_lock_starvation" });
+    expect(runState(db, spec.runId)).toBe("REFUSED");
+    releaseClaimLock(lockFile);
+  });
+
+  test("concurrent disjoint dispatches drain through the claim lock with mutually exclusive claims", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-burst-"));
+    const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) => queueRun(db, makeDispatchSpec({
+      runId: `run_lock_burst_${index + 1}`,
+      input: { repo: "wt-worker", ticket },
+    })));
+    let now = T0;
+    let releaseFirst;
+    let markFirstStarted;
+    const firstStarted = new Promise((resolve) => { markFirstStarted = resolve; });
+    const firstRelease = new Promise((resolve) => { releaseFirst = resolve; });
+    let activeClaims = 0;
+    let maxActiveClaims = 0;
+    const claimedTickets = [];
+    const o = opts({
+      now: () => now,
+      dispatch: {
+        locksDir: lockDir,
+        random: () => 1,
+        fetchTicket: (ticket) => ({ identifier: ticket, state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: async ({ ticket }) => {
+          activeClaims += 1;
+          maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
+          claimedTickets.push(ticket);
+          if (ticket === "WM-710") {
+            markFirstStarted();
+            await firstRelease;
+          }
+          activeClaims -= 1;
+          return { ok: true };
+        },
+      },
+    });
+
+    const first = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    await firstStarted;
+    const second = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    const third = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect([second.reasonCode, third.reasonCode]).toEqual(["claim_lock_contention", "claim_lock_contention"]);
+    releaseFirst();
+    expect((await first).terminalState).toBe("COMPLETED");
+
+    now += Math.max(second.requeueAfterMs, third.requeueAfterMs);
+    const drained = [
+      await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
+      await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
+    ];
+    expect(drained.map((summary) => summary.terminalState)).toEqual(["COMPLETED", "COMPLETED"]);
+    expect(specs.map((spec) => runState(db, spec.runId))).toEqual(["COMPLETED", "COMPLETED", "COMPLETED"]);
+    expect(specs.map((spec) => db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts)).toEqual([1, 1, 1]);
+    expect(claimedTickets.sort()).toEqual(["WM-710", "WM-711", "WM-712"]);
+    expect(maxActiveClaims).toBe(1);
   });
 
   test("execute-time re-checks refuse on ticket_not_todo, ticket_assigned, capacity_full, owned_paths_overlap, ticket_claim_lost", async () => {


### PR DESCRIPTION
## Summary
- requeue dispatch claim-lock contention without consuming execution attempts
- add durable bounded exponential backoff with jitter and a distinct starvation ceiling
- verify stale-lock reclaim, idempotent retry, and mutually exclusive burst draining

## Verification
- `bun test event-runtime/lib/worker.test.mjs` (71 pass, 0 fail)

UX critique: skipped — backend event-runtime worker change with no user-facing surface

Fixes WM-506

## Handoff

### File scope (+203 / -22)
| File | +/- |
| --- | --- |
| `event-runtime/lib/worker.mjs` | +96 / -13 |
| `event-runtime/lib/worker.test.mjs` | +107 / -9 |

No other files touched. Backend-only; no schema migration, no config surface.

### Behaviour change
Losing the per-repo dispatch claim lock at execute time used to be a **terminal REFUSAL** (`claim_lock_busy`), burning the dispatch. It now **requeues**: `RUNNING → QUEUED` with reason `claim_lock_contention:N:backoff_Mms`, and **does not spend an execution attempt** (`runs.attempts` stays put; no `attempts`/`results` rows are written).

- **Backoff:** exponential with jitter — base 25ms, `×2^(n-1)`, capped at 1000ms, jittered to `cap/2 + random*cap/2`.
- **Starvation ceiling:** `DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 8`, after which the run refuses with the distinct reason `claim_lock_starvation` (`{starved: true}`) rather than looping forever.
- **Durable not-before:** the retry deadline is stored in the lifecycle event reason and read back in `claimNext` via a JOIN on the latest lifecycle event — deliberately **not** `updated_at`, which other writers mutate. The deferral therefore survives a worker restart.

### Latent bug also fixed (worth calling out)
`acquireClaimLock` previously contained:

```js
if (alive && now - at < 120_000) return false;
```

which meant a lock whose owner was **alive and still working** became stealable once it was 120s old. A slow-but-healthy Linear claim holding the lock past two minutes would have it yanked out from under it by another worker — the exact double-claim race the lock exists to prevent. Age alone no longer makes a lock stale: **only a dead owner** does. `acquireClaimLock preserves old locks from live owners and reclaims dead owners` covers both halves.

### Test coverage — updated, not deleted
The pre-existing test that asserted the defective behaviour (`contended claim lock at execute time causes typed refusal claim_lock_busy`) was **rewritten in place**, not removed. It is now `contended claim lock requeues with jittered backoff without consuming an attempt, then runs`, and it asserts the full new path end to end: `QUEUED` + `claim_lock_contention`, `attempts == 0`, zero `attempts`/`results` rows, `claimNext` returning `null` while the not-before is in the future, then — after the clock advances by `requeueAfterMs` and the lock is released — a run through to `COMPLETED` at `attempt: 1`.

Two further tests were added: the starvation ceiling, and a concurrent burst test proving three disjoint dispatches drain through the lock with **mutually exclusive** claims (`maxActiveClaims` never exceeds 1).

### Verification actually run
Verified in an isolated worktree with `origin/develop` merged in first (develop had moved: WM-290's `api.mjs` restructure, WM-493, WM-495, WM-473, WM-339). **The merge was clean — no conflicts.**

```
$ bun test event-runtime/lib/worker.test.mjs
 71 pass
 0 fail
 348 expect() calls
Ran 71 tests across 1 file. [5.26s]

$ bun test
 2044 pass
 0 fail
 8069 expect() calls
Ran 2044 tests across 150 files. [213.74s]

$ bun build/emit.mjs --check
exit 0   (prints the pre-existing "floor delivery: stale AGENTS.md" advisory — not a failure)
```

GitHub Actions CI on the pushed head `61c8226`: **success** (run `32024316624`).

### UX critique
Not applicable — no user-visible surface. This changes worker-internal dispatch scheduling only; there is no UI, CLI output contract, or API response shape affected.
