### PR TITLE
fix(event-runtime-web): stabilize graph viewport

### DIFF
--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -2,9 +2,10 @@ import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
+import { useRef } from "react";
 import { AgentNode, EventTypeNode, ProposalNode, TerminalNode, nodeAccessibleName } from "./nodes";
 import type { GraphNode } from "./model";
-import { Graph, focusedNodeFit } from "../views/Graph";
+import { Graph, focusedNodeFit, useSelectedNodeReveal } from "../views/Graph";
 import {
   changeInput,
   createAgentsFixture,
@@ -334,6 +335,20 @@ const graphAgents = (): AgentsView =>
     ],
   });
 
+function SelectedNodeRevealHarness({
+  focusNodeId,
+  overlayVersion,
+  fitView,
+}: {
+  focusNodeId: string | null;
+  overlayVersion: number;
+  fitView: (options: unknown) => void;
+}) {
+  const flowRef = useRef({ getZoom: () => 1, fitView });
+  useSelectedNodeReveal(focusNodeId, 1, flowRef);
+  return <div>overlay {overlayVersion}</div>;
+}
+
 function renderGraph(props: Partial<Parameters<typeof Graph>[0]> = {}) {
   return renderWithClient(
     <Graph
@@ -465,6 +480,32 @@ describe("Graph view inspect loop", () => {
         expect(onSelectNode).toHaveBeenCalledWith(null);
       },
     );
+  });
+
+  test("background overlay rerenders do not re-center an unchanged focused node", async () => {
+    const fitView = mock((_options: unknown) => {});
+    const view = render(
+      <SelectedNodeRevealHarness
+        focusNodeId="event:gh.failed"
+        overlayVersion={0}
+        fitView={fitView}
+      />,
+    );
+    await waitFor(() => expect(fitView).toHaveBeenCalledTimes(1));
+    expect(fitView.mock.calls[0]?.[0]).toMatchObject({
+      nodes: [{ id: "event:gh.failed" }],
+      duration: 180,
+    });
+
+    view.rerender(
+      <SelectedNodeRevealHarness
+        focusNodeId="event:gh.failed"
+        overlayVersion={1}
+        fitView={fitView}
+      />,
+    );
+    expect(view.getByText("overlay 1")).toBeTruthy();
+    expect(fitView).toHaveBeenCalledTimes(1);
   });
 
   test("selected proposal node shows Open in Proposals jumping via hashPath", async () => {

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -58,6 +58,36 @@ export function focusedNodeFit(id: string, zoom: number): GraphFitViewOptions {
   };
 }
 
+type FlowViewport = {
+  getZoom: () => number;
+  fitView: (opts: GraphFitViewOptions) => void;
+};
+
+// Reveal the selected node without fighting the operator's viewport: the effect
+// depends only on `revealSelected` (which changes with `focusNodeId`) and
+// `flowReady`, so the 5s background poll — which rebuilds `positioned` on every
+// refetch — cannot re-center or interrupt a drag.
+export function useSelectedNodeReveal(
+  focusNodeId: string | null,
+  flowReady: number,
+  flowRef: { current: FlowViewport | null },
+) {
+  const revealSelected = useCallback(() => {
+    if (!focusNodeId || !flowRef.current) return;
+    const zoom = flowRef.current.getZoom();
+    flowRef.current.fitView(focusedNodeFit(focusNodeId, zoom));
+  }, [focusNodeId, flowRef]);
+
+  // `flowReady` makes an initial deep link wait for React Flow's onInit.
+  // Deliberately exclude `positioned`: Reset layout should fit the whole
+  // graph instead of immediately snapping back to the selected node.
+  useEffect(() => {
+    revealSelected();
+  }, [revealSelected, flowReady]);
+
+  return revealSelected;
+}
+
 function flowEdges(graph: { edges: Array<{ id: string; source: string; target: string; kind: keyof typeof EDGE_STYLES; label?: string }> }): Edge[] {
   return graph.edges.map((edge) => ({
     id: edge.id,
@@ -128,10 +158,7 @@ export function Graph({
   const lastIdentityRef = useRef<string | null>(null);
   const epochLaidOutRef = useRef(0);
   const [completedLayoutEpoch, setCompletedLayoutEpoch] = useState(-1);
-  const flowRef = useRef<{
-    getZoom: () => number;
-    fitView: (opts: GraphFitViewOptions) => void;
-  } | null>(null);
+  const flowRef = useRef<FlowViewport | null>(null);
   const [flowReady, setFlowReady] = useState(0);
 
   const { graph, mappingError } = useMemo(() => {
@@ -244,11 +271,7 @@ export function Graph({
 
   const pendingC = useRef<number>(0);
 
-  const revealSelected = useCallback(() => {
-    if (!focusNodeId || !flowRef.current) return;
-    const zoom = flowRef.current.getZoom();
-    flowRef.current.fitView(focusedNodeFit(focusNodeId, zoom));
-  }, [focusNodeId]);
+  const revealSelected = useSelectedNodeReveal(focusNodeId, flowReady, flowRef);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -320,14 +343,6 @@ export function Graph({
     lastFittedLayoutEpoch.current = layoutEpoch;
     flowRef.current.fitView({ padding: GRAPH_FIT_PADDING, maxZoom: 1 });
   }, [completedLayoutEpoch, flowReady, graph, layoutEpoch, positioned]);
-
-  useEffect(() => {
-    revealSelected();
-    // `flowReady` makes an initial deep link wait for React Flow's onInit.
-    // Deliberately exclude `positioned`: Reset layout should fit the whole
-    // graph instead of immediately snapping back to the selected node.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusNodeId, flowReady]);
 
   // Center the current search match at the operator's zoom; `currentMatch` is
   // a stable string, so background refetches do not re-center the viewport.


### PR DESCRIPTION
## Summary
- decouple focused-node reveal from background graph overlay position updates
- preserve explicit selection and “Show on canvas” centering
- add regression coverage for overlay-driven rerenders

## Verification
- `cd event-runtime/web && bun test` — pass, 674 tests

UX critique: required — SHIP
Evidence: http://127.0.0.1:7777/#/graph/agent%3Aci-log-capture%401
Screenshot: /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-dc2f9b8e-1b3e-4beb-bf47-bd6cdf0c17ec.png

Fixes WM-265