### PR TITLE
fix(work-scan): reject contradictory empty queues

### DIFF
--- a/event-runtime/agents/work-scan.json
+++ b/event-runtime/agents/work-scan.json
@@ -24,8 +24,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/work-scan.md": "sha256:334e0cf401c4e06b98c686d68562c3da20137594613dd542a50e20e48430af04",
+    "agents/work-scan.md": "sha256:80a767e3e8ad8539c079871ffe8cadcf80a12ba67770b6e7ea3c900fc541c45a",
     "schemas/work-scan.input.json": "sha256:3d596ece1e34c9d3a8711596076df67357d8eeec3d29bc5bfb64e02ed4f32c10",
-    "schemas/work-scan.output.json": "sha256:2be46ed08bb9a28f5054b0c37789aa65a046061d2500b0eb8ff7647f11d0d662"
+    "schemas/work-scan.output.json": "sha256:62d81edf5aafc73fe62930be4c3b900107c333e58d4ebeb1f494330882b178e1"
   }
 }

--- a/event-runtime/agents/work-scan.md
+++ b/event-runtime/agents/work-scan.md
@@ -36,8 +36,14 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    excludes the ticket, regardless of state or labels; an `agent:*` or `ai:*`
    label proves nothing about assignment. A ticket without `ai:agent-ready` is
    also excluded. An excluded ticket must never appear in `plan` or `deferred`.
-   `readyCandidates` counts only tickets left after this complete filter and
-   before cap/overlap pruning. If the read errors, truncates, or returns
+   `readyCandidates` and `evidence.candidatesSeen` both count only tickets left
+   after this complete filter and before cap/overlap pruning; they must be equal.
+   Preserve those tickets in queue order in `evidence.candidates`, each exactly
+   `{ticket, disposition}`. `disposition` is `selected`, `owned_paths_overlap`,
+   or `cap_full`, and must agree with `plan`/`deferred`/`noopReason` below.
+   `evidence.candidatesSeen` is a non-negative integer equal to that array's
+   length, not a prose estimate or the raw count before filtering. If the read
+   errors, truncates, or returns
    malformed JSON, refuse with `reasonCode: "needs_human"` rather than inventing
    candidate order.
 2. **Order the filtered candidates** with this explicit Linear priority rank,
@@ -66,10 +72,11 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    not produce that result.
 3. **Count the cap**: the repo's `max_in_flight` from
    `$FACTORY_ROOT/config/repos.yaml`, falling back to
