### PR TITLE
feat(event-runtime-web): linkify run trace refs (WM-546)

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import type { RunState, TraceEntry } from "../types";
 import { changeInput, renderWithClient, restoreApi } from "../test-render";
-import { formatErrorRowLabel, LIVE_STATES, RunTrace } from "./RunTrace";
+import {
+  formatErrorRowLabel,
+  formatUsageSummary,
+  LIVE_STATES,
+  RunTrace,
+} from "./RunTrace";
 
 afterEach(() => {
   cleanup();
@@ -150,6 +155,79 @@ describe("RunTrace error context (WM-588)", () => {
   });
 });
 
+describe("RunTrace links and usage (WM-546)", () => {
+  test("linkifies assistant text but keeps tool-input JSON as code", async () => {
+    const prUrl = "https://github.com/watt-mind/factory/pull/486";
+    const genericUrl = "https://example.com/runs/42";
+    const trace: TraceEntry[] = [
+      entry(1, "assistant_text", {
+        text: `Review ${prUrl}, **${genericUrl}**, and ~~WM-546~~.`,
+      }),
+      entry(2, "tool_use", {
+        name: "Bash",
+        input: { command: `open ${prUrl}` },
+      }),
+    ];
+    const r = renderWithClient(
+      <RunTrace runId="run_trace_links" state="COMPLETED" variant="full" />,
+      {
+        apiMocks: {
+          trace: async () => ({ head: trace[trace.length - 1].seq, entries: trace }),
+        },
+      },
+    );
+
+    await waitForChrome(r);
+
+    const prLink = r.getByRole("link", { name: "watt-mind/factory#486" });
+    expect(prLink.getAttribute("href")).toBe(prUrl);
+    expect(prLink.getAttribute("title")).toBe(prUrl);
+    expect(prLink.getAttribute("target")).toBe("_blank");
+    expect(prLink.getAttribute("rel")).toBe("noopener");
+    expect(r.getByRole("link", { name: genericUrl }).getAttribute("href")).toBe(genericUrl);
+    expect(r.getByRole("link", { name: "WM-546" }).getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-546",
+    );
+
+    fireEvent.click(r.getByText("input"));
+    expect(await r.findByText(/open https:\/\/github\.com\/watt-mind\/factory\/pull\/486/)).toBeTruthy();
+    expect(r.getAllByRole("link")).toHaveLength(3);
+  });
+
+  test("formats missing zero token counts with a real cost without placeholders", async () => {
+    expect(formatUsageSummary(undefined, undefined, 0.7657)).toBe("tokens n/a · $0.77");
+    expect(formatUsageSummary(0, 0, 0.7657)).toBe("tokens n/a · $0.77");
+    expect(formatUsageSummary(12, 34, 0.0123)).toBe("12 in · 34 out · $0.01");
+
+    const trace = [
+      entry(1, "usage", {
+        numTurns: 1,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        costUSD: 0,
+      }),
+      entry(2, "usage", {
+        numTurns: 86,
+        usage: { inputTokens: 0, outputTokens: 0 },
+        costUSD: 0.7657,
+      }),
+    ];
+    const r = renderWithClient(
+      <RunTrace runId="run_trace_usage_na" state="COMPLETED" variant="full" />,
+      {
+        apiMocks: {
+          trace: async () => ({ head: 2, entries: trace }),
+        },
+      },
+    );
+
+    await waitForChrome(r);
+    expect(r.getByText("tokens n/a · $0.77")).toBeTruthy();
+    expect(r.getByText("86 turns · tokens n/a · $0.77")).toBeTruthy();
+    expect(r.container.textContent).not.toContain("0 in · 0 out");
+    expect(r.container.textContent).not.toContain("?");
+  });
+});
+
 describe("RunTrace timing (WM-272)", () => {
   test("filtered views use the next unfiltered entry for duration", async () => {
     const start = Date.parse("2025-01-01T00:00:00.000Z");
@@ -217,7 +295,7 @@ describe("RunTrace a11y (WM-143)", () => {
     const tablist = await waitForChrome(r);
 
     expect(r.getByText("tool · Read")).toBeTruthy();
-    expect(r.getByText(/12 in · 34 out/)).toBeTruthy();
+    expect(r.getAllByText(/12 in · 34 out/)).toHaveLength(2);
     const errorJump = r.getByRole("button", { name: /next error/ });
     expect(errorJump).toBeTruthy();
 
@@ -249,12 +327,13 @@ describe("RunTrace a11y (WM-143)", () => {
       r.getByRole("button", { name: /Jump to latest/ }),
     );
 
+    const usageSummary = r.getAllByText(/12 in · 34 out/)[0];
     const chrome = [
       tablist,
       errorJump,
       clear,
       jump,
-      r.getByText(/12 in · 34 out/).parentElement!,
+      usageSummary.parentElement!,
     ];
     for (const el of chrome) {
       expect(el.textContent ?? "").not.toMatch(/🔧|🔥|⚠️|⬇|✕/);

--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -172,7 +172,10 @@ describe("RunTrace links and usage (WM-546)", () => {
       <RunTrace runId="run_trace_links" state="COMPLETED" variant="full" />,
       {
         apiMocks: {
-          trace: async () => ({ head: trace[trace.length - 1].seq, entries: trace }),
+          trace: async () => ({
+            head: trace[trace.length - 1].seq,
+            entries: trace,
+          }),
         },
       },
     );
@@ -184,18 +187,26 @@ describe("RunTrace links and usage (WM-546)", () => {
     expect(prLink.getAttribute("title")).toBe(prUrl);
     expect(prLink.getAttribute("target")).toBe("_blank");
     expect(prLink.getAttribute("rel")).toBe("noopener");
-    expect(r.getByRole("link", { name: genericUrl }).getAttribute("href")).toBe(genericUrl);
+    expect(r.getByRole("link", { name: genericUrl }).getAttribute("href")).toBe(
+      genericUrl,
+    );
     expect(r.getByRole("link", { name: "WM-546" }).getAttribute("href")).toBe(
       "https://linear.app/watt-mind/issue/WM-546",
     );
 
     fireEvent.click(r.getByText("input"));
-    expect(await r.findByText(/open https:\/\/github\.com\/watt-mind\/factory\/pull\/486/)).toBeTruthy();
+    expect(
+      await r.findByText(
+        /open https:\/\/github\.com\/watt-mind\/factory\/pull\/486/,
+      ),
+    ).toBeTruthy();
     expect(r.getAllByRole("link")).toHaveLength(3);
   });
 
   test("formats missing zero token counts with a real cost without placeholders", async () => {
-    expect(formatUsageSummary(undefined, undefined, 0.7657)).toBe("tokens n/a · $0.77");
+    expect(formatUsageSummary(undefined, undefined, 0.7657)).toBe(
+      "tokens n/a · $0.77",
+    );
     expect(formatUsageSummary(0, 0, 0.7657)).toBe("tokens n/a · $0.77");
     expect(formatUsageSummary(12, 34, 0.0123)).toBe("12 in · 34 out · $0.01");
 

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -131,7 +131,10 @@ function useTraceFeed(runId: string, live: boolean) {
   };
 }
 
-function renderLinkifiedText(text: string, keyPrefix: string): React.ReactNode[] {
+function renderLinkifiedText(
+  text: string,
+  keyPrefix: string,
+): React.ReactNode[] {
   return linkifyText(text).map((part, index) => {
     if (part.kind === "text") return part.text;
     return (
@@ -158,7 +161,12 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
 
   while ((match = tokenRegex.exec(text)) !== null) {
     if (match.index > lastIdx) {
-      nodes.push(...renderLinkifiedText(text.slice(lastIdx, match.index), `text-${lastIdx}`));
+      nodes.push(
+        ...renderLinkifiedText(
+          text.slice(lastIdx, match.index),
+          `text-${lastIdx}`,
+        ),
+      );
     }
     const full = match[0];
     if (match[1]) {
@@ -216,8 +224,10 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
 
 function usageTokenCounts(usage?: Record<string, number>) {
   return {
-    inputTokens: usage?.input_tokens ?? usage?.prompt_tokens ?? usage?.inputTokens,
-    outputTokens: usage?.output_tokens ?? usage?.completion_tokens ?? usage?.outputTokens,
+    inputTokens:
+      usage?.input_tokens ?? usage?.prompt_tokens ?? usage?.inputTokens,
+    outputTokens:
+      usage?.output_tokens ?? usage?.completion_tokens ?? usage?.outputTokens,
   };
 }
 
@@ -226,9 +236,15 @@ function hasUsableTokenCounts(
   outputTokens: number | null | undefined,
   costUSD: number | null | undefined,
 ): boolean {
-  const hasInput = typeof inputTokens === "number" && Number.isFinite(inputTokens);
-  const hasOutput = typeof outputTokens === "number" && Number.isFinite(outputTokens);
-  const zeroWithCost = typeof costUSD === "number" && costUSD > 0 && inputTokens === 0 && outputTokens === 0;
+  const hasInput =
+    typeof inputTokens === "number" && Number.isFinite(inputTokens);
+  const hasOutput =
+    typeof outputTokens === "number" && Number.isFinite(outputTokens);
+  const zeroWithCost =
+    typeof costUSD === "number" &&
+    costUSD > 0 &&
+    inputTokens === 0 &&
+    outputTokens === 0;
   return hasInput && hasOutput && !zeroWithCost;
 }
 
@@ -723,7 +739,9 @@ function TraceBody({
       p.numTurns != null ? `${p.numTurns} turns` : null,
       p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : null,
       formatUsageSummary(inputTokens, outputTokens, p.costUSD),
-    ].filter(Boolean).join(" · ");
+    ]
+      .filter(Boolean)
+      .join(" · ");
     return (
       <div className="min-w-0 flex-1 text-(--text-faint)">
         {summary}

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -18,6 +18,7 @@ import {
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard } from "../hooks";
+import { linkifyText } from "../linkify";
 import type { RunState, TraceEntry, TracePayload } from "../types";
 import {
   DisclosureChevron,
@@ -130,6 +131,24 @@ function useTraceFeed(runId: string, live: boolean) {
   };
 }
 
+function renderLinkifiedText(text: string, keyPrefix: string): React.ReactNode[] {
+  return linkifyText(text).map((part, index) => {
+    if (part.kind === "text") return part.text;
+    return (
+      <a
+        key={`${keyPrefix}-${index}`}
+        href={part.href}
+        title={part.title}
+        target="_blank"
+        rel="noopener"
+        className="text-(--text-dim) underline-offset-2 hover:text-(--accent) hover:underline"
+      >
+        {part.text}
+      </a>
+    );
+  });
+}
+
 function renderInlineMarkdown(text: string): React.ReactNode[] {
   const tokenRegex =
     /(`[^`]+`)|(\*\*[^*]+\*\*|__[^_]+__)|(\*[^*]+\*|_[^_]+_)|(~~[^~]+~~)|(\[[^\]]+\]\([^)]+\))/g;
@@ -139,7 +158,7 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
 
   while ((match = tokenRegex.exec(text)) !== null) {
     if (match.index > lastIdx) {
-      nodes.push(text.slice(lastIdx, match.index));
+      nodes.push(...renderLinkifiedText(text.slice(lastIdx, match.index), `text-${lastIdx}`));
     }
     const full = match[0];
     if (match[1]) {
@@ -154,19 +173,19 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
     } else if (match[2]) {
       nodes.push(
         <strong key={match.index} className="font-semibold text-(--text)">
-          {full.slice(2, -2)}
+          {renderLinkifiedText(full.slice(2, -2), `strong-${match.index}`)}
         </strong>,
       );
     } else if (match[3]) {
       nodes.push(
         <em key={match.index} className="italic text-(--text-dim)">
-          {full.slice(1, -1)}
+          {renderLinkifiedText(full.slice(1, -1), `em-${match.index}`)}
         </em>,
       );
     } else if (match[4]) {
       nodes.push(
         <del key={match.index} className="line-through text-(--text-faint)">
-          {full.slice(2, -2)}
+          {renderLinkifiedText(full.slice(2, -2), `del-${match.index}`)}
         </del>,
       );
     } else if (match[5]) {
@@ -177,7 +196,7 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
             key={match.index}
             href={linkMatch[2]}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener"
             className="text-(--accent) underline hover:opacity-80"
           >
             {linkMatch[1]}
@@ -190,9 +209,39 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
     lastIdx = tokenRegex.lastIndex;
   }
   if (lastIdx < text.length) {
-    nodes.push(text.slice(lastIdx));
+    nodes.push(...renderLinkifiedText(text.slice(lastIdx), `text-${lastIdx}`));
   }
   return nodes.length ? nodes : [text];
+}
+
+function usageTokenCounts(usage?: Record<string, number>) {
+  return {
+    inputTokens: usage?.input_tokens ?? usage?.prompt_tokens ?? usage?.inputTokens,
+    outputTokens: usage?.output_tokens ?? usage?.completion_tokens ?? usage?.outputTokens,
+  };
+}
+
+function hasUsableTokenCounts(
+  inputTokens: number | null | undefined,
+  outputTokens: number | null | undefined,
+  costUSD: number | null | undefined,
+): boolean {
+  const hasInput = typeof inputTokens === "number" && Number.isFinite(inputTokens);
+  const hasOutput = typeof outputTokens === "number" && Number.isFinite(outputTokens);
+  const zeroWithCost = typeof costUSD === "number" && costUSD > 0 && inputTokens === 0 && outputTokens === 0;
+  return hasInput && hasOutput && !zeroWithCost;
+}
+
+export function formatUsageSummary(
+  inputTokens: number | null | undefined,
+  outputTokens: number | null | undefined,
+  costUSD: number | null | undefined,
+): string {
+  const hasCost = typeof costUSD === "number" && Number.isFinite(costUSD);
+  const tokens = hasUsableTokenCounts(inputTokens, outputTokens, costUSD)
+    ? `${inputTokens!.toLocaleString()} in · ${outputTokens!.toLocaleString()} out`
+    : "tokens n/a";
+  return hasCost ? `${tokens} · $${costUSD.toFixed(2)}` : tokens;
 }
 
 export function MarkdownView({
@@ -669,11 +718,15 @@ function TraceBody({
     );
   }
   if (kind === "usage") {
+    const { inputTokens, outputTokens } = usageTokenCounts(p.usage);
+    const summary = [
+      p.numTurns != null ? `${p.numTurns} turns` : null,
+      p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : null,
+      formatUsageSummary(inputTokens, outputTokens, p.costUSD),
+    ].filter(Boolean).join(" · ");
     return (
       <div className="min-w-0 flex-1 text-(--text-faint)">
-        {p.numTurns ?? "?"} turns ·{" "}
-        {p.durationMs != null ? `${(p.durationMs / 1000).toFixed(1)}s` : "?"} ·{" "}
-        {p.costUSD != null ? `$${p.costUSD.toFixed(4)}` : "?"}
+        {summary}
         {p.usage && Object.keys(p.usage).length > 0 && (
           <Disclosure label="tokens" forceOpen={forceOpen}>
             <JsonBlock value={p.usage} />
@@ -807,26 +860,46 @@ export function RunTrace({
   }, [entries]);
 
   const tokenStats = useMemo(() => {
-    let promptTokens = 0;
-    let completionTokens = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
     let totalCost = 0;
-    let hasTokens = false;
+    let hasInputTokens = false;
+    let hasOutputTokens = false;
+    let hasUsage = false;
+    let hasUnknownCostTokens = false;
     for (const e of entries) {
       if (e.payload?.usage) {
-        hasTokens = true;
-        const u = e.payload.usage;
-        promptTokens += u.input_tokens ?? u.prompt_tokens ?? u.inputTokens ?? 0;
-        completionTokens +=
-          u.output_tokens ?? u.completion_tokens ?? u.outputTokens ?? 0;
+        hasUsage = true;
+        const counts = usageTokenCounts(e.payload.usage);
+        if (counts.inputTokens != null) {
+          inputTokens += counts.inputTokens;
+          hasInputTokens = true;
+        }
+        if (counts.outputTokens != null) {
+          outputTokens += counts.outputTokens;
+          hasOutputTokens = true;
+        }
+        if (
+          e.payload.costUSD != null &&
+          e.payload.costUSD > 0 &&
+          !hasUsableTokenCounts(
+            counts.inputTokens,
+            counts.outputTokens,
+            e.payload.costUSD,
+          )
+        ) {
+          hasUnknownCostTokens = true;
+        }
       }
-      if (e.payload?.costUSD) totalCost += e.payload.costUSD;
+      if (e.payload?.costUSD != null) totalCost += e.payload.costUSD;
     }
     return {
-      promptTokens,
-      completionTokens,
-      totalTokens: promptTokens + completionTokens,
+      inputTokens:
+        hasInputTokens && !hasUnknownCostTokens ? inputTokens : undefined,
+      outputTokens:
+        hasOutputTokens && !hasUnknownCostTokens ? outputTokens : undefined,
       totalCost,
-      hasTokens,
+      show: hasUsage || totalCost > 0,
     };
   }, [entries]);
 
@@ -1195,17 +1268,15 @@ export function RunTrace({
           <div />
         )}
 
-        {tokenStats.hasTokens && (
+        {tokenStats.show && (
           <div className="flex items-center gap-1.5 rounded bg-(--surface-1) border border-(--border) px-2 py-0.5 text-[11px] mono text-(--text-dim)">
             <span title="Cumulative token burn across trace">
-              {tokenStats.promptTokens.toLocaleString()} in ·{" "}
-              {tokenStats.completionTokens.toLocaleString()} out
+              {formatUsageSummary(
+                tokenStats.inputTokens,
+                tokenStats.outputTokens,
+                tokenStats.totalCost,
+              )}
             </span>
-            {tokenStats.totalCost > 0 && (
-              <span className="text-(--text-faint)">
-                (${tokenStats.totalCost.toFixed(4)})
-              </span>
-            )}
           </div>
         )}
       </div>

--- a/event-runtime/web/src/linkify.test.ts
+++ b/event-runtime/web/src/linkify.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { linkifyText } from "./linkify";
+
+describe("linkifyText", () => {
+  test("linkifies a plain URL", () => {
+    expect(linkifyText("See https://example.com/runs/42.")).toEqual([
+      { kind: "text", text: "See " },
+      {
+        kind: "link",
+        text: "https://example.com/runs/42",
+        href: "https://example.com/runs/42",
+        title: "https://example.com/runs/42",
+      },
+      { kind: "text", text: "." },
+    ]);
+  });
+
+  test("shortens GitHub pull request URLs and excludes closing delimiters", () => {
+    const url = "https://github.com/watt-mind/factory/pull/486";
+    expect(linkifyText(`<${url}>`)).toEqual([
+      { kind: "text", text: "<" },
+      {
+        kind: "link",
+        text: "watt-mind/factory#486",
+        href: url,
+        title: url,
+      },
+      { kind: "text", text: ">" },
+    ]);
+  });
+
+  test("links Linear-style ticket ids", () => {
+    expect(linkifyText("Fixes WM-546")).toEqual([
+      { kind: "text", text: "Fixes " },
+      {
+        kind: "link",
+        text: "WM-546",
+        href: "https://linear.app/watt-mind/issue/WM-546",
+        title: "WM-546",
+      },
+    ]);
+  });
+
+  test("leaves text without matches unchanged", () => {
+    expect(linkifyText("Nothing to link here.")).toEqual([
+      { kind: "text", text: "Nothing to link here." },
+    ]);
+  });
+});

--- a/event-runtime/web/src/linkify.ts
+++ b/event-runtime/web/src/linkify.ts
@@ -1,0 +1,81 @@
+export type LinkifiedPart =
+  | { kind: "text"; text: string }
+  | { kind: "link"; text: string; href: string; title: string };
+
+const CANDIDATE = /https?:\/\/[^\s<>"']+|[A-Z]{2,5}-\d+/g;
+const TRAILING_PUNCTUATION = /[.,!?;:\]\}]+$/;
+const GITHUB_PR = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/;
+const LINEAR_ISSUE_ROOT = "https://linear.app/watt-mind/issue";
+
+function splitTrailingPunctuation(candidate: string): [string, string] {
+  let link = candidate;
+  let trailing = "";
+
+  const punctuation = TRAILING_PUNCTUATION.exec(link);
+  if (punctuation) {
+    trailing = punctuation[0];
+    link = link.slice(0, -trailing.length);
+  }
+
+  while (link.endsWith(")")) {
+    const opens = (link.match(/\(/g) ?? []).length;
+    const closes = (link.match(/\)/g) ?? []).length;
+    if (closes <= opens) break;
+    link = link.slice(0, -1);
+    trailing = `)${trailing}`;
+  }
+
+  return [link, trailing];
+}
+
+function pushText(parts: LinkifiedPart[], text: string) {
+  if (!text) return;
+  const previous = parts[parts.length - 1];
+  if (previous?.kind === "text") {
+    previous.text += text;
+  } else {
+    parts.push({ kind: "text", text });
+  }
+}
+
+/** Split prose into safe render tokens without interpreting markdown or code. */
+export function linkifyText(text: string): LinkifiedPart[] {
+  const parts: LinkifiedPart[] = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(CANDIDATE)) {
+    const index = match.index;
+    const candidate = match[0];
+    pushText(parts, text.slice(cursor, index));
+
+    if (candidate.startsWith("http://") || candidate.startsWith("https://")) {
+      const [href, trailing] = splitTrailingPunctuation(candidate);
+      const pr = GITHUB_PR.exec(href);
+      parts.push({
+        kind: "link",
+        text: pr ? `${pr[1]}/${pr[2]}#${pr[3]}` : href,
+        href,
+        title: href,
+      });
+      pushText(parts, trailing);
+    } else {
+      const before = text[index - 1] ?? "";
+      const after = text[index + candidate.length] ?? "";
+      if (/[A-Za-z0-9_-]/.test(before) || /[A-Za-z0-9_-]/.test(after)) {
+        pushText(parts, candidate);
+      } else {
+        parts.push({
+          kind: "link",
+          text: candidate,
+          href: `${LINEAR_ISSUE_ROOT}/${candidate}`,
+          title: candidate,
+        });
+      }
+    }
+
+    cursor = index + candidate.length;
+  }
+
+  pushText(parts, text.slice(cursor));
+  return parts.length > 0 ? parts : [{ kind: "text", text }];
+}

--- a/event-runtime/web/src/linkify.ts
+++ b/event-runtime/web/src/linkify.ts
@@ -4,7 +4,8 @@ export type LinkifiedPart =
 
 const CANDIDATE = /https?:\/\/[^\s<>"']+|[A-Z]{2,5}-\d+/g;
 const TRAILING_PUNCTUATION = /[.,!?;:\]\}]+$/;
-const GITHUB_PR = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/;
+const GITHUB_PR =
+  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/;
 const LINEAR_ISSUE_ROOT = "https://linear.app/watt-mind/issue";
 
 function splitTrailingPunctuation(candidate: string): [string, string] {

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -129,6 +129,38 @@ describe("RunFull header (WM-193)", () => {
   });
 });
 
+describe("RunFull responsive trace flow (WM-546)", () => {
+  test("stacks trace and details in document flow below xl", async () => {
+    const runId = "run_responsive_trace";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "COMPLETED" } as RunDetail["run"],
+    });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "COMPLETED" })],
+        }),
+      },
+      async () => {
+        const { container } = renderRunFull(runId);
+
+        await waitFor(() => {
+          const main = container.querySelector("main");
+          const layout = main?.parentElement;
+          const aside = container.querySelector("aside");
+          expect(layout?.classList.contains("overflow-y-auto")).toBe(true);
+          expect(layout?.classList.contains("xl:overflow-hidden")).toBe(true);
+          expect(main?.classList.contains("flex-none")).toBe(true);
+          expect(main?.classList.contains("xl:flex-1")).toBe(true);
+          expect(aside?.classList.contains("overflow-visible")).toBe(true);
+          expect(aside?.classList.contains("xl:overflow-y-auto")).toBe(true);
+        });
+      },
+    );
+  });
+});
+
 describe("RunFull deadline extension (WM-566)", () => {
   test("shows remaining time and extends by preset or custom increments", async () => {
     const runId = "run_extend_controls";

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -531,10 +531,10 @@ export function RunFull({
           {detail.isError ? "Could not load run detail." : "Loading run…"}
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto xl:flex-row xl:overflow-hidden">
           {/* Main column: the trace, at a readable measure — the point of the
               page — scrolling on its own so the sidebar never moves with it. */}
-          <main className="min-w-0 flex-1 overflow-y-auto">
+          <main className="min-w-0 flex-none overflow-visible xl:flex-1 xl:overflow-y-auto">
             <div className="p-6 xl:mx-auto xl:max-w-[900px]">
               {/* The failure first (WM-93) — renders nothing for other states. */}
               <RunFailureBanner
@@ -588,7 +588,7 @@ export function RunFull({
               rather than the whole layout reflowing (WM-136). Stacks full
               width below the trace under xl, where there is no room for two
               columns. */}
-          <aside className="w-full shrink-0 overflow-y-auto border-(--border) bg-(--surface-1) p-4 xl:w-[460px] xl:border-l">
+          <aside className="w-full shrink-0 overflow-visible border-(--border) bg-(--surface-1) p-4 xl:w-[460px] xl:overflow-y-auto xl:border-l">
             <div onClickCapture={handleRunArtifactClick}>
               <RunDetailBlocks
                 d={d}


### PR DESCRIPTION
## Summary
- linkify HTTP(S), GitHub PR, and Linear issue references in run-trace prose while preserving code/tool-input rendering
- format unknown or zero-with-cost usage as `tokens n/a` with two-decimal cost, including partial aggregate usage
- keep full-run trace and detail panes in normal stacked flow below the desktop breakpoint

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (680 tests)

UX critique: required — FIX-FIRST unresolved after 2 rounds. All WM-546 link and usage criteria passed in the running app at desktop and 1200px; the remaining 390px limitation is the persistent app-level sidebar outside Owned Paths and is tracked by WM-572. Evidence: http://127.0.0.1:7405/#/run/run_5fb19dca-6337-4e29-a7ff-dc75081aad35 and `wm546-390-mobile-links.png` in the run workspace.

Fixes WM-546
