### PR TITLE
fix(verify): retain actionable repository failures

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -11,7 +11,7 @@
  * evidence checking is slice 2.
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
 import { validate } from "./schema.mjs";
@@ -96,6 +96,58 @@ function matchesRedBaseline(baseline, verifyOutput) {
   const verifySig = failureSignature(verifyOutput);
   if (!baselineSig || !verifySig) return false;
   return baselineSig === verifySig;
+}
+
+const REPO_VERIFY_REASON_MAX_LINES = 40;
+const REPO_VERIFY_REASON_MAX_CHARS = 8 * 1024;
+const REPO_VERIFY_TEST_FAILURE_LINE = /\(fail\)|✗/i;
+const REPO_VERIFY_ERROR_LINE = /\berror\b/i;
+
+function boundedDiagnostic(lines) {
+  const excerpt = [];
+  let remaining = REPO_VERIFY_REASON_MAX_CHARS;
+  for (const line of lines) {
+    const separatorLength = excerpt.length === 0 ? 0 : 1;
+    if (remaining <= separatorLength) break;
+    remaining -= separatorLength;
+    if (line.length <= remaining) {
+      excerpt.push(line);
+      remaining -= line.length;
+      continue;
+    }
+    excerpt.push(`${line.slice(0, Math.max(0, remaining - 1))}…`);
+    break;
+  }
+  return excerpt.join("\n");
+}
+
+/**
+ * Keep the actionable lines from a failed repository verification bounded for
+ * the run reason. Explicit test-failure markers are retained before generic
+ * errors, so later runner noise cannot displace the failing test names.
+ */
+function repoVerifyFailureExcerpt(output) {
+  const lines = String(output ?? "")
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return "";
+
+  const testFailures = lines.filter((line) => REPO_VERIFY_TEST_FAILURE_LINE.test(line));
+  const errors = lines.filter(
+    (line) => !REPO_VERIFY_TEST_FAILURE_LINE.test(line) && REPO_VERIFY_ERROR_LINE.test(line),
+  );
+  if (testFailures.length === 0 && errors.length === 0) {
+    return boundedDiagnostic(lines.slice(-REPO_VERIFY_REASON_MAX_LINES));
+  }
+
+  const excerpt = testFailures.slice(-REPO_VERIFY_REASON_MAX_LINES);
+  const errorCapacity = Math.max(0, REPO_VERIFY_REASON_MAX_LINES - excerpt.length - 1);
+  if (errorCapacity > 0) excerpt.push(...errors.slice(-errorCapacity));
+  const summary = lines.at(-1);
+  if (excerpt.length < REPO_VERIFY_REASON_MAX_LINES && !excerpt.includes(summary)) excerpt.push(summary);
+  return boundedDiagnostic(excerpt);
 }
 
 export { normalizeFailureOutput, failureSignature };
@@ -305,17 +357,24 @@ function verifyCompleted({
     const worktreePath = worktreeRecord.path && existsSync(worktreeRecord.path)
       ? worktreeRecord.path
       : path.join(workspaceDir, "repo");
-    const vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], {
-      cwd: worktreePath,
-      encoding: "utf8",
-      timeout: verifyTimeoutMs,
-    });
+    const verifyLogPath = path.join(workspaceDir, ".verify.log");
+    const verifyLogFd = openSync(verifyLogPath, "w");
+    let vres;
+    try {
+      vres = spawnSync("/bin/bash", ["-c", worktreeRecord.verify], {
+        cwd: worktreePath,
+        stdio: ["ignore", verifyLogFd, verifyLogFd],
+        timeout: verifyTimeoutMs,
+      });
+    } finally {
+      closeSync(verifyLogFd);
+    }
+    const output = readFileSync(verifyLogPath, "utf8");
     if (vres.error?.code === "ETIMEDOUT" || vres.status !== 0) {
-      const output = [vres.stdout, vres.stderr].filter(Boolean).join("\n").trim();
       const timedOut = vres.error?.code === "ETIMEDOUT";
       const why = timedOut
         ? `timed out after ${verifyTimeoutMs}ms`
-        : output.split("\n").filter(Boolean).pop() || `exit ${vres.status}`;
+        : repoVerifyFailureExcerpt(output) || `exit ${vres.status}`;
       const baselineStillRed = !timedOut && matchesRedBaseline(worktreeRecord.baseline, output);
       throw new ContractViolation(
         [`repo_verify_failed: ${why}`],

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { hashJson, sha256Hex } from "./canonical.mjs";
@@ -352,6 +352,42 @@ describe("worktree baseline verification (WM-334)", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
       expect(err.reasonCode).toBe("contract_violation");
+    }
+  });
+
+  test("a multi-line verification failure retains the failing test name and full log", () => {
+    const dir = worktreeWorkspace(
+      "printf 'suite start\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
+      null,
+    );
+    try {
+      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations[0]).toContain("(fail) totals > rejects an invalid total");
+      expect(err.violations[0]).toContain("error: expected 400, received 200");
+    }
+
+    const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");
+    expect(verifyLog).toContain("suite start");
+    expect(verifyLog).toContain("(fail) totals > rejects an invalid total");
+    expect(verifyLog).toContain("Ran 2045 tests across 150 files.");
+    expect(verifyLog).toContain("error: expected 400, received 200");
+  });
+
+  test("later error noise cannot displace a failing test name from the bounded reason", () => {
+    const dir = worktreeWorkspace(
+      "printf '(fail) billing > rejects a duplicate charge\\n'; i=1; while [ \"$i\" -le 45 ]; do printf 'error: detail %s\\n' \"$i\"; i=$((i + 1)); done; exit 1",
+      null,
+    );
+    try {
+      verifyResult({ spec: dispatchSpec, def: dispatchDef, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations[0]).toContain("(fail) billing > rejects a duplicate charge");
+      expect(err.violations[0].split("\n").length).toBeLessThanOrEqual(40);
     }
   });
 


### PR DESCRIPTION
## Summary
- persist complete repository verification stdout/stderr to the workspace `.verify.log`
- retain bounded failing-test and error diagnostics in `repo_verify_failed` reasons
- add regression coverage for multi-line failures and noisy error output

## Verification
- `bun test event-runtime/lib/verify.test.mjs` — 23 pass, 0 fail

UX critique: skipped — backend runtime verification change with no user-facing flow

Fixes WM-524