### PR TITLE
fix(schedules): return manual trigger metadata (WM-259)

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -42,6 +42,7 @@ import { githubWebhookSecret } from "./intake.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos } from "./repos.mjs";
+import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
 
@@ -180,7 +181,31 @@ export function createApi({
         url.pathname === "/schedules" ||
         url.pathname.startsWith("/schedules/")
       ) {
-        const result = await handleScheduleApiRoute(common);
+        const triggerMatch = url.pathname.match(
+          /^\/schedules\/([^/]+)\/(run|trigger)$/,
+        );
+        const scheduleSend = (status, body) => {
+          if (req.method !== "POST" || status !== 200 || !triggerMatch) {
+            return send(status, body);
+          }
+          const loop = decodeURIComponent(triggerMatch[1]);
+          const schedule = scheduleView(db, registry, { now: nowMs }).find(
+            (item) => item.loop === loop,
+          );
+          if (!schedule) return send(status, body);
+          const repo = registry.schedules?.[loop]?.payload?.repo;
+          return send(status, {
+            ...body,
+            schedule: {
+              ...schedule,
+              repo: typeof repo === "string" && repo !== "" ? repo : null,
+            },
+          });
+        };
+        const result = await handleScheduleApiRoute({
+          ...common,
+          send: scheduleSend,
+        });
         if (result !== false) return result;
       }
       if (

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -34,6 +34,61 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+import { emitDueTicks } from "./schedules.mjs";
+
+describe("schedule trigger metadata (WM-259)", () => {
+  test("run and trigger return the unchanged next scheduled tick", async () => {
+    const nowMs = Date.parse("2026-08-17T11:35:00.000Z");
+    const scheduleRegistry = {
+      ...registry,
+      schedules: {
+        reaper: {
+          ...registry.schedules.reaper,
+          every: "60m",
+          enabled: true,
+          payload: { repo: "factory" },
+        },
+      },
+    };
+    const s = await makeServer({ registry: scheduleRegistry, now: () => nowMs });
+    try {
+      emitDueTicks(s.db, scheduleRegistry, {
+        now: Date.parse("2026-08-17T11:00:00.000Z"),
+      });
+
+      for (const action of ["run", "trigger"]) {
+        const res = await fetch(s.url(`/schedules/reaper/${action}`), {
+          method: "POST",
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.schedule).toMatchObject({
+          loop: "reaper",
+          repo: "factory",
+          lastSlot: "2026-08-17T11:00:00.000Z",
+          nextDue: "2026-08-17T12:00:00.000Z",
+          stopped: false,
+        });
+      }
+
+      const operatorEvents = s.db
+        .query(`SELECT envelope_json FROM events WHERE source = 'operator' ORDER BY event_id`)
+        .all()
+        .map((row) => JSON.parse(row.envelope_json));
+      expect(operatorEvents).toHaveLength(2);
+      expect(operatorEvents.every((event) => event.payload.repo === "factory")).toBe(true);
+
+      const schedules = await (await fetch(s.url("/schedules"))).json();
+      expect(schedules.schedules[0]).toMatchObject({
+        lastSlot: "2026-08-17T11:00:00.000Z",
+        nextDue: "2026-08-17T12:00:00.000Z",
+        stopped: false,
+      });
+    } finally {
+      s.close();
+    }
+  });
+});
 
 describe("environment identity (webui chip)", () => {
   test("health and status expose the env the server was started with", async () => {

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -420,6 +420,14 @@ describe("scheduleView (§9)", () => {
   test("reports cadence, last fire, next due — and a stopped clock", () => {
     const d = db();
     const registry = withLoop();
+
+    const unticked = scheduleView(d, registry, { now: at("2026-08-13T21:30:00Z") })[0];
+    expect(unticked).toMatchObject({
+      lastSlot: null,
+      nextDue: "2026-08-13T21:00:00.000Z",
+      stopped: false,
+    });
+
     emitDueTicks(d, registry, { now: at("2026-08-13T21:00:00Z") });
 
     const soon = scheduleView(d, registry, { now: at("2026-08-13T21:30:00Z") })[0];


### PR DESCRIPTION
## Summary
- return the current schedule view, including `nextDue`, from successful manual `/run` and `/trigger` calls
- preserve static schedule payload on operator events without advancing scheduled `lastSlot`
- cover ticked and unticked `scheduleView()` calculations plus both trigger aliases

## Verification
- `bun test event-runtime/lib/schedules.test.mjs event-runtime/lib/api.test.mjs` (31 pass)
- `bun test event-runtime/lib/api-schedules.test.mjs` (10 pass)

UX critique: skipped — backend API and scheduling metadata change with no user-facing flow

Fixes WM-259