-   `concurrency.max_in_flight_per_repo` in `config/policy.yaml`, else 3. The
-   in-flight count against it is the repo team/project's `In Progress`
-   tickets — the same set the dispatch gate reads. Free slots = cap minus
-   in-flight; zero or fewer → NOOP `cap_full`.
+   `concurrency.max_in_flight_per_repo` in `config/policy.yaml`, else 3. Record
+   that value as `evidence.maxInFlight`. The in-flight count against it is the
+   repo team/project's `In Progress` tickets — the same set the dispatch gate
+   reads; record it as `evidence.inFlightSeen`. Free slots = cap minus in-flight;
+   zero or fewer → NOOP `cap_full`.
 4. **Pin each candidate's Owned Paths**: parse each candidate's
    `## Owned Paths` section and check the globs against the real tree at
    `./repo`. A glob matching nothing that exists is only a smell (new files
@@ -78,14 +85,22 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    still plannable, but only alone, with nothing in flight. Ambiguous overlap
    is overlap — the same biases as `orchestrator/owned-paths.mjs`, always toward
    collision.
-5. **Select the plan**: walk the ordered queue; take each ticket whose Owned
-   Paths are disjoint from every in-flight ticket's paths AND from every
-   ticket already selected; skip colliding ones (they wait for a later scan);
-   stop when the free slots are full. Selected in order, each item pinning
-   `{ticket, ownedPaths, reason}`.
+5. **Select the plan**: walk the entire ordered candidate queue. Take each
+   ticket whose Owned Paths are disjoint from every in-flight ticket's paths AND
+   from every ticket already selected while a free slot remains. Selected in
+   order, each item pins `{ticket, ownedPaths, reason}`. Every candidate not
+   selected goes in `deferred` as `{ticket, reason}`, where `reason` is the typed
+   value `owned_paths_overlap` for a collision or `cap_full` when no slot remains.
+   Do not stop accounting when the slots fill: mark every remaining candidate
+   `cap_full`.
 
-   Track the complete candidate count before cap/overlap pruning as
-   `readyCandidates`.
+   Track the complete candidate count before cap/overlap pruning as both
+   `readyCandidates` and `evidence.candidatesSeen`. Record the same candidates,
+   in the same queue order, in `evidence.candidates`: selected tickets use
+   `disposition: "selected"`; each deferred ticket's disposition equals its
+   typed `reason`. On `DISPATCH`, `plan.length + deferred.length` must equal the
+   count, with no duplicate ticket across the two arrays, and their ticket IDs
+   and dispositions must exactly match `evidence.candidates`.
 
    If the walk has any dispatch candidates, do not read Triage and emit
    `DISPATCH` or `NOOP` (`cap_full`/`all_overlapping`) according to the result.
@@ -97,8 +112,9 @@ ticket — dispatching is the chained `factory.dispatch.requested` run's job
    `reasonCode: "needs_human"`.
 
    If `readyCandidates` is greater than 0 and there are no dispatch candidates,
-   keep the `NOOP`/`cap_full` or `all_overlapping` outcome and still set
-   `triageBacklog` to 0.
+   keep the `NOOP`/`cap_full` or `all_overlapping` outcome, leave `deferred`
+   empty because the whole queue is accounted for by `noopReason`, and still set
+   `triageBacklog` to 0. A non-empty candidate read can never emit `queue_empty`.
 
    If there are no dispatch candidates and non-empty Triage backlog, emit
    `LOW_SUPPLY` with `readyCandidates` and `triageBacklog` counts in the
@@ -115,10 +131,10 @@ chained `factory.dispatch.requested` is re-gated by WM-108's plan-time checks
 dispatch run's claim read-back refuses a lost race as `NOT_CLAIMED`. Your
 plan is advisory input to that gate, not a reservation.
 
-Only the **first** plan item chains into a dispatch this run (one chain event
-per run); list every later item's ticket id in `deferred`. Rolling dispatch
-comes from re-firing `factory.work.requested` after each completion, which
-re-plans the deferred tickets against a fresh world.
+Every `plan` item chains into its own re-gated dispatch request. `deferred`
+contains only ready candidates that cannot start in this scan, never selected
+plan items. Rolling dispatch comes from re-firing `factory.work.requested` after
+completion, which re-plans those candidates against a fresh world.
 
 ## Output
 
@@ -132,21 +148,34 @@ re-plans the deferred tickets against a fresh world.
     "repo": "bj29",
     "ticket": "CLNT-123",
     "plan": [
-      { "ticket": "CLNT-123", "ownedPaths": ["src/feature-a/**"], "reason": "priority Urgent, paths disjoint from all in-flight" },
-      { "ticket": "CLNT-124", "ownedPaths": ["src/feature-b/**"], "reason": "priority High, disjoint from CLNT-123 and in-flight" }
+      { "ticket": "CLNT-123", "ownedPaths": ["src/feature-a/**"], "reason": "priority Urgent, paths disjoint from all in-flight" }
     ],
-    "deferred": ["CLNT-124"],
+    "deferred": [
+      { "ticket": "CLNT-124", "reason": "owned_paths_overlap" }
+    ],
     "summary": "one line an operator can act on",
     "readyCandidates": 2,
     "triageBacklog": 0
   },
