### PR TITLE
fix(web): add context to trace errors

### DIFF
--- a/event-runtime/web/src/components/RunTrace.test.tsx
+++ b/event-runtime/web/src/components/RunTrace.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import type { RunState, TraceEntry } from "../types";
 import { changeInput, renderWithClient, restoreApi } from "../test-render";
-import { LIVE_STATES, RunTrace } from "./RunTrace";
+import { formatErrorRowLabel, LIVE_STATES, RunTrace } from "./RunTrace";
 
 afterEach(() => {
   cleanup();
@@ -78,6 +78,48 @@ describe("RunTrace feed", () => {
   });
 });
 
+describe("RunTrace error context (WM-588)", () => {
+  test("formats the tool name and a truncated first error line", () => {
+    const firstLine = "x".repeat(120);
+    const formatted = formatErrorRowLabel("bash", `${firstLine}\nsecond line`);
+
+    expect(formatted.label.startsWith("bash · ")).toBe(true);
+    expect(formatted.label.endsWith("…")).toBe(true);
+    expect(formatted.label).not.toContain("second line");
+    expect(formatted.title).toBe(`bash · ${firstLine}`);
+  });
+
+  test("error rows retain their originating call input in the Errors tab", async () => {
+    const ts = "2026-08-17T15:26:37Z";
+    const contextualTrace: TraceEntry[] = [
+      { ...entry(1, "tool_use", { id: "call_bash", name: "bash", input: { command: "bun test missing.test.ts" } }), ts },
+      { ...entry(2, "tool_result", { toolUseId: "call_bash", content: "Command exited with code 2\nfull stderr", isError: true }), ts },
+    ];
+    const r = renderWithClient(
+      <RunTrace runId="run_error_context" state="COMPLETED" variant="full" />,
+      {
+        apiMocks: {
+          trace: async () => ({ head: 2, entries: contextualTrace }),
+        },
+      },
+    );
+    await waitForChrome(r);
+
+    fireEvent.click(r.getByRole("tab", { name: /^Errors/ }));
+    const label = r.getByText("bash · Command exited with code 2");
+    expect(label.getAttribute("title")).toBe("bash · Command exited with code 2");
+    const timestamp = r.getByTitle(ts);
+    expect(timestamp.textContent).toContain("15:26:37");
+
+    const summary = label.closest("summary")!;
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(summary);
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    expect(await r.findByText("Originating call · bash")).toBeTruthy();
+    expect(r.getByText(/bun test missing\.test\.ts/)).toBeTruthy();
+  });
+});
+
 describe("RunTrace timing (WM-272)", () => {
   test("filtered views use the next unfiltered entry for duration", async () => {
     const start = Date.parse("2025-01-01T00:00:00.000Z");
@@ -131,7 +173,7 @@ describe("RunTrace a11y (WM-143)", () => {
 
     expect(r.getByText("tool · Read")).toBeTruthy();
     expect(r.getByText(/12 in · 34 out/)).toBeTruthy();
-    const errorJump = r.getByRole("button", { name: /1 error/ });
+    const errorJump = r.getByRole("button", { name: /next error/ });
     expect(errorJump).toBeTruthy();
 
     const search = r.getByPlaceholderText("Search trace…") as HTMLInputElement;
@@ -312,13 +354,13 @@ describe("RunTrace a11y (WM-143)", () => {
     const r = renderTrace();
     await waitForChrome(r);
 
-    const errorBtn = r.getByRole("button", { name: /1 error/ });
+    const errorBtn = r.getByRole("button", { name: /next error/ });
     expect(errorBtn).toBeTruthy();
 
     act(() => {
       document.body.dispatchEvent(new KeyboardEvent("keydown", { key: ".", bubbles: true }));
     });
-    expect(r.getByText(/\(1\/1\)/)).toBeTruthy();
+    expect(r.getByText("1/1")).toBeTruthy();
 
     // G triggers jump to latest
     act(() => {
@@ -373,6 +415,6 @@ describe("RunTrace a11y (WM-143)", () => {
     expect(r.getByRole("button", { name: /Follow live/ }).textContent).toContain("l");
 
     // . hint on Error button
-    expect(r.getByRole("button", { name: /1 error/ }).textContent).toContain(".");
+    expect(r.getByRole("button", { name: /next error/ }).textContent).toContain(".");
   });
 });

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -1,15 +1,41 @@
 import { useQuery } from "@tanstack/react-query";
+import { ArrowDownIcon, CodeIcon, CopyIcon, FileTextIcon } from "@radix-ui/react-icons";
 import { Fragment, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard } from "../hooks";
 import type { RunState, TraceEntry, TracePayload } from "../types";
-import { humanSize, JsonBlock, Section, notify } from "./ui";
+import { DisclosureChevron, humanSize, JsonBlock, Section, notify } from "./ui";
 
 function copyText(text: string, label: string = "text") {
   navigator.clipboard.writeText(text);
   notify(`Copied ${label} to clipboard`, "info");
 }
+
+function TraceIconButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="inline-flex size-6 items-center justify-center rounded text-(--text-faint) transition-colors hover:bg-(--surface-2) hover:text-(--text) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+    >
+      {children}
+    </button>
+  );
+}
+
+const TRACE_QUIET_BUTTON =
+  "inline-flex h-7 items-center gap-1.5 rounded border border-(--border) bg-(--surface-0) px-2 text-[11px] font-medium text-(--text-faint) transition-colors hover:bg-(--surface-1) hover:text-(--text-dim)";
 
 /** States in which the trace is still being written — poll incrementally. */
 export const LIVE_STATES: readonly RunState[] = ["LEASED", "RUNNING", "VERIFYING"];
@@ -135,9 +161,13 @@ export function MarkdownView({
     return (
       <div className={`relative ${className}`}>
         {allowToggle && (
-          <div className="mb-1 flex justify-end gap-2 text-[11px]">
-            <button type="button" onClick={() => copyText(text, "raw markdown")} className="text-(--text-faint) hover:text-(--text)">Copy</button>
-            <button type="button" onClick={() => setRaw(false)} className="text-(--accent) hover:underline">Formatted view</button>
+          <div className="mb-1 flex justify-end gap-1" role="group" aria-label="Markdown actions">
+            <TraceIconButton label="Copy raw markdown" onClick={() => copyText(text, "raw markdown")}>
+              <CopyIcon className="size-3.5" />
+            </TraceIconButton>
+            <TraceIconButton label="Show formatted view" onClick={() => setRaw(false)}>
+              <FileTextIcon className="size-3.5" />
+            </TraceIconButton>
           </div>
         )}
         <pre className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap text-(--text-dim)">
@@ -190,7 +220,9 @@ export function MarkdownView({
           <div key={`code-${i}`} className="my-1.5 overflow-hidden rounded-md border border-(--border) bg-(--surface-0)">
             <div className="flex items-center justify-between border-b border-(--border) bg-(--surface-1) px-2.5 py-0.5 text-[11px] text-(--text-faint) mono">
               <span>{codeLang || "code"}</span>
-              <button type="button" onClick={() => copyText(codeText, "code block")} className="hover:text-(--text)">Copy</button>
+              <TraceIconButton label="Copy code block" onClick={() => copyText(codeText, "code block")}>
+                <CopyIcon className="size-3.5" />
+              </TraceIconButton>
             </div>
             <pre className="mono overflow-auto p-2.5 text-[11px] leading-relaxed whitespace-pre-wrap text-(--text)">
               {codeText}
@@ -270,14 +302,45 @@ export function MarkdownView({
   return (
     <div className={`relative ${className}`}>
       {allowToggle && text.length > 50 && (
-        <div className="mb-1 flex justify-end gap-2 text-[11px]">
-          <button type="button" onClick={() => copyText(text, "markdown text")} className="text-(--text-faint) hover:text-(--text)">Copy</button>
-          <button type="button" onClick={() => setRaw(true)} className="text-(--text-faint) hover:text-(--accent)">Raw</button>
+        <div className="mb-1 flex justify-end gap-1" role="group" aria-label="Markdown actions">
+          <TraceIconButton label="Copy markdown text" onClick={() => copyText(text, "markdown text")}>
+            <CopyIcon className="size-3.5" />
+          </TraceIconButton>
+          <TraceIconButton label="Show raw markdown" onClick={() => setRaw(true)}>
+            <CodeIcon className="size-3.5" />
+          </TraceIconButton>
         </div>
       )}
       <div className="space-y-0.5">{blocks}</div>
     </div>
   );
+}
+
+const ERROR_PREVIEW_LENGTH = 96;
+
+function errorText(content: unknown): string {
+  if (typeof content === "string") return content;
+  try {
+    return JSON.stringify(content ?? "");
+  } catch {
+    return String(content ?? "");
+  }
+}
+
+/** Stable collapsed-row label: tool name plus one bounded line of error output. */
+export function formatErrorRowLabel(
+  toolName: string | undefined,
+  content: unknown,
+): { label: string; title: string } {
+  const tool = toolName?.trim() || "unknown tool";
+  const firstLine = errorText(content).split(/\r?\n/, 1)[0].trim() || "No error message";
+  const preview = firstLine.length > ERROR_PREVIEW_LENGTH
+    ? `${firstLine.slice(0, ERROR_PREVIEW_LENGTH - 1)}…`
+    : firstLine;
+  return {
+    label: `${tool} · ${preview}`,
+    title: `${tool} · ${firstLine}`,
+  };
 }
 
 function ContentBlock({ content }: { content: unknown }) {
@@ -352,8 +415,12 @@ function Disclosure({
   };
 
   return (
-    <details open={open} onToggle={onToggle} className="mb-1.5">
-      <summary className="cursor-pointer text-[11px] text-(--text-faint) select-none hover:text-(--text-dim)">
+    <details open={open} onToggle={onToggle} className="mb-1.5 list-none">
+      <summary
+        aria-expanded={open}
+        className="flex cursor-pointer list-none items-center gap-1.5 text-[11px] text-(--text-faint) select-none hover:text-(--text-dim) [&::-webkit-details-marker]:hidden"
+      >
+        <DisclosureChevron open={open} />
         {label}
       </summary>
       {rendered && <div className="mt-1.5">{children}</div>}
@@ -368,12 +435,14 @@ function TraceBody({
   forceOpen,
   durationMs,
   maxMs,
+  originatingCall,
 }: {
   kind: string;
   p: TracePayload;
   forceOpen?: boolean;
   durationMs?: number | null;
   maxMs?: number;
+  originatingCall?: TracePayload;
 }) {
   // Oversize payload clipped in place: whatever the kind was, only the
   // preview survives — say so rather than rendering half a payload silently.
@@ -427,18 +496,31 @@ function TraceBody({
     );
   }
   if (kind === "tool_result") {
+    const errorLabel = p.isError
+      ? formatErrorRowLabel(originatingCall?.name ?? p.name, p.content)
+      : null;
     return (
       <div className="min-w-0 flex-1">
         <Disclosure
           forceOpen={forceOpen}
           label={
-            p.isError ? (
-              <span style={{ color: "var(--hue-err)" }}>tool result — error</span>
+            errorLabel ? (
+              <span className="block max-w-full truncate" style={{ color: "var(--hue-err)" }} title={errorLabel.title}>
+                {errorLabel.label}
+              </span>
             ) : (
               "tool result"
             )
           }
         >
+          {originatingCall?.input !== undefined && (
+            <div className="mb-2">
+              <div className="mb-1 text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+                Originating call · {originatingCall.name ?? "unknown tool"}
+              </div>
+              <JsonBlock value={originatingCall.input} />
+            </div>
+          )}
           <ContentBlock content={p.content} />
         </Disclosure>
       </div>
@@ -542,6 +624,27 @@ export function RunTrace({
   }, [entries]);
 
   const allErrorEntries = useMemo(() => entries.filter(isErrorKind), [entries]);
+
+  // Results carry a correlation id but the Errors filter hides their calls.
+  // Pair against the complete feed before filtering; adapters without ids fall
+  // back to the nearest preceding call in the same attempt.
+  const originatingCalls = useMemo(() => {
+    const byId = new Map<string, TracePayload>();
+    const latestByAttempt = new Map<number, TracePayload>();
+    const byResultSeq = new Map<number, TracePayload>();
+    for (const entry of entries) {
+      const payload = entry.payload ?? {};
+      if (entry.kind === "tool_use") {
+        if (payload.id != null) byId.set(String(payload.id), payload);
+        latestByAttempt.set(entry.attempt, payload);
+      } else if (entry.kind === "tool_result") {
+        const exact = payload.toolUseId != null ? byId.get(String(payload.toolUseId)) : undefined;
+        const call = exact ?? latestByAttempt.get(entry.attempt);
+        if (call) byResultSeq.set(entry.seq, call);
+      }
+    }
+    return byResultSeq;
+  }, [entries]);
 
   const tokenStats = useMemo(() => {
     let promptTokens = 0;
@@ -835,10 +938,8 @@ export function RunTrace({
                   jumpToLatest();
                 }
               }}
-              className={`flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors ${
-                followLive
-                  ? "border-(--border-strong) bg-(--surface-2) text-(--text)"
-                  : "border-(--border) bg-(--surface-0) text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text-dim)"
+              className={`${TRACE_QUIET_BUTTON} ${
+                followLive ? "border-(--border-strong) bg-(--surface-2) text-(--text)" : ""
               }`}
               title={followLive ? "Auto-scrolling live (l). Click to pause." : "Auto-scroll paused (l). Click to follow live."}
             >
@@ -899,20 +1000,15 @@ export function RunTrace({
               <button
                 type="button"
                 onClick={handleJumpToError}
-                className="flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors hover:opacity-80"
-                style={{
-                  borderColor: "var(--hue-err)",
-                  color: "var(--hue-err)",
-                  background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
-                }}
+                className={TRACE_QUIET_BUTTON}
+                style={{ color: "var(--hue-err)" }}
                 title="Jump to next error entry (.)"
               >
-                <span>{counts.errors === 1 ? "1 error" : `${counts.errors} errors`}</span>
-                {activeErrorIdx !== null && (
-                  <span className="mono text-[10px] opacity-75">
-                    ({(activeErrorIdx % counts.errors) + 1}/{counts.errors})
-                  </span>
-                )}
+                <ArrowDownIcon aria-hidden="true" className="size-3" />
+                <span>next error</span>
+                <span className="mono text-[10px] opacity-75">
+                  {activeErrorIdx === null ? 0 : (activeErrorIdx % counts.errors) + 1}/{counts.errors}
+                </span>
                 <span aria-hidden="true" className="mono ml-0.5 opacity-75 text-[10px]">.</span>
               </button>
             )}
@@ -981,7 +1077,7 @@ export function RunTrace({
                 setExpandAll((v) => !v);
                 if (expandAll) setExpandedSeqs(new Set());
               }}
-              className="flex items-center gap-1 text-[11px] text-(--text-faint) hover:text-(--text-dim)"
+              className={TRACE_QUIET_BUTTON}
               title="Toggle expand/collapse details (e)"
             >
               <span>{expandAll ? "Collapse details" : "Expand details"}</span>
@@ -1038,8 +1134,8 @@ export function RunTrace({
                             : ""
                     }`}
                   >
-                    <span className="mono w-[64px] shrink-0 text-(--text-faint)" title={e.ts}>
-                      {new Date(e.ts).toLocaleTimeString([], { hour12: false })}
+                    <span className="mono w-[72px] shrink-0 text-(--text-faint)" title={e.ts}>
+                      {new Date(e.ts).toLocaleTimeString([], { hour12: false })} ·
                     </span>
                     <TraceBody
                       kind={e.kind}
@@ -1047,6 +1143,7 @@ export function RunTrace({
                       forceOpen={expandAll || expandedSeqs.has(e.seq)}
                       durationMs={durations.get(e.seq)}
                       maxMs={maxDurationMs}
+                      originatingCall={originatingCalls.get(e.seq)}
                     />
                   </div>
                 </Fragment>

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,6 +1,7 @@
 import { createContext, type ReactNode, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
 import { attrIcon } from "./attrIcons";
 import { createPortal } from "react-dom";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 import { modal, useFocusReturn, useNow } from "../hooks";
 import type { Section, SortDir } from "../displayOptions";
 import { tokenizeJson, TOKEN_CLASSES } from "../highlight";
@@ -702,6 +703,22 @@ export function Th({
   );
 }
 
+/** One disclosure marker everywhere: Radix weight, aligned box, 150ms rotation. */
+export function DisclosureChevron({
+  open,
+  className = "",
+}: {
+  open: boolean;
+  className?: string;
+}) {
+  return (
+    <ChevronRightIcon
+      aria-hidden="true"
+      className={`size-3 shrink-0 text-(--text-faint) transition-transform duration-150 ${open ? "rotate-90" : ""} ${className}`}
+    />
+  );
+}
+
 /**
  * A Linear-style section header row: chevron, state dot, label, count. The
  * whole band is one button (Enter/Space toggle for free, `aria-expanded` for
@@ -734,12 +751,7 @@ export function GroupHeaderRow({
             sub ? "h-7 pl-8" : "h-8"
           }`}
         >
-          <span
-            aria-hidden
-            className={`text-[9px] text-(--text-faint) transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
-          >
-            ▶
-          </span>
+          <DisclosureChevron open={!collapsed} />
           {!sub && (
             <span
               aria-hidden
@@ -1236,13 +1248,11 @@ export function Disclosure({
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="group mb-1.5 list-none"
     >
-      <summary className="flex cursor-pointer items-center gap-1.5 text-[11px] text-(--text-faint) select-none hover:text-(--text-dim) [&::-webkit-details-marker]:hidden list-none">
-        <span
-          aria-hidden
-          className={`inline-block text-[9px] text-(--text-faint) transition-transform duration-150 ${open ? "rotate-90" : ""}`}
-        >
-          ▶
-        </span>
+      <summary
+        aria-expanded={open}
+        className="flex cursor-pointer items-center gap-1.5 text-[11px] text-(--text-faint) select-none hover:text-(--text-dim) [&::-webkit-details-marker]:hidden list-none"
+      >
+        <DisclosureChevron open={open} />
         <span>{label}</span>
       </summary>
       <div className="mt-1.5">{children}</div>
@@ -1336,12 +1346,7 @@ export function Section({
           aria-expanded={!collapsed}
           className="mb-1.5 flex w-full cursor-pointer items-center gap-1.5 text-left hover:text-(--text-dim)"
         >
-          <span
-            aria-hidden="true"
-            className={`text-[9px] text-(--text-faint) transition-transform ${collapsed ? "" : "rotate-90"}`}
-          >
-            ▶
-          </span>
+          <DisclosureChevron open={!collapsed} />
           {heading}
         </button>
       ) : (


### PR DESCRIPTION
## Summary
- correlate failed tool results with their originating calls and surface tool/error context inline
- normalize trace controls, markdown actions, and disclosure chevrons
- add full ISO timestamp titles and focused error-context/accessibility coverage

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (683 tests)

UX critique: required — SHIP; evidence: http://127.0.0.1:7709/#/run/run_9d9564f8-2d50-48ca-a6db-6d0e599ac626 and `/var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-47d3b9d5-8444-45fa-b38b-b88f27d752aa.png`

Fixes WM-588