### PR TITLE
fix(worker): accept valid result after timeout (WM-538)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -878,18 +878,35 @@ export async function executeClaimed(db, registry, adapters, claim, {
     }
 
     const { exitCode, timedOut, policyDenials = [] } = outcome ?? {};
+    let lateCompletion = false;
 
     if (timedOut) {
-      if (ticketClaimed) {
-        try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "timeout", log: null }); } catch {}
+      // The adapter's stream may outlive the agent-authored artifact. Perform
+      // an output-contract preflight before recording TIMED_OUT, but suppress
+      // worktree command verification until after the fenced VERIFYING
+      // transition below. The normal verifier then runs again in full.
+      try {
+        verifyResult({
+          spec, def, registry, workspaceDir, attempt,
+          extraArtifacts: RUNTIME_ARTIFACTS, worktreeRecord: {},
+        });
+        lateCompletion = true;
+      } catch (err) {
+        if (!(err instanceof ContractViolation)) throw err;
       }
-      const res = failTerminal("TIMED_OUT", "timeout", "timeout");
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
-      if (res?.fenced) return { fenced: true };
-      return { runId, attempt, terminalState: "TIMED_OUT", reasonCode: "timeout" };
+
+      if (!lateCompletion) {
+        if (ticketClaimed) {
+          try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "timeout", log: null }); } catch {}
+        }
+        const res = failTerminal("TIMED_OUT", "timeout", "timeout");
+        destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+        if (res?.fenced) return { fenced: true };
+        return { runId, attempt, terminalState: "TIMED_OUT", reasonCode: "timeout" };
+      }
     }
     const denial = policyDenials[0];
-    if (denial) {
+    if (!lateCompletion && denial) {
       if (ticketClaimed) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `policy_denied:${denial.tool}`, log: null }); } catch {}
       }
@@ -899,7 +916,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
-    if (exitCode !== 0) {
+    if (!lateCompletion && exitCode !== 0) {
       if (ticketClaimed) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `agent_exit_${exitCode}`, log: null }); } catch {}
       }
@@ -929,7 +946,8 @@ export async function executeClaimed(db, registry, adapters, claim, {
       }
       transition(db, {
         runId, to: "VERIFYING", expectFrom: "RUNNING",
-        actor: owner, reason: "exit_0", attempt, policyVersion, now: currentNow,
+        actor: owner, reason: lateCompletion ? "late_completion_after_timeout" : "exit_0",
+        attempt, policyVersion, now: currentNow,
       });
       return { ok: true };
     });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -397,6 +397,56 @@ describe("worker", () => {
     expect(runState(db, spec.runId)).toBe("TIMED_OUT");
   });
 
+  test("timeout accepts a valid result.json written before the adapter hangs (WM-538)", async () => {
+    const db = openDb(":memory:");
+    const writesThenHangs = {
+      async execute({ workspaceDir, timeoutMs }) {
+        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "completed",
+          artifact: {
+            repos: [{ name: "late", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 }],
+            recommendedAction: "dispatch",
+          },
+          evidence: { queries: ["fake"] },
+        }));
+        await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+        return { exitCode: null, timedOut: true };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "writes-then-hangs", timeoutSeconds: 0.01 }));
+
+    const summary = await runOnce(db, registry, { "writes-then-hangs": writesThenHangs }, opts());
+
+    expect(summary.terminalState).toBe("COMPLETED");
+    expect(summary.reasonCode).toBe("ok");
+    expect(runState(db, spec.runId)).toBe("COMPLETED");
+    expect(lifecycleOf(db, spec.runId)).toContainEqual(expect.objectContaining({
+      to_state: "VERIFYING",
+      reason: "late_completion_after_timeout",
+    }));
+    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeTruthy();
+    expect(db.query(`SELECT * FROM outbox`).all()).toHaveLength(1);
+  });
+
+  test("timeout ignores an invalid result.json and remains TIMED_OUT", async () => {
+    const db = openDb(":memory:");
+    const invalidThenTimesOut = {
+      async execute({ workspaceDir }) {
+        writeFileSync(path.join(workspaceDir, "result.json"), "{}\n");
+        return { exitCode: null, timedOut: true };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "invalid-then-timeout" }));
+
+    const summary = await runOnce(db, registry, { "invalid-then-timeout": invalidThenTimesOut }, opts());
+
+    expect(summary.terminalState).toBe("TIMED_OUT");
+    expect(summary.reasonCode).toBe("timeout");
+    expect(runState(db, spec.runId)).toBe("TIMED_OUT");
+    expect(db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId)).toBeNull();
+  });
+
   test("crash with maxAttempts 2: FAILED then auto re-QUEUED; second claim has higher fencing token", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ input: { repos: ["crash"] }, maxAttempts: 2 }));


### PR DESCRIPTION
## Summary
- preflight a timed-out workspace artifact against the agent output contract before recording TIMED_OUT
- route valid late artifacts through the fenced VERIFYING path with `late_completion_after_timeout`
- keep missing/invalid late artifacts TIMED_OUT and add regression coverage

## Verification
- `bun test event-runtime/lib/worker.test.mjs` — 78 pass, 0 fail

UX critique: skipped — backend worker lifecycle change with no user-facing surface

Fixes WM-538