### PR TITLE
fix(worktree): reserve fallback port pairs atomically

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -93,6 +93,7 @@ BASE_BRANCH="${FACTORY_BASE_BRANCH:-develop}"
 # are unchanged for real use.
 PORT_BASE="${FACTORY_PORT_BASE:-7400}"
 PORT_SPAN="${FACTORY_PORT_SPAN:-200}"
+PORT_RESERVATION_ROOT="${FACTORY_PORT_RESERVATION_ROOT:-$HOME/.factory/locks/worktree-ports}"
 HERE_API_PORT=7391
 HERE_WEB_PORT=7392
 
@@ -105,6 +106,7 @@ warn() { printf '\033[33mwarn:\033[0m %s\n' "$*" >&2; }
 
 [[ "$PORT_BASE" =~ ^[0-9]+$ ]] || die "FACTORY_PORT_BASE must be numeric (got '$PORT_BASE')"
 [[ "$PORT_SPAN" =~ ^[0-9]+$ ]] || die "FACTORY_PORT_SPAN must be numeric (got '$PORT_SPAN')"
+(( PORT_BASE % 2 == 0 )) || die "FACTORY_PORT_BASE must be even so API/web pairs stay aligned (got '$PORT_BASE')"
 
 repo_root() { git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel; }
 
@@ -179,6 +181,165 @@ write_ports() { # <worktree> <api> <web>
   printf 'api=%s\nweb=%s\n' "$2" "$3" >"$(run_dir "$1")/ports"
 }
 
