### PR TITLE
fix(event-runtime-web): restore theme surface hierarchy

### DIFF
--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -2,10 +2,10 @@
 @import "@fontsource-variable/inter/opsz.css";
 
 /*
- * Three theme tokens, everything else derived (webui spec §5.1, after
- * Linear's redesign). Dark is the default; light and high-contrast only
- * re-declare the three tokens — every surface, border, and text shade below
- * is computed, never hand-picked per theme.
+ * Three color tokens drive text, borders, and state hues (webui spec §5.1,
+ * after Linear's redesign). Dark is the default. Light additionally declares
+ * explicit semantic surfaces: mixing toward its dark contrast token cannot
+ * produce the white main canvas between the two grey chrome/card steps.
  */
 :root {
   --base: oklch(0.16 0.007 260);
@@ -42,12 +42,22 @@
 
   /* meaningful color: state hues derived from the accent by hue rotation,
      sharing its lightness/chroma so badges sit consistently on any theme */
+  --hue-accent: var(--accent);
   --hue-ok: oklch(from var(--accent) l c 150);
   --hue-warn: oklch(from var(--accent) l c 75);
   --hue-err: oklch(from var(--accent) l c 25);
   --hue-verify: oklch(from var(--accent) l c 310);
   --hue-info: var(--accent);
   --hue-idle: color-mix(in oklch, var(--text-faint) 100%, transparent);
+}
+
+/* A white canvas between soft-grey chrome and slightly deeper raised surfaces
+   restores the same three-step hierarchy that dark gets from its mixes. */
+[data-theme="light"] {
+  --surface-0: oklch(0.965 0.003 260);
+  --surface-1: oklch(1 0 0);
+  --surface-2: oklch(0.94 0.004 260);
+  --surface-3: oklch(0.9 0.006 260);
 }
 
 body {
@@ -74,18 +84,18 @@ body {
     font-size: 11.5px;
   }
 
+  /* Table banding is intentionally a semantic surface rather than a separate
+     colour, so row text keeps the same contrast contract in every theme. */
+  tbody > tr:nth-child(even):not(.row-selected):not(.row-wash-err):not(.row-wash-warn) {
+    background: color-mix(in oklch, var(--surface-2) 70%, var(--surface-1));
+  }
+
   /* Status washes on inbox rows — declared before .row-selected so selection wins. */
   .row-wash-err {
     background: color-mix(in oklch, var(--hue-err) 6%, transparent);
   }
   .row-wash-warn {
     background: color-mix(in oklch, var(--hue-warn) 6%, transparent);
-  }
-
-  /* Row selection ring used by keyboard navigation. */
-  .row-selected {
-    background: color-mix(in oklch, var(--accent) 16%, var(--surface-0));
-    box-shadow: inset 3px 0 0 var(--accent);
   }
 
   /* Prevent list/data table cells from breaking into multiple lines across tables */
@@ -98,6 +108,14 @@ body {
     font-size: 11px;
     color: var(--text-faint);
   }
+}
+
+/* Selection must beat table hover/background utilities, which Tailwind emits
+   after the components layer. Keeping this paint-only rule unlayered preserves
+   the accent wash for every selected table row. */
+.row-selected {
+  background: color-mix(in oklch, var(--hue-accent) 14%, transparent);
+  box-shadow: inset 2px 0 0 var(--hue-accent);
 }
 
 :focus-visible {

--- a/event-runtime/web/src/theme.test.ts
+++ b/event-runtime/web/src/theme.test.ts
@@ -76,6 +76,11 @@ interface ParsedTheme {
   textDim: OklchColor;
   textFaint: OklchColor;
   surface0: OklchColor;
+  surface1: OklchColor;
+  surface2: OklchColor;
+  surface3: OklchColor;
+  hueAccent: OklchColor;
+  hueWarn: OklchColor;
   border: OklchColor;
   borderStrong: OklchColor;
 }
@@ -98,8 +103,22 @@ function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedThe
     return m ? m[1].trim() : null;
   }
 
+  function extractAllBlocks(selector: string): string {
+    const blocks: string[] = [];
+    let from = 0;
+    while (true) {
+      const startIdx = css.indexOf(selector, from);
+      if (startIdx === -1) break;
+      const openBrace = css.indexOf("{", startIdx);
+      const closeBrace = css.indexOf("}", openBrace);
+      blocks.push(css.slice(openBrace + 1, closeBrace));
+      from = closeBrace + 1;
+    }
+    return blocks.join("\n");
+  }
+
   const rootBlock = extractBlock(":root");
-  const lightBlock = extractBlock('[data-theme="light"]');
+  const lightBlock = extractAllBlocks('[data-theme="light"]');
   const contrastBlock = extractBlock('[data-theme="contrast"]');
   const sharedBlock = extractBlock("[data-theme]");
 
@@ -114,6 +133,11 @@ function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedThe
   const textFaintPct = parseMixPct(extractVar(sharedBlock, "text-faint")!, "contrast");
   const borderPct = parseMixPct(extractVar(sharedBlock, "border")!, "base");
   const borderStrongPct = parseMixPct(extractVar(sharedBlock, "border-strong")!, "base");
