### PR TITLE
fix(dispatch): retry transient claim gate reads

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -305,8 +305,16 @@ function evidenceInFlight(issue) {
   };
 }
 
-function refusal(reason, evidence, decision = "noop") {
-  return { ok: false, refusal: { decision, reason }, evidence };
+function refusal(reason, evidence, decision = "noop", detail = null) {
+  return {
+    ok: false,
+    refusal: {
+      decision,
+      reason,
+      ...(detail ? { detail } : {}),
+    },
+    evidence,
+  };
 }
 
 /**
@@ -378,6 +386,15 @@ export function worktreeDispatchAutoEligibility(payload, {
     return refusal("ticket_escalated", evidence);
   }
 
+  // Never let effectiveOwnedPaths' fail-closed `**` sentinel masquerade as a
+  // real path during a sensitive-path check. Unknown ticket scope is its own
+  // refusal, before overlap or escalate_paths can assign a misleading cause.
+  if (!evidence.ticket.ownedPathsParsed) {
+    evidence.checks.owned_paths_parsed = false;
+    return refusal("owned_paths_unknown", evidence);
+  }
+  evidence.checks.owned_paths_parsed = true;
+
   try {
     const gaps = ownedPathsClosureDetails(repo.name, repo, ticket.description);
     if (gaps.length) {
@@ -420,9 +437,13 @@ export function worktreeDispatchAutoEligibility(payload, {
     intersect: evidence.escalatePathIntersections,
   };
   if (evidence.escalatePathIntersections.length > 0) {
-    return refusal("escalate_paths_intersect", evidence);
+    return refusal(
+      "escalate_paths_intersect",
+      evidence,
+      "noop",
+      `intersecting escalate_paths globs: ${evidence.escalatePathIntersections.join(", ")}`,
+    );
   }
-  evidence.checks.owned_paths_parsed = evidence.ticket.ownedPathsParsed;
   return { ok: true, evidence };
 }
 
@@ -432,7 +453,14 @@ export function worktreeDispatchAutoEligibility(payload, {
  */
 export function worktreeDispatchGate(payload, options = {}) {
   const result = worktreeDispatchAutoEligibility(payload, options);
-  return result.ok ? null : result.refusal;
+  if (result.ok) return null;
+  // Keep the historical gate contract stable for planner/orchestrator callers;
+  // richer claim-time consumers use worktreeDispatchAutoEligibility directly
+  // to retain evidence and operator-facing detail.
+  return {
+    decision: result.refusal.decision,
+    reason: result.refusal.reason,
+  };
 }
 
 function insertProposal(db, { id, event, runId = null, decision, specJson = null, specHash = null, idempotencyKey = null, status, reason = null, at, ttlSeconds }) {
@@ -504,7 +532,8 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
         typeof preEnvelope.payload?.ticket === "string" &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
-        worktreeRefusal = worktreeDispatchGate(preEnvelope.payload, dispatch);
+        const eligibility = worktreeDispatchAutoEligibility(preEnvelope.payload, dispatch);
+        worktreeRefusal = eligibility.ok ? null : eligibility.refusal;
       }
     }
   }
