### PR TITLE
chore(agents): raise merge-scan timeout to 1500s for the cursor adapter (WM-540)

### DIFF
--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -20,7 +20,7 @@
     ]
   },
   "limits": {
-    "timeout_seconds": 900,
+    "timeout_seconds": 1500,
     "attempts": 1
   },
   "mutating": false,


### PR DESCRIPTION
Fixes WM-540

## Why
merge-scan@2 now runs on the cursor adapter (grok-4.6-high, WM-523). run_f8eeb97b wrote a valid result.json at 14.7 min and was killed at 15.0 min (TIMED_OUT at 900 s); the two completed cursor scans took 9.4 / 9.6 min. Schedule cadence is 1800 s, so 1500 s fits.

## Change
- `event-runtime/agents/merge-scan.json`: `limits.timeout_seconds` 900 -> 1500
- `merge-fix.json` already has 2700 — no change. Agent definitions have no `notes`/`description` key, so the rationale lives here and in WM-540.
- `update-pins`: pins already current (limits are not pinned).

## Verification
- `bun event-runtime/cli.mjs update-pins` -> pins already current
- `bun test event-runtime/merge.test.mjs` -> 34 pass, 0 fail

## Handoff
UX critique: n/a (no user-facing surface).