### PR TITLE
Fix merge scan singleton across all origins

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -219,7 +219,7 @@ function agentSingletonEnabled(registry, agentRef) {
 
 function singletonApplies(registry, envelope, agentRef) {
   const loop = envelope.payload?.loop;
-  const schedule = envelope.source === "schedule" && loop ? registry.schedules?.[loop] : null;
+  const schedule = loop ? registry.schedules?.[loop] : null;
   if (schedule && registry.eventTypes?.[schedule.eventType]?.agent === agentRef) {
     return schedule.singleton !== false;
   }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -31,7 +31,7 @@ import { getAgent, getEventType, resolveModel } from "./registry.mjs";
 import { pinRepo } from "./repository.mjs";
 import { RepoError, getRepo, loadRepos, reposConfigPath, reposRoot } from "./repos.mjs";
 import { validate } from "./schema.mjs";
-import { loopInFlight } from "./schedules.mjs";
+import { inFlightRunsForAgent } from "./schedules.mjs";
 import { resolveInputRef } from "./workspace.mjs";
 import { autoApproveChains, buildChainApprovalPolicy } from "./auto-approval.mjs";
 
@@ -193,6 +193,37 @@ function policyMaxInFlight(root = reposRoot()) {
   } catch {
     return DEFAULT_MAX_IN_FLIGHT;
   }
+}
+
+/** Fail-safe merge admission cap when policy is absent or malformed. */
+export const DEFAULT_MAX_CONCURRENT_MERGES = 1;
+
+export function policyMaxConcurrentMerges(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return DEFAULT_MAX_CONCURRENT_MERGES;
+  try {
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency?.max_concurrent_merges;
+    return Number.isInteger(value) && value > 0 ? value : DEFAULT_MAX_CONCURRENT_MERGES;
+  } catch {
+    return DEFAULT_MAX_CONCURRENT_MERGES;
+  }
+}
+
+function agentSingletonEnabled(registry, agentRef) {
+  return Object.values(registry.schedules ?? {}).some((candidate) =>
+    candidate.enabled &&
+    candidate.singleton !== false &&
+    registry.eventTypes?.[candidate.eventType]?.agent === agentRef
+  );
+}
+
+function singletonApplies(registry, envelope, agentRef) {
+  const loop = envelope.payload?.loop;
+  const schedule = envelope.source === "schedule" && loop ? registry.schedules?.[loop] : null;
+  if (schedule && registry.eventTypes?.[schedule.eventType]?.agent === agentRef) {
+    return schedule.singleton !== false;
+  }
+  return agentSingletonEnabled(registry, agentRef);
 }
 
 function loadRepoEscalatePaths(repoName, root = reposRoot()) {
@@ -510,18 +541,28 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const scopeRefusal = repoNotAllowed(def, envelope.payload);
     if (scopeRefusal) return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
 
-    // §5 singleton: a scheduled loop whose previous run is still in flight
-    // plans a typed NOOP, never a second queued run. A reaper that takes 70
-    // minutes must not accumulate a backlog of reapers.
-    const loop = envelope.payload?.loop;
-    const schedule = loop ? registry.schedules?.[loop] : null;
-    if (schedule && schedule.singleton !== false && loopInFlight(db, mapping.agent)) {
+    // §5 singleton is agent policy, not clock-envelope policy: operator and
+    // chain origins mapped to an enabled singleton agent must not bypass it by
+    // omitting payload.loop. Merge scans additionally obey the git-owned
+    // global admission cap even when a concrete schedule opts out of
+    // singleton behavior. PROPOSED remains excluded (OPS-436).
+    const inFlight = inFlightRunsForAgent(db, mapping.agent);
+    const singletonBlocked = singletonApplies(registry, envelope, mapping.agent) && inFlight.length > 0;
+    const mergeCap = envelope.type === "factory.merge.requested" ? policyMaxConcurrentMerges() : null;
+    const mergeCapBlocked = mergeCap !== null && inFlight.length >= mergeCap;
+    if (singletonBlocked || mergeCapBlocked) {
+      const blockingRun = inFlight[0];
       const proposal = insertProposal(db, {
-        id: newProposalId(), event, decision: "noop", status: "resolved",
+        id: newProposalId(), event, runId: blockingRun.run_id, decision: "noop", status: "resolved",
         reason: "previous_run_in_flight", at, ttlSeconds,
       });
       setEventStatus(db, event, "noop");
-      return { decision: "noop", proposal, reason: "previous_run_in_flight" };
+      return {
+        decision: "noop",
+        proposal,
+        runId: blockingRun.run_id,
+        reason: "previous_run_in_flight",
+      };
     }
 
     const input = validate(def.inputSchema, envelope.payload);

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -8,7 +8,13 @@ import { DEAD_LETTER_AFTER } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
-import { buildRunSpec, idempotencyKeyFor, planAdmittedEvents, planEvent } from "./planner.mjs";
+import {
+  buildRunSpec,
+  idempotencyKeyFor,
+  planAdmittedEvents,
+  planEvent,
+  policyMaxConcurrentMerges,
+} from "./planner.mjs";
 import { loadRegistry } from "./registry.mjs";
 
 const registry = loadRegistry();
@@ -63,6 +69,22 @@ describe("idempotencyKeyFor", () => {
     expect(() => idempotencyKeyFor({ idempotencyScope: ["deliveryColor"] }, def, envelope(), "sha256:x")).toThrow(
       /unknown idempotency scope/,
     );
+  });
+});
+
+describe("merge concurrency policy", () => {
+  test("reads a positive integer max_concurrent_merges and fails safe otherwise", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-merge-policy-"));
+    mkdirSync(path.join(root, "config"));
+    const policy = path.join(root, "config", "policy.yaml");
+
+    writeFileSync(policy, "concurrency:\n  max_concurrent_merges: 2\n");
+    expect(policyMaxConcurrentMerges(root)).toBe(2);
+
+    for (const invalid of ["0", "1.5", "many"]) {
+      writeFileSync(policy, `concurrency:\n  max_concurrent_merges: ${invalid}\n`);
+      expect(policyMaxConcurrentMerges(root)).toBe(1);
+    }
   });
 });
 

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -152,16 +152,26 @@ export function emitDueTicks(db, registry, { now = Date.now() } = {}) {
   return { emitted, errors };
 }
 
