### PR TITLE
fix(web): label Projects scope caption

### DIFF
--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -86,14 +86,14 @@ describe("Projects unscoped caption (WM-157)", () => {
     });
   });
 
-  test("repo context tab captions that the registry is factory-wide", async () => {
+  test("repo context tab captions that Projects are factory-wide", async () => {
     window.location.hash = "#/projects?project=factory";
     await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {
       const r = renderProjects();
       await waitFor(() => {
         expect(r.getByText("factory")).toBeTruthy();
       });
-      expect(r.getByText("registry is not scoped to factory.")).toBeTruthy();
+      expect(r.getByText("Projects are not scoped to factory.")).toBeTruthy();
     });
   });
 
@@ -128,7 +128,7 @@ describe("Projects unscoped caption (WM-157)", () => {
         window.removeEventListener("hashchange", swallow, true);
       }
 
-      expect(r.getByText("registry is not scoped to factory.")).toBeTruthy();
+      expect(r.getByText("Projects are not scoped to factory.")).toBeTruthy();
     });
   });
 });

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -382,7 +382,7 @@ export function Projects({
             <ScopeCaption
               context={context}
               surface="registry"
-              subject={{ label: "registry", plural: false }}
+              subject={{ label: "Projects", plural: true }}
             />
             <div className="mb-3">
               <FilterInput


### PR DESCRIPTION
## Summary
- render the Projects registry caption with a user-facing plural subject
- update Projects caption assertions for repository context

## Verification
- `cd event-runtime/web && bun test src/views/Projects.test.tsx`

UX critique: skipped — isolated copy-only correction with no changed interaction or flow

Fixes WM-184