### PR TITLE
fix(ci): checkout via git instead of actions/checkout to dodge codeload 429 (WM-573)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,46 @@ jobs:
     # measured job durations before lowering.
     timeout-minutes: 25
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      # No `uses:` steps in this job on purpose (WM-573). Every marketplace
+      # action is fetched from codeload.github.com at "Set up job", and the
+      # shadow fleet (eight runners, one egress IP, no action archive cache)
+      # got 429 Too Many Requests on actions/checkout for every Verify job on
+      # 2026-08-17 — no repo code ran at all. A plain git fetch of github.sha
+      # is exactly what actions/checkout@v7 did here (shallow, no submodules,
+      # merge commit on pull_request) minus the download that was failing.
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
 
-      # Installs bun rather than assuming the runner has it, so CI doesn't break
-      # the first time this lands on a runner that was never provisioned for it.
-      - name: Setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      # Same reason: oven-sh/setup-bun@v2 is the next codeload download in
+      # line, and it also re-fetched bun-linux-x64.zip from GitHub releases on
+      # every job. The runner user on the shadow host already has bun under
+      # ~/.bun; only install (from bun.sh, not codeload) if it is missing.
+      - name: Setup bun (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
+            curl -fsSL https://bun.sh/install | bash
+          fi
+          if [ -x "$HOME/.bun/bin/bun" ]; then
+            echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            "$HOME/.bun/bin/bun" --version
+          else
+            bun --version
+          fi
 
       - name: Acquire host memory slot
         id: memory-slot

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -680,6 +680,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
         state: { name: "Todo" },
         assignee: null,
         labels: { nodes: [{ name: "ai:agent-ready" }] },
+        // The claim gate fails closed on tickets whose Owned Paths do not
+        // parse (owned_paths_unknown, WM-575); a stub ticket must carry a
+        // parseable section or the demo stub refuses every dispatch.
+        description: "## Owned Paths\n- demo/**\n",
       }),
       fetchInFlight: () => [],
       countLeases: () => 0,


### PR DESCRIPTION
Fixes WM-573
Fixes WM-575

Every Verify job on the shadow fleet was failing at "Set up job" with `429 Too Many Requests` from codeload.github.com while downloading `actions/checkout@v7` (runs 32035509150, 32036745966, ~6 PRs today). Consolidates WM-565 / WM-570.

- Replace `actions/checkout@v7` with a plain `git init` / `fetch --depth 1 <github.sha>` / `checkout FETCH_HEAD` step (same semantics the job used: shallow, no submodules, merge commit on PRs; nothing later pushes).
- Replace `oven-sh/setup-bun@v2` (next codeload download in line, and it re-downloaded bun each job) with a step that puts the runner's existing `~/.bun/bin` on `GITHUB_PATH`, installing from bun.sh only if missing.
- Verify job now has zero `uses:` steps — nothing is fetched from codeload.

WM-575 (second commit): the first Verify run of this PR got past "Set up job" and exposed that develop's tip (a75c027, #488) is red — the explicit demo dispatch stub from #487 returns a ticket with no Owned Paths, and #488's gate now refuses that as `owned_paths_unknown`. Bisected cd88289/8ae0fe6 green, a75c027 red. Bundled here because no other PR can get a Verify run at all until this one lands, and this one cannot go green while develop's suite is red.

## Handoff

- Verification: this PR's own Verify run is the proof — it must get past "Set up job" and run the real suite green.
- UX critique: n/a (CI only)