+# Port selection and reservation are separate from TCP bind: dependency
+# installation and the web build can take long enough for a second worktree to
+# observe the selected pair as still free. A short global allocator lock makes
+# selection atomic, while one persistent directory per API/web pair bridges
+# that bind gap and records which checkout owns the pair.
+port_allocation_lock_dir() { printf '%s/allocation.lock' "$PORT_RESERVATION_ROOT"; }
+port_reservation_dir() { printf '%s/%s.lock' "$PORT_RESERVATION_ROOT" "$1"; }
+
+acquire_port_allocation_lock() {
+  local lock start now holder age mtime stale
+  lock="$(port_allocation_lock_dir)"
+  mkdir -p "$PORT_RESERVATION_ROOT"
+  start=$(date +%s)
+  while ! mkdir "$lock" 2>/dev/null; do
+    holder=$(cat "$lock/pid" 2>/dev/null || true)
+    now=$(date +%s)
+    stale=0
+    if [[ "$holder" =~ ^[0-9]+$ ]]; then
+      kill -0 "$holder" 2>/dev/null || stale=1
+    else
+      if stat -f '%m' "$lock" >/dev/null 2>&1; then
+        mtime=$(stat -f '%m' "$lock" 2>/dev/null || printf '0')
+      else
+        mtime=$(stat -c '%Y' "$lock" 2>/dev/null || printf '0')
+      fi
+      [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+      age=$((now - mtime))
+      (( age >= 2 )) && stale=1
+    fi
+    if [[ "$stale" -eq 1 ]]; then
+      local stale_lock="${lock}.stale.$$.$RANDOM"
+      if mv "$lock" "$stale_lock" 2>/dev/null; then
+        rm -rf "$stale_lock"
+        continue
+      fi
+    fi
+    (( now - start < 10 )) || die "timed out waiting for worktree port allocation lock ($lock)"
+    sleep 0.05
+  done
+  local pid_tmp="$lock/pid.$$.$RANDOM"
+  printf '%s\n' "$$" >"$pid_tmp"
+  mv "$pid_tmp" "$lock/pid"
+}
+
+release_port_allocation_lock() {
+  local lock holder
+  lock="$(port_allocation_lock_dir)"
+  holder=$(cat "$lock/pid" 2>/dev/null || true)
+  [[ "$holder" == "$$" ]] && rm -rf "$lock" || true
+}
+
+# A reservation remains active while its allocating shell is alive, or after
+# that shell exits while the recorded checkout still owns live daemons/ports.
+# Otherwise it is stale residue from a failed or killed startup and can be
+# reclaimed under the allocator lock. Both API and web ports get reservation
+# directories so odd --here pairs cannot overlap an even ticket pair.
+port_reservation_active() { # <reserved-port>
+  local port="$1" dir owner claimant api web rdir
+  dir="$(port_reservation_dir "$port")"
+  [[ -d "$dir" ]] || return 1
+  claimant=$(cat "$dir/pid" 2>/dev/null || true)
+  if [[ "$claimant" =~ ^[0-9]+$ ]] && kill -0 "$claimant" 2>/dev/null; then
+    return 0
+  fi
+  owner=$(cat "$dir/worktree" 2>/dev/null || true)
+  api=$(awk -F= '$1 == "api" { print $2 }' "$dir/ports" 2>/dev/null || true)
+  web=$(awk -F= '$1 == "web" { print $2 }' "$dir/ports" 2>/dev/null || true)
+  [[ -n "$owner" && -d "$owner" && "$api" =~ ^[0-9]+$ && "$web" =~ ^[0-9]+$ ]] || return 1
+  rdir="$(run_dir "$owner")"
+  if pid_alive "$rdir/serve.pid" || pid_alive "$rdir/web.pid" \
+    || port_listening "$api" || port_listening "$web"; then
+    return 0
+  fi
+  return 1
+}
+
+port_pair_reserved_by_other() { # <api-port> <worktree>
+  local api="$1" wt="$2" port dir owner
+  for port in "$api" "$((api + 1))"; do
+    dir="$(port_reservation_dir "$port")"
+    [[ -d "$dir" ]] || continue
+    if ! port_reservation_active "$port"; then
+      rm -rf "$dir"
+      continue
+    fi
+    owner=$(cat "$dir/worktree" 2>/dev/null || true)
+    [[ "$owner" == "$wt" ]] || return 0
+  done
+  return 1
+}
+
+reserve_port_pair() { # <worktree> <api-port> <web-port>; allocator lock held
+  local wt="$1" api="$2" web="$3" port dir owner tmp
+  [[ "$web" -eq $((api + 1)) ]] || return 1
+  port_pair_reserved_by_other "$api" "$wt" && return 1
+  for port in "$api" "$web"; do
+    dir="$(port_reservation_dir "$port")"
+    if [[ -d "$dir" ]]; then
+      owner=$(cat "$dir/worktree" 2>/dev/null || true)
+      if [[ "$owner" != "$wt" ]]; then
+        rm -rf "$(port_reservation_dir "$api")" "$(port_reservation_dir "$web")"
+        return 1
+      fi
+    else
+      if ! mkdir "$dir"; then
+        rm -rf "$(port_reservation_dir "$api")" "$(port_reservation_dir "$web")"
+        return 1
+      fi
+    fi
+    tmp="$dir/worktree.$$.$RANDOM"
+    printf '%s\n' "$wt" >"$tmp"
+    mv "$tmp" "$dir/worktree"
+    tmp="$dir/pid.$$.$RANDOM"
+    printf '%s\n' "$$" >"$tmp"
+    mv "$tmp" "$dir/pid"
+    printf 'api=%s\nweb=%s\n' "$api" "$web" >"$dir/ports"
+  done
+}
+
+release_port_reservation() { # <worktree> [api-port]
+  local wt="$1" api="${2:-}" web="" recorded dir owner port
+  if [[ -z "$api" ]]; then
+    recorded=$(read_ports "$wt" 2>/dev/null || true)
+    if [[ -n "$recorded" ]]; then
+      api="${recorded%% *}"
+      web="${recorded##* }"
+    elif [[ "${API_PORT:-}" =~ ^[0-9]+$ ]]; then
+      api="$API_PORT"
+    else
+      return 0
+    fi
+  fi
+  if [[ -z "$web" ]]; then
+    dir="$(port_reservation_dir "$api")"
+    web=$(awk -F= '$1 == "web" { print $2 }' "$dir/ports" 2>/dev/null || true)
+    [[ "$web" =~ ^[0-9]+$ ]] || web=$((api + 1))
+  fi
+  acquire_port_allocation_lock
+  for port in "$api" "$web"; do
+    dir="$(port_reservation_dir "$port")"
+    owner=$(cat "$dir/worktree" 2>/dev/null || true)
+    [[ "$owner" == "$wt" ]] && rm -rf "$dir" || true
+  done
+  release_port_allocation_lock
+}
+
+# Failed bring-up calls this after stopping only the daemons it started. Keep
+# an established checkout's reservation, but remove dead partial pid/port
+# state so the next invocation can retry the same preferred pair.
+release_worktree_ports_if_idle() { # <worktree>
+  local wt="$1" rdir
+  rdir="$(run_dir "$wt")"
+  if pid_alive "$rdir/serve.pid" || pid_alive "$rdir/worker.pid" || pid_alive "$rdir/web.pid"; then
+    return 0
+  fi
+  release_port_reservation "$wt"
+  rm -f "$rdir/serve.pid" "$rdir/worker.pid" "$rdir/web.pid" "$rdir/ports"
+}
+
 # Listening TCP port for a pidfile, or fail. Used to recover ports from a
 # daemon started before .factory/run/ports existed.
 listen_tcp_port() { # <pidfile>
@@ -188,12 +349,14 @@ listen_tcp_port() { # <pidfile>
   pid=$(cat "$1" 2>/dev/null) || return 1
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  port=$(lsof -nP -iTCP -sTCP:LISTEN -p "$pid" 2>/dev/null \
+  port=$(lsof -nP -a -iTCP -sTCP:LISTEN -p "$pid" 2>/dev/null \
     | awk -v pid="$pid" 'NR > 1 && $2 == pid {name=$9; sub(/^.*:/, "", name); print name; exit}') \
     || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   [[ "$port" =~ ^[0-9]+$ ]] || return 1
-  (( port >= PORT_BASE && port < PORT_BASE + 2 * PORT_SPAN )) || return 1
+  if [[ "$port" -ne "$HERE_API_PORT" && "$port" -ne "$HERE_WEB_PORT" ]]; then
+    (( port >= PORT_BASE && port < PORT_BASE + 2 * PORT_SPAN )) || return 1
+  fi
   printf '%s' "$port"
 }
 
@@ -230,7 +393,9 @@ allocate_api_port() { # <preferred> <expected_home> [worktree]
   [[ "$preferred" =~ ^[0-9]+$ ]] || die "invalid preferred port '$preferred'"
   while [[ $i -lt $PORT_SPAN ]]; do
     api_available=0
-    if port_listening "$port"; then
+    if [[ -n "$wt" ]] && port_pair_reserved_by_other "$port" "$wt"; then
+      warn "port pair $port/$((port + 1)) is reserved by another worktree — trying next"
+    elif port_listening "$port"; then
       json=$(health_json "$port")
       occupant=$(health_field "$json" home)
       if [[ -n "$occupant" && "$occupant" == "$expected" ]]; then
@@ -263,9 +428,13 @@ allocate_api_port() { # <preferred> <expected_home> [worktree]
       warn "web port $web_port is owned by another process — trying next pair"
     fi
 
-    port=$((port + 2))
-    if [[ $port -ge $((PORT_BASE + 2 * PORT_SPAN)) ]]; then
+    if [[ $port -lt $PORT_BASE ]]; then
       port=$PORT_BASE
+    else
+      port=$((port + 2))
+      if [[ $port -ge $((PORT_BASE + 2 * PORT_SPAN)) ]]; then
+        port=$PORT_BASE
+      fi
     fi
     i=$((i + 1))
   done
@@ -278,14 +447,19 @@ allocate_api_port() { # <preferred> <expected_home> [worktree]
 # Sets API_PORT and WEB_PORT for the caller.
 resolve_worktree_ports() { # <worktree> <preferred-api-port> <expected-home>
   local wt="$1" preferred="$2" expected="$3"
-  local rdir resolved=0 recorded occupant sp wp recorded_web_pid_port api_reusable web_reusable
+  local rdir resolved=0 recorded occupant sp wp recorded_web_pid_port api_reusable web_reusable pair_available stale_port stale_dir stale_owner
   rdir="$(run_dir "$wt")"
+  acquire_port_allocation_lock
 
   if recorded=$(read_ports "$wt"); then
     API_PORT="${recorded%% *}"
     WEB_PORT="${recorded##* }"
     api_reusable=0
     web_reusable=0
+    pair_available=1
+    if [[ "$WEB_PORT" -ne $((API_PORT + 1)) ]] || port_pair_reserved_by_other "$API_PORT" "$wt"; then
+      pair_available=0
+    fi
 
     if port_listening "$API_PORT"; then
       occupant=$(health_field "$(health_json "$API_PORT")" home)
@@ -301,34 +475,54 @@ resolve_worktree_ports() { # <worktree> <preferred-api-port> <expected-home>
       [[ "$recorded_web_pid_port" == "$WEB_PORT" ]] && web_reusable=1
     fi
 
-    if [[ "$api_reusable" -eq 1 && "$web_reusable" -eq 1 ]]; then
+    if [[ "$pair_available" -eq 1 && "$api_reusable" -eq 1 && "$web_reusable" -eq 1 ]] \
+      && reserve_port_pair "$wt" "$API_PORT" "$WEB_PORT"; then
       info "reusing recorded ports $API_PORT / $WEB_PORT"
       resolved=1
     else
-      warn "recorded ports $API_PORT / $WEB_PORT are occupied by another process — allocating a free pair"
+      warn "recorded ports $API_PORT / $WEB_PORT are occupied or reserved by another process — allocating a free pair"
+      for stale_port in "$API_PORT" "$WEB_PORT"; do
+        stale_dir="$(port_reservation_dir "$stale_port")"
+        stale_owner=$(cat "$stale_dir/worktree" 2>/dev/null || true)
+        [[ "$stale_owner" == "$wt" ]] && rm -rf "$stale_dir" || true
+      done
     fi
   fi
 
   if [[ "$resolved" -eq 0 ]] && pid_alive "$rdir/serve.pid"; then
     if sp=$(listen_tcp_port "$rdir/serve.pid"); then
       API_PORT="$sp"
+      WEB_PORT=$((API_PORT + 1))
       if pid_alive "$rdir/web.pid" && wp=$(listen_tcp_port "$rdir/web.pid"); then
-        WEB_PORT="$wp"
-      else
-        WEB_PORT=$((API_PORT + 1))
+        if [[ "$wp" -ne "$WEB_PORT" ]]; then
+          release_port_allocation_lock
+          die "live daemon ports $API_PORT / $wp are not an adjacent API/web pair"
+        fi
+      elif port_listening "$WEB_PORT"; then
+        release_port_allocation_lock
+        die "adjacent web port $WEB_PORT is occupied by a process not owned by this worktree"
       fi
-      info "reusing live daemon ports $API_PORT / $WEB_PORT"
-      write_ports "$wt" "$API_PORT" "$WEB_PORT"
-      resolved=1
+      if port_pair_reserved_by_other "$API_PORT" "$wt"; then
+        release_port_allocation_lock
+        die "live daemon port pair $API_PORT/$WEB_PORT is reserved by another worktree"
+      fi
+      if reserve_port_pair "$wt" "$API_PORT" "$WEB_PORT"; then
+        info "reusing live daemon ports $API_PORT / $WEB_PORT"
+        write_ports "$wt" "$API_PORT" "$WEB_PORT"
+        resolved=1
+      fi
     fi
   fi
 
   if [[ "$resolved" -eq 0 ]]; then
     API_PORT="$(allocate_api_port "$preferred" "$expected" "$wt")"
     WEB_PORT=$((API_PORT + 1))
+    reserve_port_pair "$wt" "$API_PORT" "$WEB_PORT" \
+      || die "port pair $API_PORT/$WEB_PORT was claimed during allocation"
     write_ports "$wt" "$API_PORT" "$WEB_PORT"
     info "allocated ports $API_PORT / $WEB_PORT (preferred $preferred)"
   fi
+  release_port_allocation_lock
 }
 
 # Refuse to proceed (and never seed) when /health is a different event home.

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -1,7 +1,7 @@
 import { chmodSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
 
 const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
 
@@ -40,11 +40,17 @@ function pickPortBase() {
 }
 
 const PORT_BASE = pickPortBase();
+const PORT_RESERVATION_ROOT = mkdtempSync(path.join(tmpdir(), "factory-port-reservations-"));
 const P = (offset) => PORT_BASE + offset;
 const BAND_ENV = {
   FACTORY_PORT_BASE: String(PORT_BASE),
   FACTORY_PORT_SPAN: String(PORT_SPAN),
+  FACTORY_PORT_RESERVATION_ROOT: PORT_RESERVATION_ROOT,
 };
+
+afterAll(() => {
+  rmSync(PORT_RESERVATION_ROOT, { recursive: true, force: true });
+});
 
 function sh(body, extraEnv = {}) {
   const result = Bun.spawnSync({
@@ -157,6 +163,21 @@ test("listen_tcp_port rejects a recovered port outside the configured band", () 
   }
 });
 
+test("listen_tcp_port accepts the fixed --here web port below the ticket band", () => {
+  const dir = mockLsofDir();
+  const pidfile = path.join(dir, "here.pid");
+  try {
+    const r = sh(`printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`, {
+      PATH: `${dir}:${process.env.PATH}`,
+      MOCK_LSOF_PORT: "7392",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("7392");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolve_worktree_ports reuses free recorded ports for --here", () => {
   const wt = mkdtempSync(path.join(tmpdir(), "wm-176-recorded-"));
   try {
@@ -223,6 +244,40 @@ test("resolve_worktree_ports skips a preferred pair whose web port is occupied",
   }
 });
 
+test("overlapping odd and even preferred pairs cannot be reserved concurrently", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "wm-351-overlap-"));
+  const wtOdd = path.join(root, "odd");
+  const wtEven = path.join(root, "even");
+  const oddReady = path.join(root, "odd.ready");
+  const evenReady = path.join(root, "even.ready");
+  mkdirSync(wtOdd);
+  mkdirSync(wtEven);
+
+  const contend = (wt, preferred, ownReady, otherReady) => shAsync([
+    `resolve_worktree_ports "${wt}" ${preferred} "${wt}/.factory/event-runtime"`,
+    `touch "${ownReady}"`,
+    `for _ in {1..200}; do [[ -e "${otherReady}" ]] && break; sleep 0.01; done`,
+    `test -e "${otherReady}"`,
+    'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
+  ].join("\n"));
+
+  try {
+    const [odd, even] = await Promise.all([
+      contend(wtOdd, P(359), oddReady, evenReady),
+      contend(wtEven, P(360), evenReady, oddReady),
+    ]);
+    expect(odd.status).toBe(0);
+    expect(even.status).toBe(0);
+    const oddPorts = [...odd.stdout.matchAll(/(?:api|web)=(\d+)/g)].map((match) => Number(match[1]));
+    const evenPorts = [...even.stdout.matchAll(/(?:api|web)=(\d+)/g)].map((match) => Number(match[1]));
+    expect(oddPorts).toHaveLength(2);
+    expect(evenPorts).toHaveLength(2);
+    expect(oddPorts.some((port) => evenPorts.includes(port))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("resolve_worktree_ports replaces recorded ports when the web port is occupied", async () => {
   const wt = mkdtempSync(path.join(tmpdir(), "wm-176-recorded-web-collision-"));
   const listener = Bun.listen({
@@ -270,6 +325,83 @@ test("resolve_worktree_ports reuses recorded ports owned by this checkout", asyn
     expect(r.stdout).toContain(`resolved=${api} ${P(375)}`);
   } finally {
     server.stop(true);
+    rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test("colliding WM-294 and WM-345 startups reserve distinct pairs and stop independently", async () => {
+  const wt1 = mkdtempSync(path.join(tmpdir(), "wm-351-runtime-a-"));
+  const wt2 = mkdtempSync(path.join(tmpdir(), "wm-351-runtime-b-"));
+  const preferred1 = sh("ticket_api_port WM-294");
+  const preferred2 = sh("ticket_api_port WM-345");
+  expect(preferred1.status).toBe(0);
+  expect(preferred2.status).toBe(0);
+  expect(preferred1.stdout).toBe(preferred2.stdout);
+  const preferred = Number(preferred1.stdout);
+
+  const launch = (wt) => shAsync([
+    `home="${wt}/.factory/event-runtime"`,
+    `resolve_worktree_ports "${wt}" ${preferred} "$home"`,
+    `spawn_daemon "$(run_dir "${wt}")/serve.pid" "$(run_dir "${wt}")/serve.log" "${wt}" env MOCK_HOME="$home" MOCK_PORT="$API_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return Response.json({ env: { home: process.env.MOCK_HOME } }); } });'`,
+    `spawn_daemon "$(run_dir "${wt}")/web.pid" "$(run_dir "${wt}")/web.log" "${wt}" env MOCK_PORT="$WEB_PORT" bun --eval 'Bun.serve({ hostname: "127.0.0.1", port: Number(process.env.MOCK_PORT), fetch() { return new Response("web"); } });'`,
+    'for _ in {1..100}; do port_listening "$API_PORT" && port_listening "$WEB_PORT" && break; sleep 0.01; done',
+    'port_listening "$API_PORT" && port_listening "$WEB_PORT"',
+    'printf "api=%s web=%s\\n" "$API_PORT" "$WEB_PORT"',
+  ].join("\n"));
+
+  const stop = (wt) => sh([
+    `rdir="$(run_dir "${wt}")"`,
+    'term_daemon "$rdir/web.pid" "web"',
+    'term_daemon "$rdir/serve.pid" "serve"',
+    'await_daemon "$rdir/web.pid" "web"',
+    'await_daemon "$rdir/serve.pid" "serve"',
+    `release_port_reservation "${wt}"`,
+  ].join("\n"));
+
+  try {
+    const [a, b] = await Promise.all([launch(wt1), launch(wt2)]);
+    expect(a.status).toBe(0);
+    expect(b.status).toBe(0);
+    const api1 = Number(a.stdout.match(/api=(\d+)/)?.[1]);
+    const api2 = Number(b.stdout.match(/api=(\d+)/)?.[1]);
+    expect(api1).not.toBe(api2);
+    expect(Math.abs(api1 - api2)).toBe(2);
+
+    const rerun = sh([
+      `resolve_worktree_ports "${wt1}" ${preferred} "${wt1}/.factory/event-runtime"`,
+      'printf "%s %s\\n" "$API_PORT" "$WEB_PORT"',
+    ].join("\n"));
+    expect(rerun.status).toBe(0);
+    expect(rerun.stdout).toContain(`${api1} ${api1 + 1}`);
+
+    expect(stop(wt1).status).toBe(0);
+    expect(sh(`port_listening ${api2}`).status).toBe(0);
+    expect(stop(wt2).status).toBe(0);
+    expect(sh(`port_listening ${api2}`).status).not.toBe(0);
+  } finally {
+    stop(wt1);
+    stop(wt2);
+    rmSync(wt1, { recursive: true, force: true });
+    rmSync(wt2, { recursive: true, force: true });
+  }
+});
+
+test("failed startup cleanup removes partial pid and port reservation state", () => {
+  const wt = mkdtempSync(path.join(tmpdir(), "wm-351-failed-startup-"));
+  try {
+    const r = sh([
+      `resolve_worktree_ports "${wt}" ${P(360)} "${wt}/.factory/event-runtime"`,
+      `rdir="$(run_dir "${wt}")"`,
+      'printf "2147483647\\n" >"$rdir/serve.pid"',
+      `reservation="$(port_reservation_dir "$API_PORT")"`,
+      'rm -f "$rdir/ports"',
+      `release_worktree_ports_if_idle "${wt}"`,
+      'test ! -e "$rdir/serve.pid"',
+      'test ! -e "$rdir/ports"',
+      'test ! -e "$reservation"',
+    ].join("\n"));
+    expect(r.status).toBe(0);
+  } finally {
     rmSync(wt, { recursive: true, force: true });
   }
 });

--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -46,6 +46,7 @@ term_daemon "$RUN_DIR/serve.pid" "event runtime"
 await_daemon "$RUN_DIR/web.pid" "web server"
 await_daemon "$RUN_DIR/worker.pid" "worker"
 await_daemon "$RUN_DIR/serve.pid" "event runtime"
+release_port_reservation "$WT"
 
 if [[ "$HERE" -eq 1 ]]; then
   info "removing demo state $(event_home "$WT")"

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -184,6 +184,12 @@ else
   fi
 fi
 
+WEB_AVAILABLE=1
+if [[ -f "$BASELINE_REPORT" && ! -f "$WEB_DIR/dist/index.html" ]]; then
+  WEB_AVAILABLE=0
+  warn "web UI unavailable because the baseline web build failed; control API and worker remain usable"
+fi
+
 # ---------------------------------------------------------------- daemons ---
 FRESH=0
 [[ -f "$HOME_DIR/runtime.db" ]] || FRESH=1
@@ -266,32 +272,34 @@ else
   STARTED_WORKER=1
 fi
 
-if pid_alive "$RUN_DIR/web.pid"; then
-  info "web server already running (pid $(cat "$RUN_DIR/web.pid"), port $WEB_PORT)"
-else
-  info "starting web server on $WEB_PORT"
-  spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$WT" \
-    env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
-    bun event-runtime/web/serve.mjs
-  STARTED_WEB=1
-fi
-
-# A listener alone is insufficient: an alien process could have occupied the
-# adjacent port after allocation. Require the recorded web daemon itself to own
-# the persisted port before reporting the environment ready.
-WEB_PID_PORT=""
-for _ in {1..50}; do
-  if ! pid_alive "$RUN_DIR/web.pid"; then
-    dump_daemon_log "$RUN_DIR/web.log" "web server"
-    die "web server died during startup on $WEB_PORT — see $RUN_DIR/web.log"
+if [[ "$WEB_AVAILABLE" -eq 1 ]]; then
+  if pid_alive "$RUN_DIR/web.pid"; then
+    info "web server already running (pid $(cat "$RUN_DIR/web.pid"), port $WEB_PORT)"
+  else
+    info "starting web server on $WEB_PORT"
+    spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$WT" \
+      env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+      bun event-runtime/web/serve.mjs
+    STARTED_WEB=1
   fi
-  WEB_PID_PORT=$(listen_tcp_port "$RUN_DIR/web.pid" || true)
-  [[ "$WEB_PID_PORT" == "$WEB_PORT" ]] && break
-  sleep 0.1
-done
-if [[ "$WEB_PID_PORT" != "$WEB_PORT" ]]; then
-  dump_daemon_log "$RUN_DIR/web.log" "web server"
-  die "web server pid $(cat "$RUN_DIR/web.pid") did not bind reserved port $WEB_PORT"
+
+  # A listener alone is insufficient: an alien process could have occupied the
+  # adjacent port after allocation. Require the recorded web daemon itself to own
+  # the persisted port before reporting the environment ready.
+  WEB_PID_PORT=""
+  for _ in {1..50}; do
+    if ! pid_alive "$RUN_DIR/web.pid"; then
+      dump_daemon_log "$RUN_DIR/web.log" "web server"
+      die "web server died during startup on $WEB_PORT — see $RUN_DIR/web.log"
+    fi
+    WEB_PID_PORT=$(listen_tcp_port "$RUN_DIR/web.pid" || true)
+    [[ "$WEB_PID_PORT" == "$WEB_PORT" ]] && break
+    sleep 0.1
+  done
+  if [[ "$WEB_PID_PORT" != "$WEB_PORT" ]]; then
+    dump_daemon_log "$RUN_DIR/web.log" "web server"
+    die "web server pid $(cat "$RUN_DIR/web.pid") did not bind reserved port $WEB_PORT"
+  fi
 fi
 
 # ------------------------------------------------------------------- seed ---
@@ -338,6 +346,11 @@ if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
 fi
 
 # ----------------------------------------------------------------- report ---
+if [[ "$WEB_AVAILABLE" -eq 1 ]]; then
+  WEB_UI_REPORT="http://127.0.0.1:$WEB_PORT"
+else
+  WEB_UI_REPORT="unavailable (baseline web build failed)"
+fi
 WORKTREE_UP_OK=1
 cat <<EOF
 
@@ -346,7 +359,7 @@ $(info "ready — $LABEL")
   checkout   $WT
   event home $HOME_DIR
   control    http://127.0.0.1:$API_PORT      $(adapter_banner "$HEALTH_ADAPTER")
-  web UI     http://127.0.0.1:$WEB_PORT
+  web UI     $WEB_UI_REPORT
   logs       $RUN_DIR/{serve,worker,web}.log
 
   status:  FACTORY_EVENT_PORT=$API_PORT bun event-runtime/cli.mjs status

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -93,6 +93,7 @@ if [[ "$CHECKOUT_ONLY" -eq 1 ]]; then
 fi
 
 command -v bun >/dev/null || die "bun is required (https://bun.sh)"
+command -v lsof >/dev/null || die "lsof is required to verify daemon port ownership"
 
 RUN_DIR="$(run_dir "$WT")"
 HOME_DIR="$(event_home "$WT")"
@@ -121,7 +122,32 @@ record_red_baseline() {
 
 # Resolve API/web ports only after the checkout exists so we can persist them.
 # --here prefers 7391/7392 but follows the same recorded-port reuse and
-# collision fallback path as named ticket worktrees.
+# collision fallback path as named ticket worktrees. If anything after the
+# reservation fails, stop only daemons created by this invocation and release
+# dead partial pid/port state so a retry can claim the pair.
+STARTED_SERVE=0
+STARTED_WORKER=0
+STARTED_WEB=0
+WORKTREE_UP_OK=0
+cleanup_worktree_up() {
+  local code=$?
+  trap - EXIT INT TERM
+  release_port_allocation_lock
+  if [[ "$code" -ne 0 && "$WORKTREE_UP_OK" -ne 1 ]]; then
+    [[ "$STARTED_WEB" -eq 1 ]] && term_daemon "$RUN_DIR/web.pid" "web server"
+    [[ "$STARTED_WORKER" -eq 1 ]] && term_daemon "$RUN_DIR/worker.pid" "worker"
+    [[ "$STARTED_SERVE" -eq 1 ]] && term_daemon "$RUN_DIR/serve.pid" "event runtime"
+    [[ "$STARTED_WEB" -eq 1 ]] && await_daemon "$RUN_DIR/web.pid" "web server"
+    [[ "$STARTED_WORKER" -eq 1 ]] && await_daemon "$RUN_DIR/worker.pid" "worker"
+    [[ "$STARTED_SERVE" -eq 1 ]] && await_daemon "$RUN_DIR/serve.pid" "event runtime"
+    release_worktree_ports_if_idle "$WT"
+  fi
+  exit "$code"
+}
+trap cleanup_worktree_up EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 if [[ "$HERE" -eq 1 ]]; then
   preferred="$HERE_API_PORT"
 else
@@ -174,7 +200,6 @@ if port_listening "$API_PORT"; then
   occupant=$(health_field "$(health_json "$API_PORT")" home)
   if [[ "$occupant" != "$HOME_DIR" ]]; then
     if ! pid_alive "$RUN_DIR/serve.pid"; then
-      rm -f "$RUN_DIR/ports"
       die "port $API_PORT is owned by another runtime (env.home=${occupant:-unknown}, this worktree=$HOME_DIR) — refusing to seed"
     fi
   fi
@@ -187,6 +212,7 @@ else
   spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$WT" \
     env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
     bun event-runtime/cli.mjs serve ${ADAPTER_ARGS[@]+"${ADAPTER_ARGS[@]}"}
+  STARTED_SERVE=1
 fi
 
 # Wait for /health BEFORE starting the worker: on a fresh DB, serve and worker
@@ -210,19 +236,16 @@ for _ in {1..50}; do
   HEALTH_JSON=$(curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" 2>/dev/null) && break
   HEALTH_JSON=""
   if ! pid_alive "$RUN_DIR/serve.pid"; then
-    rm -f "$RUN_DIR/ports"
     dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
     die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
   fi
   sleep 0.1
 done
 if ! pid_alive "$RUN_DIR/serve.pid"; then
-  rm -f "$RUN_DIR/ports"
   dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
   die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
 fi
 if [[ -z "$HEALTH_JSON" ]]; then
-  rm -f "$RUN_DIR/ports"
   dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
   HEALTH_JSON=$(curl -sf -m 2 "http://127.0.0.1:$API_PORT/health") \
     || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
@@ -240,6 +263,7 @@ else
   spawn_daemon "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$WT" \
     env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
     bun event-runtime/cli.mjs work ${ADAPTER_ARGS[@]+"${ADAPTER_ARGS[@]}"}
+  STARTED_WORKER=1
 fi
 
 if pid_alive "$RUN_DIR/web.pid"; then
@@ -249,6 +273,25 @@ else
   spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$WT" \
     env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
     bun event-runtime/web/serve.mjs
+  STARTED_WEB=1
+fi
+
+# A listener alone is insufficient: an alien process could have occupied the
+# adjacent port after allocation. Require the recorded web daemon itself to own
+# the persisted port before reporting the environment ready.
+WEB_PID_PORT=""
+for _ in {1..50}; do
+  if ! pid_alive "$RUN_DIR/web.pid"; then
+    dump_daemon_log "$RUN_DIR/web.log" "web server"
+    die "web server died during startup on $WEB_PORT — see $RUN_DIR/web.log"
+  fi
+  WEB_PID_PORT=$(listen_tcp_port "$RUN_DIR/web.pid" || true)
+  [[ "$WEB_PID_PORT" == "$WEB_PORT" ]] && break
+  sleep 0.1
+done
+if [[ "$WEB_PID_PORT" != "$WEB_PORT" ]]; then
+  dump_daemon_log "$RUN_DIR/web.log" "web server"
+  die "web server pid $(cat "$RUN_DIR/web.pid") did not bind reserved port $WEB_PORT"
 fi
 
 # ------------------------------------------------------------------- seed ---
@@ -295,6 +338,7 @@ if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
 fi
 
 # ----------------------------------------------------------------- report ---
+WORKTREE_UP_OK=1
 cat <<EOF
 
 $(info "ready — $LABEL")


### PR DESCRIPTION
## Summary
- reserve both ports in each selected API/web pair under an atomic allocator lock
- deterministically probe bounded alternatives and reuse persisted ports across invocations
- release reservations during teardown and clean failed startup PID/port state
- verify daemon port ownership and cover real WM-294/WM-345 collisions plus overlapping-pair races

## Verification
- `bun test bin/worktree-common.test.mjs bin/worktree-checkout.test.mjs` — 46 pass, 0 fail

UX critique: skipped — backend worktree lifecycle tooling; no user-facing flow

Fixes WM-351