### PR TITLE
feat(event-runtime): resume harness sessions after lease loss

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -584,6 +584,19 @@ result rows never reference files that died with a workspace. Passing work
 between agents means materializing an accepted artifact into a new workspace,
 not letting two agents share a live directory.
 
+A requeued attempt still gets its own `${runId}-a${attempt}` directory. Before
+starting attempt 2 or later, the workspace provider checks retained earlier
+attempt directories, newest first, for adapter-authored session metadata in
+`.transcript.json`. The metadata must identify the expected adapter and prior
+workspace cwd. When present, the worker gives that session identifier to the
+same adapter (Claude's `--resume ... --fork-session`; pi's explicit `--fork`
+continuation because the new attempt has a different cwd), so a lease-loss retry
+can continue the harness conversation under a new native session without
+sharing the stale attempt's writable workspace. A missing, cleaned, partial,
+malformed, mismatched, or unsupported transcript is an expected condition and
+produces an ordinary cold start. Transcript
+availability is an optimization, never durable run state.
+
 Working-directory separation alone is not a security sandbox. For Claude
 `mutating: false` runs, the adapter additionally passes a generated settings
 policy: Bash is sandboxed with unsandboxed fallback disabled, the repository
@@ -626,8 +639,10 @@ Delivery is **at least once**, never assumed exactly once:
 - unique source event IDs deduplicate intake;
 - unique run idempotency keys deduplicate planning (§5.4);
 - leases expire and carry fencing tokens;
