### PR TITLE
feat(event-types): route merge-scan and merge-fix to the cursor adapter (WM-523)

### DIFF
--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -155,7 +155,7 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
-    "adapter": "pi",
+    "adapter": "cursor",
     "idempotencyScope": [
       "inputHash"
     ],
@@ -179,7 +179,7 @@
   },
   "factory.merge-fix.requested": {
     "agent": "merge-fix@1",
-    "adapter": "pi",
+    "adapter": "cursor",
     "idempotencyScope": [
       "inputHash"
     ],

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -327,11 +327,12 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {
     expect(registry.eventTypes["factory.merge.requested"]).toMatchObject({
       agent: "merge-scan@2",
-      adapter: "pi",
+      adapter: "cursor",
     });
-    expect(registry.eventTypes["factory.merge-fix.requested"].agent).toBe(
-      "merge-fix@1",
-    );
+    expect(registry.eventTypes["factory.merge-fix.requested"]).toMatchObject({
+      agent: "merge-fix@1",
+      adapter: "cursor",
+    });
     expect(registry.eventTypes["factory.merge-apply.requested"].agent).toBe(
       "merge-apply@2",
     );
@@ -625,7 +626,7 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       const summary = await runOnce(
         db,
         registry,
-        { pi: adapter },
+        { cursor: adapter },
         { workspacesRoot: workspaces, owner: "merge-test", policyVersion: PV },
       );
 


### PR DESCRIPTION
Fixes WM-523

## Handoff

**What changed**
- `event-runtime/event-types.json`: `factory.merge.requested` (merge-scan@2) and `factory.merge-fix.requested` (merge-fix@1) now route to `"adapter": "cursor"` (Cursor Agent CLI, Grok 4.6 per `config/policy.yaml` `models.cursor`) instead of `pi`. `factory.merge-apply.requested` (actions) and all other event types untouched.
- `event-runtime/merge.test.mjs`: registry assertion updated to expect `cursor` for both mappings; the merge-scan workspace-pin test backs the run with `{ cursor: adapter }` instead of `{ pi: adapter }`.

**Verification**
- `bun event-runtime/cli.mjs update-pins` -> `pins already current` (event-types.json is not content-pinned).
- Registry loads: `factory.merge.requested cursor merge-scan@2`, `factory.merge-fix.requested cursor merge-fix@1`, `factory.merge-apply.requested actions merge-apply@2`.
- `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/registry*.test.mjs event-runtime/merge.test.mjs event-runtime/loop.test.mjs event-runtime/lib/auto-approval.test.mjs` -> 114 pass; the only failures are the WM-412 `merge-apply` command tests hitting the 5s local timeout, which also fail identically on `develop` (pre-existing flake under load, unrelated).
- Cursor CLI operable on this host: `agent` 2026.08.11-e8db854 on PATH, `agent --list-models` lists the 8 `cursor-grok-4.6-*` variants, `CURSOR_API_KEY` set.

**File scope**: `event-runtime/event-types.json`, `event-runtime/merge.test.mjs`

UX critique: n/a — no user-facing surface.