### PR TITLE
fix(web): keep model names visible in narrow columns

### DIFF
--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -10,6 +10,7 @@ import {
   JsonBlock,
   JumpLink,
   KV,
+  ModelCell,
   Section,
   STATE_HUES,
   StateBadge,
@@ -18,6 +19,7 @@ import {
   shortId,
 } from "./ui";
 import { AgentHoverCard } from "./AgentHoverCard";
+import { attrIcon } from "./attrIcons";
 
 export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
 export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && state !== "VERIFYING";
@@ -329,6 +331,22 @@ export const modelTierText = (spec: Pick<RunSpec, "adapter" | "modelTier" | "mod
   return spec.model ? "override" : "not declared";
 };
 
+/** Model detail rows need enough label width for `model (observed)` plus its icon. */
+function ModelDetailRow({ label, value }: { label: string; value: ReactNode }) {
+  const icon = attrIcon(label);
+  return (
+    <div className="grid grid-cols-[minmax(0,9.25rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
+      <div className="flex min-w-0 items-center gap-1.5 whitespace-nowrap text-(--text-faint)" title={label}>
+        <i className="inline-flex size-3.5 shrink-0 items-center justify-center not-italic [&>svg]:size-3.5" aria-hidden="true">
+          {icon}
+        </i>
+        <span>{label}</span>
+      </div>
+      <div className="min-w-0 text-(--text-dim)">{value}</div>
+    </div>
+  );
+}
+
 /**
  * The model rows, next to `adapter` (WM-221): tier and pinned come from the
  * spec, observed from the transcript the runtime stored. A non-model adapter
@@ -358,11 +376,10 @@ function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null 
   const pinned = pinnedModelText(spec.adapter, spec.model);
   return (
     <>
-      <KV
-        k="model tier"
-        v={
+      <ModelDetailRow
+        label="model tier"
+        value={
           <span
-            className="text-(--text-dim)"
             title={
               spec.modelTier
                 ? "Declared intent, resolved to a model at plan time (WM-135)."
@@ -375,36 +392,32 @@ function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null 
           </span>
         }
       />
-      <KV
-        k="model (pinned)"
-        v={
-          <span
-            className={pinned === DEFAULT_MODEL_TEXT ? "text-(--text-dim)" : "mono text-(--text-dim)"}
+      <ModelDetailRow
+        label="model (pinned)"
+        value={
+          <ModelCell
+            model={pinned}
+            className={pinned === DEFAULT_MODEL_TEXT ? "" : "text-(--text-dim)"}
             title={
               pinned !== DEFAULT_MODEL_TEXT
-                ? "What the planner pinned into this RunSpec — passed to the CLI as --model."
+                ? pinned
                 : spec.model === DEFAULT_MODEL
                   ? "The tier resolved to the `default` sentinel: no --model is passed and the CLI picks."
                   : "This spec pins nothing, so no --model was passed and the CLI picked."
             }
-          >
-            {pinned}
-          </span>
+          />
         }
       />
-      <KV
-        k="model (observed)"
-        v={
-          <span
-            className={observed ? "mono text-(--text-dim)" : "text-(--text-faint)"}
-            title={
-              observed
-                ? "What the harness reported it ran on, read from this run's stored transcript."
-                : "No model id in this run's transcript — it may predate the capture, or none was stored."
-            }
-          >
-            {observed ?? "not recorded"}
-          </span>
+      <ModelDetailRow
+        label="model (observed)"
+        value={
+          observed ? (
+            <ModelCell model={observed} className="text-(--text-dim)" />
+          ) : (
+            <span className="text-(--text-faint)" title="No model id in this run's transcript — it may predate the capture, or none was stored.">
+              not recorded
+            </span>
+          )
         }
       />
     </>

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -93,6 +93,42 @@ export function shortId(id: string): string {
   return body.length <= 8 ? id : id.slice(0, sep + 1) + body.slice(0, 8);
 }
 
+/**
+ * A model id that keeps its distinguishing name visible in narrow columns.
+ * The provider prefix is allowed to shrink away first; the full id remains in
+ * the tooltip. Sentinel values such as `n/a` and `-` render unchanged.
+ */
+export function ModelCell({
+  model,
+  className = "",
+  title = model,
+}: {
+  model: string;
+  className?: string;
+  title?: string;
+}) {
+  const slash = model.indexOf("/");
+  if (slash <= 0 || slash === model.length - 1) {
+    return (
+      <span className={`mono block max-w-full truncate ${className}`} title={title}>
+        {model}
+      </span>
+    );
+  }
+
+  const provider = model.slice(0, slash + 1);
+  const name = model.slice(slash + 1);
+  return (
+    <span className={`mono block min-w-0 max-w-full ${className}`} title={title}>
+      <span className="sr-only">{model}</span>
+      <span aria-hidden="true" className="flex min-w-0 max-w-full items-baseline">
+        <span className="min-w-0 truncate text-(--text-faint)">{provider}</span>
+        <span className="max-w-full shrink-0 truncate">{name}</span>
+      </span>
+    </span>
+  );
+}
+
 export function copyText(text: string, label: string) {
   navigator.clipboard.writeText(text);
   notify(`Copied ${label}`, "info");

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -28,6 +28,7 @@ import {
   KVGroup,
   ListEmpty,
   ListPane,
+  ModelCell,
   Section,
   Th,
   copyText,
@@ -339,11 +340,8 @@ export function Agents({
                     </td>
                   )}
                   {show.has("model") && (
-                    <td
-                      className="mono max-w-56 truncate border-b border-(--border) px-3 py-1.5 text-(--text-dim) whitespace-nowrap"
-                      title={modelText(a)}
-                    >
-                      {modelText(a)}
+                    <td className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <ModelCell model={modelText(a)} className="text-(--text-dim)" />
                     </td>
                   )}
                   {show.has("mutating") && (

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -46,6 +46,7 @@ import {
   DetailPane,
   JumpLink,
   ListEmpty,
+  ModelCell,
   notify,
   StateBadge,
   STATE_HUES,
@@ -779,17 +780,8 @@ export function Runs({
                     </td>
                   )}
                   {show.has("model") && (
-                    <td
-                      className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
-                      title={
-                        rowModel(r) === "n/a"
-                          ? `The ${r.adapter} adapter runs a fixed argv, not a model.`
-                          : r.model && r.model !== "default"
-                            ? `Pinned into the RunSpec at plan time${r.modelTier ? ` from model_tier "${r.modelTier}"` : ""} — open the run for the model it was observed on.`
-                            : "This run pinned no model, so the CLI picked — open the run for the one it was observed on."
-                      }
-                    >
-                      {rowModel(r)}
+                    <td className="max-w-40 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <ModelCell model={rowModel(r)} className="text-(--text-faint)" />
                     </td>
                   )}
                   {show.has("attempts") && (

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -39,6 +39,7 @@ import {
   KV,
   ListEmpty,
   ListPane,
+  ModelCell,
   GroupHeaderRow,
   Section,
   StateBadge,
@@ -759,15 +760,8 @@ export function Workers({
                     </td>
                   )}
                   {show.has("activeModel") && (
-                    <td
-                      className="mono max-w-40 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
-                      title={w.activeModel !== "-" ? w.activeModel : undefined}
-                    >
-                      {w.activeModel !== "-" ? (
-                        <span>{w.activeModel}</span>
-                      ) : (
-                        <span className="text-(--text-faint)">-</span>
-                      )}
+                    <td className="max-w-40 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <ModelCell model={w.activeModel} className="text-(--text-faint)" />
                     </td>
                   )}
                   {show.has("run") && (
@@ -931,7 +925,7 @@ export function Workers({
               {sel.runItem && (
                 <KV
                   k="model"
-                  v={<span className="mono">{pinnedModelText(sel.runItem.adapter, sel.runItem.model)}</span>}
+                  v={<ModelCell model={pinnedModelText(sel.runItem.adapter, sel.runItem.model)} />}
                 />
               )}
               {sel.runItem && <KV k="adapter" v={<span className="mono">{sel.runItem.adapter}</span>} />}


### PR DESCRIPTION
## Summary
- add a shared model cell that dims and yields the provider prefix before the model name
- use it across Runs, Workers, Agents, and run model detail rows
- widen run-detail model labels so `model (observed)` remains readable

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (673 tests)

UX critique: skipped — isolated model-cell readability styling; no interaction or user-completable flow changed

Fixes WM-545