-/** Is a run for this loop's agent still in flight? (§5 singleton; OPS-436 excludes PROPOSED) */
-export function loopInFlight(db, agentRef) {
-  const row = db
+/**
+ * Runs for an agent that are still in flight, oldest first. PROPOSED remains
+ * excluded (OPS-436): an unapproved watched proposal must not silence later
+ * schedule slots. Returning the rows lets singleton NOOPs identify the run
+ * they deferred to instead of dropping that audit evidence.
+ */
+export function inFlightRunsForAgent(db, agentRef) {
+  return db
     .query(
-      `SELECT COUNT(*) AS n FROM runs
+      `SELECT run_id, state, created_at FROM runs
        WHERE state NOT IN ('PROPOSED','COMPLETED','REFUSED','FAILED','TIMED_OUT','CANCELLED')
-         AND json_extract(spec_json, '$.agent') = ?`,
+         AND json_extract(spec_json, '$.agent') = ?
+       ORDER BY created_at ASC, rowid ASC`,
     )
-    .get(agentRef);
-  return row.n > 0;
+    .all(agentRef);
+}
+
+/** Is a run for this loop's agent still in flight? (§5 singleton) */
+export function loopInFlight(db, agentRef) {
+  return inFlightRunsForAgent(db, agentRef).length > 0;
 }
 
 /** The newest slot that successfully completed for a loop, or null if never completed (OPS-436). */

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import * as fake from "./adapters/fake.mjs";
 import { openDb } from "./db.mjs";
-import { planAdmittedEvents } from "./planner.mjs";
+import { admitEvent } from "./intake.mjs";
+import { planAdmittedEvents, planEvent } from "./planner.mjs";
 import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 import {
@@ -40,6 +41,26 @@ const withLoop = (overrides = {}) => ({
 });
 
 const at = (iso) => Date.parse(iso);
+
+function planMergeRequest(d, registry, {
+  eventId,
+  source = "operator",
+  now = at("2026-08-17T10:30:45Z"),
+} = {}) {
+  const admitted = admitEvent(d, registry, {
+    schemaVersion: "factory.event/v1",
+    eventId,
+    type: "factory.merge.requested",
+    source,
+    subject: "factory",
+    occurredAt: new Date(now).toISOString(),
+    correlationId: eventId,
+    causationId: source === "chain" ? "run-parent" : null,
+    payload: { repo: "factory" },
+  }, { now });
+  expect(admitted.admitted).toBe(true);
+  return planEvent(d, registry, { source, eventId }, { now, policyVersion: PV });
+}
 
 describe("cadence and slots", () => {
   test("parses the interval forms and rejects everything else", () => {
@@ -368,6 +389,79 @@ describe("planning a tick (§5, §6)", () => {
       .query(`SELECT decision, reason FROM proposals WHERE decision = 'noop' ORDER BY rowid DESC LIMIT 1`)
       .get();
     expect(noop.reason).toBe("previous_run_in_flight");
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("scheduled merge in flight makes an operator request a named typed NOOP", () => {
+    const d = db();
+    const registry = withLoop({
+      eventType: "factory.merge.requested",
+      payload: { repo: "factory" },
+      approval: "auto",
+    });
+    emitDueTicks(d, registry, { now: at("2026-08-17T10:30:00Z") });
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    const [approved] = autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV }).approved;
+
+    const operator = planMergeRequest(d, registry, { eventId: "operator-merge-overlap" });
+    expect(operator).toMatchObject({
+      decision: "noop",
+      reason: "previous_run_in_flight",
+      runId: approved.runId,
+    });
+    expect(operator.proposal.run_id).toBe(approved.runId);
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("operator merge in flight makes a scheduled request a named NOOP via max_concurrent_merges", () => {
+    const d = db();
+    const registry = withLoop({
+      eventType: "factory.merge.requested",
+      payload: { repo: "factory" },
+      singleton: false,
+      approval: "auto",
+    });
+    const operator = planMergeRequest(d, registry, { eventId: "operator-merge-first" });
+    approveProposal(d, registry, operator.proposal.id, { actor: "operator", policyVersion: PV });
+
+    const tickAt = at("2026-08-17T11:00:00Z");
+    emitDueTicks(d, registry, { now: tickAt });
+    const scheduled = planEvent(
+      d,
+      registry,
+      { source: "schedule", eventId: tickEventId("reaper", "2026-08-17T11:00:00.000Z") },
+      { now: tickAt, policyVersion: PV },
+    );
+    expect(scheduled).toMatchObject({
+      decision: "noop",
+      reason: "previous_run_in_flight",
+      runId: operator.runId,
+    });
+    expect(scheduled.proposal.run_id).toBe(operator.runId);
+    expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+  });
+
+  test("chain-originated merge request uses the same named singleton NOOP", () => {
+    const d = db();
+    const registry = withLoop({
+      eventType: "factory.merge.requested",
+      payload: { repo: "factory" },
+      approval: "auto",
+    });
+    const operator = planMergeRequest(d, registry, { eventId: "operator-before-chain" });
+    approveProposal(d, registry, operator.proposal.id, { actor: "operator", policyVersion: PV });
+
+    const chained = planMergeRequest(d, registry, {
+      eventId: "chain-merge-overlap",
+      source: "chain",
+      now: at("2026-08-17T10:31:00Z"),
+    });
+    expect(chained).toMatchObject({
+      decision: "noop",
+      reason: "previous_run_in_flight",
+      runId: operator.runId,
+    });
+    expect(chained.proposal.run_id).toBe(operator.runId);
     expect(d.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- apply enabled schedule singleton policy to operator and chain merge requests
- enforce `concurrency.max_concurrent_merges` during merge-scan planning
- return typed `previous_run_in_flight` NOOPs that identify the blocking run
- cover scheduled/operator overlap in both directions and chain-origin requests

## Verification
- `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/schedules.test.mjs` — 62 pass, 0 fail

UX critique: skipped — backend runtime admission change; no user-facing surface

Fixes WM-504