### PR TITLE
fix(repos): narrow the factory VERIFYING gate to a fast deterministic subset (WM-528)

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -397,7 +397,21 @@ repos:
     # Cap on concurrent ticket agents; per repo, not per supervisor, like bj29.
     max_in_flight: 20
 
-    verify: bun test && bun build/emit.mjs --check
+    # Fast, deterministic local gate — deliberately a strict SUBSET of CI
+    # (WM-528). GitHub CI (.github/workflows/ci.yml, `bun test
+    # --max-concurrency=4` over the whole tree) remains the full-suite merge
+    # gate; merge already requires CI green, so re-running the full ~2050-test
+    # suite (~200-250s) inside every dispatched worktree only duplicated it and
+    # generated load-induced flakes: on 2026-08-17 four of six dispatches
+    # (WM-259, WM-350, WM-338, WM-512) failed `repo_verify_failed` on commits
+    # that were green in CI, because up to ~8 sibling worktrees run their own
+    # serve/worker/web daemons and suites at once. `event-runtime/lib` is the
+    # unit-only slice: it binds `port: 0` and shells out to git only — no
+    # daemons, no demo seed (those live in event-runtime/*.test.mjs, cli/,
+    # demo/, web/, bin/, orchestrator/ and stay CI-only). Measured 70-72s wall
+    # on the loaded host, 0 failures over repeated runs. `emit.mjs --check` is
+    # the contract check that must never be skipped locally.
+    verify: bun test event-runtime/lib && bun build/emit.mjs --check
 
     # Owned Paths closure rules for this repo's control-plane ticket types.
     owned_paths_policy:

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -31,10 +31,13 @@ export const EVIDENCE_INLINE_LIMIT_BYTES = 256 * 1024;
  * performance budget — it exists to tell "wedged forever" from "running".
  *
  * 120s was below the real cost and failed every dispatch (WM-510): this repo's
- * own `bun test && bun build/emit.mjs --check` measures 196-217s, so nothing
- * could ever pass. Sized at ~3x the slowest observed run, which leaves room for
- * a loaded host while staying far under `limits.max_run_minutes: 45` in
- * config/policy.yaml — the bound that actually caps a wedged run.
+ * own verify at the time (`bun test && bun build/emit.mjs --check`, the full
+ * suite) measured 196-217s, so nothing could ever pass. Sized at ~3x the
+ * slowest observed run, which leaves room for a loaded host while staying far
+ * under `limits.max_run_minutes: 45` in config/policy.yaml — the bound that
+ * actually caps a wedged run. (The factory verify has since been narrowed to
+ * `bun test event-runtime/lib && bun build/emit.mjs --check`, ~70s, WM-528 —
+ * the ceiling stays where it is for the other repos.)
  *
  * Raise this rather than trimming it to fit: a ceiling that only just fits is
  * the same outage with a longer fuse. Per-repo tuning goes through

--- a/orchestrator/repos-config.test.mjs
+++ b/orchestrator/repos-config.test.mjs
@@ -46,8 +46,13 @@ test("factory routes to WM / Factory and caps in-flight at 20", () => {
   expect(factory.maxInFlight).toBe(20);
 });
 
-test("factory branches and verify are unchanged by OPS-463", () => {
+test("factory branches are unchanged by OPS-463; verify is the fast lib-only gate (WM-528)", () => {
   expect(factory.base).toBe("develop");
   expect(factory.deployBranch).toBe("main");
-  expect(factory.verify).toBe("bun test && bun build/emit.mjs --check");
+  // The local VERIFYING gate is deliberately a strict subset of CI: unit-only
+  // event-runtime/lib (no daemons/ports/demo seed) plus the emit contract check.
+  // The full `bun test` stays in .github/workflows/ci.yml, the real merge gate.
+  expect(factory.verify).toBe(
+    "bun test event-runtime/lib && bun build/emit.mjs --check",
+  );
 });


### PR DESCRIPTION
Fixes WM-528

## Handoff

**What/why.** `config/repos.yaml` factory `verify:` re-ran the full ~2050-test suite (`bun test`, ~200-250s) inside every dispatched worktree while up to ~8 sibling worktrees run their own serve/worker/web daemons and suites. On 2026-08-17 four of six dispatches (WM-259 run_1ce750c8, WM-350 run_cb093f22, WM-338 run_3c716f96, WM-512 run_a4afd407) failed `repo_verify_failed` on commits that were green in GitHub CI — the required merge gate anyway. The local gate is now a strict subset of CI: `bun test event-runtime/lib && bun build/emit.mjs --check`. `event-runtime/lib` binds `port: 0` and only shells out to git (no daemons / demo seed); CI still runs the full tree via `bun test --max-concurrency=4`. Comment above `verify:` documents this; the WM-510 doc comment in `event-runtime/lib/verify.mjs` was updated so it no longer describes the old string as current. No `update-pins --check` command exists, so `emit.mjs --check` is the only contract check kept.

**Measured.** In the WM-528 worktree, on the loaded host: `bun test event-runtime/lib` → `831 pass, 0 fail, Ran 831 tests across 61 files. [~70s]`; whole verify command 1:19 wall (previously ~250s), exit 0. Three consecutive runs of the lib subset on the main checkout: 0 failures.

**Verification output.**
```
$ bun test event-runtime/lib && bun build/emit.mjs --check
 831 pass
 0 fail
 3658 expect() calls
Ran 831 tests across 61 files. [70.36s]
(emit --check: exit 0)
```

**UX critique:** n/a (config/infra only).
