### PR TITLE
fix(web): compact workers table columns (WM-544)

### DIFF
--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -17,6 +17,7 @@ import type { Worker, WorkerCapacity, WorkerState } from "../types";
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 const NOW = new Date().toISOString();
@@ -389,7 +390,7 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
     });
   }
 
-  test("renders Agent, Target, Active Model columns by default with run details and inline agent", async () => {
+  test("renders Agent, Target, and Model columns by default without repeating the agent in Current run", async () => {
     const workerBusy: Worker = {
       ...stubWorker("w_busy_active", "busy"),
       currentRun: "run_active_463",
@@ -406,15 +407,42 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
       // Verify Column headers exist
       expect(getByRole("columnheader", { name: "Agent" })).toBeTruthy();
       expect(getByRole("columnheader", { name: "Target" })).toBeTruthy();
-      expect(getByRole("columnheader", { name: "Active Model" })).toBeTruthy();
+      expect(getByRole("columnheader", { name: "Model" })).toBeTruthy();
 
-      // Verify busy worker displays agent, target, active model, and inline agent with run
-      expect(getAllByText("dispatch@1").length).toBeGreaterThanOrEqual(1);
+      // Verify busy worker displays agent once, plus target and active model.
+      expect(getAllByText("dispatch@1")).toHaveLength(1);
       expect(getByText("factory · WM-253")).toBeTruthy();
       expect(getByText("openai-codex/gpt-5.6-sol")).toBeTruthy();
 
       // Verify idle worker displays dashes for active columns
       expect(getByText("w_idle_free")).toBeTruthy();
+    });
+  });
+
+  test("uses the compact default column set and renders optional adapters as a titled count", async () => {
+    const workerBusy: Worker = {
+      ...stubWorker("w_busy_active", "busy"),
+      currentRun: "run_active_463",
+      adapters: ["actions", "agy", "claude", "command", "cursor", "fake", "pi"],
+    };
+
+    await withRunsAndWorkers([workerBusy], [stubRun], async () => {
+      const { getByRole, getByTitle, queryByRole } = renderWorkers();
+      await waitFor(() => expect(getByRole("columnheader", { name: "Worker" })).toBeTruthy());
+
+      for (const name of ["Worker", "State", "Agent", "Target", "Model", "Current run", "Uptime", "Heartbeat"]) {
+        expect(getByRole("columnheader", { name })).toBeTruthy();
+      }
+      for (const name of ["Host", "PID", "Adapters", "Labels"]) {
+        expect(queryByRole("columnheader", { name })).toBeNull();
+      }
+
+      fireEvent.click(getByRole("button", { name: /display/i }));
+      fireEvent.click(getByRole("button", { name: "Adapters" }));
+
+      expect(getByRole("columnheader", { name: "Adapters" })).toBeTruthy();
+      const adapters = getByTitle("actions, agy, claude, command, cursor, fake, pi");
+      expect(adapters.textContent).toBe("7 adapters");
     });
   });
 

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -196,7 +196,7 @@ const WORKERS_DISPLAY: DisplayConfig<EnrichedWorker> = {
     { key: "state", label: "State", get: workerDisplayState, column: "state" },
     { key: "agent", label: "Agent", get: (w) => w.activeAgent, column: "agent" },
     { key: "target", label: "Target", get: (w) => w.activeTarget, column: "target" },
-    { key: "activeModel", label: "Active Model", get: (w) => w.activeModel, column: "activeModel" },
+    { key: "activeModel", label: "Model", get: (w) => w.activeModel, column: "activeModel" },
     { key: "labels", label: "Labels", get: (w) => labelText(w.labels), column: "labels" },
     { key: "adapters", label: "Adapters", get: (w) => w.adapters.join(", "), column: "adapters" },
     { key: "run", label: "Current run", get: (w) => w.currentRun ?? "", column: "run" },
@@ -205,15 +205,15 @@ const WORKERS_DISPLAY: DisplayConfig<EnrichedWorker> = {
   ],
   columns: [
     { key: "worker", label: "Worker", always: true },
-    { key: "host", label: "Host" },
-    { key: "pid", label: "PID" },
+    { key: "host", label: "Host", defaultHidden: true },
+    { key: "pid", label: "PID", defaultHidden: true },
     { key: "state", label: "State" },
     { key: "agent", label: "Agent" },
     { key: "target", label: "Target" },
-    { key: "activeModel", label: "Active Model" },
+    { key: "activeModel", label: "Model" },
     { key: "run", label: "Current run" },
-    { key: "adapters", label: "Adapters" },
-    { key: "labels", label: "Labels" },
+    { key: "adapters", label: "Adapters", defaultHidden: true },
+    { key: "labels", label: "Labels", defaultHidden: true },
     { key: "uptime", label: "Uptime" },
     { key: "heartbeat", label: "Heartbeat" },
   ],
@@ -773,17 +773,9 @@ export function Workers({
                   {show.has("run") && (
                     <td className="mono max-w-56 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)">
                       {w.currentRun ? (
-                        <div className="flex items-baseline gap-1.5 truncate whitespace-nowrap">
-                          {w.runItem?.agent && (
-                            <span className="truncate text-(--text-dim) text-[11px]" title={`Agent: ${w.runItem.agent}`}>
-                              {w.runItem.agent}
-                            </span>
-                          )}
-                          {w.runItem?.agent && <span className="text-(--text-faint)">·</span>}
-                          <JumpLink onClick={() => openRun(w.currentRun!)} title={`Open ${w.currentRun}`}>
-                            {shortId(w.currentRun)}
-                          </JumpLink>
-                        </div>
+                        <JumpLink onClick={() => openRun(w.currentRun!)} title={`Open ${w.currentRun}`}>
+                          {shortId(w.currentRun)}
+                        </JumpLink>
                       ) : (
                         "-"
                       )}
@@ -794,7 +786,9 @@ export function Workers({
                       className="max-w-40 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
                       title={w.adapters.length > 0 ? w.adapters.join(", ") : undefined}
                     >
-                      {w.adapters.join(", ") || "-"}
+                      {w.adapters.length > 0
+                        ? `${w.adapters.length} adapter${w.adapters.length === 1 ? "" : "s"}`
+                        : "-"}
                     </td>
                   )}
                   {show.has("labels") && (


### PR DESCRIPTION
## Summary
- hide low-information Host, PID, Adapters, and Labels columns by default
- remove the duplicate agent from Current run and compact optional adapter lists to a titled count
- add regression coverage for the default Workers column set and optional adapter rendering

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (674 tests)

UX critique: required — SHIP; verified at 1280px closed and 1440px with the detail pane open, with no horizontal overflow.

Fixes WM-544