### PR TITLE
fix(web): group context scope controls

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -33,6 +33,24 @@ type NavBadge = {
   title?: string;
 };
 
+function NavCount({ id, badge }: { id: string; badge: NavBadge }) {
+  return (
+    <span
+      id={id}
+      aria-hidden="true"
+      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-medium leading-none tabular-nums"
+      title={badge.title}
+      style={{
+        color: badge.hue,
+        background: `color-mix(in oklch, ${badge.hue} 12%, transparent)`,
+      }}
+    >
+      {badge.count}
+      {badge.word && <span className="ml-1">{badge.word}</span>}
+    </span>
+  );
+}
+
 const Artifacts = lazy(() => import("./views/Artifacts").then((m) => ({ default: m.Artifacts })));
 const Graph = lazy(() => import("./views/Graph").then((m) => ({ default: m.Graph })));
 const Chain = lazy(() => import("./views/Chain").then((m) => ({ default: m.Chain })));
@@ -249,8 +267,7 @@ export function App() {
     artifacts: {
       count: status.data?.artifacts.orphans ?? 0,
       hue: "var(--hue-warn)",
-      word: "orphan",
-      title: `${status.data?.artifacts.orphans ?? 0} unreferenced artifact${status.data?.artifacts.orphans === 1 ? "" : "s"}`,
+      title: `${status.data?.artifacts.orphans ?? 0} orphan artifact${status.data?.artifacts.orphans === 1 ? "" : "s"} (unreferenced)`,
     },
     schedules:
       stoppedSchedulesCount > 0
@@ -490,19 +507,7 @@ export function App() {
                      aria-describedby reference above still reads it back as
                      the button's description (accname spec includes hidden
                      nodes referenced by labelledby/describedby). */
-                  <span
-                    id={`nav-badge-${n.key}`}
-                    aria-hidden="true"
-                    className="rounded px-1.5 text-[11px] tabular-nums"
-                    title={badge.title}
-                    style={{
-                      color: badge.hue,
-                      background: `color-mix(in oklch, ${badge.hue} 12%, transparent)`,
-                    }}
-                  >
-                    {badge.count}
-                    {badge.word && <span className="ml-1">{badge.word}</span>}
-                  </span>
+                  <NavCount id={`nav-badge-${n.key}`} badge={badge} />
                 )}
               </button>
             );

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -76,7 +76,7 @@ describe("ContextTabs", () => {
     expect(all.className).toContain("focus-visible:ring-2");
   });
 
-  test("gives the navbar breathing room and every context tab consistent pill geometry", () => {
+  test("groups scope chips on the left, separates In flight, and leaves a labeled Repo action on the right", () => {
     const r = render(
       <ContextTabs
         repos={[repo("factory")]}
@@ -96,9 +96,24 @@ describe("ContextTabs", () => {
 
     for (const name of ["All", "factory", "run_abc", "In flight"]) {
       const tab = r.getByRole("button", { name });
+      expect(toolbar.contains(tab)).toBe(true);
       expect(tab.className).toContain("h-7");
       expect(tab.className).toContain("rounded-full");
     }
+
+    const repoScroller = toolbar.querySelector("[data-context-repos-scroll]");
+    expect(repoScroller?.className).toContain("min-w-0");
+    expect(repoScroller?.className).toContain("overflow-x-auto");
+    expect(repoScroller?.className).not.toContain("flex-1");
+
+    const divider = toolbar.querySelector("[data-context-filter-divider]");
+    expect(divider).not.toBeNull();
+    expect(divider?.nextElementSibling).toBe(r.getByRole("button", { name: "In flight" }));
+
+    const repoAction = r.getByRole("button", { name: "Open a repo tab" });
+    expect(toolbar.contains(repoAction)).toBe(false);
+    expect(repoAction.textContent).toBe("+Repo");
+    expect(repoAction.getAttribute("title")).toBe("Open a repo tab (g 1–9)");
 
     for (const name of ["Close factory", "Close run_abc"]) {
       const close = r.getByRole("button", { name });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -355,7 +355,8 @@ export function ContextTabs({
         </button>
         <div
           role="presentation"
-          className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+          data-context-repos-scroll
+          className="flex min-w-0 items-center gap-0.5 overflow-x-auto"
         >
           {openRepos.map((name, idx) => (
             <div key={name} role="presentation" className={`group ${groupedTabClass(name)}`}>
@@ -438,6 +439,11 @@ export function ContextTabs({
             );
           })}
         </div>
+        <span
+          aria-hidden="true"
+          data-context-filter-divider
+          className="mx-0.5 h-5 w-px shrink-0 bg-(--border)"
+        />
         <button
           type="button"
           data-context-tab={INFLIGHT}
@@ -473,12 +479,13 @@ export function ContextTabs({
           aria-haspopup="listbox"
           aria-controls="repo-picker-listbox"
           aria-label="Open a repo tab"
-          title="Open a repo"
-          className="h-7 w-7 rounded-full text-[14px] text-(--text-dim) outline-none transition-colors hover:bg-(--surface-2) hover:text-(--text) focus-visible:ring-2 focus-visible:ring-(--accent)"
+          title="Open a repo tab (g 1–9)"
+          className="flex h-7 items-center gap-1 rounded-full px-2.5 text-[12px] font-medium text-(--text-dim) outline-none transition-colors hover:bg-(--surface-2) hover:text-(--text) focus-visible:ring-2 focus-visible:ring-(--accent)"
           onClick={() => setPicker((open) => !open)}
           onKeyDown={handlePickerTriggerKeyDown}
         >
-          +
+          <span aria-hidden="true" className="text-[14px] leading-none">+</span>
+          <span>Repo</span>
         </button>
         {picker && (
           <div


### PR DESCRIPTION
Fixes WM-561

Groups scope controls, labels the repo-tab action, and normalizes sidebar count chips through NavCount. Repo tabs scroll independently at narrow widths so All, In flight, and + Repo remain available.

UX critique: required — SHIP after 2 rounds

Verification: `cd event-runtime/web && bun run build && bun test`