### PR TITLE
fix(verify): raise the repo-verify hang guard above the command's real cost (WM-510)

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -26,8 +26,21 @@ import { PathViolation, safeJoin } from "./workspace.mjs";
  */
 export const EVIDENCE_INLINE_LIMIT_BYTES = 256 * 1024;
 
-/** Hard ceiling for the repository-owned verification command (WM-262). */
-export const DEFAULT_REPO_VERIFY_TIMEOUT_MS = 120_000;
+/**
+ * Hang guard for the repository-owned verification command (WM-262), not a
+ * performance budget — it exists to tell "wedged forever" from "running".
+ *
+ * 120s was below the real cost and failed every dispatch (WM-510): this repo's
+ * own `bun test && bun build/emit.mjs --check` measures 196-217s, so nothing
+ * could ever pass. Sized at ~3x the slowest observed run, which leaves room for
+ * a loaded host while staying far under `limits.max_run_minutes: 45` in
+ * config/policy.yaml — the bound that actually caps a wedged run.
+ *
+ * Raise this rather than trimming it to fit: a ceiling that only just fits is
+ * the same outage with a longer fuse. Per-repo tuning goes through
+ * FACTORY_REPO_VERIFY_TIMEOUT_MS.
+ */
+export const DEFAULT_REPO_VERIFY_TIMEOUT_MS = 600_000;
 
 function repoVerifyTimeoutMs() {
   const configured = Number(process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS);


### PR DESCRIPTION
Fixes WM-510

## Summary

`DEFAULT_REPO_VERIFY_TIMEOUT_MS` was 120s while the command it bounds takes 196–217s, so every dispatched ticket failed verification by timeout. Raised to 600s.

## What broke and why

WM-262 (PR #447, `cf2453f`) bounded a genuinely unbounded `spawnSync` in `verifyResult` — a real hang risk, correctly identified. But the ceiling was set below the real cost of the command:

```yaml
# config/repos.yaml
factory:  verify: bun test && bun build/emit.mjs --check
```

Measured on this host during one session: **196s, 203s, 209s, 217s**. Against 120s, it could never complete — so this was not flaky, it was total:

```
run_6a2d9b63-8975-430e-813b-d404ba2e9a79   (WM-506)
  VERIFYING → FAILED
  failure:agent_error:contract_violation: repo_verify_failed: timed out after 120000ms
```

Every dispatch died the same way, regardless of whether its own work was correct. It also landed on **WM-506**, the fix for the dispatch claim-lock throughput ceiling, so it was blocking the repair of a separate blocker.

The blast radius is total because this bound lives on the **worker's** side of the agent boundary: the agent writes `result.json` and exits, and the worker independently re-runs the repo's gate. An agent cannot detect, influence, or route around a broken verifier — and GitHub CI stays green throughout, so there is no external symptom.

## Why raise it rather than trim the command

It is a **hang guard, not a performance budget** — WM-262's own framing was that an unbounded `spawnSync` "risks permanent worker process hang". Its job is to distinguish *wedged forever* from *running normally*, and 120s was simply set below normal.

600s is ~3× the slowest observed run, leaving headroom for a loaded host, and sits far under `limits.max_run_minutes: 45` in `config/policy.yaml` — the bound that actually caps a wedged run. WM-262's protection is preserved, not reverted: a genuinely hung subprocess still gets killed.

This is the second instance of the same mistake today — `SEED_TIMEOUT_MS` (WM-503) was 10s against a 10.1–10.5s reality. The comment added here names the pattern explicitly so the next person raises the ceiling rather than trimming to fit.

## Handoff

**Scope.** One constant plus its explanatory comment in `event-runtime/lib/verify.mjs`. No behavioural change beyond the bound.

**Verification.**

```
$ bun test event-runtime/lib/verify.test.mjs
 21 pass
 0 fail
 57 expect() calls
Ran 21 tests across 1 file. [98.00ms]

$ bun build/emit.mjs --check ; echo $?
0
```

(`emit --check` prints a "floor delivery: stale AGENTS.md" advisory — pre-existing on `develop`, exits 0, unrelated to this change.)

**UX critique.** Not applicable — no user-visible surface.

**Follow-up not addressed here.** WM-510's criterion that the timeout message report elapsed time *and* the configured ceiling is not implemented in this PR; the message still reads only `timed out after 120000ms`. This PR is scoped to stopping the outage. Also still open is WM-503's second half: `matchesRedBaseline` at `verify.mjs:319` would classify a pre-existing failure as `baseline_red` rather than blaming the branch, but the baseline is never captured for the test suite, so it never fires.