### PR TITLE
fix(worker): give the demo dispatch stub explicit Owned Paths (WM-578)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -680,6 +680,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
         state: { name: "Todo" },
         assignee: null,
         labels: { nodes: [{ name: "ai:agent-ready" }] },
+        // The plan/verify gate refuses tickets whose Owned Paths cannot be parsed
+        // (owned_paths_unknown). The demo stub is a synthetic ticket, so give it
+        // a narrow, explicit scope that never intersects real escalate_paths.
+        description: "## Owned Paths\n- demo/**\n",
       }),
       fetchInFlight: () => [],
       countLeases: () => 0,


### PR DESCRIPTION
Fixes WM-578

#487 (WM-533) made the demo dispatch stub explicit with a stub `fetchTicket` that has no description; #488 (WM-532) added the `owned_paths_unknown` gate refusal for tickets without a parseable Owned Paths section. Each was green alone; together every stub-mode dispatch (and `worker.test.mjs`) is refused at VERIFYING. Develop CI missed it because runners were env-red (codeload 429).

Fix: the stub ticket now carries `## Owned Paths\n- demo/**` — an explicit, narrow scope that satisfies the gate without weakening it for real tickets and cannot intersect real escalate_paths.

Verification: `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs` — 121 pass, 0 fail.

## Handoff
UX critique: n/a (backend test/runtime fix, no user-visible surface).