+  const surfacePcts = {
+    surface1: parseMixPct(extractVar(sharedBlock, "surface-1")!, "base"),
+    surface2: parseMixPct(extractVar(sharedBlock, "surface-2")!, "base"),
+    surface3: parseMixPct(extractVar(sharedBlock, "surface-3")!, "base"),
+  };
 
   function buildTheme(block: string, defaultOnAccent: string): ParsedTheme {
     const baseStr = extractVar(block, "base")!;
@@ -135,12 +159,24 @@ function resolveThemesFromCss(): Record<"dark" | "light" | "contrast", ParsedThe
       onAccent = parseOklch(onAccentStr);
     }
 
+    const surface = (name: "surface-0" | "surface-1" | "surface-2" | "surface-3"): OklchColor => {
+      const explicit = extractVar(block, name);
+      if (explicit) return parseOklch(explicit);
+      if (name === "surface-0") return base;
+      return mixOklch(base, contrast, surfacePcts[name.replace("-", "") as keyof typeof surfacePcts]);
+    };
+
     return {
       base,
       contrast,
       accent,
       onAccent,
-      surface0: base,
+      surface0: surface("surface-0"),
+      surface1: surface("surface-1"),
+      surface2: surface("surface-2"),
+      surface3: surface("surface-3"),
+      hueAccent: accent,
+      hueWarn: { ...accent, h: 75 },
       text: mixOklch(contrast, base, textPct),
       textDim: mixOklch(contrast, base, textDimPct),
       textFaint: mixOklch(contrast, base, textFaintPct),
@@ -196,5 +232,37 @@ describe("Theme contrast & accessibility (OPS-447, OPS-338)", () => {
 
     expect(contrastBtnCr).toBeGreaterThanOrEqual(darkBtnCr);
     expect(contrastBtnCr).toBeGreaterThanOrEqual(lightBtnCr);
+  });
+
+  test("light theme has white main between soft-grey chrome and deeper raised surfaces (WM-558)", () => {
+    const light = themes.light;
+    expect(light.surface0.l).toBeCloseTo(0.965, 3);
+    expect(light.surface0.c).toBeCloseTo(0.003, 3);
+    expect(light.surface1.l).toBe(1);
+    expect(light.surface2.l).toBeLessThan(light.surface0.l);
+    expect(light.surface0.l).toBeLessThan(light.surface1.l);
+  });
+
+  test("light theme chips and zebra-row content clear non-text contrast (>= 3:1) (WM-558)", () => {
+    const light = themes.light;
+    // These percentages mirror App's LIVE and nav count recipes, ContextTabs'
+    // active In flight token, and theme.css's zebra row recipe.
+    const liveWash = mixOklch(light.hueWarn, light.surface1, 0.15);
+    const inFlightWash = mixOklch(light.hueAccent, light.base, 0.25);
+    const sidebarAccentWash = mixOklch(light.hueAccent, light.surface1, 0.12);
+    const sidebarWarnWash = mixOklch(light.hueWarn, light.surface1, 0.12);
+    const zebra = mixOklch(light.surface2, light.surface1, 0.7);
+
+    expect(contrastRatio(light.hueWarn, liveWash)).toBeGreaterThanOrEqual(3);
+    expect(contrastRatio(light.text, inFlightWash)).toBeGreaterThanOrEqual(3);
+    expect(contrastRatio(light.hueAccent, sidebarAccentWash)).toBeGreaterThanOrEqual(3);
+    expect(contrastRatio(light.hueWarn, sidebarWarnWash)).toBeGreaterThanOrEqual(3);
+    expect(contrastRatio(light.textDim, zebra)).toBeGreaterThanOrEqual(3);
+  });
+
+  test("row treatments use semantic zebra surfaces and accent-hued 2px selection (WM-558)", () => {
+    const css = fs.readFileSync(path.resolve(__dirname, "theme.css"), "utf-8");
+    expect(css).toMatch(/tbody\s*>\s*tr:nth-child\(even\)[^{]*\{[^}]*var\(--surface-2\)/s);
+    expect(css).toMatch(/\.row-selected\s*\{[^}]*var\(--hue-accent\)\s+1[2-6]%,\s*transparent[^}]*inset\s+2px\s+0\s+0\s+var\(--hue-accent\)/s);
   });
 });


### PR DESCRIPTION
Fixes WM-558

- give light mode explicit chrome, canvas, and raised surface steps
- add semantic zebra rows and contrast-safe chip assertions
- keep selected rows on the accent hue with a 14% wash and 2px accent bar

Verification: `cd event-runtime/web && bun run build && bun test` — 676 tests pass.

UX critique: skipped — isolated theme-token/styling change with no user flow or interaction change.

Visual checks: Runs pane-open screenshots captured in the ticket worktree at `screenshots/WM-558-light.png` and `screenshots/WM-558-contrast.png`.