-- each attempt has its own identity;
-- only the current fencing token may publish a terminal result; and
+- each attempt has its own identity and workspace, even when it resumes an
+  earlier harness session;
+- session resumption does not transfer publication authority: only the current
+  fencing token may publish a terminal result; and
 - storing an accepted result and its derived event is one transaction via an
   outbox.
 

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -165,8 +165,16 @@ export function safeChildEnvironment(env = {}, defOrOpts = {}) {
  * passed verbatim as `--model` unless it is the "default" sentinel or null,
  * both of which mean "ride the CLI's own default" — today's behavior.
  */
-export function buildClaudeArgv({ prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig, settingsPath, model }) {
-  const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
+export function buildClaudeArgv({
+  prompt, def, allowedTools = deriveAllowedTools(def), mcpConfig, settingsPath, model, resumeSessionId,
+}) {
+  const args = ["-p", prompt];
+  if (typeof resumeSessionId === "string" && resumeSessionId) {
+    // Continue from the stale attempt's context under a new native session ID;
+    // the expired source process may still exist and must not share writes.
+    args.push("--resume", resumeSessionId, "--fork-session");
+  }
+  args.push("--output-format", "stream-json", "--verbose");
   if (def?.mutating !== false) {
     args.push("--dangerously-skip-permissions");
   }
@@ -300,6 +308,7 @@ export async function execute({
   env = {},
   onTrace,
   onUsage,
+  resume = null,
   abortSignal,
   signal,
 }) {
@@ -310,7 +319,9 @@ export async function execute({
   const settings = buildClaudeSettings({ spec, def, workspaceDir });
   const settingsPath = settings ? path.join(workspaceDir, ".claude-policy.json") : null;
   if (settingsPath) writeFileSync(settingsPath, `${JSON.stringify(settings)}\n`, "utf8");
-  const argv = buildClaudeArgv({ prompt, def, mcpConfig, settingsPath, model: spec?.model });
+  const argv = buildClaudeArgv({
+    prompt, def, mcpConfig, settingsPath, model: spec?.model, resumeSessionId: resume?.sessionId,
+  });
 
   return new Promise((resolve, reject) => {
     const child = spawn("claude", argv, {

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -137,8 +137,14 @@ export function resolvePiCommand({ which = Bun.which } = {}) {
  * `model` is the planner-resolved value pinned in the RunSpec (WM-135):
  * passed verbatim as `--model` unless it is the "default" sentinel or null/empty.
  */
-export function buildPiArgv({ def, model }) {
+export function buildPiArgv({ def, model, resumeSessionId }) {
   const args = ["-p", "--mode", "json"];
+  // A resumed attempt has a different cwd. `--session <id>` asks whether to
+  // fork sessions found in another project, which is interactive; `--fork`
+  // performs that continuation explicitly and remains deterministic headlessly.
+  if (typeof resumeSessionId === "string" && resumeSessionId) {
+    args.push("--fork", resumeSessionId);
+  }
   if (typeof model === "string" && model !== "" && model !== "default") {
     args.push("--model", model);
   }
@@ -333,6 +339,7 @@ export async function execute({
   env = {},
   onTrace,
   onUsage,
+  resume = null,
   abortSignal,
   signal,
 }) {
@@ -348,7 +355,10 @@ export async function execute({
       "neither pi nor npx is on PATH — install the pi CLI, or ensure npx can fetch it (docs/event-runtime.md §6)",
     );
   }
-  const argv = [...resolved.args, ...buildPiArgv({ def, model: spec?.model })];
+  const argv = [
+    ...resolved.args,
+    ...buildPiArgv({ def, model: spec?.model, resumeSessionId: resume?.sessionId }),
+  ];
 
   return new Promise((resolve, reject) => {
     const child = spawn(resolved.command, argv, {

--- a/event-runtime/lib/transcripts.mjs
+++ b/event-runtime/lib/transcripts.mjs
@@ -10,7 +10,9 @@
  * guaranteeing the artifact store's core invariant: stored bytes always equal
  * the computed hash and the agent's full output.
  */
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync, copyFileSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, statSync,
+} from "node:fs";
 import { createWriteStream } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +20,78 @@ import { sha256Hex } from "./canonical.mjs";
 import { artifactPath } from "./artifacts.mjs";
 
 export const TRANSCRIPT_FILENAME = ".transcript.json";
+
+/** Session metadata is emitted at the head of both supported NDJSON streams. */
+export const MAX_RESUME_SCAN_BYTES = 1024 * 1024;
+
+function validSessionId(value, adapter) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 256) return false;
+  if (adapter === "claude") {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+  }
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value);
+}
+
+/**
+ * Extract the native harness session identifier from recognized top-level
+ * metadata for the expected adapter and prior workspace. Nested agent text or
+ * metadata naming a different cwd is never interpreted as resume context.
+ */
+export function transcriptSessionId(transcriptPath, adapter) {
+  if (adapter !== "claude" && adapter !== "pi") return null;
+
+  let fd;
+  try {
+    fd = openSync(transcriptPath, "r");
+    const buffer = Buffer.alloc(MAX_RESUME_SCAN_BYTES);
+    const size = readSync(fd, buffer, 0, buffer.byteLength, 0);
+    const lines = buffer.subarray(0, size).toString("utf8").split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const priorWorkspace = path.dirname(transcriptPath);
+      const candidate = adapter === "claude"
+        && event?.type === "system"
+        && event?.subtype === "init"
+        && event?.cwd === priorWorkspace
+        ? event.session_id
+        : adapter === "pi"
+          && event?.type === "session"
+          && event?.cwd === priorWorkspace
+          ? event.id
+          : null;
+      if (validSessionId(candidate, adapter)) return candidate;
+    }
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch {}
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the newest earlier attempt whose retained workspace contains native
+ * session metadata. Missing, cleaned, partial, or malformed transcripts are a
+ * normal cold-start condition, not a workspace provisioning failure.
+ */
+export function findPriorResumeContext({ root, runId, attempt, adapter }) {
+  if (!Number.isInteger(attempt) || attempt <= 1) return null;
+  for (let priorAttempt = attempt - 1; priorAttempt >= 1; priorAttempt -= 1) {
+    const transcriptPath = path.join(root, `${runId}-a${priorAttempt}`, TRANSCRIPT_FILENAME);
+    if (!existsSync(transcriptPath)) continue;
+    const sessionId = transcriptSessionId(transcriptPath, adapter);
+    if (sessionId) return { attempt: priorAttempt, sessionId, transcriptPath };
+  }
+  return null;
+}
 
 /**
  * Await a writable stream's complete flush to disk and close.

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -796,9 +796,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
       leaseHeartbeat?.unref?.();
     }
 
+    const adapterKey = adapterOverride ?? spec.adapter;
     const created = createWorkspace({
       root: workspacesRoot, runId, attempt, input: spec.input, workspace: spec.workspace,
-      artifactStore,
+      artifactStore, adapter: adapterKey,
     });
     workspaceDir = created.dir;
     checkoutPath = created.checkout?.path ?? null;
@@ -807,7 +808,6 @@ export async function executeClaimed(db, registry, adapters, claim, {
     db.query(`UPDATE attempts SET workspace_path = ? WHERE run_id = ? AND attempt = ?`)
       .run(workspaceDir, runId, attempt);
 
-    const adapterKey = adapterOverride ?? spec.adapter;
     const adapter = adapters[adapterKey];
     if (!adapter) {
       const res = failTerminal("FAILED", "unknown_adapter", "unknown_adapter");
@@ -846,6 +846,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     try {
       outcome = await adapter.execute({
         spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env, onTrace, onUsage,
+        resume: created.resume ?? null,
         abortSignal: abortController.signal, signal: abortController.signal,
       });
     } finally {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { buildClaudeArgv, execute as executeClaude } from "./adapters/claude.mjs";
 import * as fake from "./adapters/fake.mjs";
+import { buildPiArgv, execute as executePi } from "./adapters/pi.mjs";
 import { pinRunArtifact } from "./artifacts.mjs";
 import { admitEvent } from "./intake.mjs";
 import { planEvent } from "./planner.mjs";
@@ -14,6 +16,7 @@ import { openDb, runUsage } from "./db.mjs";
 import { createRun, lifecycleOf, runState, transition, IllegalTransition } from "./lifecycle.mjs";
 import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
+import { transcriptSessionId } from "./transcripts.mjs";
 import {
   acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
   createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
@@ -418,6 +421,146 @@ describe("worker", () => {
     expect(summary.terminalState).toBe("FAILED");
     expect(runState(db, spec.runId)).toBe("FAILED");
     expect(claimNext(db, opts())).toBeNull();
+  });
+
+  test("attempt 2 resumes the prior harness session and stale attempt 1 remains fenced", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "claude", maxAttempts: 2 }));
+    const o = opts();
+    const stale = claimNext(db, o);
+    const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
+    mkdirSync(priorWorkspace, { recursive: true });
+    const priorTranscript = path.join(priorWorkspace, ".transcript.json");
+    writeFileSync(priorTranscript, `${JSON.stringify({
+      type: "system", subtype: "init", cwd: priorWorkspace,
+      session_id: "11111111-2222-4333-8444-555555555555",
+    })}\n`);
+
+    const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    const fresh = claimNext(db, { ...o, now: afterExpiry });
+    expect(fresh.attempt).toBe(2);
+
+    let observedResume = null;
+    const resumeAdapter = {
+      async execute(args) {
+        observedResume = args.resume;
+        return fake.execute(args);
+      },
+    };
+    const done = await executeClaimed(db, registry, { claude: resumeAdapter }, fresh, { ...o, now: afterExpiry });
+    expect(done.terminalState).toBe("COMPLETED");
+    expect(observedResume).toEqual({
+      attempt: 1,
+      sessionId: "11111111-2222-4333-8444-555555555555",
+      transcriptPath: priorTranscript,
+    });
+
+    const zombie = await executeClaimed(db, registry, { claude: resumeAdapter }, stale, { ...o, now: afterExpiry });
+    expect(zombie.fenced === true || zombie.cancelled === true).toBe(true);
+    expect(db.query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`).get(spec.runId).n).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM outbox`).get().n).toBe(1);
+  });
+
+  test("attempt 2 cold-starts cleanly when the prior transcript has no resumable session", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "claude", maxAttempts: 2 }));
+    const o = opts();
+    claimNext(db, o);
+    const priorWorkspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
+    mkdirSync(priorWorkspace, { recursive: true });
+    writeFileSync(path.join(priorWorkspace, ".transcript.json"), [
+      JSON.stringify({ type: "system", subtype: "init", cwd: priorWorkspace, session_id: "not-a-uuid" }),
+      JSON.stringify({
+        type: "system", subtype: "init", cwd: "/another/run",
+        session_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      }),
+    ].join("\n") + "\n");
+
+    const afterExpiry = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+    expect(reapExpiredLeases(db, { now: afterExpiry, policyVersion: "test" })).toBe(1);
+    const fresh = claimNext(db, { ...o, now: afterExpiry });
+
+    let observedResume = "not-called";
+    const coldAdapter = {
+      async execute(args) {
+        observedResume = args.resume;
+        return fake.execute(args);
+      },
+    };
+    const done = await executeClaimed(db, registry, { claude: coldAdapter }, fresh, { ...o, now: afterExpiry });
+    expect(done.terminalState).toBe("COMPLETED");
+    expect(observedResume).toBeNull();
+  });
+
+  test("adapter argv carries an extracted resume session identifier", () => {
+    const root = freshRoot();
+    const claudeTranscript = path.join(root, "claude.ndjson");
+    const piTranscript = path.join(root, "pi.ndjson");
+    const claudeId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    writeFileSync(claudeTranscript, `${JSON.stringify({
+      type: "system", subtype: "init", cwd: root, session_id: claudeId,
+    })}\n`);
+    writeFileSync(piTranscript, `${JSON.stringify({
+      type: "session", version: 3, cwd: root, id: "pi-session",
+    })}\n`);
+
+    const claudeSession = transcriptSessionId(claudeTranscript, "claude");
+    const piSession = transcriptSessionId(piTranscript, "pi");
+    expect(claudeSession).toBe(claudeId);
+    expect(piSession).toBe("pi-session");
+
+    const claude = buildClaudeArgv({
+      prompt: "continue", def: { mutating: false }, resumeSessionId: claudeSession,
+    });
+    expect(claude.slice(0, 4)).toEqual(["-p", "continue", "--resume", claudeId]);
+    expect(claude).toContain("--fork-session");
+
+    const pi = buildPiArgv({
+      def: { mutating: false }, model: null, resumeSessionId: piSession,
+    });
+    expect(pi).toContain("--fork");
+    expect(pi[pi.indexOf("--fork") + 1]).toBe("pi-session");
+  });
+
+  test("real adapter execute paths forward resume context to their spawned CLIs", async () => {
+    const root = freshRoot();
+    const bin = path.join(root, "bin");
+    mkdirSync(bin);
+    for (const command of ["claude", "pi"]) {
+      const executable = path.join(bin, command);
+      writeFileSync(executable, "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FACTORY_TEST_ARGV\"\n");
+      chmodSync(executable, 0o755);
+    }
+    const promptPath = path.join(root, "prompt.md");
+    writeFileSync(promptPath, "Continue the run.\n");
+    const def = { promptPath, mutating: true, capabilities: { tools: [] } };
+    const spec = { model: null, input: {} };
+
+    const claudeWorkspace = path.join(root, "claude-workspace");
+    const claudeArgv = path.join(root, "claude-argv.txt");
+    mkdirSync(claudeWorkspace);
+    const claudeOutcome = await executeClaude({
+      spec, def, workspaceDir: claudeWorkspace, timeoutMs: 5_000,
+      env: { PATH: `${bin}${path.delimiter}${process.env.PATH}`, FACTORY_TEST_ARGV: claudeArgv },
+      resume: { sessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" },
+    });
+    expect(claudeOutcome.exitCode).toBe(0);
+    expect(readFileSync(claudeArgv, "utf8").split("\n")).toContain("--resume");
+    expect(readFileSync(claudeArgv, "utf8")).toContain("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
+    expect(readFileSync(claudeArgv, "utf8").split("\n")).toContain("--fork-session");
+
+    const piWorkspace = path.join(root, "pi-workspace");
+    const piArgv = path.join(root, "pi-argv.txt");
+    mkdirSync(piWorkspace);
+    const piOutcome = await executePi({
+      spec, def, workspaceDir: piWorkspace, timeoutMs: 5_000,
+      env: { PATH: `${bin}${path.delimiter}${process.env.PATH}`, FACTORY_TEST_ARGV: piArgv },
+      resume: { sessionId: "pi-session" },
+    });
+    expect(piOutcome.exitCode).toBe(0);
+    expect(readFileSync(piArgv, "utf8").split("\n")).toContain("--fork");
+    expect(readFileSync(piArgv, "utf8")).toContain("pi-session");
   });
 
   test("fencing: a stale claim can never publish over a newer attempt", async () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -16,6 +16,7 @@ import { materializeArtifact } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { getRepo, loadRepos } from "./repos.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
+import { findPriorResumeContext } from "./transcripts.mjs";
 
 /** Hard ceiling for repository-owned worktree lifecycle scripts (WM-262). */
 export const DEFAULT_WORKTREE_SCRIPT_TIMEOUT_MS = 120_000;
@@ -202,7 +203,12 @@ export function createWorkspace({
   workspace = {},
   artifactStore = artifactsRoot(),
   worktreeTimeoutMs = worktreeScriptTimeoutMs(),
+  adapter = null,
 }) {
+  // Lease loss can leave the prior attempt's scratch directory behind. Read
+  // recognized harness session metadata before creating the new attempt;
+  // absence (including normal cleanup after an orderly failure) means cold start.
+  const resume = findPriorResumeContext({ root, runId, attempt, adapter });
   const dir = path.join(root, `${runId}-a${attempt}`);
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "input.json"), `${canonicalJson(input)}\n`, "utf8");
@@ -246,7 +252,7 @@ export function createWorkspace({
       timeoutMs: worktreeTimeoutMs,
     });
   }
-  return { dir, checkout, materialized, worktree };
+  return { dir, checkout, materialized, worktree, resume };
 }
 
 /**


### PR DESCRIPTION
## Summary
- discover resumable Claude/Pi session metadata in retained prior-attempt transcripts
- continue retries in forked native sessions while preserving per-attempt workspaces and fencing
- cold-start safely when transcript metadata is absent, invalid, mismatched, or cleaned
- document retry resumption and add lifecycle, fallback, fencing, and real adapter argv coverage

## Verification
- `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/transcripts.test.mjs event-runtime/lib/reaper.test.mjs` — 88 pass, 0 fail
- `bun test event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/pi.test.mjs` — 75 pass, 0 fail

UX critique: skipped — backend event-runtime lifecycle change with no user-facing flow

Fixes WM-225