### PR TITLE
test(event-runtime): isolate omitted merge schedule planning (WM-571)

### DIFF
--- a/event-runtime/lib/api-schedules.test.mjs
+++ b/event-runtime/lib/api-schedules.test.mjs
@@ -142,7 +142,11 @@ describe("POST /schedules/:loop/run (OPS-401)", () => {
   });
 
   test("omitted merge selection preserves all-open behavior", async () => {
-    const mergeServer = await makeServer();
+    // This path still plans a merge-scan run before responding. Use the same
+    // ephemeral workspace as the selected-PR case so no shared mirror is read.
+    const mergeServer = await makeServer({
+      registry: isolatedScheduleRegistry(),
+    });
     try {
       const res = await fetch(mergeServer.url("/schedules/merge-factory/run"), {
         method: "POST",


### PR DESCRIPTION
## Summary
- isolate the omitted merge-selection schedule test with the existing ephemeral merge-scan registry
- avoid shared repository mirror work in the planner path that made the test load-sensitive

## Verification
- `bun test event-runtime/lib/api-schedules.test.mjs` — 10 pass, 0 fail
- 20/20 consecutive target-file passes while two concurrent `bun test event-runtime/lib` processes supplied load (repeated twice)

UX critique: skipped — internal test-isolation-only change with no user-facing surface

Fixes WM-571