### PR TITLE
fix(web): replace native Display option controls

### DIFF
--- a/event-runtime/web/src/components/DisplayOptions.test.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.test.tsx
@@ -71,8 +71,18 @@ afterEach(() => {
   goPrefix.armedAt = 0;
 });
 
+function chooseOption(
+  r: ReturnType<typeof render>,
+  label: string,
+  option: string,
+) {
+  fireEvent.click(r.getByRole("combobox", { name: label }));
+  const listbox = r.getByRole("listbox", { name: `${label} options` });
+  fireEvent.mouseDown(within(listbox).getByRole("option", { name: option }));
+}
+
 describe("DisplayOptions panel", () => {
-  test("opens, changes grouping, and reflects it in the select", () => {
+  test("opens, changes grouping, and reflects it in the listbox trigger", () => {
     let latest: DisplayState | undefined;
     const r = render(<Harness onState={(s) => (latest = s)} />);
     const trigger = r.getByRole("button", { name: /display/i });
@@ -80,19 +90,48 @@ describe("DisplayOptions panel", () => {
     fireEvent.click(trigger);
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
 
-    const groupSelect = r.getByLabelText("Group by") as HTMLSelectElement;
-    fireEvent.change(groupSelect, { target: { value: "state" } });
+    const groupSelect = r.getByRole("combobox", { name: "Group by" });
+    chooseOption(r, "Group by", "State");
     expect(latest?.groupBy).toBe("state");
-    expect(groupSelect.value).toBe("state");
+    expect(groupSelect.textContent).toContain("State");
+  });
+
+  test("uses styled, keyboard-navigable listboxes instead of native selects", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+
+    expect(r.container.querySelector("select")).toBeNull();
+    const group = r.getByRole("combobox", { name: "Group by" });
+    fireEvent.keyDown(group, { key: "ArrowDown" });
+    const listbox = r.getByRole("listbox", { name: "Group by options" });
+    expect(listbox).toBeTruthy();
+    fireEvent.keyDown(group, { key: "ArrowDown" });
+    expect(group.getAttribute("aria-activedescendant")).toBe(
+      within(listbox).getByRole("option", { name: "State" }).id,
+    );
+    fireEvent.keyDown(group, { key: "Enter" });
+    expect(latest?.groupBy).toBe("state");
+    expect(r.queryByRole("listbox", { name: "Group by options" })).toBeNull();
+  });
+
+  test("Escape dismisses an open nested listbox without closing Display options", () => {
+    const r = render(<Harness />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    const group = r.getByRole("combobox", { name: "Group by" });
+    fireEvent.click(group);
+    fireEvent.keyDown(group, { key: "Escape" });
+    expect(r.queryByRole("listbox", { name: "Group by options" })).toBeNull();
+    expect(r.getByRole("dialog", { name: "Display options" })).toBeTruthy();
   });
 
   test("choosing the group as sub-group is prevented by option filtering", () => {
     const r = render(<Harness />);
     fireEvent.click(r.getByRole("button", { name: /display/i }));
-    fireEvent.change(r.getByLabelText("Group by"), { target: { value: "agent" } });
-    const sub = r.getByLabelText("Sub-group by") as HTMLSelectElement;
-    const values = [...sub.options].map((o) => o.value);
-    expect(values).not.toContain("agent");
+    chooseOption(r, "Group by", "Agent");
+    fireEvent.click(r.getByRole("combobox", { name: "Sub-group by" }));
+    const subOptions = within(r.getByRole("listbox", { name: "Sub-group by options" })).getAllByRole("option");
+    expect(subOptions.map((option) => option.textContent)).not.toContain("Agent");
   });
 
   test("column pills toggle visibility but always-on columns are not offered", () => {
@@ -102,9 +141,25 @@ describe("DisplayOptions panel", () => {
     expect(r.queryByRole("button", { name: "Run" })).toBeNull();
     const pill = r.getByRole("button", { name: "Agent" });
     expect(pill.getAttribute("aria-pressed")).toBe("true");
+    expect(pill.textContent).toContain("✓");
     fireEvent.click(pill);
     expect(latest?.hiddenColumns).toEqual(["agent"]);
     expect(pill.getAttribute("aria-pressed")).toBe("false");
+    expect(pill.textContent).not.toContain("✓");
+  });
+
+  test("ordering direction is a two-state aria-pressed segment", () => {
+    let latest: DisplayState | undefined;
+    const r = render(<Harness onState={(s) => (latest = s)} />);
+    fireEvent.click(r.getByRole("button", { name: /display/i }));
+    const asc = r.getByRole("button", { name: "Ascending order" });
+    const desc = r.getByRole("button", { name: "Descending order" });
+    expect(asc.getAttribute("aria-pressed")).toBe("true");
+    expect(desc.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(desc);
+    expect(latest?.sortDir).toBe("desc");
+    expect(asc.getAttribute("aria-pressed")).toBe("false");
+    expect(desc.getAttribute("aria-pressed")).toBe("true");
   });
 
   test("groups every discovered path and derives a view-aware placeholder", () => {
@@ -218,7 +273,7 @@ describe("DisplayOptions panel", () => {
     const r = render(<Harness onState={(s) => (latest = s)} />);
     fireEvent.click(r.getByRole("button", { name: /display/i }));
     expect(r.queryByRole("button", { name: /reset/i })).toBeNull();
-    fireEvent.change(r.getByLabelText("Group by"), { target: { value: "state" } });
+    chooseOption(r, "Group by", "State");
     fireEvent.click(r.getByRole("button", { name: /reset/i }));
     expect(latest?.groupBy).toBe("none");
   });
@@ -226,17 +281,16 @@ describe("DisplayOptions panel", () => {
   test("default sort option uses operator-facing label", () => {
     const r = render(<Harness />);
     fireEvent.click(r.getByRole("button", { name: /display/i }));
-    const orderSelect = r.getByLabelText("Order by") as HTMLSelectElement;
-    const defaultOption = [...orderSelect.options].find((o) => o.value === "default");
-    expect(defaultOption?.textContent).toBe("Default order");
-    expect(defaultOption?.textContent).not.toBe("API order");
+    const orderSelect = r.getByRole("combobox", { name: "Order by" });
+    expect(orderSelect.textContent).toContain("Default order");
+    expect(orderSelect.textContent).not.toContain("API order");
   });
 
   test("opening moves focus to the first interactive control", () => {
     const r = render(<Harness />);
     const trigger = r.getByRole("button", { name: /display/i });
     fireEvent.click(trigger);
-    expect(document.activeElement).toBe(r.getByLabelText("Group by"));
+    expect(document.activeElement).toBe(r.getByRole("combobox", { name: "Group by" }));
   });
 
   test("outside-click dismiss restores focus to the Display trigger", () => {

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -45,7 +45,7 @@ function OptionRow({ label, htmlFor, children }: { label: string; htmlFor?: stri
   );
 }
 
-function Select({
+function ListboxSelect({
   id,
   ref,
   value,
@@ -55,29 +55,128 @@ function Select({
   label,
 }: {
   id?: string;
-  ref?: RefObject<HTMLSelectElement | null>;
+  ref?: RefObject<HTMLButtonElement | null>;
   value: string;
   onChange: (value: string) => void;
   options: { value: string; label: string }[];
   disabled?: boolean;
   label: string;
 }) {
+  const listId = useId();
+  const listRef = useRef<HTMLUListElement>(null);
+  const internalRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = ref ?? internalRef;
+  const selectedIndex = Math.max(0, options.findIndex((option) => option.value === value));
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(selectedIndex);
+  const selected = options[selectedIndex] ?? options[0];
+
+  useEffect(() => {
+    if (!open) return;
+    (listRef.current?.children[highlight] as HTMLElement | undefined)?.scrollIntoView({ block: "nearest" });
+  }, [highlight, listId, open]);
+
+  const show = () => {
+    if (disabled) return;
+    setHighlight(selectedIndex);
+    setOpen(true);
+  };
+
+  const pick = (index: number) => {
+    const option = options[index];
+    if (!option) return;
+    onChange(option.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!open) {
+        show();
+      } else {
+        const delta = event.key === "ArrowDown" ? 1 : -1;
+        setHighlight((index) => (index + delta + options.length) % options.length);
+      }
+      return;
+    }
+    if (open && (event.key === "Home" || event.key === "End")) {
+      event.preventDefault();
+      setHighlight(event.key === "Home" ? 0 : options.length - 1);
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (open) pick(highlight);
+      else show();
+      return;
+    }
+    if (event.key === "Escape" && open) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      return;
+    }
+    if (event.key === "Tab") setOpen(false);
+  };
+
   return (
-    <select
-      ref={ref}
-      id={id}
-      value={value}
-      disabled={disabled}
-      aria-label={label}
-      onChange={(e) => onChange(e.target.value)}
-      className="w-32 cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
-    >
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <div className="relative w-32">
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        role="combobox"
+        data-display-listbox-trigger
+        disabled={disabled}
+        aria-label={label}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listId : undefined}
+        aria-activedescendant={open ? `${listId}-option-${highlight}` : undefined}
+        onClick={() => (open ? setOpen(false) : show())}
+        onBlur={() => setOpen(false)}
+        onKeyDown={onKeyDown}
+        className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-left text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <span className="truncate">{selected?.label}</span>
+        <span aria-hidden className="shrink-0 text-[9px] text-(--text-faint)">▼</span>
+      </button>
+      {open && (
+        <ul
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label={`${label} options`}
+          className="absolute top-full right-0 z-40 mt-1 max-h-52 w-40 overflow-auto rounded-md border border-(--border-strong) bg-(--surface-1) p-1 text-[12px] shadow-xl outline-none"
+        >
+          {options.map((option, index) => (
+            <li
+              key={option.value}
+              id={`${listId}-option-${index}`}
+              role="option"
+              aria-selected={option.value === value}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                pick(index);
+              }}
+              onMouseEnter={() => setHighlight(index)}
+              className={`flex cursor-pointer items-center justify-between gap-2 rounded px-2 py-1 select-none ${
+                index === highlight
+                  ? "bg-(--surface-3) text-(--text)"
+                  : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+              }`}
+            >
+              <span className="truncate">{option.label}</span>
+              {option.value === value && <span aria-hidden className="text-(--accent)">✓</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 
@@ -346,7 +445,7 @@ export function DisplayOptions<T>({
   const [customInput, setCustomInput] = useState("");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const firstFocusRef = useRef<HTMLSelectElement>(null);
+  const firstFocusRef = useRef<HTMLButtonElement>(null);
   const groupId = useId();
   const subId = useId();
   const orderId = useId();
@@ -373,8 +472,10 @@ export function DisplayOptions<T>({
     modal.depth += 1;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      const openSuggestInput = rootRef.current?.querySelector('[aria-label="Add custom property path"][aria-expanded="true"]');
-      if (openSuggestInput && e.target === openSuggestInput) return;
+      const openNestedPopup = rootRef.current?.querySelector(
+        '[aria-label="Add custom property path"][aria-expanded="true"], [data-display-listbox-trigger][aria-expanded="true"]',
+      );
+      if (openNestedPopup && e.target === openNestedPopup) return;
       e.stopPropagation();
       setOpen(false);
       triggerRef.current?.focus();
@@ -454,7 +555,7 @@ export function DisplayOptions<T>({
           className="absolute right-0 top-full z-30 mt-1.5 w-80 max-h-[85vh] overflow-y-auto rounded-lg border border-(--border-strong) bg-(--surface-1) p-3 shadow-2xl"
         >
           <OptionRow label="Grouping" htmlFor={groupId}>
-            <Select
+            <ListboxSelect
               id={groupId}
               ref={firstFocusRef}
               label="Group by"
@@ -476,7 +577,7 @@ export function DisplayOptions<T>({
 
           {(config.subGroups?.length ?? 0) > 0 && (
             <OptionRow label="Sub-grouping" htmlFor={subId}>
-              <Select
+              <ListboxSelect
                 id={subId}
                 label="Sub-group by"
                 disabled={state.groupBy === NONE}
@@ -492,7 +593,7 @@ export function DisplayOptions<T>({
 
           <OptionRow label="Ordering" htmlFor={orderId}>
             <div className="flex items-center gap-1.5">
-              <Select
+              <ListboxSelect
                 id={orderId}
                 label="Order by"
                 value={state.sortBy}
@@ -513,15 +614,31 @@ export function DisplayOptions<T>({
                   })),
                 ]}
               />
-              <button
-                type="button"
-                aria-label={`Direction: ${state.sortDir === "asc" ? "ascending" : "descending"} — reverse`}
-                title={state.sortDir === "asc" ? "Ascending" : "Descending"}
-                onClick={() => onChange((s) => ({ ...s, sortDir: s.sortDir === "asc" ? "desc" : "asc" }))}
-                className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md border border-(--border) text-[11px] text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+              <div
+                role="group"
+                aria-label="Ordering direction"
+                className="inline-flex shrink-0 items-center rounded-md border border-(--border) bg-(--surface-0) p-0.5"
               >
-                {state.sortDir === "asc" ? "↑" : "↓"}
-              </button>
+                {(["asc", "desc"] as const).map((direction) => {
+                  const pressed = state.sortDir === direction;
+                  return (
+                    <button
+                      key={direction}
+                      type="button"
+                      aria-pressed={pressed}
+                      aria-label={direction === "asc" ? "Ascending order" : "Descending order"}
+                      onClick={() => onChange((s) => ({ ...s, sortDir: direction }))}
+                      className={`cursor-pointer rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+                        pressed
+                          ? "bg-(--surface-2) text-(--text) shadow-sm"
+                          : "text-(--text-faint) hover:text-(--text-dim)"
+                      }`}
+                    >
+                      <span aria-hidden>{direction === "asc" ? "↑" : "↓"}</span> {direction}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </OptionRow>
 
@@ -554,12 +671,14 @@ export function DisplayOptions<T>({
                             : s.hiddenColumns.filter((k) => k !== c.key),
                         }))
                       }
-                      className={`cursor-pointer rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                      className={`inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors ${
                         shown
-                          ? "border-(--border-strong) bg-(--surface-3) text-(--text)"
-                          : "border-(--border) text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text-dim)"
+                          ? "border-(--border-strong) bg-(--surface-2) text-(--text)"
+                          : "border-(--border) bg-transparent hover:bg-(--surface-2)"
                       }`}
+                      style={shown ? undefined : { color: "var(--text-muted, var(--text-faint))" }}
                     >
+                      {shown && <span aria-hidden className="text-(--accent)">✓</span>}
                       {c.label}
                     </button>
                   );


### PR DESCRIPTION
Fixes WM-556

Replaces the Display panel's native grouping and ordering selects with keyboard-navigable styled listboxes, adds a two-state ordering direction segment, and clarifies property chip states with checkmarks and pressed semantics.

UX critique: required — SHIP
Evidence: http://127.0.0.1:7747/#/runs; /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-0fd2d15b-8ca3-4e0a-b774-17b85cbad2fe.png

Verification: `cd event-runtime/web && bun run build && bun test` — 676 pass, 0 fail.