### PR TITLE
feat(event-runtime-web): chain trace view — per-correlation instance graph (WM-527)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1329,3 +1329,36 @@ worktrees a repo owns.
 
 Nothing here writes `config/repos.yaml`. The registry is edited in the file
 and read by the UI, exactly as the agent registry is in §10.6.
+
+### 10.15 Chain trace (`#/chain/:correlationId`) — WM-527
+
+The Graph (§10.13) answers "what can happen"; the chain trace answers "what
+happened to *this* one, and where did it start". A chain instance is stitched
+by two ids the emitter writes on every hop (`lib/chain.mjs`): `correlationId`,
+inherited unchanged from the origin event (falling back to the origin's own
+`eventId` when it carried none), and `causationId`, the run id that produced
+the derived event. `GET /chain/:correlationId` returns every event and run
+under that key — flat lists, `causationId` intact, 404 when unknown — and the
+client builds the DAG: origin event → run → emitted events → runs …, laid out
+left-to-right on the same React Flow + elk canvas as the map, with tighter
+layer spacing because chains are long and thin.
+
+- **Reachable from wherever an operator is standing.** The event panel shows
+  `correlationId` (a link into the chain) and `causationId` (a link to the
+  run that emitted it) and has a **View chain** action; the full run page has
+  the same action, keyed by the run's origin event. Both land on the chain
+  with that event/run pre-selected (`#/chain/:correlationId/:nodeId`).
+- **Every node is an instance.** Event nodes carry source, type, status,
+  short id, age and repos; run nodes carry agent, state, adapter, attempt and
+  reason code. The left border is the event status / run state hue, so a
+  failed hop reads at a glance. The header sums it up: origin, event/run
+  counts, hop depth, and a state tally.
+- **Same chrome as the map.** `j`/`k` (and arrows) walk nodes in reading
+  order, `z` / **Show on canvas** pans the selection into view, `Esc` closes,
+  **Reset layout** re-runs elk. The panel links out to Events, Runs, the run
+  page, Proposals and Agents, and to the parent run / origin event *inside*
+  the chain. Positions are reused across the 3 s poll while node/edge
+  identity is unchanged (§10.13's identity rule).
+
+It is a drill-in like `#/run/:id`, not a nav item: you arrive from an event
+or a run, never cold.

--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -1,0 +1,124 @@
+/**
+ * Chain trace endpoint (WM-527): everything that shares one correlation id.
+ *
+ * A chain instance is stitched by two ids the emitter writes on every hop
+ * (lib/chain.mjs): `correlationId` — inherited unchanged from the origin
+ * event, falling back to the origin's own eventId when it carried none — and
+ * `causationId` — the run id that produced the derived event. So the whole
+ * tree is one `correlation_id` lookup, and the tree shape is
+ * `run → proposal → event.causation_id → parent run` — reconstructed here as
+ * flat event + run lists; the client builds the graph.
+ */
+import { repoNamesFromInput } from "./api-runs.mjs";
+
+/** The id that names an event's chain: its correlation id, else its own id. */
+export function chainKeyOf(event) {
+  return event?.correlationId ?? event?.correlation_id ?? event?.eventId ?? event?.event_id ?? null;
+}
+
+export function chainView(db, correlationId) {
+  const eventRows = db
+    .query(
+      `SELECT e.source, e.event_id, e.type, e.subject, e.status, e.occurred_at,
+              e.received_at, e.admitted_at, e.correlation_id, e.causation_id,
+              e.envelope_json,
+              p.id AS proposal_id, p.status AS proposal_status,
+              p.decision AS proposal_decision, p.run_id AS run_id
+       FROM events e
+       LEFT JOIN proposals p ON p.rowid = (
+         SELECT p2.rowid FROM proposals p2
+         WHERE p2.event_source = e.source AND p2.event_id = e.event_id
+         ORDER BY p2.created_at DESC, p2.rowid DESC
+         LIMIT 1
+       )
+       WHERE e.correlation_id = ?1
+          OR (e.correlation_id IS NULL AND e.event_id = ?1)
+       ORDER BY e.admitted_at ASC, e.rowid ASC`,
+    )
+    .all(correlationId);
+  if (eventRows.length === 0) return null;
+
+  const events = eventRows.map((row) => {
+    let payload = null;
+    try {
+      payload = JSON.parse(row.envelope_json)?.payload ?? null;
+    } catch {
+      payload = null;
+    }
+    return {
+      source: row.source,
+      eventId: row.event_id,
+      type: row.type,
+      subject: row.subject,
+      status: row.status,
+      occurredAt: row.occurred_at,
+      receivedAt: row.received_at,
+      admittedAt: row.admitted_at,
+      correlationId: row.correlation_id,
+      causationId: row.causation_id,
+      proposalId: row.proposal_id ?? null,
+      proposalStatus: row.proposal_status ?? null,
+      proposalDecision: row.proposal_decision ?? null,
+      runId: row.run_id ?? null,
+      repos: repoNamesFromInput(payload),
+    };
+  });
+
+  // Runs the events produced, plus any parent named by a causation id that is
+  // not otherwise in the set — the client draws those as roots so a chain
+  // whose origin lives under a different correlation still traces.
+  const runIds = new Set();
+  for (const e of events) {
+    if (e.runId) runIds.add(e.runId);
+    if (e.causationId) runIds.add(e.causationId);
+  }
+  const runs = [];
+  for (const runId of runIds) {
+    const row = db
+      .query(
+        `SELECT r.run_id, r.state, r.attempts, r.spec_json, r.created_at, r.updated_at,
+                a.reason_code, a.started_at, a.finished_at,
+                p.event_id, p.event_source
+         FROM runs r
+         LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+         LEFT JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
+         WHERE r.run_id = ?
+         LIMIT 1`,
+      )
+      .get(runId);
+    if (!row) continue;
+    let spec = {};
+    try {
+      spec = JSON.parse(row.spec_json) ?? {};
+    } catch {
+      spec = {};
+    }
+    runs.push({
+      runId: row.run_id,
+      state: row.state,
+      attempts: row.attempts,
+      agent: spec.agent ?? null,
+      adapter: spec.adapter ?? null,
+      reasonCode: row.reason_code ?? null,
+      eventId: row.event_id ?? null,
+      eventSource: row.event_source ?? null,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      startedAt: row.started_at ?? null,
+      finishedAt: row.finished_at ?? null,
+      repos: repoNamesFromInput(spec.input),
+    });
+  }
+  runs.sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  return { correlationId, events, runs };
+}
+
+export function handleChainApiRoute({ route, url, send, db }) {
+  const match = url.pathname.match(/^\/chain\/([^/]+)$/);
+  if (!match || route !== `GET ${url.pathname}`) return false;
+  const correlationId = decodeURIComponent(match[1]);
+  const view = chainView(db, correlationId);
+  if (!view) return send(404, { error: "chain not found" });
+  return send(200, view);
+}

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chainKeyOf, chainView } from "./api-chain.mjs";
+import { envelope, makeServer, registry } from "./api-test-helpers.mjs";
+import { admitChainEvent } from "./chain.mjs";
+
+/**
+ * Chain trace endpoint (WM-527). Fixture is a fan-out tree:
+ *
+ *   origin (test/origin-1, correlationId corr-1)
+ *     └─ run-1 (work-scan)
+ *          ├─ chain-run-1-A → run-2 (dispatch)
+ *          │     └─ chain-run-2 → run-3 (merge-scan)
+ *          └─ chain-run-1-B → (dead-lettered, no run)
+ *
+ * plus an unrelated event under another correlation that must not leak in.
+ */
+describe("GET /chain/:correlationId (WM-527)", () => {
+  let s;
+  const t = (n) => new Date(Date.UTC(2026, 7, 17, 12, n)).toISOString();
+
+  function insertRun(db, runId, agent, state, at, { eventSource, eventId }) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+    ).run(
+      runId,
+      `${runId}-key`,
+      JSON.stringify({ agent, adapter: "fake", input: { repo: "factory" } }),
+      `sha256:${runId}`,
+      state,
+      at,
+      at,
+    );
+    db.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, started_at, finished_at, terminal_state, reason_code)
+       VALUES (?, 1, 1, ?, ?, ?, ?)`,
+    ).run(runId, at, state === "RUNNING" ? null : at, state === "RUNNING" ? null : state, null);
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, ?, ?, ?, 'run', 'approved', ?, 600)`,
+    ).run(`prop-${runId}`, eventSource, eventId, runId, at);
+  }
+
+  beforeAll(async () => {
+    s = await makeServer();
+    // `chain` is a reserved provenance at the public intake; derived events
+    // enter through the emitter's admission path like the real chain does.
+    const admit = (overrides) => {
+      if (overrides.source !== "chain") return s.client.replay(envelope(overrides));
+      const result = admitChainEvent(s.db, registry, envelope(overrides));
+      expect(result.admitted).toBe(true);
+      return result;
+    };
+    await admit({ eventId: "origin-1", correlationId: "corr-1", occurredAt: t(0) });
+    await admit({ eventId: "elsewhere", correlationId: "corr-other", occurredAt: t(0) });
+    insertRun(s.db, "run-1", "work-scan@1", "COMPLETED", t(1), {
+      eventSource: "test",
+      eventId: "origin-1",
+    });
+    await admit({
+      eventId: "chain-run-1-A",
+      source: "chain",
+      type: "factory.work.requested",
+      correlationId: "corr-1",
+      causationId: "run-1",
+      occurredAt: t(2),
+    });
+    await admit({
+      eventId: "chain-run-1-B",
+      source: "chain",
+      type: "factory.work.requested",
+      correlationId: "corr-1",
+      causationId: "run-1",
+      occurredAt: t(2),
+    });
+    insertRun(s.db, "run-2", "dispatch@1", "COMPLETED", t(3), {
+      eventSource: "chain",
+      eventId: "chain-run-1-A",
+    });
+    await admit({
+      eventId: "chain-run-2",
+      source: "chain",
+      type: "factory.merge.scan.requested",
+      correlationId: "corr-1",
+      causationId: "run-2",
+      occurredAt: t(4),
+    });
+    insertRun(s.db, "run-3", "merge-scan@1", "RUNNING", t(5), {
+      eventSource: "chain",
+      eventId: "chain-run-2",
+    });
+    s.db
+      .query(`UPDATE events SET status = 'dead_lettered' WHERE event_id = 'chain-run-1-B'`)
+      .run();
+  });
+  afterAll(() => s.close());
+
+  test("returns every event and run under the correlation, parent links intact", async () => {
+    const res = await fetch(s.url("/chain/corr-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.correlationId).toBe("corr-1");
+    expect(body.events.map((e) => e.eventId).sort()).toEqual([
+      "chain-run-1-A",
+      "chain-run-1-B",
+      "chain-run-2",
+      "origin-1",
+    ]);
+    expect(body.events.find((e) => e.eventId === "elsewhere")).toBeUndefined();
+
+    const byId = Object.fromEntries(body.events.map((e) => [e.eventId, e]));
+    expect(byId["origin-1"].causationId).toBeNull();
+    expect(byId["origin-1"].runId).toBe("run-1");
+    expect(byId["origin-1"].proposalId).toBe("prop-run-1");
+    expect(byId["chain-run-1-A"].causationId).toBe("run-1");
+    expect(byId["chain-run-1-A"].runId).toBe("run-2");
+    expect(byId["chain-run-1-B"].causationId).toBe("run-1");
+    expect(byId["chain-run-1-B"].runId).toBeNull();
+    expect(byId["chain-run-1-B"].status).toBe("dead_lettered");
+    expect(byId["chain-run-2"].causationId).toBe("run-2");
+    expect(byId["chain-run-2"].runId).toBe("run-3");
+
+    expect(body.runs.map((r) => r.runId)).toEqual(["run-1", "run-2", "run-3"]);
+    const run2 = body.runs.find((r) => r.runId === "run-2");
+    expect(run2).toMatchObject({
+      state: "COMPLETED",
+      agent: "dispatch@1",
+      adapter: "fake",
+      eventSource: "chain",
+      eventId: "chain-run-1-A",
+      repos: ["factory"],
+    });
+    expect(run2.startedAt).toBeTruthy();
+    const run3 = body.runs.find((r) => r.runId === "run-3");
+    expect(run3.state).toBe("RUNNING");
+    expect(run3.finishedAt).toBeNull();
+  });
+
+  test("falls back to the origin's own eventId when it carried no correlation id", async () => {
+    await s.client.replay(
+      envelope({ eventId: "bare-origin", correlationId: null, occurredAt: t(6) }),
+    );
+    insertRun(s.db, "run-bare", "triage-scan@1", "COMPLETED", t(7), {
+      eventSource: "test",
+      eventId: "bare-origin",
+    });
+    expect(
+      admitChainEvent(
+        s.db,
+        registry,
+        envelope({
+          eventId: "chain-run-bare",
+          source: "chain",
+          correlationId: "bare-origin",
+          causationId: "run-bare",
+          occurredAt: t(8),
+        }),
+      ).admitted,
+    ).toBe(true);
+    const body = await (await fetch(s.url("/chain/bare-origin"))).json();
+    expect(body.events.map((e) => e.eventId).sort()).toEqual(["bare-origin", "chain-run-bare"]);
+    expect(body.runs.map((r) => r.runId)).toEqual(["run-bare"]);
+    expect(chainKeyOf({ correlationId: null, eventId: "bare-origin" })).toBe("bare-origin");
+    expect(chainKeyOf({ correlationId: "corr-1", eventId: "x" })).toBe("corr-1");
+  });
+
+  test("includes a causation parent run that lives outside the correlation, as a root", () => {
+    s.db
+      .query(
+        `UPDATE events SET correlation_id = 'corr-split' WHERE event_id = 'chain-run-2'`,
+      )
+      .run();
+    try {
+      const view = chainView(s.db, "corr-split");
+      expect(view.events.map((e) => e.eventId)).toEqual(["chain-run-2"]);
+      // run-2 is the parent (via causationId), run-3 is the child run.
+      expect(view.runs.map((r) => r.runId)).toEqual(["run-2", "run-3"]);
+    } finally {
+      s.db
+        .query(`UPDATE events SET correlation_id = 'corr-1' WHERE event_id = 'chain-run-2'`)
+        .run();
+    }
+  });
+
+  test("unknown correlation → 404; id is URL-decoded", async () => {
+    expect((await fetch(s.url("/chain/nope"))).status).toBe(404);
+    expect((await fetch(s.url("/chain/" + encodeURIComponent("corr-1")))).status).toBe(200);
+    expect((await fetch(s.url("/chain/"))).status).not.toBe(200);
+  });
+});

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -21,6 +21,7 @@ import {
   send as sendJson,
 } from "./api-http.mjs";
 import { handleIntakeApiRoute } from "./api-intake.mjs";
