### PR TITLE
fix(worktree): refresh redispatched ticket bases

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -332,6 +332,167 @@ test("worktree-up --checkout-only creates checkout without daemons and worktree-
   }
 });
 
+test("re-dispatch fast-forwards a deliberately stale branch to the current base", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-stale-"));
+  const ticketId = makeTestTicket("STALE");
+  const branch = `feat/${ticketId}`;
+  const git = (args) => Bun.spawnSync({ cmd: ["git", ...args], cwd: path.resolve(import.meta.dir, ".."), stdout: "pipe", stderr: "pipe" });
+
+  try {
+    expect(git(["branch", branch, "origin/develop~1"]).exitCode).toBe(0);
+    const staleSha = git(["rev-parse", branch]).stdout.toString().trim();
+    const baseSha = git(["rev-parse", "origin/develop"]).stdout.toString().trim();
+    expect(staleSha).not.toBe(baseSha);
+
+    const upRes = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(upRes.exitCode).toBe(0);
+    expect(git(["-C", path.join(tempWtRoot, ticketId), "rev-parse", "HEAD"]).stdout.toString().trim()).toBe(baseSha);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    git(["branch", "-D", branch]);
+  }
+});
+
+test("re-dispatch refuses a branch carrying unique commits and names it", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-unique-"));
+  const ticketId = makeTestTicket("UNIQUE");
+  const branch = `feat/${ticketId}`;
+  const expectedPath = path.join(tempWtRoot, ticketId);
+
+  try {
+    const firstUp = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(firstUp.exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "unique.txt"), "ticket work\n");
+    expect(Bun.spawnSync({ cmd: ["git", "add", "unique.txt"], cwd: expectedPath }).exitCode).toBe(0);
+    expect(Bun.spawnSync({
+      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "unique ticket commit"],
+      cwd: expectedPath,
+      stdout: "pipe",
+      stderr: "pipe",
+    }).exitCode).toBe(0);
+    expect(Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      stdout: "pipe",
+      stderr: "pipe",
+    }).exitCode).toBe(0);
+
+    const secondUp = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(secondUp.exitCode).not.toBe(0);
+    expect(secondUp.stderr.toString()).toContain("worktree_branch_has_commits");
+    expect(secondUp.stderr.toString()).toContain(branch);
+    expect(existsSync(expectedPath)).toBe(false);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+  }
+});
+
+test("worktree-down --prune removes only clean terminal worktrees and preserves dirty or live trees", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-bin-"));
+  const tickets = [makeTestTicket("TERMINAL"), makeTestTicket("DIRTY"), makeTestTicket("LIVE")];
+  const [terminalTicket, dirtyTicket, liveTicket] = tickets;
+
+  try {
+    for (const ticket of tickets) {
+      const up = Bun.spawnSync({
+        cmd: ["bash", UP, ticket, "--checkout-only", "--no-fetch"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      });
+      expect(up.exitCode).toBe(0);
+    }
+    writeFileSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), "do not remove\n");
+    mkdirSync(path.join(tempWtRoot, liveTicket, ".factory", "run"), { recursive: true });
+    writeFileSync(path.join(tempWtRoot, liveTicket, ".factory", "run", "worker.pid"), `${process.pid}\n`);
+
+    writeFileSync(path.join(mockBin, "bun"), "#!/usr/bin/env bash\nprintf '{\"state\":{\"name\":\"Done\"}}\\n'\n", { mode: 0o755 });
+    const pruned = Bun.spawnSync({
+      cmd: ["bash", DOWN, "--prune"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    expect(pruned.exitCode).toBe(0);
+    expect(existsSync(path.join(tempWtRoot, terminalTicket))).toBe(false);
+    expect(existsSync(path.join(tempWtRoot, dirtyTicket))).toBe(true);
+    expect(existsSync(path.join(tempWtRoot, liveTicket))).toBe(true);
+    expect(pruned.stdout.toString()).toContain("pruned 1 terminal worktree");
+  } finally {
+    rmSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), { force: true });
+    rmSync(path.join(tempWtRoot, liveTicket, ".factory"), { recursive: true, force: true });
+    for (const ticket of tickets) {
+      Bun.spawnSync({ cmd: ["bash", DOWN, ticket, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    }
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    Bun.spawnSync({
+      cmd: ["git", "branch", "-D", ...tickets.map((ticket) => `feat/${ticket}`)],
+      cwd: path.resolve(import.meta.dir, ".."),
+    });
+  }
+});
+
+test("worktree-down --prune recognizes a merged PR for the worktree branch", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-merged-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-prune-merged-bin-"));
+  const ticketId = makeTestTicket("MERGED");
+  const branch = `feat/${ticketId}`;
+
+  try {
+    const up = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(up.exitCode).toBe(0);
+
+    writeFileSync(path.join(mockBin, "bun"), "#!/usr/bin/env bash\nprintf '{\"state\":{\"name\":\"In Review\"}}\\n'\n", { mode: 0o755 });
+    writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash\n[[ "$*" == *"--head ${branch}"* ]] && printf '1\\n' || printf '0\\n'\n`, { mode: 0o755 });
+    const pruned = Bun.spawnSync({
+      cmd: ["bash", DOWN, "--prune"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    expect(pruned.exitCode).toBe(0);
+    expect(existsSync(path.join(tempWtRoot, ticketId))).toBe(false);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+  }
+});
+
 test("concurrent worktree-up --checkout-only succeed in parallel", async () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-conc-"));
   const ticket1 = makeTestTicket("CONCA");

--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -5,6 +5,8 @@
 #   bin/worktree-down.sh OPS-123 --force   # ...even with uncommitted changes
 #   bin/worktree-down.sh --here            # stop the current checkout's demo
 #                                          # daemons and delete its demo state
+#   bin/worktree-down.sh --prune           # remove clean, inactive worktrees
+#                                          # whose ticket is Done or PR merged
 #
 # Branches are never deleted here — merged branches are cleaned up by the
 # merge flow, unmerged ones are someone's work.
@@ -13,11 +15,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 TICKET=""
 HERE=0
 FORCE=0
+PRUNE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --here) HERE=1 ;;
     --force) FORCE=1 ;;
+    --prune) PRUNE=1 ;;
     -h | --help)
       sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
@@ -29,14 +33,148 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO="$(repo_root)"
+WORKTREE_LIFECYCLE_LOCK=""
+
+worktree_lifecycle_lock_path() { # <ticket>
+  local common
+  common=$(git -C "$REPO" rev-parse --git-common-dir)
+  [[ "$common" == /* ]] || common="$REPO/$common"
+  printf '%s/factory-worktree-locks/%s.lock' "$common" "$1"
+}
+
+try_worktree_lifecycle_lock() { # <ticket>
+  local lock holder=""
+  lock=$(worktree_lifecycle_lock_path "$1")
+  mkdir -p "$(dirname "$lock")"
+  if ! mkdir "$lock" 2>/dev/null; then
+    holder=$(cat "$lock/pid" 2>/dev/null || true)
+    if [[ "$holder" =~ ^[0-9]+$ ]] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lock"
+      mkdir "$lock" 2>/dev/null || return 1
+    else
+      return 1
+    fi
+  fi
+  printf '%s\n' "$$" >"$lock/pid"
+  WORKTREE_LIFECYCLE_LOCK="$lock"
+}
+
+release_worktree_lifecycle_lock() {
+  if [[ -n "$WORKTREE_LIFECYCLE_LOCK" && "$(cat "$WORKTREE_LIFECYCLE_LOCK/pid" 2>/dev/null || true)" == "$$" ]]; then
+    rm -rf "$WORKTREE_LIFECYCLE_LOCK"
+  fi
+  WORKTREE_LIFECYCLE_LOCK=""
+}
+
+# A ticket is terminal for cleanup when Linear says Done or GitHub has a
+# merged PR mentioning its identifier. Lookup failures fail closed: an
+# unreachable control plane leaves the worktree in place.
+ticket_is_terminal() { # <ticket> <branch>
+  local ticket="$1" branch="$2" json="" state="" merged=""
+  if json=$(bun "$REPO/tools/linear.mjs" get "$ticket" --json 2>/dev/null); then
+    state=$(printf '%s\n' "$json" | awk '
+      {
+        line=$0
+        if (!in_state && line ~ /"state"[[:space:]]*:[[:space:]]*\{/) {
+          in_state=1
+          sub(/^.*"state"[[:space:]]*:[[:space:]]*\{/, "", line)
+        }
+        if (in_state && line ~ /"name"[[:space:]]*:/) {
+          sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line)
+          sub(/".*$/, "", line)
+          print line
+          exit
+        }
+      }
+    ')
+    [[ "$state" == "Done" ]] && return 0
+  fi
+
+  if command -v gh >/dev/null 2>&1; then
+    merged=$(cd "$REPO" && gh pr list --state merged --head "$branch" --json number --limit 1 --jq 'length' 2>/dev/null || true)
+    [[ "$merged" =~ ^[1-9][0-9]*$ ]] && return 0
+  fi
+  return 1
+}
+
+if [[ "$PRUNE" -eq 1 ]]; then
+  [[ "$HERE" -eq 0 && "$FORCE" -eq 0 && -z "$TICKET" ]] \
+    || die "--prune takes no ticket and cannot be combined with --here or --force"
+  pruned=0
+  for WT in "$WT_ROOT"/*; do
+    [[ -d "$WT" ]] || continue
+    ticket=$(basename "$WT")
+    [[ "$ticket" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || continue
+
+    status=$(git -C "$WT" status --porcelain 2>/dev/null) || {
+      warn "skipping $ticket — cannot inspect worktree status"
+      continue
+    }
+    if [[ -n "$status" ]]; then
+      warn "skipping $ticket — worktree has uncommitted changes"
+      continue
+    fi
+
+    RUN_DIR="$(run_dir "$WT")"
+    if pid_alive "$RUN_DIR/web.pid" || pid_alive "$RUN_DIR/worker.pid" || pid_alive "$RUN_DIR/serve.pid"; then
+      warn "skipping $ticket — worktree has live daemons"
+      continue
+    fi
+    branch=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    [[ -n "$branch" ]] || {
+      warn "skipping $ticket — worktree is detached"
+      continue
+    }
+    ticket_is_terminal "$ticket" "$branch" || continue
+
+    if ! try_worktree_lifecycle_lock "$ticket"; then
+      warn "skipping $ticket — worktree lifecycle is busy"
+      continue
+    fi
+    trap release_worktree_lifecycle_lock EXIT
+    trap 'release_worktree_lifecycle_lock; exit 130' INT
+    trap 'release_worktree_lifecycle_lock; exit 143' TERM
+
+    # Revalidate under the same per-ticket lifecycle lock used by bring-up and
+    # ordinary teardown. Nothing using the paved road can dirty or start this
+    # worktree between these checks and removal.
+    status=$(git -C "$WT" status --porcelain 2>/dev/null) || {
+      warn "skipping $ticket — cannot re-check worktree status"
+      release_worktree_lifecycle_lock
+      continue
+    }
+    if [[ -n "$status" ]] || pid_alive "$RUN_DIR/web.pid" || pid_alive "$RUN_DIR/worker.pid" || pid_alive "$RUN_DIR/serve.pid"; then
+      warn "skipping $ticket — worktree became dirty or live"
+      release_worktree_lifecycle_lock
+      continue
+    fi
+
+    FACTORY_WORKTREE_LOCK_HELD="$WORKTREE_LIFECYCLE_LOCK" /bin/bash "${BASH_SOURCE[0]}" "$ticket" \
+      || die "failed to prune terminal worktree $ticket"
+    release_worktree_lifecycle_lock
+    pruned=$((pruned + 1))
+  done
+  git -C "$REPO" worktree prune
+  info "pruned $pruned terminal worktree(s)"
+  exit 0
+fi
 
 if [[ "$HERE" -eq 1 ]]; then
   [[ -z "$TICKET" ]] || die "--here takes no ticket"
   WT="$REPO"
 else
-  [[ -n "$TICKET" ]] || die "usage: worktree-down.sh <TICKET-ID> [--force] | --here"
+  [[ -n "$TICKET" ]] || die "usage: worktree-down.sh <TICKET-ID> [--force] | --here | --prune"
   WT="$WT_ROOT/$TICKET"
   [[ -d "$WT" ]] || die "no worktree at $WT"
+
+  expected_lock=$(worktree_lifecycle_lock_path "$TICKET")
+  if [[ "${FACTORY_WORKTREE_LOCK_HELD:-}" != "$expected_lock" ]]; then
+    try_worktree_lifecycle_lock "$TICKET" \
+      || die "worktree_lifecycle_busy: another process is provisioning or removing $TICKET"
+    trap release_worktree_lifecycle_lock EXIT
+    trap 'release_worktree_lifecycle_lock; exit 130' INT
+    trap 'release_worktree_lifecycle_lock; exit 143' TERM
+  fi
 fi
 
 RUN_DIR="$(run_dir "$WT")"

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -61,6 +61,34 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO="$(repo_root)"
+WORKTREE_LIFECYCLE_LOCK=""
+
+try_worktree_lifecycle_lock() { # <ticket>
+  local common root lock holder=""
+  common=$(git -C "$REPO" rev-parse --git-common-dir)
+  [[ "$common" == /* ]] || common="$REPO/$common"
+  root="$common/factory-worktree-locks"
+  lock="$root/$1.lock"
+  mkdir -p "$root"
+  if ! mkdir "$lock" 2>/dev/null; then
+    holder=$(cat "$lock/pid" 2>/dev/null || true)
+    if [[ "$holder" =~ ^[0-9]+$ ]] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lock"
+      mkdir "$lock" 2>/dev/null || return 1
+    else
+      return 1
+    fi
+  fi
+  printf '%s\n' "$$" >"$lock/pid"
+  WORKTREE_LIFECYCLE_LOCK="$lock"
+}
+
+release_worktree_lifecycle_lock() {
+  if [[ -n "$WORKTREE_LIFECYCLE_LOCK" && "$(cat "$WORKTREE_LIFECYCLE_LOCK/pid" 2>/dev/null || true)" == "$$" ]]; then
+    rm -rf "$WORKTREE_LIFECYCLE_LOCK"
+  fi
+  WORKTREE_LIFECYCLE_LOCK=""
+}
 
 if [[ "$HERE" -eq 1 ]]; then
   [[ -z "$TICKET" ]] || die "--here takes no ticket — it provisions the current checkout"
@@ -73,17 +101,60 @@ else
   LABEL="$TICKET"
   BRANCH="$TYPE/$TICKET${SLUG:+-$SLUG}"
 
-  if [[ -d "$WT" ]]; then
-    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists: $WT"
+  try_worktree_lifecycle_lock "$TICKET" \
+    || die "worktree_lifecycle_busy: another process is provisioning or removing $TICKET"
+  trap release_worktree_lifecycle_lock EXIT
+  trap 'release_worktree_lifecycle_lock; exit 130' INT
+  trap 'release_worktree_lifecycle_lock; exit 143' TERM
+
+  [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
+  if [[ "$NO_FETCH" -eq 1 ]]; then
+    FACTORY_SKIP_FETCH=1 git_fetch "$REPO" "origin" "$BASE_BRANCH"
   else
-    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
-    if [[ "$NO_FETCH" -eq 1 ]]; then
-      FACTORY_SKIP_FETCH=1 git_fetch "$REPO" "origin" "$BASE_BRANCH"
-    else
-      git_fetch "$REPO" "origin" "$BASE_BRANCH"
+    git_fetch "$REPO" "origin" "$BASE_BRANCH"
+  fi
+
+  BASE_REF="origin/$BASE_BRANCH"
+  if git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    BRANCH_SHA=$(git -C "$REPO" rev-parse "refs/heads/$BRANCH") \
+      || die "worktree_branch_inspection_failed: could not resolve branch '$BRANCH'"
+    BASE_SHA=$(git -C "$REPO" rev-parse "$BASE_REF") \
+      || die "worktree_branch_inspection_failed: could not resolve $BASE_REF"
+    UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
+      || die "worktree_branch_inspection_failed: could not compare branch '$BRANCH' with $BASE_REF"
+    if [[ "$UNIQUE_COMMITS" -gt 0 ]]; then
+      die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF — resume or remove it explicitly before re-dispatch"
     fi
+
+    if [[ -d "$WT" ]]; then
+      CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+      [[ "$CURRENT_BRANCH" == "$BRANCH" ]] \
+        || die "worktree_branch_mismatch: $WT is on '${CURRENT_BRANCH:-detached HEAD}', expected '$BRANCH'"
+      [[ -z "$(git -C "$WT" status --porcelain)" ]] \
+        || die "worktree_branch_dirty: $WT has uncommitted work — resume or clean it explicitly before re-dispatch"
+      # `merge --ff-only` is non-destructive if another process commits after
+      # inspection; unlike reset --hard, it can never discard that commit.
+      git -C "$WT" merge --ff-only "$BASE_REF" >/dev/null \
+        || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
+    else
+      # Compare-and-swap the ref so a concurrent commit cannot be overwritten.
+      git -C "$REPO" update-ref "refs/heads/$BRANCH" "$BASE_SHA" "$BRANCH_SHA" \
+        || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
+    fi
+
+    UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
+      || die "worktree_branch_inspection_failed: could not re-check branch '$BRANCH'"
+    [[ "$UNIQUE_COMMITS" -eq 0 ]] \
+      || die "worktree_branch_has_commits: branch '$BRANCH' gained $UNIQUE_COMMITS unique commit(s) while moving to $BASE_REF — refusing re-dispatch"
+  elif [[ -d "$WT" ]]; then
+    die "worktree_branch_missing: $WT exists but branch '$BRANCH' does not"
+  fi
+
+  if [[ -d "$WT" ]]; then
+    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists at current $BASE_REF: $WT"
+  else
     [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "creating worktree $WT on $BRANCH"
-    worktree_add "$WT" "$BRANCH" "origin/$BASE_BRANCH" "$REPO"
+    worktree_add "$WT" "$BRANCH" "$BASE_REF" "$REPO"
   fi
 fi
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1177,6 +1177,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       `#!/bin/bash\necho "dependency install failed" >&2\nexit 12\n`,
     );
     writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-link-collision.sh"),
+      `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\nmkdir -p "$(dirname "$FACTORY_WORKTREE_REPORT")/repo"\n`,
+    );
+    writeFileSync(
       path.join(repoDir, "bin", "worktree-up-startup-crash.sh"),
       `#!/bin/bash\n` +
       `mkdir -p "${wtRoot}/$1/.factory/run"\n` +
@@ -1215,6 +1219,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         `  - name: wt-startup-crash\n    path: ${repoDir}\n    github: watt-mind/wt-startup-crash\n    base: develop\n` +
         `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
         `    worktree_up: bin/worktree-up-startup-crash.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: echo never\n    escalate_paths: []\n` +
+        `  - name: wt-link-collision\n    path: ${repoDir}\n    github: watt-mind/wt-link-collision\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    max_in_flight: 2\n` +
+        `    worktree_up: bin/worktree-up-link-collision.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n    verify: echo never\n    escalate_paths: []\n`,
     );
     previousReposRoot = process.env.FACTORY_REPOS_ROOT;
@@ -1952,6 +1960,31 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("workspace_provisioning_error");
     expect(summary.error).toContain("dependency install failed");
+    expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("workspace_provisioning_error");
+  });
+
+  test("filesystem failures after worktree_up remain typed workspace provisioning errors", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-link-collision-locks-"));
+    let executed = false;
+    const observingAdapter = { async execute() { executed = true; return { exitCode: 0, timedOut: false }; } };
+
+    const spec = queueRun(db, makeDispatchSpec({ input: { repo: "wt-link-collision", ticket: "WM-734" } }));
+    const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
+      dispatch: {
+        locksDir: lockDir,
+        fetchTicket: () => ({ identifier: "WM-734", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+      },
+    }));
+
+    expect(executed).toBe(false);
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("workspace_provisioning_error");
+    expect(summary.error).toContain("worktree provisioning failed for wt-link-collision/WM-734");
+    expect(summary.error).toContain("EEXIST");
     expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ?`).get(spec.runId).reason_code).toBe("workspace_provisioning_error");
   });
 

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -239,12 +239,21 @@ export function createWorkspace({
 
   let worktree = null;
   if (workspace.type === "worktree") {
-    worktree = materializeWorktree({
-      workspaceDir: dir,
-      input,
-      checkoutDir: workspace.checkoutDir ?? "repo",
-      timeoutMs: worktreeTimeoutMs,
-    });
+    try {
+      worktree = materializeWorktree({
+        workspaceDir: dir,
+        input,
+        checkoutDir: workspace.checkoutDir ?? "repo",
+        timeoutMs: worktreeTimeoutMs,
+      });
+    } catch (err) {
+      if (err instanceof WorktreeError) throw err;
+      const repoName = input?.repo ?? "unknown repo";
+      const ticket = input?.ticket ?? "unknown ticket";
+      throw new WorktreeError(
+        `worktree provisioning failed for ${repoName}/${ticket}: ${err?.message ?? String(err)}`,
+      );
+    }
   }
   return { dir, checkout, materialized, worktree };
 }


### PR DESCRIPTION
## Summary
- fast-forward stale reusable ticket branches to the current base using non-destructive ref updates
- refuse branches with unique or dirty work and serialize per-ticket worktree lifecycle changes
- add safe terminal-worktree pruning for Done tickets or merged PR branches
- keep all worktree provisioning failures typed as `workspace_provisioning_error`

## Verification
- `bun test bin/ event-runtime/lib/worker.test.mjs && bun run format:check && bash -n bin/worktree-up.sh && bash -n bin/worktree-down.sh`
- 161 tests passed

UX critique: skipped — backend/infrastructure worktree lifecycle tooling has no user-facing flow.

Fixes WM-338