### PR TITLE
fix(worktree): resume committed ticket branches (WM-536)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
@@ -375,8 +375,127 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
   }
 });
 
-test("re-dispatch refuses a branch carrying unique commits and names it", () => {
+test("merge-fix re-dispatch resumes a committed PR branch as-is", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-merge-fix-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-open-pr-bin-"));
+  const ticketId = makeTestTicket("MERGEFIX");
+  const branch = `fix/${ticketId}`;
+  const expectedPath = path.join(tempWtRoot, ticketId);
+  const ghArgs = path.join(mockBin, "gh-args.txt");
+
+  try {
+    const firstUp = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "fix", "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(firstUp.exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "merge-fix.txt"), "resolved conflict\n");
+    expect(Bun.spawnSync({ cmd: ["git", "add", "merge-fix.txt"], cwd: expectedPath }).exitCode).toBe(0);
+    expect(Bun.spawnSync({
+      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "merge fix"],
+      cwd: expectedPath,
+      stdout: "pipe",
+      stderr: "pipe",
+    }).exitCode).toBe(0);
+    const committedSha = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim();
+    expect(Bun.spawnSync({
+      cmd: ["bash", DOWN, ticketId],
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      stdout: "pipe",
+      stderr: "pipe",
+    }).exitCode).toBe(0);
+
+    writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "${ghArgs}"
+printf '1\\n'
+`, { mode: 0o755 });
+    const resumed = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "fix", "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    expect(resumed.exitCode).toBe(0);
+    expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim()).toBe(committedSha);
+    expect(readFileSync(ghArgs, "utf8")).toBe(`pr list --head ${branch} --state open --json number --limit 1 --jq length\n`);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+  }
+});
+
+test("explicit resume flag and environment preserve committed branches without querying PRs", () => {
+  for (const mode of ["flag", "environment"]) {
+    const tempWtRoot = mkdtempSync(path.join(tmpdir(), `factory-wt-resume-${mode}-`));
+    const mockBin = mkdtempSync(path.join(tmpdir(), `factory-wt-resume-${mode}-bin-`));
+    const ticketId = makeTestTicket(mode === "flag" ? "RESUMEFLAG" : "RESUMEENV");
+    const branch = `feat/${ticketId}`;
+    const expectedPath = path.join(tempWtRoot, ticketId);
+    const ghCalled = path.join(mockBin, "gh-called.txt");
+
+    try {
+      expect(Bun.spawnSync({
+        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      }).exitCode).toBe(0);
+      writeFileSync(path.join(expectedPath, "resume.txt"), `${mode}\n`);
+      expect(Bun.spawnSync({ cmd: ["git", "add", "resume.txt"], cwd: expectedPath }).exitCode).toBe(0);
+      expect(Bun.spawnSync({
+        cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", `explicit ${mode} resume`],
+        cwd: expectedPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode).toBe(0);
+      const committedSha = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim();
+      expect(Bun.spawnSync({
+        cmd: ["bash", DOWN, ticketId],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exitCode).toBe(0);
+
+      writeFileSync(path.join(mockBin, "gh"), `#!/usr/bin/env bash
+touch "${ghCalled}"
+exit 99
+`, { mode: 0o755 });
+      const resumeArgs = mode === "flag" ? ["--resume"] : [];
+      const resumed = Bun.spawnSync({
+        cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch", ...resumeArgs],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          FACTORY_WT_ROOT: tempWtRoot,
+          FACTORY_WORKTREE_RESUME: mode === "environment" ? "1" : "0",
+          FACTORY_BASE_BRANCH: `missing-base-${ticketId}`,
+          PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+        },
+      });
+      expect(resumed.exitCode).toBe(0);
+      expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath }).stdout.toString().trim()).toBe(committedSha);
+      expect(existsSync(ghCalled)).toBe(false);
+    } finally {
+      Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+      rmSync(tempWtRoot, { recursive: true, force: true });
+      rmSync(mockBin, { recursive: true, force: true });
+      Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+    }
+  }
+});
+
+test("re-dispatch refuses a branch carrying unique commits and names the escape", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-unique-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-no-pr-bin-"));
   const ticketId = makeTestTicket("UNIQUE");
   const branch = `feat/${ticketId}`;
   const expectedPath = path.join(tempWtRoot, ticketId);
@@ -404,19 +523,26 @@ test("re-dispatch refuses a branch carrying unique commits and names it", () => 
       stderr: "pipe",
     }).exitCode).toBe(0);
 
+    writeFileSync(path.join(mockBin, "gh"), "#!/usr/bin/env bash\nprintf '0\\n'\n", { mode: 0o755 });
     const secondUp = Bun.spawnSync({
       cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
     });
     expect(secondUp.exitCode).not.toBe(0);
     expect(secondUp.stderr.toString()).toContain("worktree_branch_has_commits");
     expect(secondUp.stderr.toString()).toContain(branch);
+    expect(secondUp.stderr.toString()).toContain("re-run with --resume");
     expect(existsSync(expectedPath)).toBe(false);
   } finally {
     Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
     rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
     Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
   }
 });

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -8,6 +8,7 @@
 #   bin/worktree-up.sh OPS-123 --no-seed       # start empty (no demo data)
 #   bin/worktree-up.sh OPS-123 --no-fetch      # skip git fetch when base ref exists
 #   bin/worktree-up.sh OPS-123 --reseed        # seed again under a fresh prefix
+#   bin/worktree-up.sh OPS-123 --resume        # preserve an existing branch as-is
 #
 # What it isolates that `git worktree add` does not: the control-API and web
 # ports (hashed from the full ticket id, persisted in .factory/run/ports) and
@@ -32,6 +33,7 @@ RESEED=0
 LIVE=0
 CHECKOUT_ONLY=0
 NO_FETCH=0
+RESUME="${FACTORY_WORKTREE_RESUME:-0}"
 POS=0
 
 while [[ $# -gt 0 ]]; do
@@ -41,6 +43,7 @@ while [[ $# -gt 0 ]]; do
     --no-seed) SEED=0 ;;
     --no-fetch) NO_FETCH=1 ;;
     --reseed) RESEED=1 ;;
+    --resume) RESUME=1 ;;
     --checkout-only) CHECKOUT_ONLY=1 ;;
     -h | --help)
       sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -59,6 +62,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+[[ "$RESUME" == "0" || "$RESUME" == "1" ]] \
+  || die "FACTORY_WORKTREE_RESUME must be 0 or 1 (got '$RESUME')"
 
 REPO="$(repo_root)"
 WORKTREE_LIFECYCLE_LOCK=""
@@ -95,7 +101,7 @@ if [[ "$HERE" -eq 1 ]]; then
   WT="$REPO"
   LABEL="here"
 else
-  [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--checkout-only, --no-seed, --no-fetch, --reseed)"
+  [[ -n "$TICKET" ]] || die "usage: worktree-up.sh <TICKET-ID> [type] [slug] | --here   (--checkout-only, --no-seed, --no-fetch, --reseed, --resume)"
   [[ "$TICKET" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || die "ticket must look like OPS-123 or OPS-123-scratch"
   WT="$WT_ROOT/$TICKET"
   LABEL="$TICKET"
@@ -107,51 +113,85 @@ else
   trap 'release_worktree_lifecycle_lock; exit 130' INT
   trap 'release_worktree_lifecycle_lock; exit 143' TERM
 
-  [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
-  if [[ "$NO_FETCH" -eq 1 ]]; then
-    FACTORY_SKIP_FETCH=1 git_fetch "$REPO" "origin" "$BASE_BRANCH"
+  BASE_REF="origin/$BASE_BRANCH"
+  BRANCH_EXISTS=0
+  RESUMING=0
+  git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH" && BRANCH_EXISTS=1
+
+  # An explicit resume is a promise not to refresh or inspect the existing
+  # branch against the base. Auto-resume still fetches so its unique-commit
+  # and open-PR checks use the current remote base.
+  if [[ "$BRANCH_EXISTS" -eq 1 && "$RESUME" -eq 1 ]]; then
+    RESUMING=1
   else
-    git_fetch "$REPO" "origin" "$BASE_BRANCH"
+    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "fetching origin/$BASE_BRANCH"
+    if [[ "$NO_FETCH" -eq 1 ]]; then
+      FACTORY_SKIP_FETCH=1 git_fetch "$REPO" "origin" "$BASE_BRANCH"
+    else
+      git_fetch "$REPO" "origin" "$BASE_BRANCH"
+    fi
   fi
 
-  BASE_REF="origin/$BASE_BRANCH"
-  if git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  if [[ "$BRANCH_EXISTS" -eq 1 ]]; then
     BRANCH_SHA=$(git -C "$REPO" rev-parse "refs/heads/$BRANCH") \
       || die "worktree_branch_inspection_failed: could not resolve branch '$BRANCH'"
-    BASE_SHA=$(git -C "$REPO" rev-parse "$BASE_REF") \
-      || die "worktree_branch_inspection_failed: could not resolve $BASE_REF"
-    UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
-      || die "worktree_branch_inspection_failed: could not compare branch '$BRANCH' with $BASE_REF"
-    if [[ "$UNIQUE_COMMITS" -gt 0 ]]; then
-      die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF — resume or remove it explicitly before re-dispatch"
+
+    if [[ "$RESUMING" -eq 0 ]]; then
+      BASE_SHA=$(git -C "$REPO" rev-parse "$BASE_REF") \
+        || die "worktree_branch_inspection_failed: could not resolve $BASE_REF"
+      UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
+        || die "worktree_branch_inspection_failed: could not compare branch '$BRANCH' with $BASE_REF"
     fi
 
-    if [[ -d "$WT" ]]; then
-      CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-      [[ "$CURRENT_BRANCH" == "$BRANCH" ]] \
-        || die "worktree_branch_mismatch: $WT is on '${CURRENT_BRANCH:-detached HEAD}', expected '$BRANCH'"
-      [[ -z "$(git -C "$WT" status --porcelain)" ]] \
-        || die "worktree_branch_dirty: $WT has uncommitted work — resume or clean it explicitly before re-dispatch"
-      # `merge --ff-only` is non-destructive if another process commits after
-      # inspection; unlike reset --hard, it can never discard that commit.
-      git -C "$WT" merge --ff-only "$BASE_REF" >/dev/null \
-        || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
+    if [[ "$RESUMING" -eq 0 && "$UNIQUE_COMMITS" -gt 0 ]]; then
+      OPEN_PR_COUNT=$(cd "$REPO" && gh pr list --head "$BRANCH" --state open --json number --limit 1 --jq 'length' 2>/dev/null) \
+        || die "worktree_pr_inspection_failed: could not check for an open PR on branch '$BRANCH'"
+      [[ "$OPEN_PR_COUNT" == "1" ]] && RESUMING=1
+    fi
+
+    if [[ "$RESUMING" -eq 1 ]]; then
+      if [[ -d "$WT" ]]; then
+        CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+        [[ "$CURRENT_BRANCH" == "$BRANCH" ]] \
+          || die "worktree_branch_mismatch: $WT is on '${CURRENT_BRANCH:-detached HEAD}', expected '$BRANCH'"
+      fi
+      [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "resuming branch $BRANCH as-is"
     else
-      # Compare-and-swap the ref so a concurrent commit cannot be overwritten.
-      git -C "$REPO" update-ref "refs/heads/$BRANCH" "$BASE_SHA" "$BRANCH_SHA" \
-        || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
-    fi
+      if [[ "$UNIQUE_COMMITS" -gt 0 ]]; then
+        die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF — re-run with --resume or remove branch '$BRANCH' explicitly before re-dispatch"
+      fi
 
-    UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
-      || die "worktree_branch_inspection_failed: could not re-check branch '$BRANCH'"
-    [[ "$UNIQUE_COMMITS" -eq 0 ]] \
-      || die "worktree_branch_has_commits: branch '$BRANCH' gained $UNIQUE_COMMITS unique commit(s) while moving to $BASE_REF — refusing re-dispatch"
+      if [[ -d "$WT" ]]; then
+        CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+        [[ "$CURRENT_BRANCH" == "$BRANCH" ]] \
+          || die "worktree_branch_mismatch: $WT is on '${CURRENT_BRANCH:-detached HEAD}', expected '$BRANCH'"
+        [[ -z "$(git -C "$WT" status --porcelain)" ]] \
+          || die "worktree_branch_dirty: $WT has uncommitted work — re-run with --resume or clean it explicitly before re-dispatch"
+        # `merge --ff-only` is non-destructive if another process commits after
+        # inspection; unlike reset --hard, it can never discard that commit.
+        git -C "$WT" merge --ff-only "$BASE_REF" >/dev/null \
+          || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
+      else
+        # Compare-and-swap the ref so a concurrent commit cannot be overwritten.
+        git -C "$REPO" update-ref "refs/heads/$BRANCH" "$BASE_SHA" "$BRANCH_SHA" \
+          || die "worktree_branch_update_failed: branch '$BRANCH' changed while moving to $BASE_REF"
+      fi
+
+      UNIQUE_COMMITS=$(git -C "$REPO" rev-list --count "$BASE_REF..$BRANCH") \
+        || die "worktree_branch_inspection_failed: could not re-check branch '$BRANCH'"
+      [[ "$UNIQUE_COMMITS" -eq 0 ]] \
+        || die "worktree_branch_has_commits: branch '$BRANCH' gained $UNIQUE_COMMITS unique commit(s) while moving to $BASE_REF — refusing re-dispatch"
+    fi
   elif [[ -d "$WT" ]]; then
     die "worktree_branch_missing: $WT exists but branch '$BRANCH' does not"
   fi
 
   if [[ -d "$WT" ]]; then
-    [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists at current $BASE_REF: $WT"
+    if [[ "$RESUMING" -eq 1 ]]; then
+      [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists on resumed branch: $WT"
+    else
+      [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "worktree already exists at current $BASE_REF: $WT"
+    fi
   else
     [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "creating worktree $WT on $BRANCH"
     worktree_add "$WT" "$BRANCH" "$BASE_REF" "$REPO"


### PR DESCRIPTION
## Summary
- preserve existing worktree branches when `--resume` or `FACTORY_WORKTREE_RESUME=1` is explicit
- automatically resume unique-commit branches backed by an open pull request
- retain fail-closed stale-branch handling with an actionable escape message
- add fixture coverage for merge-fix, explicit resume, and stale branch refusal

## Verification
- `bun test bin/worktree-checkout.test.mjs bin/worktree-common.test.mjs` — 52 pass, 0 fail

UX critique: skipped — backend worktree provisioning change with no user-facing flow

Fixes WM-536