### PR TITLE
fix(analytics): parse --since durations by unit

### DIFF
--- a/lib/transcript.mjs
+++ b/lib/transcript.mjs
@@ -25,6 +25,26 @@ export const LOG_DIR = path.join(homedir(), ".factory/logs");
 export const METRICS_DIR = path.join(homedir(), ".factory/metrics");
 export const ROLLUP = path.join(METRICS_DIR, "runs.jsonl");
 
+const DURATION_UNIT_MS = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/** Parse a CLI duration into milliseconds. Unitless values preserve the
+ * historical `--since` behavior and are interpreted as days. */
+export function parseDuration(value) {
+  const match = String(value ?? "").trim().toLowerCase().match(/^(\d+)([smhdw])?$/);
+  if (!match) throw new TypeError(`invalid duration: ${value}`);
+
+  const amount = Number(match[1]);
+  const durationMs = amount * DURATION_UNIT_MS[match[2] ?? "d"];
+  if (!Number.isSafeInteger(durationMs)) throw new RangeError(`duration is too large: ${value}`);
+  return durationMs;
+}
+
 const oneLine = (s, n = 120) => String(s ?? "").replace(/\s+/g, " ").trim().slice(0, n);
 
 // Sonnet-ish per-token rates, used ONLY for harnesses that report no cost of

--- a/lib/transcript.test.mjs
+++ b/lib/transcript.test.mjs
@@ -8,9 +8,29 @@
  * assertion that matters is that a non-Claude run produces non-zero numbers.
  */
 import { test, expect } from "bun:test";
-import { parseRun, identify, messageSignature, errorSignature, estimateUSD } from "./transcript.mjs";
+import { parseRun, identify, messageSignature, errorSignature, estimateUSD, parseDuration } from "./transcript.mjs";
 
 const jsonl = (...events) => events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+
+// ------------------------------------------------------------- duration ---
+test("parseDuration supports seconds, minutes, hours, days, and weeks", () => {
+  expect(parseDuration("10s")).toBe(10_000);
+  expect(parseDuration("30m")).toBe(1_800_000);
+  expect(parseDuration("2h")).toBe(7_200_000);
+  expect(parseDuration("3d")).toBe(259_200_000);
+  expect(parseDuration("2w")).toBe(1_209_600_000);
+});
+
+test("parseDuration defaults unitless integers to days", () => {
+  expect(parseDuration("7")).toBe(604_800_000);
+});
+
+test("parseDuration rejects invalid or unsafe values", () => {
+  for (const value of ["", "nope", "1.5h", "-2d", "10ms"]) {
+    expect(() => parseDuration(value)).toThrow(/invalid duration/);
+  }
+  expect(() => parseDuration("999999999999999999999d")).toThrow(/too large/);
+});
 
 // ------------------------------------------------------------- identify ---
 test("identify pulls repo, stage and ticket out of the log filename", () => {

--- a/orchestrator/economics.mjs
+++ b/orchestrator/economics.mjs
@@ -34,7 +34,7 @@
 import { readdirSync, readFileSync, statSync, existsSync, mkdirSync, appendFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { LOG_DIR, METRICS_DIR, ROLLUP, parseRun, messageSignature } from "../lib/transcript.mjs";
+import { LOG_DIR, METRICS_DIR, ROLLUP, parseRun, messageSignature, parseDuration } from "../lib/transcript.mjs";
 
 const argv = process.argv.slice(2);
 const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -67,9 +67,7 @@ if (argv.includes("--gate")) {
 }
 
 const sinceArg = val("--since");
-const sinceMs = sinceArg
-  ? Date.now() - Number(sinceArg.replace(/[^\d]/g, "")) * (sinceArg.endsWith("h") ? 3600e3 : 86400e3)
-  : 0;
+const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
 
 const files = readdirSync(LOG_DIR)
   .filter((f) => f.endsWith(".jsonl"))

--- a/orchestrator/friction.mjs
+++ b/orchestrator/friction.mjs
@@ -27,7 +27,7 @@
  * change" is not a job for a histogram.
  */
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
-import { parseRun, LOG_DIR } from "../lib/transcript.mjs";
+import { parseRun, LOG_DIR, parseDuration } from "../lib/transcript.mjs";
 
 const argv = process.argv.slice(2);
 const val = (f) => { const i = argv.indexOf(f); return i === -1 ? null : argv[i + 1]; };
@@ -36,9 +36,7 @@ const JSON_OUT = argv.includes("--json");
 if (!existsSync(LOG_DIR)) { console.error(`no transcripts at ${LOG_DIR}`); process.exit(1); }
 
 const sinceArg = val("--since");
-const sinceMs = sinceArg
-  ? Date.now() - Number(sinceArg.replace(/[^\d]/g, "")) * (sinceArg.endsWith("h") ? 3600e3 : 86400e3)
-  : 0;
+const sinceMs = sinceArg ? Date.now() - parseDuration(sinceArg) : 0;
 const onlyRun = val("--run");
 
 const files = readdirSync(LOG_DIR)


### PR DESCRIPTION
## Summary
- add a shared, strict duration parser supporting seconds through weeks
- preserve unitless `--since` values as days
- use the parser in economics and friction analytics

## Verification
- `bun test lib/transcript.test.mjs` (18 pass, 0 fail)

UX critique: skipped — internal analytics CLI with no user-facing surface

Fixes WM-279