### PR TITLE
fix(web): fit capability graph viewport

### DIFF
--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { AgentNode, EventTypeNode, ProposalNode, TerminalNode, nodeAccessibleName } from "./nodes";
 import type { GraphNode } from "./model";
-import { Graph } from "../views/Graph";
+import { Graph, focusedNodeFit } from "../views/Graph";
 import {
   changeInput,
   createAgentsFixture,
@@ -348,6 +348,16 @@ function renderGraph(props: Partial<Parameters<typeof Graph>[0]> = {}) {
 }
 
 describe("Graph view inspect loop", () => {
+  test("deep-link focus fit centres only the requested node at the current zoom", () => {
+    expect(focusedNodeFit("event:gh.failed", 0.8)).toEqual({
+      nodes: [{ id: "event:gh.failed" }],
+      padding: 0.45,
+      duration: 180,
+      minZoom: 0.8,
+      maxZoom: 0.8,
+    });
+  });
+
   test("search input is mounted before layout so / does not leave Graph", async () => {
     await withApi(
       {

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -15,7 +15,7 @@ import { api } from "../api";
 import { keyGuard, useNow } from "../hooks";
 import { buildCapabilityGraph, type GraphNode } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
-import { largestComponentIds, matchNodes, missingFocusNode, searchEnter } from "../graph/search";
+import { matchNodes, missingFocusNode, searchEnter } from "../graph/search";
 import { EDGE_STYLES, legendEntries } from "../graph/style";
 import { hashPath, hashProject, withProject } from "../hash";
 import type { EventFocus } from "../types";
@@ -37,10 +37,26 @@ import {
 } from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
 
-// Fit-all on a large graph lands at ~0.1–0.3 zoom where labels are unreadable
-// (WM-99). The initial fit centers on the largest component and never goes
-// below this floor — the minimap covers "where is everything else".
-const INITIAL_FIT_MIN_ZOOM = 0.65;
+const GRAPH_FIT_PADDING = "24px";
+const FOCUSED_NODE_MIN_ZOOM = 0.65;
+
+type GraphFitViewOptions = {
+  nodes?: Array<{ id: string }>;
+  padding?: number | `${number}px` | `${number}%`;
+  duration?: number;
+  minZoom?: number;
+  maxZoom?: number;
+};
+
+export function focusedNodeFit(id: string, zoom: number): GraphFitViewOptions {
+  return {
+    nodes: [{ id }],
+    padding: 0.45,
+    duration: 180,
+    minZoom: zoom,
+    maxZoom: zoom,
+  };
+}
 
 function flowEdges(graph: { edges: Array<{ id: string; source: string; target: string; kind: keyof typeof EDGE_STYLES; label?: string }> }): Edge[] {
   return graph.edges.map((edge) => ({
@@ -111,15 +127,10 @@ export function Graph({
   const [layoutEpoch, setLayoutEpoch] = useState(0);
   const lastIdentityRef = useRef<string | null>(null);
   const epochLaidOutRef = useRef(0);
+  const [completedLayoutEpoch, setCompletedLayoutEpoch] = useState(-1);
   const flowRef = useRef<{
     getZoom: () => number;
-    fitView: (opts: {
-      nodes?: Array<{ id: string }>;
-      padding?: number;
-      duration?: number;
-      minZoom?: number;
-      maxZoom?: number;
-    }) => void;
+    fitView: (opts: GraphFitViewOptions) => void;
   } | null>(null);
   const [flowReady, setFlowReady] = useState(0);
 
@@ -177,6 +188,7 @@ export function Graph({
                   })),
                   edges: flowEdges(graph),
                 });
+                setCompletedLayoutEpoch(layoutEpoch);
               } catch (err) {
                 if (cancelled) return;
                 console.error("graph node/edge positioning failed", err);
@@ -235,13 +247,7 @@ export function Graph({
   const revealSelected = useCallback(() => {
     if (!focusNodeId || !flowRef.current) return;
     const zoom = flowRef.current.getZoom();
-    flowRef.current.fitView({
-      nodes: [{ id: focusNodeId }],
-      padding: 0.45,
-      duration: 180,
-      minZoom: zoom,
-      maxZoom: zoom,
-    });
+    flowRef.current.fitView(focusedNodeFit(focusNodeId, zoom));
   }, [focusNodeId]);
 
   useEffect(() => {
@@ -298,26 +304,30 @@ export function Graph({
     return () => window.removeEventListener("keydown", onKey);
   }, [onSelectNode, focusNodeId, graph, positioned, revealSelected]);
 
-  // Initial view (WM-99): fit the largest connected component with a zoom
-  // floor instead of squeezing every island on screen at label-illegible zoom.
-  // Runs once per mount; refetches must not yank the viewport afterwards.
-  const didInitialFit = useRef(false);
+  // Fit every component after the initial layout and each explicit reset. The
+  // completed epoch prevents Reset layout from fitting the stale positions
+  // while ELK is still calculating the replacement layout.
+  const lastFittedLayoutEpoch = useRef(-1);
   useEffect(() => {
-    if (didInitialFit.current || !flowRef.current || !positioned || !graph || graph.nodes.length === 0)
-      return;
-    didInitialFit.current = true;
-    flowRef.current.fitView({
-      nodes: largestComponentIds(graph).map((id) => ({ id })),
-      padding: 0.25,
-      minZoom: INITIAL_FIT_MIN_ZOOM,
-      maxZoom: 1,
-    });
-  }, [graph, positioned, flowReady]);
+    if (
+      lastFittedLayoutEpoch.current === layoutEpoch ||
+      completedLayoutEpoch !== layoutEpoch ||
+      !flowRef.current ||
+      !positioned ||
+      !graph ||
+      graph.nodes.length === 0
+    ) return;
+    lastFittedLayoutEpoch.current = layoutEpoch;
+    flowRef.current.fitView({ padding: GRAPH_FIT_PADDING, maxZoom: 1 });
+  }, [completedLayoutEpoch, flowReady, graph, layoutEpoch, positioned]);
 
   useEffect(() => {
     revealSelected();
+    // `flowReady` makes an initial deep link wait for React Flow's onInit.
+    // Deliberately exclude `positioned`: Reset layout should fit the whole
+    // graph instead of immediately snapping back to the selected node.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusNodeId, flowReady, positioned]);
+  }, [focusNodeId, flowReady]);
 
   // Center the current search match at the operator's zoom; `currentMatch` is
   // a stable string, so background refetches do not re-center the viewport.
@@ -326,7 +336,7 @@ export function Graph({
   }, [query]);
   useEffect(() => {
     if (!currentMatch || !flowRef.current) return;
-    const zoom = Math.max(flowRef.current.getZoom(), INITIAL_FIT_MIN_ZOOM);
+    const zoom = Math.max(flowRef.current.getZoom(), FOCUSED_NODE_MIN_ZOOM);
     flowRef.current.fitView({
       nodes: [{ id: currentMatch }],
       padding: 0.45,
@@ -354,7 +364,7 @@ export function Graph({
   return (
     <div className="flex h-full min-w-0">
       <div className="relative min-w-0 flex-1">
-        <div className="absolute top-4 left-5 z-10">
+        <div className="absolute top-4 left-5 z-10 rounded-md bg-(--surface-0)/85 px-2.5 py-2 backdrop-blur-sm">
           <h1 className="display text-lg font-semibold">Graph</h1>
           <div className="text-[11px] text-(--text-faint)">
             what this runtime can do — registered routes and recommendation edges


### PR DESCRIPTION
## Summary
- fit every capability-graph component on initial mount and after Reset layout with 24px viewport padding
- protect the Graph heading and subtitle with a translucent blurred surface
- preserve deep-link node centering and cover its fit options with a regression test

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (674 tests)

## UX critique
UX critique: required — SHIP (round 1)

Evidence: `http://127.0.0.1:7641/#/graph` at 1440×900 and 1100×800; all 86 nodes visible on mount/reset, heading backdrop verified, direct deep links centered.

### Before — 1440×900
![Before: cropped graph nodes and heading overlap](https://gist.githubusercontent.com/hdkiller/68af1a8de3626731093fc66f912fefd5/raw/5aebae44a84f84cfbc9d3b43eac7ae7835a0f659/WM-553-before-1440x900.svg)

### After — 1440×900
![After: full graph fitted with protected heading](https://gist.githubusercontent.com/hdkiller/68af1a8de3626731093fc66f912fefd5/raw/7f3a2178e5dfef2e825487c3f4b7f00f3c310dca/WM-553-after-1440x900.svg)

Fixes WM-553