-  "evidence": { "commands": ["the linear reads this rests on"], "candidatesSeen": 5, "inFlightSeen": 1 }
+  "evidence": {
+    "commands": ["the linear reads this rests on"],
+    "candidatesSeen": 2,
+    "candidates": [
+      { "ticket": "CLNT-123", "disposition": "selected" },
+      { "ticket": "CLNT-124", "disposition": "owned_paths_overlap" }
+    ],
+    "inFlightSeen": 1,
+    "maxInFlight": 3
+  }
 }
 ```
 
 `ticket` is always `plan[0].ticket` when `recommendation: "DISPATCH"`.
-`readyCandidates` is the final count of dispatch candidates before cap/overlap
-pruning; `triageBacklog` is the complete count of Linear `Triage` issues.
+`readyCandidates` and `evidence.candidatesSeen` are the identical complete count
+of qualifying candidates before cap/overlap pruning, and
+`evidence.candidates.length` is the same count with the ordered ticket IDs and
+normalized dispositions retained. `triageBacklog` is the complete count of
+Linear `Triage` issues when that independent read is required, and 0 otherwise.
 
 `LOW_SUPPLY` means zero ready candidates and non-empty Triage backlog with a
 successful complete read for both; emit `readyCandidates` and `triageBacklog` in
@@ -154,7 +183,12 @@ that artifact.
 
 `NOOP` still means no ready work (`queue_empty`), zero free slots
 (`cap_full`), or ownership overlap (`all_overlapping`) with an empty `plan`,
-empty `deferred`, `ticket: null`, and typed `noopReason`. A NOOP is a good
+empty `deferred`, `ticket: null`, and typed `noopReason`. `queue_empty` is valid
+only when `readyCandidates` and `evidence.candidatesSeen` are both exactly 0
+and `evidence.candidates` is empty. `cap_full` requires a non-empty candidate
+array whose dispositions are all `cap_full` plus capacity evidence showing
+`inFlightSeen >= maxInFlight`; `all_overlapping` requires a non-empty candidate
+array whose dispositions are all `owned_paths_overlap`. A NOOP is a good
 outcome, not a failure. If Linear is unreachable, or the repo has no
 team/project in `config/repos.yaml`, refuse:
 `{"schemaVersion": "factory.agent-result/v1", "terminalState": "refused", "reasonCode": "needs_human"}`.

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -210,22 +210,166 @@ function parseProbeBytes(raw) {
   return match ? Number(match[1]) : null;
 }
 
-/** `LOW_SUPPLY` in work-scan must carry exact candidate-count semantics. */
+/**
+ * Work-scan is model-authored, so its individually valid fields still need a
+ * deterministic consistency check (WM-350). The normalized candidate evidence
+ * lets this verifier reconcile identities and dispositions instead of trusting
+ * a summary count or model prose.
+ */
 function checkWorkPlan(candidate) {
-  const artifact = candidate?.artifact;
-  if (artifact?.recommendation !== "LOW_SUPPLY") return [];
+  const { artifact, evidence } = candidate;
   const violations = [];
+  const candidatesSeen = evidence?.candidatesSeen;
+  const candidates = evidence?.candidates;
+  const dispositions = new Set(["selected", "cap_full", "owned_paths_overlap"]);
+
+  if (!Number.isInteger(candidatesSeen) || candidatesSeen < 0) {
+    violations.push("evidence_candidatesSeen_required");
+  }
+  if (!Array.isArray(candidates)) {
+    violations.push("evidence_candidates_required");
+  }
+
+  const normalizedCandidates = [];
+  if (Array.isArray(candidates)) {
+    for (const [index, entry] of candidates.entries()) {
+      const valid = entry !== null
+        && typeof entry === "object"
+        && !Array.isArray(entry)
+        && Object.keys(entry).length === 2
+        && typeof entry.ticket === "string"
+        && /^[A-Z]+-[0-9]+$/.test(entry.ticket)
+        && dispositions.has(entry.disposition);
+      if (!valid) {
+        violations.push(`evidence_candidate_invalid_at_index_${index}`);
+      } else {
+        normalizedCandidates.push(entry);
+      }
+    }
+    const candidateTickets = normalizedCandidates.map((entry) => entry.ticket);
+    if (new Set(candidateTickets).size !== candidateTickets.length) {
+      violations.push("evidence_candidate_tickets_must_be_unique");
+    }
+    if (Number.isInteger(candidatesSeen) && candidatesSeen !== candidates.length) {
+      violations.push(
+        `evidence_candidate_count_mismatch: candidatesSeen ${candidatesSeen} != candidates.length ${candidates.length}`,
+      );
+    }
+  }
 
   if (!Number.isInteger(artifact.readyCandidates) || artifact.readyCandidates < 0) {
-    violations.push("readyCandidates_required_for_low_supply");
-  } else if (artifact.readyCandidates !== 0) {
-    violations.push(`low_supply_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`);
+    violations.push("readyCandidates_required_for_work_plan");
+  } else if (Number.isInteger(candidatesSeen) && artifact.readyCandidates !== candidatesSeen) {
+    violations.push(
+      `candidate_count_mismatch: readyCandidates ${artifact.readyCandidates} != evidence.candidatesSeen ${candidatesSeen}`,
+    );
   }
 
   if (!Number.isInteger(artifact.triageBacklog) || artifact.triageBacklog < 0) {
-    violations.push("triageBacklog_required_for_low_supply");
-  } else if (artifact.triageBacklog < 1) {
-    violations.push(`low_supply_triage_backlog_must_be_at_least_1 (got ${artifact.triageBacklog})`);
+    violations.push("triageBacklog_required_for_work_plan");
+  }
+
+  const planTickets = artifact.plan.map((item) => item.ticket);
+  const deferredTickets = artifact.deferred.map((item) => item.ticket);
+  const accountedTickets = [...planTickets, ...deferredTickets];
+  if (new Set(accountedTickets).size !== accountedTickets.length) {
+    violations.push("work_plan_ticket_accounting_must_be_unique");
+  }
+
+  const expectedTicket = planTickets[0] ?? null;
+  if (artifact.ticket !== expectedTicket) {
+    violations.push(`work_plan_ticket_must_equal_first_plan_ticket (expected ${expectedTicket})`);
+  }
+
+  if (artifact.recommendation === "DISPATCH") {
+    if (artifact.plan.length === 0) violations.push("dispatch_plan_must_not_be_empty");
+    if (Object.hasOwn(artifact, "noopReason")) violations.push("dispatch_must_not_have_noopReason");
+
+    const evidencePlan = normalizedCandidates
+      .filter((entry) => entry.disposition === "selected")
+      .map((entry) => entry.ticket);
+    const evidenceDeferred = normalizedCandidates
+      .filter((entry) => entry.disposition !== "selected")
+      .map((entry) => ({ ticket: entry.ticket, reason: entry.disposition }));
+    if (JSON.stringify(planTickets) !== JSON.stringify(evidencePlan)) {
+      violations.push("dispatch_plan_must_match_candidate_evidence");
+    }
+    if (JSON.stringify(artifact.deferred) !== JSON.stringify(evidenceDeferred)) {
+      violations.push("dispatch_deferred_must_match_candidate_evidence");
+    }
+    if (Number.isInteger(candidatesSeen) && accountedTickets.length !== candidatesSeen) {
+      violations.push(
+        `dispatch_candidate_accounting_mismatch: plan ${artifact.plan.length} + deferred ${artifact.deferred.length} != candidatesSeen ${candidatesSeen}`,
+      );
+    }
+
+    const hasCapDeferral = normalizedCandidates.some((entry) => entry.disposition === "cap_full");
+    if (hasCapDeferral) {
+      const inFlightSeen = evidence?.inFlightSeen;
+      const maxInFlight = evidence?.maxInFlight;
+      if (!Number.isInteger(inFlightSeen) || inFlightSeen < 0
+        || !Number.isInteger(maxInFlight) || maxInFlight < 1) {
+        violations.push("capacity_evidence_required_for_cap_full");
+      } else if (inFlightSeen + artifact.plan.length < maxInFlight) {
+        violations.push(
+          `cap_full_contradicts_capacity: inFlightSeen ${inFlightSeen} + plan ${artifact.plan.length} < maxInFlight ${maxInFlight}`,
+        );
+      }
+    }
+    if (artifact.triageBacklog !== 0) {
+      violations.push(`dispatch_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`);
+    }
+  } else if (artifact.recommendation === "LOW_SUPPLY") {
+    if (artifact.plan.length > 0 || artifact.deferred.length > 0) {
+      violations.push("low_supply_plan_and_deferred_must_be_empty");
+    }
+    if (Object.hasOwn(artifact, "noopReason")) violations.push("low_supply_must_not_have_noopReason");
+    if (artifact.readyCandidates !== 0) {
+      violations.push(`low_supply_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`);
+    }
+    if (Number.isInteger(candidatesSeen) && candidatesSeen !== 0) {
+      violations.push(`low_supply_candidatesSeen_must_be_0 (got ${candidatesSeen})`);
+    }
+    if (normalizedCandidates.length !== 0) violations.push("low_supply_candidates_must_be_empty");
+    if (Number.isInteger(artifact.triageBacklog) && artifact.triageBacklog < 1) {
+      violations.push(`low_supply_triage_backlog_must_be_at_least_1 (got ${artifact.triageBacklog})`);
+    }
+  } else if (artifact.recommendation === "NOOP") {
+    if (artifact.plan.length > 0 || artifact.deferred.length > 0) {
+      violations.push("noop_plan_and_deferred_must_be_empty");
+    }
+    if (!Object.hasOwn(artifact, "noopReason")) {
+      violations.push("noopReason_required_for_noop");
+    } else if (artifact.noopReason === "queue_empty") {
+      if (artifact.readyCandidates !== 0) {
+        violations.push(`queue_empty_readyCandidates_must_be_0 (got ${artifact.readyCandidates})`);
+      }
+      if (Number.isInteger(candidatesSeen) && candidatesSeen !== 0) {
+        violations.push(`queue_empty_candidatesSeen_must_be_0 (got ${candidatesSeen})`);
+      }
+      if (normalizedCandidates.length !== 0) violations.push("queue_empty_candidates_must_be_empty");
+    } else if (artifact.noopReason === "cap_full") {
+      if (normalizedCandidates.length === 0) violations.push("cap_full_candidates_must_not_be_empty");
+      if (normalizedCandidates.some((entry) => entry.disposition !== "cap_full")) {
+        violations.push("cap_full_candidates_must_all_have_cap_full_disposition");
+      }
+      const inFlightSeen = evidence?.inFlightSeen;
+      const maxInFlight = evidence?.maxInFlight;
+      if (!Number.isInteger(inFlightSeen) || inFlightSeen < 0
+        || !Number.isInteger(maxInFlight) || maxInFlight < 1) {
+        violations.push("capacity_evidence_required_for_cap_full");
+      } else if (inFlightSeen < maxInFlight) {
+        violations.push(`cap_full_contradicts_capacity: inFlightSeen ${inFlightSeen} < maxInFlight ${maxInFlight}`);
+      }
+    } else if (artifact.noopReason === "all_overlapping") {
+      if (normalizedCandidates.length === 0) violations.push("all_overlapping_candidates_must_not_be_empty");
+      if (normalizedCandidates.some((entry) => entry.disposition !== "owned_paths_overlap")) {
+        violations.push("all_overlapping_candidates_must_all_have_overlap_disposition");
+      }
+    }
+    if (artifact.triageBacklog !== 0) {
+      violations.push(`noop_triageBacklog_must_be_0 (got ${artifact.triageBacklog})`);
+    }
   }
 
   return violations;

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -88,41 +88,161 @@ describe("verifyResult", () => {
     expect(out.receipt.journalHead).toBeNull();
   });
 
-  test("missing LOW_SUPPLY counts violates work-scan semantics", () => {
+  const candidate = (ticket, disposition) => ({ ticket, disposition });
+  const candidateEvidence = (candidates, extra = {}) => ({
+    commands: ["linear queue"],
+    candidatesSeen: candidates.length,
+    candidates,
+    inFlightSeen: 0,
+    maxInFlight: 3,
+    ...extra,
+  });
+
+  const workPlanSpec = {
+    ...makeSpec(),
+    agent: "work-scan@1",
+    outputContract: "factory.work-plan/v1",
+  };
+
+  function verifyWorkPlan(artifact, evidence) {
     const dir = makeWorkspace({
       schemaVersion: "factory.agent-result/v1",
       terminalState: "completed",
-      artifact: {
-        recommendation: "LOW_SUPPLY",
-        repo: "low",
+      artifact,
+      evidence,
+    });
+    return verifyResult({ spec: workPlanSpec, def: workScanDef, registry, workspaceDir: dir, attempt: 1 });
+  }
+
+  test("valid DISPATCH accounts for every candidate through plan or typed deferral", () => {
+    const out = verifyWorkPlan({
+      recommendation: "DISPATCH",
+      repo: "factory",
+      ticket: "WM-345",
+      plan: [
+        { ticket: "WM-345", ownedPaths: ["src/a/**"], reason: "priority Urgent, disjoint" },
+      ],
+      deferred: [
+        { ticket: "WM-294", reason: "owned_paths_overlap" },
+        { ticket: "WM-131", reason: "cap_full" },
+      ],
+      readyCandidates: 3,
+      triageBacklog: 0,
+      summary: "one candidate starts and two are accounted for",
+    }, candidateEvidence([
+      candidate("WM-345", "selected"),
+      candidate("WM-294", "owned_paths_overlap"),
+      candidate("WM-131", "cap_full"),
+    ], { inFlightSeen: 2 }));
+
+    expect(out.kind).toBe("completed");
+    expect(out.result.verification.checks).toContain("evidence_recomputed");
+  });
+
+  test("regression: three ready tickets plus two in progress cannot validate as queue_empty", () => {
+    try {
+      verifyWorkPlan({
+        recommendation: "NOOP",
+        repo: "factory",
         ticket: null,
         plan: [],
         deferred: [],
-        summary: "low supply with missing counts",
-        triageBacklog: 2,
-      },
-    });
-
-    const spec = {
-      ...makeSpec(),
-      agent: "work-scan@1",
-      outputContract: "factory.work-plan/v1",
-    };
-
-    try {
-      verifyResult({ spec, def: workScanDef, registry, workspaceDir: dir, attempt: 1 });
+        noopReason: "queue_empty",
+        readyCandidates: 3,
+        triageBacklog: 0,
+        summary: "incorrectly discarded three ready candidates",
+      }, candidateEvidence([
+        candidate("WM-345", "selected"),
+        candidate("WM-294", "selected"),
+        candidate("WM-131", "selected"),
+      ], { inFlightSeen: 2 }));
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations).toContain("readyCandidates_required_for_low_supply");
+      expect(err.violations).toContain("queue_empty_readyCandidates_must_be_0 (got 3)");
+      expect(err.violations).toContain("queue_empty_candidatesSeen_must_be_0 (got 3)");
+    }
+  });
+
+  test("queue_empty requires complete candidate evidence to agree with the artifact", () => {
+    try {
+      verifyWorkPlan({
+        recommendation: "NOOP",
+        repo: "factory",
+        ticket: null,
+        plan: [],
+        deferred: [],
+        noopReason: "queue_empty",
+        readyCandidates: 0,
+        triageBacklog: 0,
+        summary: "artifact says empty but evidence saw a candidate",
+      }, candidateEvidence([candidate("WM-345", "selected")], { candidatesSeen: 0 }));
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toContain(
+        "evidence_candidate_count_mismatch: candidatesSeen 0 != candidates.length 1",
+      );
+      expect(err.violations).toContain("queue_empty_candidates_must_be_empty");
+    }
+  });
+
+  test("cap_full cannot hide startable candidates when capacity evidence shows a free slot", () => {
+    try {
+      verifyWorkPlan({
+        recommendation: "NOOP",
+        repo: "factory",
+        ticket: null,
+        plan: [],
+        deferred: [],
+        noopReason: "cap_full",
+        readyCandidates: 3,
+        triageBacklog: 0,
+        summary: "incorrectly claims the cap is full",
+      }, candidateEvidence([
+        candidate("WM-345", "cap_full"),
+        candidate("WM-294", "cap_full"),
+        candidate("WM-131", "cap_full"),
+      ], { inFlightSeen: 2, maxInFlight: 3 }));
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toContain(
+        "cap_full_contradicts_capacity: inFlightSeen 2 < maxInFlight 3",
+      );
+    }
+  });
+
+  test("DISPATCH rejects an unaccounted candidate", () => {
+    try {
+      verifyWorkPlan({
+        recommendation: "DISPATCH",
+        repo: "factory",
+        ticket: "WM-345",
+        plan: [
+          { ticket: "WM-345", ownedPaths: ["src/a/**"], reason: "priority Urgent, disjoint" },
+        ],
+        deferred: [{ ticket: "WM-294", reason: "owned_paths_overlap" }],
+        readyCandidates: 3,
+        triageBacklog: 0,
+        summary: "one candidate disappeared",
+      }, candidateEvidence([
+        candidate("WM-345", "selected"),
+        candidate("WM-294", "owned_paths_overlap"),
+        candidate("WM-131", "cap_full"),
+      ], { inFlightSeen: 2 }));
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toContain(
+        "dispatch_candidate_accounting_mismatch: plan 1 + deferred 1 != candidatesSeen 3",
+      );
     }
   });
 
   test("invalid LOW_SUPPLY counts violate work-scan semantics", () => {
-    const dir = makeWorkspace({
-      schemaVersion: "factory.agent-result/v1",
-      terminalState: "completed",
-      artifact: {
+    try {
+      verifyWorkPlan({
         recommendation: "LOW_SUPPLY",
         repo: "low",
         ticket: null,
@@ -131,21 +251,16 @@ describe("verifyResult", () => {
         summary: "low supply with bad counts",
         readyCandidates: 3,
         triageBacklog: 0,
-      },
-    });
-
-    const spec = {
-      ...makeSpec(),
-      agent: "work-scan@1",
-      outputContract: "factory.work-plan/v1",
-    };
-
-    try {
-      verifyResult({ spec, def: workScanDef, registry, workspaceDir: dir, attempt: 1 });
+      }, candidateEvidence([
+        candidate("WM-345", "selected"),
+        candidate("WM-294", "selected"),
+        candidate("WM-131", "selected"),
+      ], { commands: ["linear queue", "linear triage"] }));
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations.some((x) => x.includes("low_supply_readyCandidates_must_be_0"))).toBe(true);
+      expect(err.violations).toContain("low_supply_readyCandidates_must_be_0 (got 3)");
+      expect(err.violations).toContain("low_supply_candidatesSeen_must_be_0 (got 3)");
     }
   });
 

--- a/event-runtime/schemas/work-scan.output.json
+++ b/event-runtime/schemas/work-scan.output.json
@@ -1,7 +1,7 @@
 {
-  "title": "factory.work-plan/v1 output artifact — ordered dispatchable-ticket plan with one chained dispatch target (WM-110)",
+  "title": "factory.work-plan/v1 output artifact — ordered dispatchable-ticket plan with complete candidate accounting (WM-350)",
   "type": "object",
-  "required": ["recommendation", "repo", "ticket", "plan", "deferred", "summary"],
+  "required": ["recommendation", "repo", "ticket", "plan", "deferred", "readyCandidates", "triageBacklog", "summary"],
   "additionalProperties": false,
   "properties": {
     "recommendation": {
@@ -16,11 +16,11 @@
     "ticket": {
       "type": ["string", "null"],
       "pattern": "^[A-Z]+-[0-9]+$",
-      "description": "The plan's first ticket — the single target the chain edge feeds into factory.dispatch.requested (chain.mjs emits exactly one chain event per run); must equal plan[0].ticket, null on NOOP"
+      "description": "The plan's first ticket; must equal plan[0].ticket for DISPATCH and be null otherwise"
     },
     "plan": {
       "type": "array",
-      "description": "Queue-ordered tickets using explicit Linear priority rank Urgent (1), High (2), Medium (3), Low (4), No priority (0), then createdAt ascending. Every item is dispatchable right now: state exactly Todo, label ai:agent-ready present, and assignee null; within the per-repo in-flight cap; Owned Paths mutually disjoint and disjoint from every in-flight ticket's paths. Item order is dispatch order; only the first item chains this run",
+      "description": "Queue-ordered tickets using explicit Linear priority rank Urgent (1), High (2), Medium (3), Low (4), No priority (0), then createdAt ascending. Every item is dispatchable right now: state exactly Todo, label ai:agent-ready present, and assignee null; within the per-repo in-flight cap; Owned Paths mutually disjoint and disjoint from every in-flight ticket's paths. Every plan item chains to its own dispatch request",
       "items": {
         "type": "object",
         "required": ["ticket", "ownedPaths", "reason"],
@@ -51,22 +51,33 @@
     },
     "deferred": {
       "type": "array",
-      "description": "Tickets after the first plan item: selected but NOT chained this run — chain.mjs emits one chain event per run, so only plan[0] becomes a factory.dispatch.requested; rolling dispatch re-fires the scan after each completion and re-plans these against a fresh world",
+      "description": "Every ready candidate not selected into plan, with the typed reason it cannot start during this scan. Together plan and deferred account for every ready candidate on DISPATCH",
       "items": {
-        "type": "string",
-        "pattern": "^[A-Z]+-[0-9]+$",
-        "description": "Linear issue identifier of a planned-but-deferred ticket (echo of a plan[1..] item's ticket)"
+        "type": "object",
+        "required": ["ticket", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "ticket": {
+            "type": "string",
+            "pattern": "^[A-Z]+-[0-9]+$",
+            "description": "Linear issue identifier of the ready candidate that was not selected"
+          },
+          "reason": {
+            "enum": ["cap_full", "owned_paths_overlap"],
+            "description": "Typed reason this candidate cannot start: no remaining in-flight slot, or Owned Paths overlap with in-flight/selected work"
+          }
+        }
       }
     },
     "readyCandidates": {
       "type": "integer",
       "minimum": 0,
-      "description": "Count after a complete read is filtered to state exactly Todo, label ai:agent-ready present, and assignee null, before cap/overlap pruning"
+      "description": "Count after a complete read is filtered to state exactly Todo, label ai:agent-ready present, and assignee null, before cap/overlap pruning; must equal evidence.candidatesSeen"
     },
     "triageBacklog": {
       "type": "integer",
       "minimum": 0,
-      "description": "Count of remaining Triage issues read from Linear in a complete read"
+      "description": "Count of remaining Triage issues from the independent complete read; 0 when Triage is not read because ready candidates exist"
     },
     "summary": {
       "type": "string",

--- a/event-runtime/work.test.mjs
+++ b/event-runtime/work.test.mjs
@@ -1,11 +1,10 @@
 /**
  * Work chain (WM-110): work-scan@1 reads a repo's agent-ready Linear queue
  * against a pinned tree and emits a typed DISPATCH plan; the chain edge feeds
- * the FIRST planned ticket into factory.dispatch.requested, where WM-108's
- * plan-time gate re-checks the world — a stale scan cannot force a dispatch.
- * chain.mjs emits exactly one chain event per run (eventId chain-<runId>), so
- * the rest of the plan rides in the artifact as `deferred`; rolling dispatch
- * comes from re-firing the scan event, never a long-lived loop. Follows the
+ * every planned ticket into factory.dispatch.requested, where WM-108's plan-time
+ * gate re-checks the world — a stale scan cannot force a dispatch.
+ * chain.mjs emits one event per selected plan item; candidates that cannot start
+ * are carried in `deferred` with typed reasons for the next fresh scan. Follows the
  * triage-scan (OPS-229) and merge-scan (WM-109) precedents.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -102,6 +101,10 @@ beforeAll(() => {
       `  - name: lowbad\n    path: ${low}\n    github: watt-mind/lowbad\n    base: develop\n` +
       `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
       `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
+      `    worktree_root: ${wtRoot}\n    escalate_paths: []\n` +
+      `  - name: contradiction\n    path: ${low}\n    github: watt-mind/contradiction\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    max_in_flight: 3\n` +
+      `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down.sh\n` +
       `    worktree_root: ${wtRoot}\n    escalate_paths: []\n`,
   );
   previousReposRoot = process.env.FACTORY_REPOS_ROOT;
@@ -129,6 +132,47 @@ const SECOND = "WM-602";
 // everything else to the fake.
 // ---------------------------------------------------------------------------
 
+const seenCandidate = (ticket, disposition) => ({ ticket, disposition });
+
+function workScanEvidence(repo) {
+  let candidates;
+  let inFlightSeen = 0;
+  if (["clean", "low"].includes(repo)) {
+    candidates = [];
+  } else if (repo === "lowbad") {
+    candidates = [seenCandidate(FIRST, "selected")];
+  } else if (repo === "contradiction") {
+    // Regression fixture from run_0e25d228: three unassigned ready tickets
+    // were read alongside two in-progress tickets, then reported queue_empty.
+    candidates = [
+      seenCandidate("WM-345", "selected"),
+      seenCandidate("WM-294", "selected"),
+      seenCandidate("WM-131", "selected"),
+    ];
+    inFlightSeen = 2;
+  } else if (repo === "overlap") {
+    candidates = [
+      seenCandidate(FIRST, "owned_paths_overlap"),
+      seenCandidate(SECOND, "owned_paths_overlap"),
+    ];
+  } else if (repo === "cap") {
+    candidates = [
+      seenCandidate(FIRST, "cap_full"),
+      seenCandidate(SECOND, "cap_full"),
+    ];
+    inFlightSeen = 3;
+  } else {
+    candidates = [seenCandidate(FIRST, "selected"), seenCandidate(SECOND, "selected")];
+  }
+  return {
+    commands: ["fake"],
+    candidatesSeen: candidates.length,
+    candidates,
+    inFlightSeen,
+    maxInFlight: 3,
+  };
+}
+
 function workScanArtifact(repo) {
   if (repo === "clean") {
     return {
@@ -138,6 +182,8 @@ function workScanArtifact(repo) {
       plan: [],
       deferred: [],
       summary: "fake: no dispatchable tickets",
+      readyCandidates: 0,
+      triageBacklog: 0,
       noopReason: "queue_empty",
     };
   }
@@ -162,7 +208,7 @@ function workScanArtifact(repo) {
       deferred: [],
       summary: "fake: overlap blocked",
       readyCandidates: 2,
-      triageBacklog: 3,
+      triageBacklog: 0,
       noopReason: "all_overlapping",
     };
   }
@@ -175,7 +221,7 @@ function workScanArtifact(repo) {
       deferred: [],
       summary: "fake: cap blocked",
       readyCandidates: 2,
-      triageBacklog: 3,
+      triageBacklog: 0,
       noopReason: "cap_full",
     };
   }
@@ -191,6 +237,19 @@ function workScanArtifact(repo) {
       readyCandidates: 1,
     };
   }
+  if (repo === "contradiction") {
+    return {
+      recommendation: "NOOP",
+      repo,
+      ticket: null,
+      plan: [],
+      deferred: [],
+      summary: "fake: discarded three ready candidates",
+      triageBacklog: 0,
+      readyCandidates: 3,
+      noopReason: "queue_empty",
+    };
+  }
   return {
     recommendation: "DISPATCH",
     repo,
@@ -199,7 +258,9 @@ function workScanArtifact(repo) {
       { ticket: FIRST, ownedPaths: ["src/feature-a/**"], reason: "fake: priority 1, disjoint" },
       { ticket: SECOND, ownedPaths: ["src/feature-b/**"], reason: "fake: priority 2, disjoint" },
     ],
-    deferred: [SECOND],
+    deferred: [],
+    readyCandidates: 2,
+    triageBacklog: 0,
     summary: `fake work plan for ${repo}`,
   };
 }
@@ -215,7 +276,7 @@ const workFake = {
           terminalState: "completed",
           reasonCode: "ok",
           artifact: workScanArtifact(spec.input.repo),
-          evidence: { commands: ["fake"], candidatesSeen: 2, inFlightSeen: 0 },
+          evidence: workScanEvidence(spec.input.repo),
         }, null, 2)}\n`,
         "utf8",
       );
