### PR TITLE
fix(web): suppress route landmark focus ring

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -363,12 +363,10 @@ describe("context strip fast jump chords (WM-235)", () => {
   });
 });
 
-describe("view navigation landmark focus and announcement (WM-325)", () => {
-  test("main landmark receives focus without visual focus ring on view navigation", async () => {
+describe("view navigation landmark focus and announcement (WM-325, WM-542)", () => {
+  test("main landmark receives focus and announces the view on navigation", async () => {
     const utils = renderApp();
     const main = utils.getByRole("main");
-    expect(main.className).toContain("focus:outline-none");
-    expect(main.className).not.toContain("focus:ring");
 
     act(() => {
       fireEvent.keyDown(document.body, { key: "g" });
@@ -377,8 +375,20 @@ describe("view navigation landmark focus and announcement (WM-325)", () => {
     expect(window.location.hash).toBe("#/runs");
 
     await waitFor(() => {
+      expect(document.activeElement).toBe(main);
       expect(main.textContent).toContain("Runs view");
     });
+  });
+
+  test("theme suppresses the landmark ring without removing interactive focus rings", async () => {
+    const themeCss = await Bun.file(new URL("./theme.css", import.meta.url)).text();
+
+    expect(themeCss).toMatch(
+      /:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--accent\);[^}]*\}/s,
+    );
+    expect(themeCss).toMatch(
+      /main\[tabindex="-1"\]:focus-visible\s*\{\s*outline:\s*none;\s*\}/,
+    );
   });
 });
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -330,7 +330,9 @@ export function App() {
     setViewAnnouncement(`${viewLabel} view`);
     // `/` intentionally sends focus to the destination view's filter instead.
     // Fall back to main when a lazy destination has not mounted its filter yet.
-    if (!document.activeElement?.matches("[data-view-filter]")) mainRef.current?.focus();
+    if (!document.activeElement?.matches("[data-view-filter]")) {
+      mainRef.current?.focus({ preventScroll: true });
+    }
   }, [view, viewLabel]);
 
   useEffect(() => {

--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -105,6 +105,12 @@ body {
   outline-offset: 2px;
 }
 
+/* Route changes focus the landmark for screen-reader context, but the landmark
+   itself is not an interactive control and must not inherit the global ring. */
+main[tabindex="-1"]:focus-visible {
+  outline: none;
+}
+
 ::selection {
   background: color-mix(in oklch, var(--accent) 30%, transparent);
 }


### PR DESCRIPTION
## Summary
- suppress the global focus-visible outline only on the programmatically focused main landmark
- preserve route focus, view announcements, and focus rings for interactive elements
- prevent route focus from scrolling and add regression coverage

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (674 tests)

UX critique: skipped — isolated focus-ring styling; no user-completable flow or interaction behavior changed

Fixes WM-542