### PR TITLE
fix(test): deepen shallow CI clone before building the stale re-dispatch branch (WM-530)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -339,6 +339,13 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
   const git = (args) => Bun.spawnSync({ cmd: ["git", ...args], cwd: path.resolve(import.meta.dir, ".."), stdout: "pipe", stderr: "pipe" });
 
   try {
+    // CI checks out with actions/checkout's default fetch-depth 1, so
+    // origin/develop has no parent in the shallow clone and `origin/develop~1`
+    // resolves to nothing (exit 128). Deepen by one commit only in that case
+    // (WM-530); a full local clone never takes this branch.
+    if (git(["rev-parse", "--verify", "--quiet", "origin/develop~1"]).exitCode !== 0) {
+      expect(git(["fetch", "--deepen=1", "origin", "develop"]).exitCode).toBe(0);
+    }
     expect(git(["branch", branch, "origin/develop~1"]).exitCode).toBe(0);
     const staleSha = git(["rev-parse", branch]).stdout.toString().trim();
     const baseSha = git(["rev-parse", "origin/develop"]).stdout.toString().trim();


### PR DESCRIPTION
Fixes WM-530

## Handoff
**What/why.** develop CI has been red since #475 (WM-338): `bin/worktree-checkout.test.mjs` 're-dispatch fast-forwards a deliberately stale branch' runs `git branch <b> origin/develop~1`, which exits 128 on actions/checkout's default depth-1 clone (runs 32032208327, 32032359686 fail only on this). The test now deepens by one commit (`git fetch --deepen=1 origin develop`) only when `origin/develop~1` is unresolvable. No workflow change.

**Verification.** `bun test bin/worktree-checkout.test.mjs` → 22 pass / 0 fail on the full clone; reproduced the failure in a fresh `git clone --depth 1` (rev-parse origin/develop~1 exit 1) and the patched test passes there (22 tests, 0 fail).

**UX critique:** n/a.