### PR TITLE
fix(event-runtime): prevent duplicate concurrent work dispatches (WM-491)

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -453,6 +453,29 @@ function isIdempotencyKeyCollision(err) {
   return err?.code === "SQLITE_CONSTRAINT_UNIQUE" || /UNIQUE constraint failed: runs\.idempotency_key/.test(String(err?.message ?? err));
 }
 
+function liveRunForInput(db, agentRef, { repo, ticket = null, includeFailed = false }) {
+  if (typeof repo !== "string" || (ticket !== null && typeof ticket !== "string")) return null;
+  return db.query(
+    `SELECT run_id, state FROM runs
+     WHERE state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
+       AND (? = 1 OR state <> 'FAILED')
+       AND json_extract(spec_json, '$.agent') = ?
+       AND json_extract(spec_json, '$.input.repo') = ?
+       AND (? IS NULL OR json_extract(spec_json, '$.input.ticket') = ?)
+     ORDER BY created_at ASC, rowid ASC
+     LIMIT 1`,
+  ).get(includeFailed ? 1 : 0, agentRef, repo, ticket, ticket);
+}
+
+function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
+  const proposal = insertProposal(db, {
+    id: newProposalId(), event, runId: blockingRun.run_id, decision: "noop", status: "resolved",
+    reason, at, ttlSeconds,
+  });
+  setEventStatus(db, event, "noop");
+  return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
+}
+
 function humanNeeded(db, event, reason, at, ttlSeconds) {
   const proposal = insertProposal(db, {
     id: newProposalId(), event, decision: "human_needed", status: "open", reason, at, ttlSeconds,
@@ -541,11 +564,53 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     const scopeRefusal = repoNotAllowed(def, envelope.payload);
     if (scopeRefusal) return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
 
+    // A work scan reserves its repo as soon as its run is PROPOSED, before the
+    // expensive model read can select a ticket. This is deliberately stronger
+    // than schedule singleton semantics (which exclude watched PROPOSED runs):
+    // two operator/chain scans for one queue must never run concurrently. The
+    // IMMEDIATE transaction makes the reservation check and run creation
+    // atomic across planner connections.
+    if (
+      envelope.type === "factory.work.requested" &&
+      typeof envelope.payload?.repo === "string"
+    ) {
+      const blockingScan = liveRunForInput(db, mapping.agent, { repo: envelope.payload.repo });
+      if (blockingScan) {
+        return noopBehindLiveRun(
+          db, event, blockingScan, "work_scan_already_in_flight", at, ttlSeconds,
+        );
+      }
+    }
+
+    // Defense in depth for stale/advisory scan results: once any dispatch for
+    // this exact repo/ticket has a live run (including an unapproved PROPOSED
+    // run), a second dispatch is refused here with the worktree owner named.
+    // It therefore never reaches provisioning where the same deterministic
+    // worktree path and port pair would masquerade as a foreign port collision.
+    if (
+      envelope.type === "factory.dispatch.requested" &&
+      typeof envelope.payload?.repo === "string" &&
+      typeof envelope.payload?.ticket === "string"
+    ) {
+      const blockingDispatch = liveRunForInput(db, mapping.agent, {
+        repo: envelope.payload.repo,
+        ticket: envelope.payload.ticket,
+        // FAILED dispatches remain retryable and retain their worktree; a new
+        // run for the same ticket would still collide with that owner.
+        includeFailed: true,
+      });
+      if (blockingDispatch) {
+        const reason = `ticket_dispatch_already_live:${blockingDispatch.run_id}:same_ticket_worktree_held`;
+        return noopBehindLiveRun(db, event, blockingDispatch, reason, at, ttlSeconds);
+      }
+    }
+
     // §5 singleton is agent policy, not clock-envelope policy: operator and
     // chain origins mapped to an enabled singleton agent must not bypass it by
     // omitting payload.loop. Merge scans additionally obey the git-owned
     // global admission cap even when a concrete schedule opts out of
-    // singleton behavior. PROPOSED remains excluded (OPS-436).
+    // singleton behavior. PROPOSED remains excluded here (OPS-436); the
+    // repo-scoped work-scan reservation above intentionally includes it.
     const inFlight = inFlightRunsForAgent(db, mapping.agent);
     const singletonBlocked = singletonApplies(registry, envelope, mapping.agent) && inFlight.length > 0;
     const mergeCap = envelope.type === "factory.merge.requested" ? policyMaxConcurrentMerges() : null;

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -455,16 +455,18 @@ function isIdempotencyKeyCollision(err) {
 
 function liveRunForInput(db, agentRef, { repo, ticket = null, includeFailed = false }) {
   if (typeof repo !== "string" || (ticket !== null && typeof ticket !== "string")) return null;
+  const versionSeparator = agentRef.lastIndexOf("@");
+  const agentFamily = versionSeparator > 0 ? `${agentRef.slice(0, versionSeparator)}@*` : agentRef;
   return db.query(
     `SELECT run_id, state FROM runs
      WHERE state NOT IN ('COMPLETED','REFUSED','TIMED_OUT','CANCELLED')
        AND (? = 1 OR state <> 'FAILED')
-       AND json_extract(spec_json, '$.agent') = ?
+       AND json_extract(spec_json, '$.agent') GLOB ?
        AND json_extract(spec_json, '$.input.repo') = ?
        AND (? IS NULL OR json_extract(spec_json, '$.input.ticket') = ?)
      ORDER BY created_at ASC, rowid ASC
      LIMIT 1`,
-  ).get(includeFailed ? 1 : 0, agentRef, repo, ticket, ticket);
+  ).get(includeFailed ? 1 : 0, agentFamily, repo, ticket, ticket);
 }
 
 function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
@@ -612,7 +614,11 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
     // singleton behavior. PROPOSED remains excluded here (OPS-436); the
     // repo-scoped work-scan reservation above intentionally includes it.
     const inFlight = inFlightRunsForAgent(db, mapping.agent);
-    const singletonBlocked = singletonApplies(registry, envelope, mapping.agent) && inFlight.length > 0;
+    // factory.work.requested already has the stricter repo-scoped reservation
+    // above. Applying the schedule's legacy agent-global singleton as well
+    // would incorrectly serialize unrelated repo queues after PROPOSED.
+    const singletonBlocked = envelope.type !== "factory.work.requested" &&
+      singletonApplies(registry, envelope, mapping.agent) && inFlight.length > 0;
     const mergeCap = envelope.type === "factory.merge.requested" ? policyMaxConcurrentMerges() : null;
     const mergeCapBlocked = mergeCap !== null && inFlight.length >= mergeCap;
     if (singletonBlocked || mergeCapBlocked) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -333,19 +333,21 @@ describe("planEvent", () => {
     });
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
 
-    // The reservation is repo-scoped, not a global scanner singleton.
+    // The reservation is repo-scoped, not a global scanner singleton — even
+    // after the first scan leaves PROPOSED and schedule singleton applies.
+    transition(db, { runId: first.runId, to: "APPROVED", actor: "test" });
     const otherRepoRef = admit(db, {
       eventId: "work-other-repo",
       type: "factory.work.requested",
       source: "operator",
       correlationId: "work-other-repo",
-      payload: { repo: "bj29" },
+      payload: { repo: "bj29", loop: "work-bj29" },
     });
     expect(planEvent(db, synthetic, otherRepoRef, { now: NOW + 2000, policyVersion: "git:test" }).decision).toBe("run");
 
     // A failed read emitted no dispatch chain and must release the queue; unlike
     // a failed dispatch, a failed scan owns no retained worktree to protect.
-    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "FAILED"]) {
+    for (const to of ["QUEUED", "LEASED", "RUNNING", "FAILED"]) {
       transition(db, { runId: first.runId, to, actor: "test" });
     }
     const afterFailureRef = admit(db, {
@@ -369,6 +371,45 @@ describe("planEvent", () => {
       payload: { repo: "factory" },
     });
     expect(planEvent(db, synthetic, nextCycleRef, { now: NOW + 4000, policyVersion: "git:test" }).decision).toBe("run");
+  });
+
+  test("live reservations survive an agent version upgrade (WM-491)", () => {
+    const synthetic = { ...registry, agents: new Map(registry.agents), eventTypes: { ...registry.eventTypes } };
+    synthetic.agents.set("work-scan@1", {
+      ...registry.agents.get("work-scan@1"),
+      workspace: { type: "ephemeral" },
+    });
+    const db = openDb(":memory:");
+    const firstRef = admit(db, {
+      eventId: "work-v1",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-v1",
+      payload: { repo: "factory" },
+    });
+    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+
+    synthetic.eventTypes["factory.work.requested"] = {
+      ...synthetic.eventTypes["factory.work.requested"],
+      agent: "work-scan@2",
+    };
+    synthetic.agents.set("work-scan@2", {
+      ...synthetic.agents.get("work-scan@1"),
+      version: 2,
+      ref: "work-scan@2",
+    });
+    const nextRef = admit(db, {
+      eventId: "work-v2",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-v2",
+      payload: { repo: "factory" },
+    });
+    expect(planEvent(db, synthetic, nextRef, { now: NOW + 1000, policyVersion: "git:test" })).toMatchObject({
+      decision: "noop",
+      reason: "work_scan_already_in_flight",
+      runId: first.runId,
+    });
   });
 
   test("a duplicate dispatch for a ticket with a live dispatch is refused at plan time (WM-491)", () => {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -297,6 +297,136 @@ describe("planEvent", () => {
     expect(db.query(`SELECT status FROM events WHERE event_id = ?`).get(collisionEventId).status).toBe("noop");
   });
 
+  test("concurrent work scans for one repo reserve selection before either can duplicate it (WM-491)", () => {
+    const synthetic = { ...registry, agents: new Map(registry.agents) };
+    synthetic.agents.set("work-scan@1", {
+      ...registry.agents.get("work-scan@1"),
+      // Keep this planner regression hermetic: repo pinning is unrelated to
+      // the reservation, whose scope comes from input.repo.
+      workspace: { type: "ephemeral" },
+    });
+    const db = openDb(":memory:");
+    const firstRef = admit(db, {
+      eventId: "work-hot-1",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-hot-1",
+      payload: { repo: "factory" },
+    });
+    const secondRef = admit(db, {
+      eventId: "work-hot-2",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-hot-2",
+      payload: { repo: "factory" },
+    });
+
+    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+    const second = planEvent(db, synthetic, secondRef, { now: NOW + 1000, policyVersion: "git:test" });
+
+    expect(first.decision).toBe("run");
+    expect(runState(db, first.runId)).toBe("PROPOSED");
+    expect(second).toMatchObject({
+      decision: "noop",
+      reason: "work_scan_already_in_flight",
+      runId: first.runId,
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+
+    // The reservation is repo-scoped, not a global scanner singleton.
+    const otherRepoRef = admit(db, {
+      eventId: "work-other-repo",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-other-repo",
+      payload: { repo: "bj29" },
+    });
+    expect(planEvent(db, synthetic, otherRepoRef, { now: NOW + 2000, policyVersion: "git:test" }).decision).toBe("run");
+
+    // A failed read emitted no dispatch chain and must release the queue; unlike
+    // a failed dispatch, a failed scan owns no retained worktree to protect.
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "FAILED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+    const afterFailureRef = admit(db, {
+      eventId: "work-after-failure",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-after-failure",
+      payload: { repo: "factory" },
+    });
+    const afterFailure = planEvent(db, synthetic, afterFailureRef, { now: NOW + 3000, policyVersion: "git:test" });
+    expect(afterFailure.decision).toBe("run");
+
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: afterFailure.runId, to, actor: "test" });
+    }
+    const nextCycleRef = admit(db, {
+      eventId: "work-hot-next",
+      type: "factory.work.requested",
+      source: "operator",
+      correlationId: "work-hot-next",
+      payload: { repo: "factory" },
+    });
+    expect(planEvent(db, synthetic, nextCycleRef, { now: NOW + 4000, policyVersion: "git:test" }).decision).toBe("run");
+  });
+
+  test("a duplicate dispatch for a ticket with a live dispatch is refused at plan time (WM-491)", () => {
+    const synthetic = { ...registry, agents: new Map(registry.agents) };
+    synthetic.agents.set("dispatch@1", {
+      ...registry.agents.get("dispatch@1"),
+      // The duplicate ledger check is local planner admission; make external
+      // Linear/worktree eligibility irrelevant to this focused test.
+      workspace: { type: "ephemeral" },
+    });
+    const db = openDb(":memory:");
+    const dispatch = (eventId) => ({
+      eventId,
+      type: "factory.dispatch.requested",
+      source: "operator",
+      correlationId: eventId,
+      causationId: null,
+      payload: { repo: "factory", ticket: "WM-480" },
+    });
+    const firstRef = admit(db, dispatch("dispatch-hot-1"));
+    const secondRef = admit(db, dispatch("dispatch-hot-2"));
+
+    const first = planEvent(db, synthetic, firstRef, { now: NOW, policyVersion: "git:test" });
+    const second = planEvent(db, synthetic, secondRef, { now: NOW + 1000, policyVersion: "git:test" });
+
+    expect(first.decision).toBe("run");
+    expect(second).toMatchObject({
+      decision: "noop",
+      reason: `ticket_dispatch_already_live:${first.runId}:same_ticket_worktree_held`,
+      runId: first.runId,
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+
+    // A malformed dispatch remains an input error; a missing ticket must not
+    // wildcard-match the live dispatch above.
+    const malformedEnvelope = dispatch("dispatch-malformed");
+    delete malformedEnvelope.payload.ticket;
+    const malformedRef = admit(db, malformedEnvelope);
+    const malformed = planEvent(db, synthetic, malformedRef, { now: NOW + 2000, policyVersion: "git:test" });
+    expect(malformed.decision).toBe("human_needed");
+    expect(malformed.reason).toMatch(/^invalid_input: /);
+
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "FAILED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+    const failedRetryRef = admit(db, dispatch("dispatch-while-retryable"));
+    expect(planEvent(db, synthetic, failedRetryRef, { now: NOW + 3000, policyVersion: "git:test" })).toMatchObject({
+      decision: "noop",
+      reason: `ticket_dispatch_already_live:${first.runId}:same_ticket_worktree_held`,
+    });
+
+    for (const to of ["QUEUED", "LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+    const nextRef = admit(db, dispatch("dispatch-next-cycle"));
+    expect(planEvent(db, synthetic, nextRef, { now: NOW + 4000, policyVersion: "git:test" }).decision).toBe("run");
+  });
+
   test("unregistered event type → human_needed", () => {
     const db = openDb(":memory:");
     const ref = admit(db, { type: "totally.unknown.type" });


### PR DESCRIPTION
## Summary
- reserve each repo when a work-scan run is PROPOSED so concurrent requests produce one scanner and a typed NOOP
- keep scheduled scans independent across repos and preserve reservations across agent version upgrades
- reject a second live dispatch for the same repo/ticket at plan time with the holding run and same-ticket worktree reason
- cover malformed inputs, retryable failures, and reservation release

## Verification
- bun test event-runtime/lib/planner.test.mjs — 37 pass, 0 fail
- bun build/emit.mjs --check — generated contracts match

UX critique: skipped — internal event-runtime planner change with no user-facing surface

Follow-up: WM-535 tracks the out-of-scope worktree diagnostic and pinned work-scan guidance.

Fixes WM-491