@@ -578,7 +607,7 @@ export function planEvent(db, registry, { source, eventId }, { now = Date.now(),
       }
       const proposal = insertProposal(db, {
         id: newProposalId(), event, decision: "noop", status: "resolved",
-        reason: worktreeRefusal.reason, at, ttlSeconds,
+        reason: worktreeRefusal.detail ?? worktreeRefusal.reason, at, ttlSeconds,
       });
       setEventStatus(db, event, "noop");
       return { decision: "noop", proposal, reason: worktreeRefusal.reason };

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -14,6 +14,7 @@ import {
   planAdmittedEvents,
   planEvent,
   policyMaxConcurrentMerges,
+  worktreeDispatchAutoEligibility,
 } from "./planner.mjs";
 import { loadRegistry } from "./registry.mjs";
 
@@ -403,6 +404,74 @@ describe("planEvent worktree gate (WM-108)", () => {
       expect(outcome.reason).toMatch(/^repo_unknown: /);
       expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
     });
+  });
+
+  test("unknown Owned Paths refuses distinctly before wildcard escalation", () => {
+    withReposRoot(
+      `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - '**'\n`,
+      () => {
+        let fetchedInFlight = false;
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-2" },
+          {
+            countLeases: () => 0,
+            budgetRefusal: () => null,
+            fetchTicket: () => ({
+              identifier: "WM-2",
+              state: { name: "Todo" },
+              assignee: null,
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+              description: "",
+            }),
+            fetchInFlight: () => { fetchedInFlight = true; return []; },
+          },
+        );
+        expect(result.refusal).toMatchObject({ decision: "noop", reason: "owned_paths_unknown" });
+        expect(result.evidence.ticket).toMatchObject({ ownedPaths: ["**"], ownedPathsParsed: false });
+        expect(result.evidence.escalatePathIntersections).toEqual([]);
+        expect(fetchedInFlight).toBe(false);
+      },
+    );
+  });
+
+  test("a genuine sensitive-path refusal names the intersecting configured globs", () => {
+    withReposRoot(
+      `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths:\n      - src/auth/**\n      - infra/**\n`,
+      () => {
+        const dispatch = {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: () => ({
+            identifier: "WM-3",
+            state: { name: "Todo" },
+            assignee: null,
+            labels: { nodes: [{ name: "ai:agent-ready" }] },
+            description: "## Owned Paths\n- src/auth/session.ts\n",
+          }),
+          fetchInFlight: () => [],
+        };
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-3" },
+          dispatch,
+        );
+        expect(result.refusal).toEqual({
+          decision: "noop",
+          reason: "escalate_paths_intersect",
+          detail: "intersecting escalate_paths globs: src/auth/**",
+        });
+        expect(result.evidence.escalatePathIntersections).toEqual(["src/auth/**"]);
+
+        const db = openDb(":memory:");
+        const ref = admit(db, dispatchEnvelope({ repo: "gated", ticket: "WM-3" }));
+        const outcome = planEvent(db, syntheticRegistry(), ref, { now: NOW, dispatch });
+        expect(outcome).toMatchObject({ decision: "noop", reason: "escalate_paths_intersect" });
+        expect(outcome.proposal.reason).toBe("intersecting escalate_paths globs: src/auth/**");
+      },
+    );
   });
 });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -22,7 +22,7 @@ import { artifactsRoot, FACTORY_ROOT } from "./config.mjs";
 import { nextCounter, recordRunUsage, tx, txImmediate } from "./db.mjs";
 import { getAgent } from "./registry.mjs";
 import { IllegalTransition, transition } from "./lifecycle.mjs";
-import { worktreeDispatchGate } from "./planner.mjs";
+import { worktreeDispatchAutoEligibility } from "./planner.mjs";
 import { closeOpenProposalForRun } from "./proposals.mjs";
 import { computeDefHash, createReceipt, verifyDefHash } from "./receipts.mjs";
 import { traceRecorder } from "./trace.mjs";
@@ -45,6 +45,7 @@ export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
 
 /** Claim-lock contention is deferred independently from execution attempts. */
 export const DEFAULT_MAX_CLAIM_LOCK_REQUEUES = 8;
+export const DEFAULT_MAX_TRANSIENT_GATE_REQUEUES = 3;
 export const CLAIM_LOCK_BACKOFF_BASE_MS = 25;
 export const CLAIM_LOCK_BACKOFF_MAX_MS = 1_000;
 