@@ -364,6 +425,8 @@ describe("work-scan registration (WM-110)", () => {
     const schema = registry.agents.get("work-scan@1").outputSchema;
     expect(schema.properties.plan.items.required).toEqual(["ticket", "ownedPaths", "reason"]);
     expect(schema.properties.plan.items.properties.ticket.pattern).toBe("^[A-Z]+-[0-9]+$");
+    expect(schema.properties.deferred.items.required).toEqual(["ticket", "reason"]);
+    expect(schema.properties.deferred.items.properties.reason.enum).toEqual(["cap_full", "owned_paths_overlap"]);
     expect(schema.properties.noopReason.enum).toEqual(["queue_empty", "cap_full", "all_overlapping"]);
   });
 
@@ -469,7 +532,7 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
       const scanResult = JSON.parse(db.query(`SELECT result_json FROM results WHERE run_id = ?`).get(scan.runId).result_json);
       expect(scanResult.artifact.noopReason).toBe(reason);
       expect(scanResult.artifact.readyCandidates).toBe(2);
-      expect(scanResult.artifact.triageBacklog).toBe(3);
+      expect(scanResult.artifact.triageBacklog).toBe(0);
 
       const chain = resolveChains(db, registry);
       expect(chain).toEqual({ emitted: 0, skipped: 1, errors: [] });
