### PR TITLE
fix(event-runtime-web): handle expired proposals

### DIFF
--- a/event-runtime/web/src/components/ApprovalRisk.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.tsx
@@ -117,7 +117,7 @@ export function ApprovalSafetyCard({
   const mutHue = risk.mutating ? "var(--hue-err)" : "var(--hue-ok)";
 
   return (
-    <div className="mb-3 rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px]">
+    <div className="mb-3 min-w-0 rounded-md border border-(--border) bg-(--surface-0) p-3 text-[12px]">
       <div className="mb-2 flex items-center justify-between border-b border-(--border) pb-2">
         <div className="flex gap-2">
           <span
@@ -213,7 +213,7 @@ export function ApprovalRiskDetails({ proposal, agent }: { proposal: Proposal; a
         <KV k="ttl" v={<Countdown createdAt={proposal.created_at} ttlSeconds={proposal.ttl_seconds} />} />
       </div>
       <ApprovalSafetyCard proposal={proposal} agent={agent} />
-      <div className="mb-3 max-h-[38vh] overflow-auto">
+      <div className="mb-3 min-w-0 max-h-[38vh] overflow-x-auto overflow-y-auto">
         <Disclosure label="immutable RunSpec" defaultOpen>
           <JsonBlock value={proposal.spec} />
         </Disclosure>

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { Proposals } from "./Proposals";
+import { filterOpenProposals, humanizeReason, Proposals } from "./Proposals";
 import { api } from "../api";
 import {
   changeInput,
@@ -457,6 +457,94 @@ describe("Proposals component harness: filter retention", () => {
   });
 });
 
+describe("Proposals expiration and reason presentation (WM-547)", () => {
+  test("humanizeReason maps known reason codes and makes unknown codes readable", () => {
+    expect(humanizeReason("auto_approval_ineligible:proposal_expired")).toBe(
+      "Auto-approval not eligible — proposal expired",
+    );
+    expect(humanizeReason("custom_reason:needs_operator_review")).toBe(
+      "custom reason:needs operator review",
+    );
+  });
+
+  test("filterOpenProposals keeps TTL-expired proposals out of Open", () => {
+    const now = Date.now();
+    const expired = stubProposal("prop_expired", "open", {
+      created_at: new Date(now - 10_000).toISOString(),
+      ttl_seconds: 1,
+    });
+    const active = stubProposal("prop_active", "open", {
+      created_at: new Date(now - 1_000).toISOString(),
+      ttl_seconds: 300,
+    });
+
+    expect(filterOpenProposals([expired, active], now, false).map((p) => p.id)).toEqual([
+      "prop_active",
+    ]);
+    expect(filterOpenProposals([expired, active], now, true).map((p) => p.id)).toEqual([
+      "prop_expired",
+    ]);
+  });
+
+  test("expired detail disables approval with a reason and the Expired filter can be cleared", async () => {
+    const now = Date.now();
+    const rawReason = "auto_approval_ineligible:proposal_expired";
+    const expired = stubProposal("prop_expired", "open", {
+      agent: "expired-agent",
+      created_at: new Date(now - 10_000).toISOString(),
+      ttl_seconds: 1,
+      reason: rawReason,
+      spec: createRunSpecFixture("run_expired"),
+    });
+    const active = stubProposal("prop_active", "open", {
+      agent: "active-agent",
+      created_at: new Date(now).toISOString(),
+      ttl_seconds: 300,
+    });
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [expired, active] }),
+        proposalHistory: async () => ({ proposals: [] }),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({ focusProposalId: expired.id });
+        const approve = await waitFor(
+          () => r.getByRole("button", { name: /^Approve/ }) as HTMLButtonElement,
+        );
+
+        expect(approve.disabled).toBe(true);
+        expect(approve.parentElement?.getAttribute("title")).toBe(
+          "This proposal has expired and can no longer be approved.",
+        );
+        expect(r.getAllByText("Auto-approval not eligible — proposal expired").length).toBeGreaterThan(0);
+        expect(r.getAllByTitle(rawReason).length).toBeGreaterThan(0);
+        expect(r.getByText("Safety & blast radius")).toBeTruthy();
+
+        const expiredRow = r.getAllByText("expired-agent").find((node) => node.closest("tr"))?.closest("tr");
+        expect(
+          Array.from(expiredRow?.querySelectorAll("td") ?? []).some(
+            (cell) =>
+              cell.classList.contains("min-w-24") &&
+              cell.classList.contains("truncate") &&
+              cell.classList.contains("whitespace-nowrap"),
+          ),
+        ).toBe(true);
+
+        act(() => {
+          fireEvent.click(r.getByRole("button", { name: /^Expired/ }));
+        });
+        await waitFor(() => {
+          expect(r.queryByText("expired-agent")).toBeNull();
+          expect(r.getByText("active-agent")).toBeTruthy();
+        });
+      },
+    );
+  });
+});
+
 describe("Proposals component harness: cross-tab reveal", () => {
   test("switches tab to History when focusProposalId is a decided proposal", async () => {
     const pOpen = stubProposal("prop_open_1", "open", { agent: "agent-open" });
@@ -615,8 +703,18 @@ describe("Proposals component harness: cross-tab reveal", () => {
 
   test("focusExpired prop sets open tab, filters to expired proposals, and calls onFocusExpiredConsumed", async () => {
     const onFocusExpiredConsumed = mock(() => {});
-    const pExpired = stubProposal("prop_exp", "open", { expired: true, agent: "agent-expired" });
-    const pActive = stubProposal("prop_act", "open", { expired: false, agent: "agent-active" });
+    const pExpired = stubProposal("prop_exp", "open", {
+      expired: true,
+      agent: "agent-expired",
+      created_at: new Date(Date.now() - 10_000).toISOString(),
+      ttl_seconds: 1,
+    });
+    const pActive = stubProposal("prop_act", "open", {
+      expired: false,
+      agent: "agent-active",
+      created_at: new Date().toISOString(),
+      ttl_seconds: 300,
+    });
 
     await withApi(
       {
@@ -792,6 +890,8 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     const p2 = stubProposal("prop_2", "open", { agent: "security-scan" });
     const replacement = stubProposal("prop_1b", "open", {
       agent: "triage-scan",
+      created_at: new Date(Date.now() - 10_000).toISOString(),
+      ttl_seconds: 1,
       spec: createRunSpecFixture("run_prop_1b", { timeoutSeconds: 900, agent: "triage-scan" }),
     });
     api.proposals = async () => ({ proposals: [p1, p2] });
@@ -823,6 +923,11 @@ describe("Proposals bulk confirm, reject reason, replan halt (WM-141)", () => {
     expect(approveCalls).toEqual(["prop_1"]);
     expect(r.getByText(/re-planned against current state/i)).toBeTruthy();
     expect(r.getByText(/nothing runs until you approve the new proposal explicitly/i)).toBeTruthy();
+    const approveReplacement = r.getByRole("button", { name: /Approve new proposal/i }) as HTMLButtonElement;
+    expect(approveReplacement.disabled).toBe(true);
+    expect(approveReplacement.parentElement?.getAttribute("title")).toBe(
+      "This replacement proposal has expired and can no longer be approved.",
+    );
   });
 
   test("repo context shows a persistent caption that the list is scoped to that repo", async () => {

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1,7 +1,7 @@
 import "../test-dom";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { filterOpenProposals, humanizeReason, Proposals } from "./Proposals";
+import { filterOpenProposals, Proposals } from "./Proposals";
 import { api } from "../api";
 import {
   changeInput,
@@ -458,15 +458,6 @@ describe("Proposals component harness: filter retention", () => {
 });
 
 describe("Proposals expiration and reason presentation (WM-547)", () => {
-  test("humanizeReason maps known reason codes and makes unknown codes readable", () => {
-    expect(humanizeReason("auto_approval_ineligible:proposal_expired")).toBe(
-      "Auto-approval not eligible — proposal expired",
-    );
-    expect(humanizeReason("custom_reason:needs_operator_review")).toBe(
-      "custom reason:needs operator review",
-    );
-  });
-
   test("filterOpenProposals keeps TTL-expired proposals out of Open", () => {
     const now = Date.now();
     const expired = stubProposal("prop_expired", "open", {
@@ -519,7 +510,8 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
         expect(approve.parentElement?.getAttribute("title")).toBe(
           "This proposal has expired and can no longer be approved.",
         );
-        expect(r.getAllByText("Auto-approval not eligible — proposal expired").length).toBeGreaterThan(0);
+        // Rendered through the shared reason table (WM-594), not a local map.
+        expect(r.getAllByText("Not eligible for auto-approval — Proposal expired").length).toBeGreaterThan(0);
         expect(r.getAllByTitle(rawReason).length).toBeGreaterThan(0);
         expect(r.getByText("Safety & blast radius")).toBeTruthy();
 
@@ -533,16 +525,164 @@ describe("Proposals expiration and reason presentation (WM-547)", () => {
           ),
         ).toBe(true);
 
+        // Clearing the chip brings the live proposals back. The focused one is
+        // exempt from the chip so the operator keeps the pane they are reading.
         act(() => {
           fireEvent.click(r.getByRole("button", { name: /^Expired/ }));
         });
         await waitFor(() => {
-          expect(r.queryByText("expired-agent")).toBeNull();
           expect(r.getByText("active-agent")).toBeTruthy();
+          expect(r.getAllByText("expired-agent").length).toBeGreaterThan(0);
         });
       },
     );
   });
+});
+
+describe("Proposals selection safety under focus and expiry (WM-547)", () => {
+  /** Re-render with a different focused row, the way the hash/parent does. */
+  function refocus(r: ReturnType<typeof renderProposals>, focusProposalId: string | null) {
+    r.rerender(
+      <Proposals
+        connected={true}
+        context={{ kind: "all" }}
+        onRunQueued={noop}
+        focusProposalId={focusProposalId}
+        onSelectProposal={noop}
+        focusExpired={false}
+        onFocusExpiredConsumed={noop}
+        onJumpAgent={noop}
+        onJumpEvent={noop}
+      />,
+    );
+  }
+
+  test("opening a row to read it keeps the bulk selection", async () => {
+    const p1 = stubProposal("prop_bulk_1", "open", { agent: "agent-one" });
+    const p2 = stubProposal("prop_bulk_2", "open", { agent: "agent-two" });
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [p1, p2] }),
+        proposalHistory: async () => ({ proposals: [] }),
+        status: async () => createStatusFixture(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({ focusProposalId: null });
+        await waitFor(() => expect(r.getByLabelText("Select proposal prop_bulk_1")).toBeTruthy());
+
+        act(() => {
+          fireEvent.click(r.getByLabelText("Select proposal prop_bulk_1"));
+          fireEvent.click(r.getByLabelText("Select proposal prop_bulk_2"));
+        });
+        expect(r.getByText("Approve selected (2)")).toBeTruthy();
+
+        // Open one of the ticked rows to read its spec before bulk-approving.
+        act(() => refocus(r, "prop_bulk_1"));
+        await waitFor(() => expect(r.container.querySelector("tr.row-selected")).toBeTruthy());
+
+        expect(r.getByRole("toolbar", { name: /bulk actions/i })).toBeTruthy();
+        expect(r.getByText("Approve selected (2)")).toBeTruthy();
+        expect((r.getByLabelText("Select proposal prop_bulk_2") as HTMLInputElement).checked).toBe(true);
+
+        // And moving on to the next row keeps it too.
+        act(() => refocus(r, "prop_bulk_2"));
+        await waitFor(() => expect(r.getByText("Approve selected (2)")).toBeTruthy());
+      },
+    );
+  });
+
+  test("losing the selection disarms the approve dialog", async () => {
+    const p1 = stubProposal("prop_armed_1", "open", {
+      agent: "armed-agent",
+      spec: createRunSpecFixture("run_armed_1"),
+    });
+    const p2 = stubProposal("prop_armed_2", "open", {
+      agent: "other-agent",
+      spec: createRunSpecFixture("run_armed_2"),
+    });
+
+    await withApi(
+      {
+        proposals: async () => ({ proposals: [p1, p2] }),
+        proposalHistory: async () => ({ proposals: [] }),
+        status: async () => createStatusFixture(),
+        runs: async () => ({ runs: [] }),
+        events: async () => ({ events: [] }),
+      },
+      async () => {
+        const r = renderProposals({ focusProposalId: "prop_armed_1" });
+        const openApprove = await waitFor(
+          () => r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
+        );
+        act(() => {
+          fireEvent.click(openApprove);
+        });
+        expect(r.getByText("Approve and queue this run?")).toBeTruthy();
+
+        // The armed proposal is decided elsewhere and leaves the open list, so
+        // the dialog unmounts with the detail pane.
+        api.proposals = async () => ({ proposals: [p2] });
+        await act(async () => {
+          await r.queryClient.invalidateQueries({ queryKey: ["proposals"] });
+        });
+        await waitFor(() => expect(r.queryByText("Approve and queue this run?")).toBeNull());
+
+        // Selecting another proposal must not re-open an approve dialog the
+        // operator never armed — Enter is bound to its confirm button.
+        act(() => refocus(r, "prop_armed_2"));
+        await waitFor(() => expect(r.getAllByText("prop_armed_2").length).toBeGreaterThan(0));
+        expect(r.queryByText("Approve and queue this run?")).toBeNull();
+      },
+    );
+  });
+
+  test("a TTL that passes while the row is selected keeps the pane and its expired banner", async () => {
+    const t0 = new Date("2026-03-01T00:00:00Z").getTime();
+    setSystemTime(new Date(t0));
+    try {
+      const live = stubProposal("prop_ticking", "open", {
+        agent: "ticking-agent",
+        created_at: new Date(t0).toISOString(),
+        ttl_seconds: 60,
+        spec: createRunSpecFixture("run_ticking"),
+      });
+
+      await withApi(
+        {
+          proposals: async () => ({ proposals: [live] }),
+          proposalHistory: async () => ({ proposals: [] }),
+          status: async () => createStatusFixture(),
+          runs: async () => ({ runs: [] }),
+          events: async () => ({ events: [] }),
+        },
+        async () => {
+          const r = renderProposals({ focusProposalId: "prop_ticking" });
+          const approve = await waitFor(
+            () => r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement,
+          );
+          expect(approve.disabled).toBe(false);
+
+          // The TTL passes under the operator, on the next useNow tick.
+          setSystemTime(new Date(t0 + 120_000));
+          await waitFor(
+            () => {
+              const b = r.getByRole("button", { name: /^Approve…/ }) as HTMLButtonElement;
+              expect(b.disabled).toBe(true);
+              expect(b.parentElement?.getAttribute("title")).toBe(
+                "This proposal has expired and can no longer be approved.",
+              );
+            },
+            { timeout: 4000 },
+          );
+        },
+      );
+    } finally {
+      setSystemTime();
+    }
+  }, 15_000);
 });
 
 describe("Proposals component harness: cross-tab reveal", () => {

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -63,6 +63,28 @@ function isTypingTarget(target: EventTarget | null): boolean {
 
 const ttlExpiry = (p: Proposal) => new Date(p.created_at).getTime() + p.ttl_seconds * 1000;
 
+export function proposalIsExpired(p: Proposal, now = Date.now()): boolean {
+  return ttlExpiry(p) < now;
+}
+
+export function filterOpenProposals(
+  proposals: Proposal[],
+  now = Date.now(),
+  expiredOnly = false,
+): Proposal[] {
+  return proposals.filter(
+    (p) => p.status === "open" && proposalIsExpired(p, now) === expiredOnly,
+  );
+}
+
+const HUMANIZED_REASONS: Record<string, string> = {
+  "auto_approval_ineligible:proposal_expired": "Auto-approval not eligible — proposal expired",
+};
+
+export function humanizeReason(reason: string): string {
+  return HUMANIZED_REASONS[reason] ?? reason.replaceAll("_", " ");
+}
+
 /** Grouping/ordering/columns per tab (OPS-493) — two views, two persisted keys. */
 const OPEN_DISPLAY: DisplayConfig<Proposal> = {
   view: "proposals-open",
@@ -179,12 +201,13 @@ export function Proposals({
     queryFn: () => api.proposalHistory("all"),
     refetchInterval: 2000,
   });
+  const [expiredOnly, setExpiredOnly] = useState(false);
   const rows = useMemo(
     () =>
       tab === "open"
-        ? (query.data?.proposals ?? [])
+        ? filterOpenProposals(query.data?.proposals ?? [], now, expiredOnly)
         : (history.data?.proposals ?? []).filter((p) => p.status !== "open"),
-    [tab, query.data, history.data],
+    [tab, query.data, history.data, now, expiredOnly],
   );
   const scoped = useMemo(
     () => rows.filter((p) => p.id === focusProposalId || matchesRepo(p.repos, context)),
@@ -193,11 +216,11 @@ export function Proposals({
   const hiddenOpenRepoCount = useMemo(
     () =>
       context.kind === "repo"
-        ? (query.data?.proposals ?? []).filter(
-            (p) => p.status === "open" && p.id !== focusProposalId && !matchesRepo(p.repos, context),
+        ? filterOpenProposals(query.data?.proposals ?? [], now).filter(
+            (p) => p.id !== focusProposalId && !matchesRepo(p.repos, context),
           ).length
         : 0,
-    [context, query.data, focusProposalId],
+    [context, query.data, focusProposalId, now],
   );
 
   // Origin event type, resolved from the shared events cache (cheap: same
@@ -239,7 +262,6 @@ export function Proposals({
   });
 
   const [filter, setFilter] = useState("");
-  const [expiredOnly, setExpiredOnly] = useState(false);
   const [rejecting, setRejecting] = useState(false);
   const [confirmApprove, setConfirmApprove] = useState(false);
   const [reason, setReason] = useState("");
@@ -255,21 +277,17 @@ export function Proposals({
   const headerCheckboxRef = useRef<HTMLInputElement>(null);
   const bulkReasonRef = useRef<HTMLInputElement>(null);
 
-  const statusQ = useQuery({ queryKey: ["status"], queryFn: () => api.status(), refetchInterval: 2000 });
   // The expired chip only exists on Open; History rows have no live TTL. Derive
   // the gate once so the row filter and the empty copy can never disagree.
   const expiredFilter = expiredOnly && tab === "open";
-  const expiredCount =
-    context.kind === "repo"
-      ? scoped.filter((p) => p.expired).length
-      : (statusQ.data?.proposals.expired ?? 0);
+  const expiredCount = filterOpenProposals(query.data?.proposals ?? [], now, true).filter(
+    (p) => context.kind !== "repo" || matchesRepo(p.repos, context),
+  ).length;
   const parsed = useMemo(() => parseFilterQuery(filter, PROPOSAL_FACETS), [filter]);
-  const visible = useMemo(() => {
-    return scoped.filter((p) => {
-      if (expiredFilter && !p.expired) return false;
-      return matchesFilterQuery(p, parsed, PROPOSAL_FACETS, { runStates });
-    });
-  }, [scoped, parsed, expiredFilter, runStates]);
+  const visible = useMemo(
+    () => scoped.filter((p) => matchesFilterQuery(p, parsed, PROPOSAL_FACETS, { runStates })),
+    [scoped, parsed, runStates],
+  );
 
   const actionableVisible = useMemo(
     () => (tab === "open" ? visible.filter((p) => p.status === "open") : []),
@@ -319,8 +337,15 @@ export function Proposals({
     [rows, selectedIds],
   );
   const approvableSelected = useMemo(
-    () => selectedRows.filter((p) => p.status === "open" && p.decision === "run" && !staleState(p)),
-    [selectedRows, runStates],
+    () =>
+      selectedRows.filter(
+        (p) =>
+          p.status === "open" &&
+          p.decision === "run" &&
+          !proposalIsExpired(p, now) &&
+          !staleState(p),
+      ),
+    [selectedRows, runStates, now],
   );
   const rejectableSelected = useMemo(
     () => selectedRows.filter((p) => p.status === "open"),
@@ -336,6 +361,11 @@ export function Proposals({
     const processed = new Set<string>();
     let haltedOnReplan: { before: Proposal; after: Proposal } | null = null;
     for (const p of approvableSelected) {
+      if (proposalIsExpired(p)) {
+        err++;
+        processed.add(p.id);
+        continue;
+      }
       try {
         const o = await api.approve(p.id);
         processed.add(p.id);
@@ -397,8 +427,8 @@ export function Proposals({
   // (chip copy, nothing for Esc to clear) or the text filter hid the expired
   // ones (filter copy + the Esc hint).
   const unfilteredCount = useMemo(
-    () => (expiredFilter ? scoped.filter((p) => p.expired).length : scoped.length),
-    [scoped, expiredFilter],
+    () => scoped.length,
+    [scoped],
   );
 
   // Esc clears the text filter and the expired chip together, so the hint is
@@ -500,22 +530,31 @@ export function Proposals({
   // Hash stays; we only switch tabs so the row is in `visible` — the selection
   // is the whole point of the deep link, so unlike selectTab we keep it. The
   // chip is cleared like selectTab does: it belongs to Open only.
+  const locatedFocusId = useRef<string | null>(null);
   useEffect(() => {
-    if (!focusProposalId) return;
+    if (!focusProposalId) {
+      locatedFocusId.current = null;
+      return;
+    }
     if (query.isPending || history.isPending) return;
-    const inOpen = (query.data?.proposals ?? []).some((p) => p.id === focusProposalId);
+    const focusedOpen = (query.data?.proposals ?? []).find((p) => p.id === focusProposalId);
+    const inOpen = Boolean(focusedOpen);
     const inHistory = (history.data?.proposals ?? []).some(
       (p) => p.id === focusProposalId && p.status !== "open",
     );
-    if (inOpen && tab !== "open") {
+    const isNewFocus = locatedFocusId.current !== focusProposalId;
+    if (isNewFocus && (inOpen || inHistory)) locatedFocusId.current = focusProposalId;
+
+    if (inOpen && (tab !== "open" || isNewFocus)) {
       setTab("open");
+      if (isNewFocus) setExpiredOnly(focusedOpen ? proposalIsExpired(focusedOpen, now) : false);
       setSelectedIds(new Set());
     } else if (!inOpen && inHistory && tab === "open") {
       setTab("history");
       setExpiredOnly(false);
       setSelectedIds(new Set());
     }
-  }, [focusProposalId, query.isPending, history.isPending, query.data, history.data, tab]);
+  }, [focusProposalId, query.isPending, history.isPending, query.data, history.data, tab, now]);
 
   useEffect(() => {
     if (!focusExpired) return;
@@ -533,7 +572,12 @@ export function Proposals({
   };
 
   const approve = useMutation({
-    mutationFn: (p: Proposal) => api.approve(p.id).then((outcome) => ({ p, outcome })),
+    mutationFn: (p: Proposal) => {
+      if (proposalIsExpired(p)) {
+        return Promise.reject(new Error("This proposal has expired and can no longer be approved."));
+      }
+      return api.approve(p.id).then((outcome) => ({ p, outcome }));
+    },
     onSuccess: ({ p, outcome }) => {
       invalidate();
       if (outcome.approved && outcome.runId) {
@@ -566,10 +610,29 @@ export function Proposals({
 
   // History rows are audit records — no verbs, ever (doc §10.2).
   const isOpen = sel !== null && sel.status === "open";
-  const canApprove = isOpen && sel.decision === "run" && !staleState(sel);
+  const selectionExpired = sel !== null && proposalIsExpired(sel, now);
+  const canApprove = isOpen && sel.decision === "run" && !selectionExpired && !staleState(sel);
+  const approvalDisabledReason = selectionExpired
+    ? "This proposal has expired and can no longer be approved."
+    : sel && staleState(sel)
+      ? `This proposal's run is already ${staleState(sel)} and can no longer be approved.`
+      : !connected
+        ? "Approval is unavailable while disconnected."
+        : undefined;
+  const openApprove = () => {
+    if (!sel || !connected || proposalIsExpired(sel) || staleState(sel)) return;
+    setConfirmApprove(true);
+  };
   const openReject = () => {
     setRejecting(true);
     setTimeout(() => reasonRef.current?.focus(), 0);
+  };
+  const replanExpired = replan !== null && proposalIsExpired(replan.after, now);
+  const approveReplan = () => {
+    if (!replan || !connected || proposalIsExpired(replan.after) || approve.isPending) return;
+    const fresh = replan.after;
+    setReplan(null);
+    approve.mutate(fresh);
   };
 
   const pendingC = useRef<number>(0);
@@ -594,7 +657,7 @@ export function Proposals({
     keys: {
       // §5: `a` opens the confirm with the spec in view — it never fires the verb directly.
       // When `*` is armed, the proposal-selection listener owns the same `a` key instead.
-      a: () => !starPrefixActive() && canApprove && connected && setConfirmApprove(true),
+      a: () => !starPrefixActive() && canApprove && connected && openApprove(),
       x: () => isOpen && connected && openReject(),
       c: () => {
         if (!sel) return;
@@ -690,7 +753,7 @@ export function Proposals({
       } else {
         setContextActions([
           ...(canApprove
-            ? [{ label: `Approve ${sel.agent ?? sel.id}…`, hint: "a", run: () => setConfirmApprove(true) }]
+            ? [{ label: `Approve ${sel.agent ?? sel.id}…`, hint: "a", run: openApprove }]
             : []),
           { label: `Reject ${sel.agent ?? sel.id}…`, hint: "x", run: openReject },
           ...copy,
@@ -729,13 +792,18 @@ export function Proposals({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        if (confirmApprove && sel && connected && !approve.isPending) {
+        if (
+          confirmApprove &&
+          sel &&
+          canApprove &&
+          connected &&
+          !proposalIsExpired(sel) &&
+          !approve.isPending
+        ) {
           setConfirmApprove(false);
           approve.mutate(sel);
-        } else if (replan && connected && !approve.isPending) {
-          const fresh = replan.after;
-          setReplan(null);
-          approve.mutate(fresh);
+        } else if (replan && connected && !replanExpired && !approve.isPending) {
+          approveReplan();
         } else if (bulkConfirmOpen && connected && !bulkApproving && approvableSelected.length > 0) {
           void handleBulkApprove();
         }
@@ -749,6 +817,8 @@ export function Proposals({
     bulkConfirmOpen,
     sel,
     connected,
+    canApprove,
+    replanExpired,
     approve,
     bulkApproving,
     approvableSelected,
@@ -775,7 +845,9 @@ export function Proposals({
           <div className="flex gap-1" role="tablist" aria-label="Proposal status">
             {PROPOSAL_TABS.map((t, idx) => {
               const count = t === "open"
-                ? (context.kind === "repo" ? (query.data?.proposals ?? []).filter((p) => matchesRepo(p.repos, context)).length : (statusQ.data?.proposals.open ?? 0))
+                ? filterOpenProposals(query.data?.proposals ?? [], now).filter(
+                    (p) => context.kind !== "repo" || matchesRepo(p.repos, context),
+                  ).length
                 : (history.data?.proposals ?? []).filter((p) => p.status !== "open" && matchesRepo(p.repos, context)).length;
               return (
                 <button
@@ -880,7 +952,7 @@ export function Proposals({
                   key={p.id}
                   onClick={() => onSelectProposal(p.id)}
                   aria-selected={p.id === selectedId}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : p.expired ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
+                  className={`cursor-pointer hover:bg-(--surface-1) ${staleState(p) ? "row-wash-err" : proposalIsExpired(p, now) ? "row-wash-warn" : ""} ${p.id === selectedId ? "row-selected" : ""}`}
                 >
                   {tab === "open" && (
                     <td className={`${tdCls} w-8`} onClick={(e) => e.stopPropagation()}>
@@ -919,7 +991,7 @@ export function Proposals({
                     </td>
                   )}
                   {show.has("ttl") && (
-                    <td className={`${tdCls} max-w-20 whitespace-nowrap`}>
+                    <td className={`${tdCls} min-w-24 max-w-28 truncate whitespace-nowrap`}>
                       <Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />
                     </td>
                   )}
@@ -968,7 +1040,7 @@ export function Proposals({
                   )}
                   {show.has("reason") && (
                     <td className={`max-w-48 truncate ${tdCls} text-(--text-dim)`} title={p.reason ?? undefined}>
-                      {p.reason ?? "-"}
+                      {p.reason ? humanizeReason(p.reason) : "-"}
                     </td>
                   )}
                   {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
@@ -1064,14 +1136,16 @@ export function Proposals({
                 >
                   Reject… <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">x</span>
                 </Button>
-                {canApprove && (
-                  <Button
-                    variant="primary"
-                    disabled={!connected || approve.isPending}
-                    onClick={() => setConfirmApprove(true)}
-                  >
-                    Approve… <span className="mono ml-1 opacity-80" aria-hidden="true">a</span>
-                  </Button>
+                {sel.decision === "run" && (
+                  <span title={approvalDisabledReason}>
+                    <Button
+                      variant="primary"
+                      disabled={!canApprove || !connected || approve.isPending}
+                      onClick={openApprove}
+                    >
+                      Approve… <span className="mono ml-1 opacity-80" aria-hidden="true">a</span>
+                    </Button>
+                  </span>
                 )}
               </div>
             ) : null
@@ -1118,8 +1192,11 @@ export function Proposals({
               <KV
                 k="planner reason"
                 v={
-                  <span className="break-words whitespace-pre-wrap leading-relaxed text-(--text-dim)">
-                    {sel.reason}
+                  <span
+                    className="break-words whitespace-pre-wrap leading-relaxed text-(--text-dim)"
+                    title={sel.reason}
+                  >
+                    {humanizeReason(sel.reason)}
                   </span>
                 }
               />
@@ -1149,7 +1226,7 @@ export function Proposals({
             const prev = (runsQuery.data?.runs ?? []).find((r) => r.agent === sel.agent && r.state === "COMPLETED");
 
             return (
-              <Section title="Summary Safety Card & Blast Radius Radar" card={false}>
+              <Section title="Safety & blast radius" card={false}>
                 {/*
                   Shared with the Runs view's approve dialog (WM-505) so both
                   approval paths present identical risk context.
@@ -1170,13 +1247,15 @@ export function Proposals({
                   }
                 />
                 <Disclosure label="immutable RunSpec" defaultOpen={isOpen}>
-                  <JsonBlock value={sel.spec} />
+                  <div className="min-w-0 overflow-x-auto">
+                    <JsonBlock value={sel.spec} />
+                  </div>
                 </Disclosure>
               </Section>
             );
           })()}
 
-          {isOpen && staleState(sel) && (
+          {isOpen && (selectionExpired || staleState(sel)) && (
             <div
               className="mb-3 rounded-md px-2.5 py-1.5 text-[12px]"
               style={{
@@ -1184,8 +1263,9 @@ export function Proposals({
                 background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
               }}
             >
-              This proposal&apos;s run is already {staleState(sel)} — it can no longer be approved.
-              Reject it to clear the queue.
+              {selectionExpired
+                ? "This proposal has expired — it can no longer be approved. Reject it to clear the queue."
+                : `This proposal's run is already ${staleState(sel)} — it can no longer be approved. Reject it to clear the queue.`}
             </div>
           )}
 
@@ -1257,16 +1337,19 @@ export function Proposals({
           <ApprovalRiskDetails proposal={sel} agent={selAgent} />
           <div className="mt-3 flex justify-end gap-2">
             <Button onClick={() => setConfirmApprove(false)}>Not yet</Button>
-            <Button
-              variant="primary"
-              disabled={!connected || approve.isPending}
-              onClick={() => {
-                setConfirmApprove(false);
-                approve.mutate(sel);
-              }}
-            >
-              Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
-            </Button>
+            <span title={approvalDisabledReason}>
+              <Button
+                variant="primary"
+                disabled={!canApprove || !connected || approve.isPending}
+                onClick={() => {
+                  if (!canApprove || proposalIsExpired(sel)) return;
+                  setConfirmApprove(false);
+                  approve.mutate(sel);
+                }}
+              >
+                Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+              </Button>
+            </span>
           </div>
         </Dialog>
       )}
@@ -1282,17 +1365,15 @@ export function Proposals({
           </div>
           <div className="mt-3 flex justify-end gap-2">
             <Button onClick={() => setReplan(null)}>Not yet</Button>
-            <Button
-              variant="primary"
-              disabled={!connected || approve.isPending}
-              onClick={() => {
-                const fresh = replan.after;
-                setReplan(null);
-                approve.mutate(fresh);
-              }}
-            >
-              Approve new proposal <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
-            </Button>
+            <span title={replanExpired ? "This replacement proposal has expired and can no longer be approved." : undefined}>
+              <Button
+                variant="primary"
+                disabled={!connected || replanExpired || approve.isPending}
+                onClick={approveReplan}
+              >
+                Approve new proposal <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+              </Button>
+            </span>
           </div>
         </Dialog>
       )}
@@ -1342,7 +1423,11 @@ export function Proposals({
                 <KV k="timeout" v={`${p.spec?.timeoutSeconds}s`} />
                 <KV k="attempts" v={String(p.spec?.maxAttempts)} />
                 <KV k="ttl" v={<Countdown createdAt={p.created_at} ttlSeconds={p.ttl_seconds} />} />
-                {p.spec && <JsonBlock value={p.spec} />}
+                {p.spec && (
+                  <div className="min-w-0 overflow-x-auto">
+                    <JsonBlock value={p.spec} />
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -25,6 +25,7 @@ import { SpecDiff } from "../components/SpecDiff";
 import { AgentHoverCard } from "../components/AgentHoverCard";
 import { ApprovalRiskDetails, ApprovalSafetyCard } from "../components/ApprovalRisk";
 import { decideRevealFilters } from "../reveal";
+import { humanizeReason } from "../reasons";
 import {
   Ago,
   BulkActionBar,
@@ -75,14 +76,6 @@ export function filterOpenProposals(
   return proposals.filter(
     (p) => p.status === "open" && proposalIsExpired(p, now) === expiredOnly,
   );
-}
-
-const HUMANIZED_REASONS: Record<string, string> = {
-  "auto_approval_ineligible:proposal_expired": "Auto-approval not eligible — proposal expired",
-};
-
-export function humanizeReason(reason: string): string {
-  return HUMANIZED_REASONS[reason] ?? reason.replaceAll("_", " ");
 }
 
 /** Grouping/ordering/columns per tab (OPS-493) — two views, two persisted keys. */
@@ -202,13 +195,16 @@ export function Proposals({
     refetchInterval: 2000,
   });
   const [expiredOnly, setExpiredOnly] = useState(false);
-  const rows = useMemo(
-    () =>
-      tab === "open"
-        ? filterOpenProposals(query.data?.proposals ?? [], now, expiredOnly)
-        : (history.data?.proposals ?? []).filter((p) => p.status !== "open"),
-    [tab, query.data, history.data, now, expiredOnly],
-  );
+  const rows = useMemo(() => {
+    if (tab !== "open") return (history.data?.proposals ?? []).filter((p) => p.status !== "open");
+    const open = query.data?.proposals ?? [];
+    const shown = new Set(filterOpenProposals(open, now, expiredOnly).map((p) => p.id));
+    // The focused proposal never drops out from under the operator: a TTL that
+    // passes while it is selected would otherwise close the detail pane and take
+    // the expired banner with it, mid-read (WM-547). `scoped` exempts the focused
+    // id from repo scoping for the same reason.
+    return open.filter((p) => p.status === "open" && (shown.has(p.id) || p.id === focusProposalId));
+  }, [tab, query.data, history.data, now, expiredOnly, focusProposalId]);
   const scoped = useMemo(
     () => rows.filter((p) => p.id === focusProposalId || matchesRepo(p.repos, context)),
     [rows, context, focusProposalId],
@@ -360,12 +356,10 @@ export function Proposals({
     let err = 0;
     const processed = new Set<string>();
     let haltedOnReplan: { before: Proposal; after: Proposal } | null = null;
+    // `approvableSelected` already dropped the expired ones. A TTL that passes
+    // mid-loop is left to the server, which answers with a re-plan the operator
+    // reviews — a silent client-side failure count would hide that.
     for (const p of approvableSelected) {
-      if (proposalIsExpired(p)) {
-        err++;
-        processed.add(p.id);
-        continue;
-      }
       try {
         const o = await api.approve(p.id);
         processed.add(p.id);
@@ -422,14 +416,10 @@ export function Proposals({
     if (err) notify(`Failed to reject ${err} proposal${err === 1 ? "" : "s"}`, "err");
   };
 
-  // What the list would show without the text filter. An empty list under the
-  // expired chip has two causes and needs two messages: no expired opens exist
-  // (chip copy, nothing for Esc to clear) or the text filter hid the expired
-  // ones (filter copy + the Esc hint).
-  const unfilteredCount = useMemo(
-    () => scoped.length,
-    [scoped],
-  );
+  // What the list would show without the text filter — the tab and the expired
+  // chip are already applied to `scoped`. ListEmpty uses it to tell "the filter
+  // hid everything" (offer Esc to clear) from "there is nothing here" (say so).
+  const unfilteredCount = useMemo(() => scoped.length, [scoped]);
 
   // Esc clears the text filter and the expired chip together, so the hint is
   // owed whenever either is set — including when the unfiltered set is itself
@@ -486,6 +476,20 @@ export function Proposals({
     [agentsQuery.data, sel],
   );
 
+  /** Planner reason for the selection, humanized off the shared table (WM-594). */
+  const selReason = useMemo(() => (sel?.reason ? humanizeReason(sel.reason) : null), [sel]);
+
+  // Losing the selection must disarm its dialogs. Both render inside `sel`, so a
+  // proposal that leaves `visible` (decided elsewhere, scoped away) unmounts them
+  // while the flag stays true — the next selection would then open an approve
+  // dialog the operator never armed, with Enter bound to it (WM-547).
+  const noSelection = sel === null;
+  useEffect(() => {
+    if (!noSelection) return;
+    setConfirmApprove(false);
+    setRejecting(false);
+  }, [noSelection]);
+
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex, windowStart]);
@@ -538,18 +542,23 @@ export function Proposals({
     }
     if (query.isPending || history.isPending) return;
     const focusedOpen = (query.data?.proposals ?? []).find((p) => p.id === focusProposalId);
-    const inOpen = Boolean(focusedOpen);
     const inHistory = (history.data?.proposals ?? []).some(
       (p) => p.id === focusProposalId && p.status !== "open",
     );
     const isNewFocus = locatedFocusId.current !== focusProposalId;
-    if (isNewFocus && (inOpen || inHistory)) locatedFocusId.current = focusProposalId;
+    if (isNewFocus && (focusedOpen || inHistory)) locatedFocusId.current = focusProposalId;
 
-    if (inOpen && (tab !== "open" || isNewFocus)) {
-      setTab("open");
-      if (isNewFocus) setExpiredOnly(focusedOpen ? proposalIsExpired(focusedOpen, now) : false);
-      setSelectedIds(new Set());
-    } else if (!inOpen && inHistory && tab === "open") {
+    if (focusedOpen) {
+      // Only a real tab switch drops the bulk selection (selectTab does the same).
+      // Moving focus between rows inside Open must keep it: ticking three rows,
+      // opening one to read its spec, then bulk-approving is the whole flow (WM-547).
+      if (tab !== "open") {
+        setTab("open");
+        setSelectedIds(new Set());
+      }
+      // A newly focused expired proposal needs the chip on to be reachable.
+      if (isNewFocus) setExpiredOnly(proposalIsExpired(focusedOpen, now));
+    } else if (inHistory && tab === "open") {
       setTab("history");
       setExpiredOnly(false);
       setSelectedIds(new Set());
@@ -1038,11 +1047,18 @@ export function Proposals({
                       <Ago iso={p.created_at} now={now} />
                     </td>
                   )}
-                  {show.has("reason") && (
-                    <td className={`max-w-48 truncate ${tdCls} text-(--text-dim)`} title={p.reason ?? undefined}>
-                      {p.reason ? humanizeReason(p.reason) : "-"}
-                    </td>
-                  )}
+                  {show.has("reason") &&
+                    (() => {
+                      const r = humanizeReason(p.reason);
+                      return (
+                        <td
+                          className={`max-w-48 truncate ${tdCls} text-(--text-dim)`}
+                          title={r.raw ?? undefined}
+                        >
+                          {r.text || "-"}
+                        </td>
+                      );
+                    })()}
                   {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
                     <CustomCell key={c.key} row={p} path={c.key.replace(/^custom:/, "")} />
                   ))}
@@ -1188,15 +1204,15 @@ export function Proposals({
             <KV k="created" v={<Ago iso={sel.created_at} now={now} />} />
             {sel.decided_at && <KV k="decided at" v={<Ago iso={sel.decided_at} now={now} />} />}
             {sel.decided_by && <KV k="decided by" v={sel.decided_by} />}
-            {sel.reason && (
+            {selReason && (
               <KV
                 k="planner reason"
                 v={
                   <span
                     className="break-words whitespace-pre-wrap leading-relaxed text-(--text-dim)"
-                    title={sel.reason}
+                    title={selReason.raw ?? undefined}
                   >
-                    {humanizeReason(sel.reason)}
+                    {selReason.text}
                   </span>
                 }
               />


### PR DESCRIPTION
## Summary
- separate TTL-expired proposals from the default Open list while keeping the Expired filter usable
- disable every expired approval path with an explanatory title and humanize proposal reason codes
- prevent TTL/origin overlap, simplify the safety header, and add horizontal JSON scrolling
- add regression coverage for expiration filtering, disabled approval, reason formatting, filter recovery, and expired replacements

## Verification
- `cd event-runtime/web && bun run build && bun test` — 676 tests passed

## UX critique
UX critique: required — SHIP
- Observed: http://127.0.0.1:7525/#/proposals
- Evidence: /tmp/WM-547-expired-detail-1440x900.png

Fixes WM-547