@@ -218,7 +219,7 @@ export function claimNext(db, { owner, now = () => Date.now(), policyVersion = "
     let row = null;
     let spec = null;
     for (const candidate of candidates) {
-      const backoff = /^claim_lock_contention:\d+:backoff_(\d+)ms$/.exec(candidate.queue_reason ?? "");
+      const backoff = /^(?:claim_lock_contention:\d+|dispatch_gate_transient:[^:]+:\d+):backoff_(\d+)ms$/.exec(candidate.queue_reason ?? "");
       if (backoff && Date.parse(candidate.queued_at) + Number(backoff[1]) > claimNow) continue;
       const candidateSpec = JSON.parse(candidate.spec_json);
       if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
@@ -332,6 +333,57 @@ function deferClaimLockContention(db, {
     db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(attempt - 1, runId);
     return { requeued: true, contentions: contentionNumber, backoffMs };
   });
+}
+
+/**
+ * A plan-time eligibility proof makes a contradictory claim-time Linear read
+ * distinguishable from a real gate refusal. Defer those reads without spending
+ * an execution attempt, with the same durable not-before mechanism as the
+ * machine-local claim lock.
+ */
+function deferTransientDispatchGate(db, {
+  runId, attempt, fencingToken, owner, policyVersion, now, reasonCode,
+  maxRequeues = DEFAULT_MAX_TRANSIENT_GATE_REQUEUES,
+  random = Math.random,
+}) {
+  return txImmediate(db, () => {
+    const currentNow = resolveNow(now);
+    if (!assertCurrentToken(db, runId, fencingToken)) {
+      recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
+      return { fenced: true };
+    }
+    const prior = Number(db.query(
+      `SELECT COUNT(*) AS n FROM lifecycle_events
+       WHERE run_id = ? AND reason GLOB ?`,
+    ).get(runId, `dispatch_gate_transient:${reasonCode}:*`)?.n ?? 0);
+    if (prior >= maxRequeues) return { exhausted: true, requeues: prior };
+
+    const requeueNumber = prior + 1;
+    const backoffMs = claimLockBackoffMs(requeueNumber, random);
+    transition(db, {
+      runId, to: "QUEUED", expectFrom: "RUNNING", actor: owner,
+      reason: `dispatch_gate_transient:${reasonCode}:${requeueNumber}:backoff_${backoffMs}ms`,
+      attempt, policyVersion, now: currentNow,
+    });
+    db.query(`DELETE FROM attempts WHERE run_id = ? AND attempt = ?`).run(runId, attempt);
+    db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(attempt - 1, runId);
+    return { requeued: true, requeues: requeueNumber, backoffMs };
+  });
+}
+
+function hasPlanTimeDispatchEvidence(spec) {
+  return Boolean(spec?.approvalPolicy?.dispatchEvidence?.ticket?.descriptionHash);
+}
+
+function contradictsPlanTimeOwnedPaths(spec, gateResult) {
+  const planned = spec?.approvalPolicy?.dispatchEvidence?.ticket;
+  const current = gateResult?.evidence?.ticket;
+  return Boolean(
+    planned?.descriptionHash &&
+    planned.ownedPathsParsed === true &&
+    current?.ownedPathsParsed === false &&
+    current.descriptionHash !== planned.descriptionHash
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -665,14 +717,14 @@ export async function executeClaimed(db, registry, adapters, claim, {
     def = getAgent(registry, spec.agent);
   } catch {}
 
-  const refuseTerminal = (reasonCode, checks = ["dispatch_gate"], { causeTyped = false } = {}) =>
+  const refuseTerminal = (reasonCode, checks = ["dispatch_gate"], { causeTyped = false, detail = null } = {}) =>
     txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
         recordFencedAttempt(db, { runId, attempt, actor: owner, policyVersion, now: currentNow });
         return { fenced: true };
       }
-      const journalReason = causeTyped ? typedFailureReason(reasonCode) : reasonCode;
+      const journalReason = causeTyped ? typedFailureReason(reasonCode) : (detail ?? reasonCode);
       transition(db, {
         runId, to: "VERIFYING", expectFrom: "RUNNING",
         actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
@@ -757,17 +809,49 @@ export async function executeClaimed(db, registry, adapters, claim, {
         return { runId, attempt, terminalState: "REFUSED", reasonCode: "claim_lock_starvation", receipt: res?.receipt };
       }
 
-      let gateRefusal = null;
+      const deferTransientGate = (reasonCode) => {
+        releaseClaimLock(lockFile);
+        const deferred = deferTransientDispatchGate(db, {
+          runId, attempt, fencingToken, owner, policyVersion, now: nowFn,
+          reasonCode,
+          maxRequeues: Number.isInteger(dispatchOpts?.maxTransientGateRequeues)
+            ? Math.max(0, dispatchOpts.maxTransientGateRequeues)
+            : DEFAULT_MAX_TRANSIENT_GATE_REQUEUES,
+          random: dispatchOpts?.random ?? Math.random,
+        });
+        if (deferred?.fenced) return { fenced: true };
+        if (deferred?.requeued) {
+          return {
+            runId, attempt, terminalState: "QUEUED", reasonCode,
+            requeueAfterMs: deferred.backoffMs,
+          };
+        }
+        const res = refuseTerminal(reasonCode, ["dispatch_gate", "transient_retry_exhausted"]);
+        if (res?.fenced) return { fenced: true };
+        return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
+      };
+
+      let gateResult;
       try {
-        gateRefusal = worktreeDispatchGate(spec.input, dispatchOpts);
+        gateResult = worktreeDispatchAutoEligibility(spec.input, dispatchOpts);
       } catch (err) {
+        if (hasPlanTimeDispatchEvidence(spec) && String(err?.message ?? err).startsWith("linear_read_failed:")) {
+          return deferTransientGate("linear_read_failed");
+        }
         releaseClaimLock(lockFile);
         throw err;
       }
 
-      if (gateRefusal) {
+      if (!gateResult.ok) {
+        const gateRefusal = gateResult.refusal;
+        if (
+          gateRefusal.reason === "owned_paths_unknown" &&
+          contradictsPlanTimeOwnedPaths(spec, gateResult)
+        ) {
+          return deferTransientGate("owned_paths_unknown");
+        }
         releaseClaimLock(lockFile);
-        const res = refuseTerminal(gateRefusal.reason, ["dispatch_gate"]);
+        const res = refuseTerminal(gateRefusal.reason, ["dispatch_gate"], { detail: gateRefusal.detail });
         if (res?.fenced) return { fenced: true };
         return { runId, attempt, terminalState: "REFUSED", reasonCode: gateRefusal.reason, receipt: res?.receipt };
       }
@@ -1157,6 +1241,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     if (res?.fenced) return { fenced: true };
     return { runId, attempt, terminalState: "FAILED", reasonCode, error: err?.message };
   } finally {
+    stopCancellationMonitor();
     if (leaseHeartbeat) clearInterval(leaseHeartbeat);
     if (ticketClaimed) {
       try { releaseWorkerLease({ repo: repoName, ticket: ticketId, owner, dir: leasesDir }); } catch {}
@@ -1360,12 +1445,28 @@ export function forceFailRun(db, runId, { actor = "operator", reason = "operator
  * Operator retry (§13): FAILED → QUEUED, or recovery from VERIFYING. Only
  * agent-caused failures spend maxAttempts; environment attempts remain retryable.
  * Retrying past the agent budget requires the explicit force override.
+ *
+ * REFUSED is immutable in the lifecycle journal. Give the operator the exact
+ * fresh watched-dispatch command instead of leaking an IllegalTransition.
  */
 export function retryRun(db, runId, { actor, force = false, now = () => Date.now(), policyVersion } = {}) {
   const currentNow = resolveNow(now);
   const row = db.query(`SELECT state, spec_json, attempts FROM runs WHERE run_id = ?`).get(runId);
   if (!row) throw new Error(`unknown run ${runId}`);
   const spec = JSON.parse(row.spec_json);
+  if (row.state === "REFUSED") {
+    const reasonCode = db.query(
+      `SELECT reason_code FROM attempts WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`,
+    ).get(runId)?.reason_code ?? "unknown_refusal";
+    const payload = JSON.stringify({ repo: spec.input?.repo, ticket: spec.input?.ticket });
+    const command = `factory dispatch event factory.dispatch.requested --payload '${payload}' --watch`;
+    const sensitive = ["ticket_security", "ticket_escalated", "escalate_paths_intersect"].includes(reasonCode);
+    throw new Error(
+      `refused_run_not_retryable: ${runId} was refused by ${reasonCode}; ` +
+      `${sensitive ? "human review is required before a fresh watched dispatch; " : "submit a fresh watched dispatch with: "}` +
+      command,
+    );
+  }
   if (!force && (failureCount(db, runId, "agent_error") >= spec.maxAttempts || failureCount(db, runId, "fatal") > 0)) {
     throw new Error("attempts_exhausted");
   }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1399,6 +1399,27 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     };
   }
 
+  const readyDispatchTicket = (identifier, overrides = {}) => ({
+    identifier,
+    state: { name: "Todo" },
+    assignee: null,
+    labels: { nodes: [{ name: "ai:agent-ready" }] },
+    description: "## Owned Paths\n- src/feature/**\n",
+    ...overrides,
+  });
+
+  const planTimeDispatchEvidence = (description = "## Owned Paths\n- src/feature/**\n") => ({
+    source: "chain",
+    mode: "auto",
+    eventType: "factory.dispatch.requested",
+    dispatchEvidence: {
+      ticket: {
+        descriptionHash: hashJson(description),
+        ownedPathsParsed: true,
+      },
+    },
+  });
+
   const dispatchFakeAdapter = {
     async execute({ spec, workspaceDir }) {
       writeFileSync(path.join(workspaceDir, ".transcript.json"), `{"fake":"dispatch transcript"}\n`, "utf8");
@@ -1467,7 +1488,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         random: () => 0,
-        fetchTicket: () => ({ identifier: "WM-701", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-701"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -1504,7 +1525,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         locksDir: lockDir,
         random: () => 0,
         maxClaimLockContentionRequeues: 1,
-        fetchTicket: () => ({ identifier: "WM-701", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-701"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -1539,7 +1560,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         random: () => 1,
-        fetchTicket: (ticket) => ({ identifier: ticket, state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: (ticket) => readyDispatchTicket(ticket),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: async ({ ticket }) => {
@@ -1585,7 +1606,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const sum1 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-702", state: { name: "In Review" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-702", { state: { name: "In Review" } }),
         fetchInFlight: () => [],
         countLeases: () => 0,
       },
@@ -1598,7 +1619,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const sum2 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-703", state: { name: "Todo" }, assignee: { id: "other" }, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-703", { assignee: { id: "other" } }),
         fetchInFlight: () => [],
         countLeases: () => 0,
       },
@@ -1611,7 +1632,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const sum3 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-704", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-704"),
         fetchInFlight: () => [],
         countLeases: () => 2, // cap is 2
       },
@@ -1624,7 +1645,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const sum4 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-705", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] }, description: "## Owned Paths\n- src/api/**\n" }),
+        fetchTicket: () => readyDispatchTicket("WM-705", { description: "## Owned Paths\n- src/api/**\n" }),
         fetchInFlight: () => [{ identifier: "WM-800", description: "## Owned Paths\n- src/api/routes.ts\n" }],
         countLeases: () => 0,
       },
@@ -1637,7 +1658,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const sum5 = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-706", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-706"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: false, reasonCode: "ticket_claim_lost" }),
@@ -1645,6 +1666,82 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }));
     expect(sum5.terminalState).toBe("REFUSED");
     expect(sum5.reasonCode).toBe("ticket_claim_lost");
+  });
+
+  test("claim-time Linear read failure contradicting plan evidence requeues with backoff", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-transient-linear-"));
+    const description = "## Owned Paths\n- src/feature/**\n";
+    const spec = queueRun(db, makeDispatchSpec({
+      input: { repo: "wt-worker", ticket: "WM-707" },
+      approvalPolicy: planTimeDispatchEvidence(description),
+    }));
+    let now = T0;
+    let reads = 0;
+    const o = opts({
+      now: () => now,
+      dispatch: {
+        locksDir: lockDir,
+        random: () => 0,
+        fetchTicket: () => {
+          reads += 1;
+          if (reads === 1) throw new Error("linear_read_failed: HTTP 503");
+          return readyDispatchTicket("WM-707", { description });
+        },
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+      },
+    });
+
+    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "linear_read_failed" });
+    expect(deferred.requeueAfterMs).toBeGreaterThan(0);
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
+    expect(claimNext(db, o)).toBeNull();
+
+    now += deferred.requeueAfterMs;
+    const completed = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(completed).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok", attempt: 1 });
+  });
+
+  test("empty claim-time description retries only when its hash contradicts plan evidence, then explains recovery", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-transient-owned-paths-"));
+    const spec = queueRun(db, makeDispatchSpec({
+      input: { repo: "wt-worker", ticket: "WM-708" },
+      approvalPolicy: planTimeDispatchEvidence(),
+    }));
+    let now = T0;
+    const o = opts({
+      now: () => now,
+      dispatch: {
+        locksDir: lockDir,
+        random: () => 0,
+        maxTransientGateRequeues: 1,
+        fetchTicket: () => readyDispatchTicket("WM-708", { description: "" }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+      },
+    });
+
+    const deferred = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(deferred).toMatchObject({ terminalState: "QUEUED", reasonCode: "owned_paths_unknown" });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+
+    now += deferred.requeueAfterMs;
+    const exhausted = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+    expect(exhausted).toMatchObject({ terminalState: "REFUSED", reasonCode: "owned_paths_unknown" });
+    expect(runState(db, spec.runId)).toBe("REFUSED");
+    expect(() => retryRun(db, spec.runId, {
+      actor: "operator",
+      force: true,
+      policyVersion: "test",
+      now,
+    })).toThrow(
+      `factory dispatch event factory.dispatch.requested --payload '{"repo":"wt-worker","ticket":"WM-708"}' --watch`,
+    );
   });
 
   test("worker lease is acquired during execution and released on completion", async () => {
@@ -1666,7 +1763,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-710", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-710"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -1689,7 +1786,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-720", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-720"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -1713,7 +1810,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-730", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-730"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -1743,7 +1840,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-731", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-731"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -2017,12 +2114,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           dispatch: {
             locksDir: lockDir,
             leasesDir: leaseDir,
-            fetchTicket: () => ({
-              identifier: ticket,
-              state: { name: "Todo" },
-              assignee: null,
-              labels: { nodes: [{ name: "ai:agent-ready" }] },
-            }),
+            fetchTicket: () => readyDispatchTicket(ticket),
             fetchInFlight: () => [],
             countLeases: () => 0,
             claimTicket: () => ({ ok: true }),
@@ -2092,7 +2184,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-732", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-732"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -2116,7 +2208,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-734", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-734"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -2140,7 +2232,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const summary = await runOnce(db, registry, { fake: observingAdapter }, opts({
       dispatch: {
         locksDir: lockDir,
-        fetchTicket: () => ({ identifier: "WM-733", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-733"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -2171,7 +2263,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-740", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-740"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),
@@ -2188,7 +2280,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       dispatch: {
         locksDir: lockDir,
         leasesDir: leaseDir,
-        fetchTicket: () => ({ identifier: "WM-741", state: { name: "Todo" }, assignee: null, labels: { nodes: [{ name: "ai:agent-ready" }] } }),
+        fetchTicket: () => readyDispatchTicket("WM-741"),
         fetchInFlight: () => [],
         countLeases: () => 0,
         claimTicket: () => ({ ok: true }),


### PR DESCRIPTION
## Summary
- refuse unknown or unparseable ticket scope as `owned_paths_unknown` before escalation checks
- persist the concrete intersecting escalation globs for genuine sensitive-path refusals
- requeue contradictory claim-time Linear reads and empty descriptions with bounded backoff, and give REFUSED retries an exact recovery command

## Verification
- `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/worker.test.mjs orchestrator/owned-paths.test.mjs` — 137 pass, 0 fail
- `bun test event-runtime/lib/dispatch.test.mjs` — 18 pass, 0 fail

UX critique: skipped — backend event-runtime dispatch behavior; no user-facing flow

Fixes WM-532