### PR TITLE
fix(worker): require explicit dispatch stubs

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -58,7 +58,7 @@ function workerSubprocessTimeoutMs() {
     : DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS;
 }
 
-const ENVIRONMENT_FAILURES = new Set(["adapter_error", "lease_expired"]);
+const ENVIRONMENT_FAILURES = new Set(["adapter_error", "lease_expired", "linear_unconfigured"]);
 const AGENT_FAILURES = new Set(["contract_violation"]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
@@ -461,6 +461,35 @@ export function createReloadWatcher({
 
 const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
 
+/**
+ * Resolve Linear credentials the same way the CLI does: process env first,
+ * then the operator's shared env file. The resolved value is copied into the
+ * supplied env so every Linear CLI child inherits it; it is never logged.
+ */
+export function resolveLinearApiKey({
+  env = process.env,
+  envFile = path.join(homedir(), "Develop", "hdkiller", ".env"),
+} = {}) {
+  if (env.LINEAR_API_KEY) return env.LINEAR_API_KEY;
+  if (!existsSync(envFile)) return null;
+
+  try {
+    for (const line of readFileSync(envFile, "utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+      const idx = trimmed.indexOf("=");
+      if (trimmed.slice(0, idx).trim() !== "LINEAR_API_KEY") continue;
+      const value = trimmed.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+      if (!value) return null;
+      env.LINEAR_API_KEY = value;
+      return value;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 /** Execute one bounded Linear CLI operation; exported for timeout regression tests. */
 export function runLinearCli(
   args,
@@ -567,7 +596,7 @@ const ACTIVE_EXECUTIONS = new Map();
  */
 export async function executeClaimed(db, registry, adapters, claim, {
   workspacesRoot, artifactStore = artifactsRoot(), now = () => Date.now(), policyVersion = "unknown", adapterOverride, env = {},
-  dispatch,
+  dispatch, resolveLinearKey = resolveLinearApiKey,
 } = {}) {
   const { runId, attempt, fencingToken, spec } = claim;
   const owner = db
@@ -587,7 +616,12 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let attemptUsage = { adapter: adapterOverride ?? spec.adapter };
 
   let dispatchOpts = dispatch;
-  if (!dispatchOpts && process.env.FACTORY_EVENT_HOME && !process.env.LINEAR_API_KEY) {
+  const explicitDispatchStub = !dispatchOpts && (
+    process.env.FACTORY_DISPATCH_STUB === "1" ||
+    adapterOverride === "fake" ||
+    spec.adapter === "fake"
+  );
+  if (explicitDispatchStub) {
     dispatchOpts = {
       fetchTicket: () => ({
         identifier: ticketId,
@@ -601,6 +635,9 @@ export async function executeClaimed(db, registry, adapters, claim, {
       unclaimTicket: () => true,
     };
   }
+  const linearConfigured = dispatchOpts || !isWorktree || !repoName || !ticketId
+    ? true
+    : Boolean(resolveLinearKey());
 
   const locksDir = dispatchOpts?.locksDir ?? defaultLocksDir();
   const leasesDir = dispatchOpts?.leasesDir ?? leaseDir();
@@ -731,6 +768,18 @@ export async function executeClaimed(db, registry, adapters, claim, {
     }
 
     if (isWorktree && repoName && ticketId) {
+      if (!linearConfigured) {
+        const res = failTerminal("FAILED", "linear_unconfigured", "linear_unconfigured");
+        stopCancellationMonitor();
+        if (res?.fenced) return { fenced: true };
+        return {
+          runId,
+          attempt,
+          terminalState: "FAILED",
+          reasonCode: "linear_unconfigured",
+        };
+      }
+
       const lockAcquired = acquireClaimLock(lockFile, { pid: process.pid, now: nowFn(), isAlive: isAliveFn });
       if (!lockAcquired) {
         const deferred = deferClaimLockContention(db, {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -18,7 +18,7 @@ import {
   acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
   createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
   executeClaimed, classifyFailureCause, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
-  repositoryStatus, retryRun, runLinearCli, runOnce,
+  repositoryStatus, resolveLinearApiKey, retryRun, runLinearCli, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
 
@@ -580,6 +580,7 @@ describe("worker", () => {
   test("failure cause taxonomy classifies retryable and fatal worker failures", () => {
     expect(classifyFailureCause("adapter_error")).toBe("environment");
     expect(classifyFailureCause("lease_expired")).toBe("environment");
+    expect(classifyFailureCause("linear_unconfigured")).toBe("environment");
     expect(classifyFailureCause("agent_exit_1")).toBe("agent_error");
     expect(classifyFailureCause("contract_violation")).toBe("agent_error");
     for (const reason of [
@@ -1284,6 +1285,77 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       return { exitCode: 0, timedOut: false };
     },
   };
+
+  test("resolves Linear credentials from env first, then the shared env file", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-linear-key-"));
+    const envFile = path.join(dir, ".env");
+    writeFileSync(envFile, "OTHER=value\nLINEAR_API_KEY='file-key'\n", "utf8");
+
+    const fromEnv = { LINEAR_API_KEY: "process-key" };
+    expect(resolveLinearApiKey({ env: fromEnv, envFile })).toBe("process-key");
+
+    const fromFile = {};
+    expect(resolveLinearApiKey({ env: fromFile, envFile })).toBe("file-key");
+    expect(fromFile.LINEAR_API_KEY).toBe("file-key");
+  });
+
+  test("missing process credentials never activate the dispatch stub implicitly (WM-533)", async () => {
+    const previousHome = process.env.FACTORY_EVENT_HOME;
+    const previousKey = process.env.LINEAR_API_KEY;
+    const previousStub = process.env.FACTORY_DISPATCH_STUB;
+    process.env.FACTORY_EVENT_HOME = mkdtempSync(path.join(os.tmpdir(), "evrt-linear-unconfigured-"));
+    delete process.env.LINEAR_API_KEY;
+    delete process.env.FACTORY_DISPATCH_STUB;
+
+    try {
+      const db = openDb(":memory:");
+      const spec = queueRun(db, makeDispatchSpec({ adapter: "pi", maxEnvironmentRetries: 1 }));
+      const runOpts = opts({ resolveLinearKey: () => null });
+      const first = await runOnce(db, registry, { pi: dispatchFakeAdapter }, runOpts);
+
+      expect(first).toMatchObject({ terminalState: "FAILED", reasonCode: "linear_unconfigured" });
+      expect(runState(db, spec.runId)).toBe("QUEUED");
+
+      const exhausted = await runOnce(db, registry, { pi: dispatchFakeAdapter }, runOpts);
+      expect(exhausted).toMatchObject({ terminalState: "FAILED", reasonCode: "linear_unconfigured" });
+      expect(runState(db, spec.runId)).toBe("FAILED");
+      expect(db.query(`SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt`).all(spec.runId))
+        .toEqual([{ reason_code: "linear_unconfigured" }, { reason_code: "linear_unconfigured" }]);
+    } finally {
+      if (previousHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      else process.env.FACTORY_EVENT_HOME = previousHome;
+      if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousKey;
+      if (previousStub === undefined) delete process.env.FACTORY_DISPATCH_STUB;
+      else process.env.FACTORY_DISPATCH_STUB = previousStub;
+    }
+  });
+
+  test("FACTORY_DISPATCH_STUB explicitly enables the demo dispatch stub", async () => {
+    const previousStub = process.env.FACTORY_DISPATCH_STUB;
+    process.env.FACTORY_DISPATCH_STUB = "1";
+    try {
+      const db = openDb(":memory:");
+      queueRun(db, makeDispatchSpec({ adapter: "pi" }));
+      const summary = await runOnce(db, registry, { pi: dispatchFakeAdapter }, opts({
+        resolveLinearKey: () => null,
+      }));
+      expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+    } finally {
+      if (previousStub === undefined) delete process.env.FACTORY_DISPATCH_STUB;
+      else process.env.FACTORY_DISPATCH_STUB = previousStub;
+    }
+  });
+
+  test("the fake adapter override explicitly enables the demo dispatch stub", async () => {
+    const db = openDb(":memory:");
+    queueRun(db, makeDispatchSpec({ adapter: "pi" }));
+    const summary = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
+      adapterOverride: "fake",
+      resolveLinearKey: () => null,
+    }));
+    expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+  });
 
   test("acquireClaimLock acquires lock file and prevents concurrent acquire, release unlocks", () => {
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-"));


### PR DESCRIPTION
## Summary
- require dispatch stubbing to be explicitly selected by `FACTORY_DISPATCH_STUB=1` or the fake adapter
- resolve `LINEAR_API_KEY` from process env, then `~/Develop/hdkiller/.env`, without logging the credential
- fail and requeue live dispatch attempts as typed `linear_unconfigured` environment failures when credentials are absent
- cover implicit-stub regression, credential fallback, retry exhaustion, explicit flag mode, and fake-adapter mode

The pinned refused dispatches include CLNT-1480, CLNT-925, CLNT-846, CLNT-31, CLNT-1512, CLNT-1491, CLNT-1488, CLNT-1509, CLNT-1506, CLNT-1505, CLNT-1487, and CLNT-1486; WM-532 owns making those historical runs re-dispatchable.

## Verification
- `bun test event-runtime/lib/worker.test.mjs` — 76 pass, 0 fail

UX critique: skipped — backend worker dispatch and credential handling; no user-facing flow.

Fixes WM-533