@@ -495,6 +558,21 @@ describe("work chain: scan → chained dispatch proposal (WM-110, WM-119)", () =
       .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
       .get(scan.runId);
     expect(journal.reason).toContain("low_supply_readyCandidates_must_be_0");
+  });
+
+  test("three ready tickets plus two in progress cannot complete as queue_empty", async () => {
+    const { db, approveNext } = harness();
+    admitEvent(db, registry, workEnvelope("contradiction", "work-contradiction-1"));
+    const scan = await approveNext("work-scan@1");
+    expect(scan.summary.terminalState).toBe("FAILED");
+    expect(scan.summary.reasonCode).toBe("contract_violation");
+
+    const chain = resolveChains(db, registry);
+    expect(chain).toEqual({ emitted: 0, skipped: 0, errors: [] });
+    const journal = db
+      .query(`SELECT reason FROM lifecycle_events WHERE run_id = ? AND to_state = 'FAILED'`)
+      .get(scan.runId);
+    expect(journal.reason).toContain("queue_empty_candidatesSeen_must_be_0");
   });
 
   test("a NOOP scan chains to nothing — no dispatch proposal exists", async () => {


### PR DESCRIPTION
## Summary
- retain normalized candidate identities and typed dispositions in work-scan evidence
- reject queue-empty, capacity, plan, deferral, and evidence contradictions in the runtime verifier
- cover the three-ready/two-in-progress incident with unit and chain regression fixtures

## Verification
- `bun test event-runtime/work.test.mjs event-runtime/lib/verify.test.mjs event-runtime/lib/registry.test.mjs && bun build/emit.mjs --check`

UX critique: skipped — backend runtime contract and verifier change with no user-facing flow

Fixes WM-350