+import { handleChainApiRoute } from "./api-chain.mjs";
 import { handleMetricsApiRoute } from "./api-metrics.mjs";
 import { handleRegistryApiRoute } from "./api-registry.mjs";
 import {
@@ -158,6 +159,10 @@ export function createApi({
         url.pathname === "/metrics/breakdown"
       ) {
         const result = handleMetricsApiRoute(common);
+        if (result !== false) return result;
+      }
+      if (url.pathname.startsWith("/chain/")) {
+        const result = handleChainApiRoute(common);
         if (result !== false) return result;
       }
       if (

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -35,6 +35,7 @@ type NavBadge = {
 
 const Artifacts = lazy(() => import("./views/Artifacts").then((m) => ({ default: m.Artifacts })));
 const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph })));
+const Chain = lazy(() => import("./views/Chain").then((m) => ({ default: m.Chain })));
 const Projects = lazy(() => import("./views/Projects").then((m) => ({ default: m.Projects })));
 const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default: m.Schedules })));
 const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
@@ -129,6 +130,10 @@ export function App() {
   const workerHealthFromHash = view === "workers" ? hashSearch(window.location.hash).get("health") : null;
   const focusWorkerHealth = isWorkerHealthFilter(workerHealthFromHash) ? workerHealthFromHash : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
+  // `#/chain/:correlationId[/:nodeId]` — the chain trace (WM-527); node
+  // selection rides the hash so a pasted link lands on the same node.
+  const chainId = view === "chain" ? (route[1] ?? null) : null;
+  const focusChainNode = view === "chain" ? (route[2] ?? null) : null;
   const artifactQuery = hashSearch(window.location.hash);
   const artifactFilters: ArtifactFilters = {
     kind: view === "artifacts" ? artifactQuery.get("kind") : null,
@@ -199,6 +204,8 @@ export function App() {
   const jumpToWorkers = (health: WorkerHealthFilter) => navigate(workerHash(null, health));
   const jumpToProject = (name: string) => navigate(hashPath("projects", name));
   const jumpToGraph = (nodeId?: string) => navigate(hashPath("graph", nodeId));
+  const jumpToChain = (correlationId: string, nodeId?: string) =>
+    navigate(hashPath("chain", correlationId, nodeId));
 
   const health = useQuery({
     queryKey: ["health"],
@@ -298,7 +305,9 @@ export function App() {
     }, [navigate, selectContext, openRepos]),
   );
 
-  const viewLabel = NAV.find((n) => n.key === view)?.label ?? (view === "run" ? "Run" : "Overview");
+  const viewLabel =
+    NAV.find((n) => n.key === view)?.label ??
+    (view === "run" ? "Run" : view === "chain" ? "Chain" : "Overview");
 
   useEffect(() => {
     const id = route.length > 1 ? route[route.length - 1] : null;
@@ -570,6 +579,7 @@ export function App() {
                 onJumpAgent={jumpToAgent}
                 onJumpEvent={jumpToEvent}
                 onJumpProposal={jumpToProposal}
+                onJumpChain={jumpToChain}
               />
             </Suspense>
           ) : view === "runs" || view === "run" ? (
@@ -592,6 +602,19 @@ export function App() {
                 connected={connected}
                 focusRepoName={focusRepoName}
                 onSelectRepo={(name) => navigate(hashPath("projects", name))}
+              />
+            </Suspense>
+          ) : view === "chain" && chainId ? (
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading chain…</div>}>
+              <Chain
+                correlationId={chainId}
+                focusNodeId={focusChainNode}
+                onSelectNode={(id) => navigate(hashPath("chain", chainId, id))}
+                onJumpEvent={jumpToEvent}
+                onJumpRun={jumpToRun}
+                onOpenRunFull={openRunFull}
+                onJumpProposal={jumpToProposal}
+                onJumpAgent={jumpToAgent}
               />
             </Suspense>
           ) : view === "graph" ? (
@@ -659,6 +682,7 @@ export function App() {
               }
               onJumpProposal={jumpToProposal}
               onJumpRun={jumpToRun}
+              onJumpChain={jumpToChain}
               onTriggerAgain={(envelope) => {
                 setInjectSeed(envelope);
                 setInjectOpen(true);

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -2,6 +2,7 @@ import type {
   AdmittedEvent,
   AgentsView,
   ArtifactInventoryItem,
+  ChainView,
   ApproveOutcome,
   CancelOutcome,
   EnvIdentity,
@@ -110,6 +111,8 @@ export const api = {
     call<{ released: boolean; runId: string }>("POST", `/workers/${encodeURIComponent(workerId)}/release`, { runId }),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
   agents: () => call<AgentsView>("GET", "/agents"),
+  // Every event + run under one correlation id (WM-527); 404 when unknown.
+  chain: (correlationId: string) => call<ChainView>("GET", `/chain/${encodeURIComponent(correlationId)}`),
   // Configured factory repositories (config/repos.yaml) — context tabs open from this list.
   repos: () => call<{ repos: RepoItem[] }>("GET", "/repos"),
   // Janitor worktree scan and cleanup (apply: false for dry run, apply: true for teardown)

--- a/event-runtime/web/src/graph/chainModel.test.ts
+++ b/event-runtime/web/src/graph/chainModel.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChainGraph,
+  chainKeyOfEvent,
+  chainOriginLabel,
+  eventNodeId,
+  runNodeId,
+} from "./chainModel";
+import type { ChainEvent, ChainRun } from "../types";
+
+const at = (n: number) => new Date(Date.UTC(2026, 7, 17, 12, n)).toISOString();
+
+function event(overrides: Partial<ChainEvent> & { eventId: string }): ChainEvent {
+  return {
+    source: "chain",
+    type: "factory.work.requested",
+    subject: null,
+    status: "planned",
+    occurredAt: at(0),
+    receivedAt: at(0),
+    admittedAt: at(0),
+    correlationId: "corr-1",
+    causationId: null,
+    proposalId: null,
+    proposalStatus: null,
+    proposalDecision: null,
+    runId: null,
+    repos: [],
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<ChainRun> & { runId: string }): ChainRun {
+  return {
+    state: "COMPLETED",
+    attempts: 1,
+    agent: "dispatch@1",
+    adapter: "fake",
+    reasonCode: null,
+    eventId: null,
+    eventSource: null,
+    created_at: at(1),
+    updated_at: at(1),
+    startedAt: at(1),
+    finishedAt: at(2),
+    repos: [],
+    ...overrides,
+  };
+}
+
+/**
+ *   origin ─▶ run-1 ─┬─▶ chain-1-A ─▶ run-2 ─▶ chain-2 ─▶ run-3
+ *                    └─▶ chain-1-B (dead-lettered, no run)
+ */
+const tree = {
+  events: [
+    event({ source: "test", eventId: "origin", type: "clock.tick.work-scan", runId: "run-1" }),
+    event({ eventId: "chain-1-A", causationId: "run-1", runId: "run-2" }),
+    event({ eventId: "chain-1-B", causationId: "run-1", status: "dead_lettered" }),
+    event({ eventId: "chain-2", causationId: "run-2", runId: "run-3", type: "factory.merge.scan.requested" }),
+  ],
+  runs: [
+    run({ runId: "run-1", agent: "work-scan@1", eventSource: "test", eventId: "origin" }),
+    run({ runId: "run-2", eventSource: "chain", eventId: "chain-1-A" }),
+    run({ runId: "run-3", agent: "merge-scan@1", state: "RUNNING", eventSource: "chain", eventId: "chain-2", finishedAt: null }),
+  ],
+};
+
+describe("buildChainGraph (WM-527)", () => {
+  test("one node per event and run; edges follow event→run and run→emitted event", () => {
+    const g = buildChainGraph(tree);
+    expect(g.nodes).toHaveLength(7);
+    const edges = g.edges.map((e) => `${e.kind}:${e.source}>${e.target}`).sort();
+    expect(edges).toEqual(
+      [
+        `produced:${eventNodeId("test", "origin")}>${runNodeId("run-1")}`,
+        `produced:${eventNodeId("chain", "chain-1-A")}>${runNodeId("run-2")}`,
+        `produced:${eventNodeId("chain", "chain-2")}>${runNodeId("run-3")}`,
+        `emitted:${runNodeId("run-1")}>${eventNodeId("chain", "chain-1-A")}`,
+        `emitted:${runNodeId("run-1")}>${eventNodeId("chain", "chain-1-B")}`,
+        `emitted:${runNodeId("run-2")}>${eventNodeId("chain", "chain-2")}`,
+      ].sort(),
+    );
+  });
+
+  test("the origin is the only root; depth counts hops from it", () => {
+    const g = buildChainGraph(tree);
+    expect(g.rootIds).toEqual([eventNodeId("test", "origin")]);
+    const depth = Object.fromEntries(g.nodes.map((n) => [n.id, n.depth]));
+    expect(depth[eventNodeId("test", "origin")]).toBe(0);
+    expect(depth[runNodeId("run-1")]).toBe(1);
+    expect(depth[eventNodeId("chain", "chain-1-A")]).toBe(2);
+    expect(depth[eventNodeId("chain", "chain-1-B")]).toBe(2);
+    expect(depth[runNodeId("run-2")]).toBe(3);
+    expect(depth[eventNodeId("chain", "chain-2")]).toBe(4);
+    expect(depth[runNodeId("run-3")]).toBe(5);
+    expect(g.maxDepth).toBe(5);
+    expect(g.nodes.find((n) => n.id === eventNodeId("test", "origin"))?.root).toBe(true);
+    expect(g.nodes.filter((n) => n.root)).toHaveLength(1);
+    expect(chainOriginLabel(g)).toBe("clock.tick.work-scan · test");
+  });
+
+  test("a run whose event's proposal join is missing still hangs off its origin event", () => {
+    const g = buildChainGraph({
+      events: [event({ source: "test", eventId: "origin", runId: null })],
+      runs: [run({ runId: "run-1", eventSource: "test", eventId: "origin" })],
+    });
+    expect(g.edges).toHaveLength(1);
+    expect(g.edges[0]).toMatchObject({ kind: "produced", source: eventNodeId("test", "origin"), target: runNodeId("run-1") });
+    expect(g.rootIds).toEqual([eventNodeId("test", "origin")]);
+  });
+
+  test("a causation parent outside the correlation becomes a root run", () => {
+    const g = buildChainGraph({
+      events: [event({ eventId: "chain-2", causationId: "run-2", runId: "run-3" })],
+      runs: [run({ runId: "run-2" }), run({ runId: "run-3", eventSource: "chain", eventId: "chain-2" })],
+    });
+    expect(g.rootIds).toEqual([runNodeId("run-2")]);
+    expect(chainOriginLabel(g)).toBe("dispatch@1 · run");
+    expect(g.maxDepth).toBe(2);
+  });
+
+  test("dangling ids never produce edges; a self-referencing cycle does not hang", () => {
+    const g = buildChainGraph({
+      events: [event({ eventId: "e", causationId: "ghost", runId: "also-ghost" })],
+      runs: [],
+    });
+    expect(g.edges).toEqual([]);
+    expect(g.rootIds).toEqual([eventNodeId("chain", "e")]);
+
+    // Malformed: run-x's own origin event claims run-x emitted it.
+    const cyc = buildChainGraph({
+      events: [event({ eventId: "e", causationId: "run-x", runId: "run-x" })],
+      runs: [run({ runId: "run-x", eventSource: "chain", eventId: "e" })],
+    });
+    expect(cyc.nodes).toHaveLength(2);
+    expect(cyc.rootIds).toEqual([]);
+    expect(Number.isFinite(cyc.maxDepth)).toBe(true);
+  });
+
+  test("chainKeyOfEvent mirrors the emitter: correlation id, else the event's own id", () => {
+    expect(chainKeyOfEvent({ correlationId: "corr-1", eventId: "x" })).toBe("corr-1");
+    expect(chainKeyOfEvent({ correlationId: null, eventId: "x" })).toBe("x");
+    expect(chainKeyOfEvent({ eventId: "x" })).toBe("x");
+  });
+});

--- a/event-runtime/web/src/graph/chainModel.ts
+++ b/event-runtime/web/src/graph/chainModel.ts
@@ -1,0 +1,135 @@
+import type { ChainEvent, ChainRun, ChainView } from "../types";
+
+/**
+ * Chain trace graph (WM-527): one correlation id → the DAG of events and
+ * runs that actually happened. Contrast with ./model (the capability map,
+ * "what can happen"): here every node is an instance.
+ *
+ * Edges follow the runtime's own provenance:
+ *   event ─produced→ run        (event.runId, via its proposal)
+ *   run   ─emitted→  event      (event.causationId = run.runId)
+ *
+ * The root is whichever event has no causation parent — normally the origin
+ * webhook/schedule tick. A run named only by a causationId (its own event
+ * lives under a different correlation) is drawn as a root run so the trace
+ * still starts somewhere.
+ */
+
+export type ChainNode =
+  | { kind: "chainEvent"; id: string; event: ChainEvent; root: boolean; depth: number }
+  | { kind: "chainRun"; id: string; run: ChainRun; root: boolean; depth: number };
+
+export interface ChainEdge {
+  id: string;
+  source: string;
+  target: string;
+  kind: "produced" | "emitted";
+}
+
+export interface ChainGraph {
+  nodes: ChainNode[];
+  edges: ChainEdge[];
+  /** Node ids with no incoming edge, in admission order. */
+  rootIds: string[];
+  /** Longest root→leaf path length in hops (0 for a single node). */
+  maxDepth: number;
+}
+
+export const eventNodeId = (source: string, eventId: string) => `event:${source}:${eventId}`;
+export const runNodeId = (runId: string) => `run:${runId}`;
+
+export function buildChainGraph(view: Pick<ChainView, "events" | "runs">): ChainGraph {
+  const nodes = new Map<string, ChainNode>();
+  const edges: ChainEdge[] = [];
+  const runsById = new Map(view.runs.map((r) => [r.runId, r]));
+
+  for (const event of view.events) {
+    const id = eventNodeId(event.source, event.eventId);
+    nodes.set(id, { kind: "chainEvent", id, event, root: false, depth: 0 });
+  }
+  for (const run of view.runs) {
+    const id = runNodeId(run.runId);
+    nodes.set(id, { kind: "chainRun", id, run, root: false, depth: 0 });
+  }
+
+  const incoming = new Set<string>();
+  const seenEdge = new Set<string>();
+  const addEdge = (edge: ChainEdge) => {
+    if (seenEdge.has(edge.id) || !nodes.has(edge.source) || !nodes.has(edge.target)) return;
+    if (edge.source === edge.target) return;
+    seenEdge.add(edge.id);
+    edges.push(edge);
+    incoming.add(edge.target);
+  };
+
+  for (const event of view.events) {
+    const eid = eventNodeId(event.source, event.eventId);
+    if (event.runId && runsById.has(event.runId)) {
+      addEdge({ id: `produced:${eid}`, source: eid, target: runNodeId(event.runId), kind: "produced" });
+    }
+    if (event.causationId && runsById.has(event.causationId)) {
+      addEdge({
+        id: `emitted:${eid}`,
+        source: runNodeId(event.causationId),
+        target: eid,
+        kind: "emitted",
+      });
+    }
+  }
+  // A run whose own origin event is in the set but whose proposal join was
+  // missed (event.runId null) still hangs off that event.
+  for (const run of view.runs) {
+    if (!run.eventSource || !run.eventId) continue;
+    const eid = eventNodeId(run.eventSource, run.eventId);
+    if (nodes.has(eid)) {
+      addEdge({ id: `produced:${eid}`, source: eid, target: runNodeId(run.runId), kind: "produced" });
+    }
+  }
+
+  const rootIds = [...nodes.keys()].filter((id) => !incoming.has(id));
+  for (const id of rootIds) nodes.get(id)!.root = true;
+
+  // Depth = longest path from a root. Causation ids always point at strictly
+  // earlier runs, so this is a DAG; the `visiting` set turns a malformed cycle
+  // into a truncated depth instead of a hang.
+  const parents = new Map<string, string[]>();
+  for (const e of edges) {
+    const list = parents.get(e.target) ?? [];
+    list.push(e.source);
+    parents.set(e.target, list);
+  }
+  const memo = new Map<string, number>();
+  const visiting = new Set<string>();
+  const depthOf = (id: string): number => {
+    const cached = memo.get(id);
+    if (cached !== undefined) return cached;
+    if (visiting.has(id)) return 0;
+    visiting.add(id);
+    let depth = 0;
+    for (const parent of parents.get(id) ?? []) depth = Math.max(depth, depthOf(parent) + 1);
+    visiting.delete(id);
+    memo.set(id, depth);
+    return depth;
+  };
+  let maxDepth = 0;
+  for (const node of nodes.values()) {
+    node.depth = depthOf(node.id);
+    if (node.depth > maxDepth) maxDepth = node.depth;
+  }
+
+  return { nodes: [...nodes.values()], edges, rootIds, maxDepth };
+}
+
+/** The chain key an event belongs to — mirrors lib/api-chain.mjs `chainKeyOf`. */
+export function chainKeyOfEvent(event: { correlationId?: string | null; eventId: string }): string {
+  return event.correlationId ?? event.eventId;
+}
+
+/** Human summary of the origin, for headers: "clock.tick.merge-scan · schedule". */
+export function chainOriginLabel(graph: ChainGraph): string | null {
+  const root = graph.nodes.find((n) => n.root && n.kind === "chainEvent");
+  if (root && root.kind === "chainEvent") return `${root.event.type} · ${root.event.source}`;
+  const rootRun = graph.nodes.find((n) => n.root && n.kind === "chainRun");
+  if (rootRun && rootRun.kind === "chainRun") return `${rootRun.run.agent ?? rootRun.run.runId} · run`;
+  return null;
+}

--- a/event-runtime/web/src/graph/chainNodes.tsx
+++ b/event-runtime/web/src/graph/chainNodes.tsx
@@ -1,0 +1,89 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { ChainNode } from "./chainModel";
+import { Line, Shell, handleStyle } from "./nodes";
+import { EVENT_STATUS_HUES, STATE_HUES, StateBadge, ago, shortId } from "../components/ui";
+
+// Chain trace nodes (WM-527): the same shell as the capability map so the two
+// canvases read as one tool, but every node is an *instance* — an admitted
+// event or a run — coloured by its own status rather than by kind.
+
+export const CHAIN_EDGE_STYLES = {
+  produced: { label: "event → run", stroke: "var(--border-strong)" },
+  emitted: { label: "run emitted event", stroke: "var(--accent)", strokeDasharray: "4 3" },
+} as const;
+
+const nowOf = (data: NodeProps["data"]) => Number((data as { now?: number }).now ?? Date.now());
+
+export function chainNodeAccessibleName(node: ChainNode): string {
+  if (node.kind === "chainEvent") {
+    return `${node.root ? "origin " : ""}event ${node.event.type}, ${node.event.status}`;
+  }
+  return `run ${node.run.agent ?? node.run.runId}, ${node.run.state}`;
+}
+
+export function ChainEventNode({ data, selected }: NodeProps) {
+  const node = data.node as Extract<ChainNode, { kind: "chainEvent" }>;
+  const e = node.event;
+  const accent = EVENT_STATUS_HUES[e.status] ?? "var(--hue-idle)";
+  const now = nowOf(data);
+  return (
+    <Shell accent={accent} selected={selected} accessibleName={chainNodeAccessibleName(node)}>
+      {!node.root && <Handle type="target" position={Position.Left} style={handleStyle} />}
+      <div className="flex items-center justify-between gap-1">
+        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
+          {node.root ? "origin event" : "event"} · {e.source}
+        </span>
+        <StateBadge state={e.status} hues={EVENT_STATUS_HUES} dot={false} />
+      </div>
+      <div className="mono truncate text-[12px]" title={e.type}>
+        {e.type}
+      </div>
+      <Line dim>
+        <span title={e.eventId}>{shortId(e.eventId)}</span>
+        {e.subject ? ` · ${e.subject}` : ""}
+      </Line>
+      <Line dim>
+        <span title={e.admittedAt}>{ago(e.admittedAt, now)}</span>
+        {e.repos.length ? ` · ${e.repos.join(", ")}` : ""}
+      </Line>
+      <Handle type="source" position={Position.Right} style={handleStyle} />
+    </Shell>
+  );
+}
+
+export function ChainRunNode({ data, selected }: NodeProps) {
+  const node = data.node as Extract<ChainNode, { kind: "chainRun" }>;
+  const r = node.run;
+  const accent = STATE_HUES[r.state] ?? "var(--hue-idle)";
+  const now = nowOf(data);
+  const when = r.finishedAt ?? r.startedAt ?? r.created_at;
+  return (
+    <Shell accent={accent} selected={selected} accessibleName={chainNodeAccessibleName(node)}>
+      {!node.root && <Handle type="target" position={Position.Left} style={handleStyle} />}
+      <div className="flex items-center justify-between gap-1">
+        <span className="text-[10px] tracking-wide uppercase" style={{ color: accent }}>
+          run{r.adapter ? ` · ${r.adapter}` : ""}
+        </span>
+        <StateBadge state={r.state} />
+      </div>
+      <div className="mono truncate text-[12px]" title={r.agent ?? r.runId}>
+        {r.agent ?? "—"}
+      </div>
+      <Line dim>
+        <span title={r.runId}>{shortId(r.runId)}</span>
+        {r.attempts > 1 ? ` · attempt ${r.attempts}` : ""}
+        {r.reasonCode ? ` · ${r.reasonCode}` : ""}
+      </Line>
+      <Line dim>
+        <span title={when}>{ago(when, now)}</span>
+        {r.repos.length ? ` · ${r.repos.join(", ")}` : ""}
+      </Line>
+      <Handle type="source" position={Position.Right} style={handleStyle} />
+    </Shell>
+  );
+}
+
+export const chainNodeTypes = {
+  chainEvent: ChainEventNode,
+  chainRun: ChainRunNode,
+};

--- a/event-runtime/web/src/graph/layout.ts
+++ b/event-runtime/web/src/graph/layout.ts
@@ -1,5 +1,10 @@
 import ELK from "elkjs/lib/elk.bundled.js";
-import type { CapabilityGraph } from "./model";
+
+/** The topology ELK needs — the capability map and the chain trace both fit. */
+export interface LayoutGraph {
+  nodes: Array<{ id: string }>;
+  edges: Array<{ id: string; source: string; target: string }>;
+}
 
 // Layered left-to-right layout via elk. Hand-rolling DAG layout is where
 // these views die; elk does it properly and runs in a worker-free bundle.
@@ -25,14 +30,21 @@ const OPTIONS = {
  * (counts, badges, invocation labels) are ignored so live polls do not
  * re-run ELK.
  */
-export function graphIdentity(graph: CapabilityGraph): string {
+export function graphIdentity<G extends LayoutGraph>(graph: G): string {
   const nodes = graph.nodes.map((n) => n.id).sort();
   const edges = graph.edges.map((e) => `${e.id}\t${e.source}\t${e.target}`).sort();
   return `${nodes.join("\n")}\n--\n${edges.join("\n")}`;
 }
 
-export type LayoutFn = (
-  graph: CapabilityGraph,
+/** Chain traces are long and thin: tighter layers keep a 6-hop chain on one screen. */
+export const CHAIN_LAYOUT_OPTIONS: Record<string, string> = {
+  ...OPTIONS,
+  "elk.layered.spacing.nodeNodeBetweenLayers": "64",
+  "elk.spacing.nodeNode": "28",
+};
+
+export type LayoutFn = <G extends LayoutGraph>(
+  graph: G,
   timeoutMs?: number,
 ) => Promise<Map<string, { x: number; y: number }>>;
 
@@ -40,8 +52,8 @@ export type LayoutFn = (
  * Run `layout` only when node/edge identity changed (or `prevIdentity` is
  * null). Overlay-only updates return `positions: null`.
  */
-export async function layoutGraphIfIdentityChanged(
-  graph: CapabilityGraph,
+export async function layoutGraphIfIdentityChanged<G extends LayoutGraph>(
+  graph: G,
   prevIdentity: string | null,
   layout: LayoutFn = layoutGraph,
 ): Promise<{ identity: string; positions: Map<string, { x: number; y: number }> | null }> {
@@ -52,9 +64,10 @@ export async function layoutGraphIfIdentityChanged(
   return { identity, positions: await layout(graph) };
 }
 
-export async function layoutGraph(
-  graph: CapabilityGraph,
+export async function layoutGraph<G extends LayoutGraph>(
+  graph: G,
   timeoutMs: number = LAYOUT_TIMEOUT_MS,
+  layoutOptions: Record<string, string> = OPTIONS,
 ): Promise<Map<string, { x: number; y: number }>> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -66,7 +79,7 @@ export async function layoutGraph(
   try {
     const layoutPromise = elk.layout({
       id: "root",
-      layoutOptions: OPTIONS,
+      layoutOptions,
       children: graph.nodes.map((n) => ({ id: n.id, width: NODE_WIDTH, height: NODE_HEIGHT })),
       edges: graph.edges.map((e) => ({ id: e.id, sources: [e.source], targets: [e.target] })),
     });

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -7,7 +7,7 @@ import { DECISION_HUES, STATE_HUES, StateBadge } from "../components/ui";
 // reads as part of the tool rather than an embedded diagram widget. Accents
 // and dash styles come from ./style so the legend stays truthful (WM-99).
 
-const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
+export const handleStyle = { background: "var(--border-strong)", width: 6, height: 6, border: "none" };
 
 const searchHitOf = (data: NodeProps["data"]) => Boolean((data as { searchHit?: boolean }).searchHit);
 const searchCurrentOf = (data: NodeProps["data"]) =>
@@ -39,7 +39,7 @@ export function nodeAccessibleName(node: GraphNode): string {
   return `${kind} ${node.label}, ${materialState(node)}`;
 }
 
-function Shell({
+export function Shell({
   children,
   accent,
   selected,
@@ -84,7 +84,7 @@ function Shell({
   );
 }
 
-function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
+export function Line({ children, dim }: { children: React.ReactNode; dim?: boolean }) {
   return (
     <div
       className="mono truncate text-[11.5px]"

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -7,6 +7,8 @@
  * full-page run view — distinct first segment so expand/back get push
  * semantics) `#/agents` `#/agents/:ref` `#/artifacts` `#/artifacts?kind=…`
  * `#/workers` `#/workers/:id` `#/graph` `#/graph/:nodeId`
+ * `#/chain/:correlationId` `#/chain/:correlationId/:nodeId` (the chain trace,
+ * WM-527 — a drill-in like `#/run/:id`, not a nav item)
  *
  * Optional `?project=` (OPS-356) restores the context-tab filter; `inflight`
  * is reserved. The path still names the view. A pasted `#/runs/:id` without

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -278,6 +278,7 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
     })),
     status: mock(async () => createStatusFixture()),
     events: mock(async (_status?: string) => ({ events: [] as AdmittedEvent[] })),
+    chain: mock(async (correlationId: string) => ({ correlationId, events: [], runs: [] })),
     proposals: mock(async () => ({ proposals: [] as Proposal[] })),
     proposalHistory: mock(async (_status = "all") => ({ proposals: [] as Proposal[] })),
     approve: mock(async (id: string): Promise<ApproveOutcome> => ({

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -80,6 +80,49 @@ export interface AdmittedEvent {
   repos: string[];
 }
 
+/** One event in a chain trace (`GET /chain/:correlationId`, WM-527). */
+export interface ChainEvent {
+  source: string;
+  eventId: string;
+  type: string;
+  subject: string | null;
+  status: string;
+  occurredAt: string;
+  receivedAt: string;
+  admittedAt: string;
+  correlationId: string | null;
+  /** The run id that emitted this event; null on the origin. */
+  causationId: string | null;
+  proposalId: string | null;
+  proposalStatus: string | null;
+  proposalDecision: string | null;
+  runId: string | null;
+  repos: string[];
+}
+
+/** One run in a chain trace. */
+export interface ChainRun {
+  runId: string;
+  state: RunState;
+  attempts: number;
+  agent: string | null;
+  adapter: string | null;
+  reasonCode: string | null;
+  eventId: string | null;
+  eventSource: string | null;
+  created_at: string;
+  updated_at: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  repos: string[];
+}
+
+export interface ChainView {
+  correlationId: string;
+  events: ChainEvent[];
+  runs: ChainRun[];
+}
+
 export interface RunListItem {
   runId: string;
   state: RunState;

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -1,0 +1,466 @@
+import {
+  applyNodeChanges,
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeChange,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api, ApiError } from "../api";
+import { keyGuard, useNow } from "../hooks";
+import {
+  buildChainGraph,
+  chainOriginLabel,
+  eventNodeId,
+  runNodeId,
+  type ChainGraph,
+  type ChainNode,
+} from "../graph/chainModel";
+import { CHAIN_EDGE_STYLES, chainNodeTypes } from "../graph/chainNodes";
+import {
+  Ago,
+  Button,
+  CopyActions,
+  DetailPane,
+  EVENT_STATUS_HUES,
+  JumpLink,
+  KV,
+  STATE_HUES,
+  Section,
+  StateBadge,
+  shortId,
+} from "../components/ui";
+
+const INITIAL_FIT_MIN_ZOOM = 0.4;
+
+function flowEdges(graph: ChainGraph): Edge[] {
+  return graph.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    animated: false,
+    style: {
+      stroke: CHAIN_EDGE_STYLES[edge.kind].stroke,
+      strokeWidth: 1.5,
+      strokeDasharray: (CHAIN_EDGE_STYLES[edge.kind] as { strokeDasharray?: string }).strokeDasharray,
+    },
+  }));
+}
+
+/**
+ * Chain trace (WM-527): `#/chain/:correlationId` — every event and run that
+ * shares one correlation id, laid out as the DAG the runtime actually walked
+ * (origin event → run → emitted events → runs …). The capability map answers
+ * "what can happen"; this answers "what happened to *this* one, and where
+ * did it start".
+ */
+export function Chain({
+  correlationId,
+  focusNodeId,
+  onSelectNode,
+  onJumpEvent,
+  onJumpRun,
+  onOpenRunFull,
+  onJumpProposal,
+  onJumpAgent,
+}: {
+  correlationId: string;
+  focusNodeId: string | null;
+  onSelectNode: (id: string | null) => void;
+  onJumpEvent: (source: string, eventId: string) => void;
+  onJumpRun: (runId: string) => void;
+  onOpenRunFull: (runId: string) => void;
+  onJumpProposal: (id: string) => void;
+  onJumpAgent: (ref: string) => void;
+}) {
+  const chainQ = useQuery({
+    queryKey: ["chain", correlationId],
+    queryFn: () => api.chain(correlationId),
+    refetchInterval: 3000,
+    retry: (count, err) => !(err instanceof ApiError && err.status === 404) && count < 2,
+  });
+  const now = useNow();
+  const notFound = chainQ.isError && chainQ.error instanceof ApiError && chainQ.error.status === 404;
+
+  const graph = useMemo(() => (chainQ.data ? buildChainGraph(chainQ.data) : null), [chainQ.data]);
+
+  const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
+  const [layoutError, setLayoutError] = useState<string | null>(null);
+  const [layoutEpoch, setLayoutEpoch] = useState(0);
+  const lastIdentityRef = useRef<string | null>(null);
+  const epochLaidOutRef = useRef(0);
+  const flowRef = useRef<{
+    getZoom: () => number;
+    fitView: (opts: {
+      nodes?: Array<{ id: string }>;
+      padding?: number;
+      duration?: number;
+      minZoom?: number;
+      maxZoom?: number;
+    }) => void;
+  } | null>(null);
+  const [flowReady, setFlowReady] = useState(0);
+  const didInitialFit = useRef(false);
+
+  // Reset canvas state when the operator moves to another chain.
+  useEffect(() => {
+    setPositioned(null);
+    lastIdentityRef.current = null;
+    didInitialFit.current = false;
+  }, [correlationId]);
+
+  useEffect(() => {
+    if (!graph) return;
+    let cancelled = false;
+    setLayoutError(null);
+    // Same async elk chunk as the capability map (OPS-255); positions are
+    // reused while node/edge identity is unchanged so the 3s poll only
+    // refreshes states/badges (WM-154 pattern).
+    import("../graph/layout")
+      .then(({ CHAIN_LAYOUT_OPTIONS, layoutGraph, layoutGraphIfIdentityChanged, NODE_HEIGHT, NODE_WIDTH }) => {
+        const prevIdentity = layoutEpoch !== epochLaidOutRef.current ? null : lastIdentityRef.current;
+        return layoutGraphIfIdentityChanged(graph, prevIdentity, (g) =>
+          layoutGraph(g, undefined, CHAIN_LAYOUT_OPTIONS),
+        ).then((result) => {
+          if (cancelled) return;
+          lastIdentityRef.current = result.identity;
+          epochLaidOutRef.current = layoutEpoch;
+          const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+          if (!result.positions) {
+            setPositioned((prev) =>
+              prev
+                ? {
+                    nodes: prev.nodes.map((n) => ({ ...n, data: { ...n.data, node: byId.get(n.id) } })),
+                    edges: flowEdges(graph),
+                  }
+                : prev,
+            );
+            return;
+          }
+          const positions = result.positions;
+          setPositioned({
+            nodes: graph.nodes.map((node) => ({
+              id: node.id,
+              type: node.kind,
+              position: positions.get(node.id) ?? { x: 0, y: 0 },
+              data: { node },
+              draggable: true,
+              width: NODE_WIDTH,
+              height: NODE_HEIGHT,
+            })),
+            edges: flowEdges(graph),
+          });
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        console.error("chain layout failed", err);
+        setLayoutError("Could not lay out the chain — the layout engine failed or timed out.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [graph, layoutEpoch]);
+
+  const nodes = useMemo(
+    () =>
+      positioned
+        ? positioned.nodes.map((n) => ({
+            ...n,
+            selected: n.id === focusNodeId,
+            data: { ...n.data, now },
+          }))
+        : [],
+    [positioned, focusNodeId, now],
+  );
+
+  const selected: ChainNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
+
+  const revealSelected = () => {
+    if (!focusNodeId || !flowRef.current) return;
+    const zoom = flowRef.current.getZoom();
+    flowRef.current.fitView({ nodes: [{ id: focusNodeId }], padding: 0.45, duration: 180, minZoom: zoom, maxZoom: zoom });
+  };
+
+  useEffect(() => {
+    if (didInitialFit.current || !flowRef.current || !positioned || !graph || graph.nodes.length === 0) return;
+    didInitialFit.current = true;
+    flowRef.current.fitView({ padding: 0.2, minZoom: INITIAL_FIT_MIN_ZOOM, maxZoom: 1 });
+  }, [graph, positioned, flowReady]);
+
+  useEffect(() => {
+    revealSelected();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusNodeId, flowReady, positioned]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (keyGuard(e) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "Escape") {
+        onSelectNode(null);
+        return;
+      }
+      if (e.key === "z" && focusNodeId) {
+        e.preventDefault();
+        revealSelected();
+        return;
+      }
+      const order = positioned
+        ? [...positioned.nodes]
+            .sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y)
+            .map((n) => n.id)
+        : [];
+      if (!order.length) return;
+      if (e.key === "j" || e.key === "ArrowDown" || e.key === "ArrowRight") {
+        e.preventDefault();
+        const idx = focusNodeId ? order.indexOf(focusNodeId) : -1;
+        onSelectNode(order[Math.min(idx + 1, order.length - 1)]);
+      } else if (e.key === "k" || e.key === "ArrowUp" || e.key === "ArrowLeft") {
+        e.preventDefault();
+        const idx = focusNodeId ? order.indexOf(focusNodeId) : order.length;
+        onSelectNode(order[Math.max(idx - 1, 0)]);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onSelectNode, focusNodeId, positioned]);
+
+  const origin = graph ? chainOriginLabel(graph) : null;
+  const eventCount = graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
+  const runCount = graph?.nodes.filter((n) => n.kind === "chainRun").length ?? 0;
+  const runStates = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const n of graph?.nodes ?? []) {
+      if (n.kind === "chainRun") counts.set(n.run.state, (counts.get(n.run.state) ?? 0) + 1);
+    }
+    return [...counts.entries()];
+  }, [graph]);
+
+  const emptyCopy = notFound
+    ? `No chain with correlation id ${correlationId} on this runtime.`
+    : chainQ.isPending
+      ? "Loading chain…"
+      : chainQ.isError
+        ? "Cannot reach the control API — the chain will appear when /chain is up."
+        : layoutError ?? "Laying out the chain…";
+
+  return (
+    <div className="flex h-full min-w-0">
+      <div className="relative min-w-0 flex-1">
+        <div className="absolute top-4 left-5 z-10 max-w-[60%]">
+          <h1 className="display text-lg font-semibold">Chain</h1>
+          <div className="mono truncate text-[11px] text-(--text-faint)" title={correlationId}>
+            {correlationId}
+          </div>
+          {graph && (
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-(--text-dim)">
+              {origin && (
+                <span>
+                  origin <span className="mono">{origin}</span>
+                </span>
+              )}
+              <span>
+                {eventCount} event{eventCount === 1 ? "" : "s"} · {runCount} run{runCount === 1 ? "" : "s"} ·{" "}
+                {graph.maxDepth} hop{graph.maxDepth === 1 ? "" : "s"}
+              </span>
+              {runStates.length > 0 && (
+                <span className="flex items-center gap-1">
+                  {runStates.map(([state, count]) => (
+                    <StateBadge key={state} state={count > 1 ? `${state} ×${count}` : state} hues={badgeHues(state, count)} dot={false} />
+                  ))}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+          <div className="flex items-center gap-2">
+            <CopyActions id={correlationId} idLabel="correlation id" />
+            {positioned && graph && graph.nodes.length > 0 && (
+              <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
+            )}
+          </div>
+          {positioned && graph && graph.nodes.length > 0 && (
+            <div
+              className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
+              role="img"
+              aria-label="Chain legend"
+            >
+              {(Object.keys(CHAIN_EDGE_STYLES) as Array<keyof typeof CHAIN_EDGE_STYLES>).map((kind) => {
+                const entry = CHAIN_EDGE_STYLES[kind] as { label: string; stroke: string; strokeDasharray?: string };
+                return (
+                  <div key={kind} className="flex items-center gap-2 text-[11px] text-(--text-dim)">
+                    <span
+                      aria-hidden
+                      className="inline-block shrink-0"
+                      style={{ width: 14, borderTop: `2px ${entry.strokeDasharray ? "dashed" : "solid"} ${entry.stroke}` }}
+                    />
+                    {entry.label}
+                  </div>
+                );
+              })}
+              <div className="text-[11px] text-(--text-faint)">left border = event status / run state</div>
+            </div>
+          )}
+        </div>
+        {positioned && graph && graph.nodes.length > 0 ? (
+          <ReactFlow
+            nodes={nodes}
+            edges={positioned.edges}
+            nodeTypes={chainNodeTypes}
+            onNodeClick={(_, node) => onSelectNode(node.id)}
+            onPaneClick={() => onSelectNode(null)}
+            onNodesChange={(changes: NodeChange[]) => {
+              const kept = changes.filter((c) => c.type === "position" || c.type === "dimensions");
+              if (kept.length === 0) return;
+              setPositioned((prev) => (prev ? { ...prev, nodes: applyNodeChanges(kept, prev.nodes) } : prev));
+            }}
+            onInit={(inst) => {
+              flowRef.current = inst;
+              setFlowReady((n) => n + 1);
+            }}
+            nodesFocusable
+            deleteKeyCode={null}
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.2}
+          >
+            <Background color="var(--border)" gap={20} size={1} />
+            <Controls showInteractive={false} style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }} />
+            <MiniMap
+              pannable
+              zoomable
+              style={{ background: "var(--surface-1)", border: "1px solid var(--border)" }}
+              maskColor="rgba(0, 0, 0, 0.55)"
+              nodeClassName={(n) => `minimap-node minimap-${n.type}`}
+            />
+          </ReactFlow>
+        ) : (
+          <div className="flex h-full items-center justify-center px-8 text-center text-(--text-faint)">{emptyCopy}</div>
+        )}
+      </div>
+
+      {selected && (
+        <DetailPane
+          widthClass="w-[420px]"
+          title={selected.kind === "chainEvent" ? selected.event.type : (selected.run.agent ?? selected.run.runId)}
+          actions={
+            <Button onClick={revealSelected}>
+              Show on canvas <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
+            </Button>
+          }
+          utility={
+            <CopyActions
+              id={selected.kind === "chainEvent" ? selected.event.eventId : selected.run.runId}
+              idLabel={selected.kind === "chainEvent" ? "event id" : "run id"}
+            />
+          }
+          close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
+        >
+          {selected.kind === "chainEvent" && (
+            <>
+              <Section id="chain-event" title={selected.root ? "Origin event" : "Event"} icons>
+                <KV k="source" v={selected.event.source} />
+                <KV k="type" v={selected.event.type} />
+                <KV k="subject" v={selected.event.subject} />
+                <KV k="status" v={<StateBadge state={selected.event.status} hues={EVENT_STATUS_HUES} />} />
+                <KV k="depth" v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`} />
+                <KV k="admittedAt" v={<Ago iso={selected.event.admittedAt} now={now} />} />
+                <KV
+                  k="emitted by run"
+                  v={
+                    selected.event.causationId ? (
+                      <JumpLink
+                        onClick={() => onSelectNode(runNodeId(selected.event.causationId!))}
+                        title={selected.event.causationId}
+                      >
+                        {shortId(selected.event.causationId)}
+                      </JumpLink>
+                    ) : (
+                      "— (origin)"
+                    )
+                  }
+                />
+                <KV
+                  k="proposal"
+                  v={
+                    selected.event.proposalId ? (
+                      <JumpLink onClick={() => onJumpProposal(selected.event.proposalId!)} title={selected.event.proposalId}>
+                        {shortId(selected.event.proposalId)}
+                        {selected.event.proposalDecision ? ` · ${selected.event.proposalDecision}` : ""}
+                      </JumpLink>
+                    ) : null
+                  }
+                />
+                <KV
+                  k="run"
+                  v={
+                    selected.event.runId ? (
+                      <JumpLink onClick={() => onSelectNode(runNodeId(selected.event.runId!))} title={selected.event.runId}>
+                        {shortId(selected.event.runId)}
+                      </JumpLink>
+                    ) : null
+                  }
+                />
+                {selected.event.repos.length > 0 && <KV k="repos" v={selected.event.repos.join(", ")} />}
+              </Section>
+              <Button onClick={() => onJumpEvent(selected.event.source, selected.event.eventId)}>Open in Events</Button>
+            </>
+          )}
+          {selected.kind === "chainRun" && (
+            <>
+              <Section id="chain-run" title="Run" icons>
+                <KV k="state" v={<StateBadge state={selected.run.state} />} />
+                <KV
+                  k="agent"
+                  v={
+                    selected.run.agent ? (
+                      <JumpLink onClick={() => onJumpAgent(selected.run.agent!)} title="Open in Agents">
+                        {selected.run.agent}
+                      </JumpLink>
+                    ) : null
+                  }
+                />
+                <KV k="adapter" v={selected.run.adapter} />
+                <KV k="attempts" v={String(selected.run.attempts)} />
+                {selected.run.reasonCode && <KV k="reason" v={selected.run.reasonCode} />}
+                <KV k="depth" v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`} />
+                <KV k="created" v={<Ago iso={selected.run.created_at} now={now} />} />
+                <KV k="started" v={<Ago iso={selected.run.startedAt} now={now} />} />
+                <KV k="finished" v={<Ago iso={selected.run.finishedAt} now={now} />} />
+                <KV
+                  k="origin event"
+                  v={
+                    selected.run.eventSource && selected.run.eventId ? (
+                      <JumpLink
+                        onClick={() => onSelectNode(eventNodeId(selected.run.eventSource!, selected.run.eventId!))}
+                        title={selected.run.eventId}
+                      >
+                        {shortId(selected.run.eventId)}
+                      </JumpLink>
+                    ) : null
+                  }
+                />
+                {selected.run.repos.length > 0 && <KV k="repos" v={selected.run.repos.join(", ")} />}
+              </Section>
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={() => onOpenRunFull(selected.run.runId)}>Open run</Button>
+                <Button onClick={() => onJumpRun(selected.run.runId)}>Show in Runs</Button>
+              </div>
+            </>
+          )}
+        </DetailPane>
+      )}
+    </div>
+  );
+}
+
+function badgeHues(state: string, count: number): Record<string, string> {
+  const hue = STATE_HUES[state] ?? "var(--hue-idle)";
+  return { ...STATE_HUES, [`${state} ×${count}`]: hue };
+}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -179,6 +179,7 @@ export function Events({
   onSelectType,
   onJumpProposal,
   onJumpRun,
+  onJumpChain,
   onTriggerAgain,
   onInject,
   rejumpEpoch,
@@ -191,6 +192,8 @@ export function Events({
   onSelectType: (type: string | null) => void;
   onJumpProposal: (id: string) => void;
   onJumpRun: (runId: string) => void;
+  /** Open the chain trace this event belongs to (WM-527). Optional so tests can omit it. */
+  onJumpChain?: (correlationId: string, nodeId?: string) => void;
   onTriggerAgain: (envelope: Record<string, unknown>) => void;
   onInject: () => void;
   rejumpEpoch?: number;
@@ -863,6 +866,13 @@ export function Events({
                 </Button>
               )}
               <div className="flex items-center gap-1.5">
+                {onJumpChain && (
+                  <Button
+                    onClick={() => onJumpChain(sel.correlationId ?? sel.eventId, `event:${sel.source}:${sel.eventId}`)}
+                  >
+                    View chain
+                  </Button>
+                )}
                 <Button disabled={!connected || replay.isPending} onClick={() => setConfirmReplay(true)}>
                   Replay…
                 </Button>
@@ -884,7 +894,28 @@ export function Events({
             <KV k="type" v={sel.type} />
             <KV k="subject" v={sel.subject} />
             <KV k="status" v={<StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />} />
-            <KV k="correlationId" v={sel.correlationId} />
+            <KV
+              k="correlationId"
+              v={
+                sel.correlationId && onJumpChain ? (
+                  <JumpLink onClick={() => onJumpChain(sel.correlationId!)} title="Open chain trace">
+                    {sel.correlationId}
+                  </JumpLink>
+                ) : (
+                  sel.correlationId
+                )
+              }
+            />
+            <KV
+              k="causationId"
+              v={
+                sel.causationId ? (
+                  <JumpLink onClick={() => onJumpRun(sel.causationId!)} title="The run that emitted this event">
+                    {shortId(sel.causationId)}
+                  </JumpLink>
+                ) : null
+              }
+            />
             <KV k="occurredAt" v={<Ago iso={sel.occurredAt} now={now} />} />
             <KV k="receivedAt" v={<Ago iso={sel.receivedAt} now={now} />} />
             <KV k="admittedAt" v={<Ago iso={sel.admittedAt} now={now} />} />

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -42,6 +42,7 @@ export function RunFull({
   onJumpAgent,
   onJumpEvent,
   onJumpProposal,
+  onJumpChain,
 }: {
   runId: string;
   connected: boolean;
@@ -49,6 +50,8 @@ export function RunFull({
   onJumpAgent: (ref: string) => void;
   onJumpEvent: (source: string, eventId: string) => void;
   onJumpProposal?: (id: string) => void;
+  /** Open the chain trace this run belongs to (WM-527). */
+  onJumpChain?: (correlationId: string, nodeId?: string) => void;
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
@@ -88,6 +91,18 @@ export function RunFull({
       (e) => e.causationId === runId || (e.envelope as any)?.causationId === runId,
     );
   }, [eventsQ.data, runId]);
+  // The chain this run belongs to: its origin event's correlation id (falling
+  // back to the event id, as the chain emitter does), or — for a run whose
+  // origin is not in the list — any event it emitted names the same chain.
+  const chainKey = useMemo(() => {
+    const events = eventsQ.data?.events ?? [];
+    const origin = listRow
+      ? events.find((e) => e.source === listRow.eventSource && e.eventId === listRow.eventId)
+      : null;
+    if (origin) return origin.correlationId ?? origin.eventId;
+    const emitted = events.find((e) => e.causationId === runId);
+    return emitted ? (emitted.correlationId ?? emitted.eventId) : null;
+  }, [eventsQ.data, listRow, runId]);
   const runsById = useMemo(() => {
     const map = new Map<string, RunListItem>();
     for (const r of listQ.data?.runs ?? []) {
@@ -393,6 +408,13 @@ export function RunFull({
                   </Button>
                 ))}
             </div>
+          )}
+          {onJumpChain && chainKey && (
+            <Button
+              onClick={() => onJumpChain(chainKey, `run:${runId}`)}
+            >
+              View chain
+            </Button>
           )}
           <Button onClick={() => toggleRunPin(runId)}>
             <span>Open in tab</span>


### PR DESCRIPTION
Fixes WM-527

## What

Operator ask: from `#/events/chain/chain-run_…` be able to see a graph of how the runs were chained and where the originating run was.

- **Backend** `GET /chain/:correlationId` (`event-runtime/lib/api-chain.mjs`): every event + run sharing one correlation id (falls back to the origin's own eventId, mirroring the chain emitter), with `causationId` / proposal / run joins; 404 when unknown. Includes a causation parent run that lives outside the correlation so a split chain still traces from somewhere.
- **Web** `#/chain/:correlationId[/:nodeId]` (`views/Chain.tsx`, `graph/chainModel.ts`, `graph/chainNodes.tsx`): instance DAG on the existing React Flow + elk canvas — origin event → run → emitted events → runs …, nodes coloured by event status / run state, header with origin + counts + hop depth + state tally, detail pane linking to Events/Runs/run page/Proposals/Agents and to the parent run / origin event inside the chain. `j`/`k`/`z`/`Esc` as on the Graph. Layout reused across the 3s poll while node/edge identity is unchanged.
- **Entry points**: event detail shows `correlationId` (→ chain) and `causationId` (→ parent run) and a **View chain** action; full run page gets **View chain**.
- `graph/layout.ts` made generic over any `{nodes,edges}` topology + a tighter `CHAIN_LAYOUT_OPTIONS`.
- Docs: `docs/event-runtime-webui.md` §10.15.

## Verification

- `bun test --max-concurrency=4` → 2079 pass, 0 fail (new: `lib/api-chain.test.mjs` 4 tests incl. fan-out + fallback key + 404; `web/src/graph/chainModel.test.ts` 6 tests).
- `cd event-runtime/web && bun run build` (tsc + vite) clean.
- `bun run format:check` clean.
- Manually checked on the seeded worktree env: `#/chain/demo-triage` (3-hop chain, FAILED leaf), `#/chain/demo-dispatch-wm100` reached via **View chain** from `#/events/chain/chain-run_demo_dispatch_wm100`, and the run page button.