### PR TITLE
chore(dispatch): raise dispatch run cap 45→90 min (WM-567)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -130,7 +130,13 @@ limits:
   # Without it, raising a harness timeout to let long work finish also raises
   # how long a stuck run holds a concurrency slot — that trade is only
   # acceptable when something else guarantees the slot eventually frees.
-  max_run_minutes: 45
+  #
+  # 90 min: raised from 45 (WM-567) after WM-470 run_5aec6675 — a large
+  # architecture ticket — hit the 45-min cap right after pushing its PR and
+  # lost the run. Must not sit below the dispatch agent's own
+  # `limits.timeout_seconds` (event-runtime/agents/dispatch.json, 5400s);
+  # a runtime "extend" for individual runs is WM-566.
+  max_run_minutes: 90
 
 circuit_breaker:
   # Two consecutive environment/build failures (not ticket-specific ones) stop

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -28,7 +28,7 @@
     ]
   },
   "limits": {
-    "timeout_seconds": 2700,
+    "timeout_seconds": 5400,
     "attempts": 1,
     "budget_usd": 15
   },

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -34,7 +34,7 @@ export const EVIDENCE_INLINE_LIMIT_BYTES = 256 * 1024;
  * own verify at the time (`bun test && bun build/emit.mjs --check`, the full
  * suite) measured 196-217s, so nothing could ever pass. Sized at ~3x the
  * slowest observed run, which leaves room for a loaded host while staying far
- * under `limits.max_run_minutes: 45` in config/policy.yaml — the bound that
+ * under `limits.max_run_minutes: 90` in config/policy.yaml — the bound that
  * actually caps a wedged run. (The factory verify has since been narrowed to
  * `bun test event-runtime/lib && bun build/emit.mjs --check`, ~70s, WM-528 —
  * the ceiling stays where it is for the other repos.)


### PR DESCRIPTION
Fixes WM-567

Raises the dispatch agent's `limits.timeout_seconds` 2700 → 5400 and the policy backstop `limits.max_run_minutes` 45 → 90 (with comment), plus the matching comment in `event-runtime/lib/verify.mjs`.

Why: WM-470 run_5aec6675 (large architecture ticket) hit the 45-min cap right after pushing its PR and lost the run. Operator asked 2026-08-17 for longer timeouts for such jobs; a runtime extend feature is tracked separately (WM-566).

Verification: `bun event-runtime/cli.mjs update-pins` (pins already current) && `bun test event-runtime/lib/planner.test.mjs orchestrator/repos-config.test.mjs` — 39 pass, 0 fail.

## Handoff
UX critique: n/a (config only).