### PR TITLE
fix(web): polish artifacts inventory

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -4,11 +4,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { useState } from "react";
 import type { ArtifactInventoryItem } from "../types";
-import { Artifacts, type ArtifactFilters } from "./Artifacts";
+import { Artifacts, formatBytes, type ArtifactFilters } from "./Artifacts";
 import { handleRunArtifactClick } from "./Runs";
 
 const originalFetch = globalThis.fetch;
 const originalClipboard = navigator.clipboard;
+const LONG_RUN_ID = "run_12345678-1234-1234-1234-123456789abc";
 
 const ITEMS: ArtifactInventoryItem[] = [
   {
@@ -18,7 +19,7 @@ const ITEMS: ArtifactInventoryItem[] = [
     referenced: true,
     references: [
       {
-        runId: "run_report",
+        runId: LONG_RUN_ID,
         kind: "report",
         agent: "reporter@1",
         state: "COMPLETED",
@@ -55,6 +56,7 @@ afterEach(() => {
   window.location.hash = "#/artifacts";
   globalThis.fetch = originalFetch;
   Object.defineProperty(navigator, "clipboard", { configurable: true, value: originalClipboard });
+  localStorage.removeItem("evrt-display-artifacts");
 });
 
 function renderArtifacts(
@@ -76,7 +78,7 @@ function renderArtifacts(
         occurredAt: "2026-01-02T03:05:05.000Z",
         receivedAt: "2026-01-02T03:05:05.000Z",
         correlationId: "corr_report",
-        causationId: "run_report",
+        causationId: LONG_RUN_ID,
         planFailures: 0,
         lastPlanError: null,
         admittedAt: "2026-01-02T03:05:05.000Z",
@@ -92,7 +94,12 @@ function renderArtifacts(
     return (
       <QueryClientProvider client={client}>
         <Artifacts
-          metrics={{ files: 3, bytes: 3_584, orphans: 1, orphanBytes: 512 }}
+          metrics={{
+            files: 318,
+            bytes: Math.round(2.4 * 1024 ** 3),
+            orphans: 28,
+            orphanBytes: Math.round(5.1 * 1024),
+          }}
           filters={filters}
           onFiltersChange={setFilters}
           onJumpRun={onJumpRun}
@@ -104,35 +111,58 @@ function renderArtifacts(
 }
 
 describe("Artifacts inventory (WM-207)", () => {
-  test("renders storage metrics, inventory columns, downloads, and run jump links", async () => {
+  test("formats byte thresholds through GB with one decimal", () => {
+    expect(formatBytes(1023)).toBe("1023 B");
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1024 ** 2)).toBe("1.0 MB");
+    expect(formatBytes(2.4 * 1024 ** 3)).toBe("2.4 GB");
+  });
+
+  test("renders storage metrics, inventory columns, downloads, and shortened run jump links", async () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
     const summary = view.getByRole("region", { name: "Artifact storage summary" });
-    expect(summary.textContent).toContain("3");
-    expect(summary.textContent).toContain("3.5 KB");
-    expect(summary.textContent).toContain("1 · 512 B");
+    expect(summary.textContent).toContain("2.4 GB");
+    expect(summary.textContent).toContain("28");
+    expect(summary.textContent).toContain("5.1 KB");
 
-    for (const heading of ["SHA", "Kind", "File size", "Age / timestamp", "Referenced by", "Orphan"]) {
+    for (const heading of ["SHA", "Kind", "File size", "Age", "Referenced by"]) {
       expect(view.getByRole("columnheader", { name: heading })).toBeTruthy();
     }
+    expect(view.queryByRole("columnheader", { name: "Orphan" })).toBeNull();
     const download = view.getByRole("link", { name: `Download artifact ${"a".repeat(64)}` });
     expect(download.getAttribute("href")).toContain(`/api/artifacts/${"a".repeat(64)}`);
 
-    fireEvent.click(view.getByRole("button", { name: "run_report" }));
-    expect(view.onJumpRun).toHaveBeenCalledWith("run_report");
+    const runLink = view.getByRole("button", { name: "run_12345678" });
+    expect(runLink.getAttribute("title")).toBe(LONG_RUN_ID);
+    fireEvent.click(runLink);
+    expect(view.onJumpRun).toHaveBeenCalledWith(LONG_RUN_ID);
+  });
+
+  test("defaults to newest artifacts first", async () => {
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    const downloads = view.getAllByRole("link", { name: /Download artifact/ });
+    expect(downloads.map((link) => link.textContent)).toEqual([
+      "cccccccccccc",
+      "bbbbbbbbbbbb",
+      "aaaaaaaaaaaa",
+    ]);
+    expect(view.getByRole("columnheader", { name: "Age" }).getAttribute("aria-sort")).toBe("descending");
   });
 
   test("filters by kind and orphan status facets", async () => {
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
-    fireEvent.click(view.getByRole("button", { name: "report" }));
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), { target: { value: "report" } });
     expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy();
     expect(view.queryByText("bbbbbbbbbbbb")).toBeNull();
 
-    fireEvent.click(view.getByRole("button", { name: "Any kind" }));
-    fireEvent.click(view.getByRole("button", { name: "Orphans" }));
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), { target: { value: "" } });
+    fireEvent.click(view.getByRole("tab", { name: "Orphans 28" }));
     expect(view.getByText("cccccccccccc")).toBeTruthy();
     expect(view.queryByText("aaaaaaaaaaaa")).toBeNull();
 
@@ -168,8 +198,8 @@ describe("Artifacts inventory (WM-207)", () => {
     expect(preview.textContent).toContain("2");
 
     const references = view.getByRole("region", { name: "Artifact run references" });
-    fireEvent.click(within(references).getByRole("button", { name: /run_report/ }));
-    expect(view.onJumpRun).toHaveBeenCalledWith("run_report");
+    fireEvent.click(within(references).getByRole("button", { name: /run_12345678/ }));
+    expect(view.onJumpRun).toHaveBeenCalledWith(LONG_RUN_ID);
     fireEvent.click(within(references).getByTitle("Open consuming run run_consumer"));
     expect(view.onJumpRun).toHaveBeenCalledWith("run_consumer");
     expect(within(references).getByText(/factory-chain:evt_consumer/)).toBeTruthy();
@@ -193,7 +223,7 @@ describe("Artifacts inventory (WM-207)", () => {
     expect(window.location.hash).toBe(`#/${`artifacts/${"a".repeat(64)}`}`);
     expect(await view.findByRole("region", { name: "Artifact content" })).toBeTruthy();
 
-    window.location.hash = "#/runs/run_report";
+    window.location.hash = `#/runs/${LONG_RUN_ID}`;
     const runLink = render(
       <div onClickCapture={handleRunArtifactClick}>
         <a href={`/api/artifacts/${"b".repeat(64)}?name=transcript`}>Open</a>

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { api, artifactUrl, fetchArtifacts } from "../api";
+import { DisplayOptions } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
 import {
   Ago,
   Button,
@@ -9,11 +11,18 @@ import {
   JumpLink,
   ListEmpty,
   ListPane,
+  Th,
   copyText,
-  humanSize,
   shortId,
 } from "../components/ui";
-import { useNow } from "../hooks";
+import {
+  cycleColumnSort,
+  removeCustomColumn,
+  sortRows,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { useDisplayOptions, useNow } from "../hooks";
 import type { AdmittedEvent, ArtifactInventoryItem, StatusView } from "../types";
 
 export type ArtifactFilters = {
@@ -27,6 +36,38 @@ const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
 function kindsOf(artifact: ArtifactInventoryItem): string[] {
   return [...new Set(artifact.references.flatMap((reference) => reference.kind ?? []))];
 }
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+const ARTIFACTS_DISPLAY: DisplayConfig<ArtifactInventoryItem> = {
+  view: "artifacts",
+  groups: [],
+  sorts: [
+    { key: "sha", label: "SHA", get: (artifact) => artifact.sha256, column: "sha" },
+    { key: "kind", label: "Kind", get: (artifact) => kindsOf(artifact).join(", "), column: "kind" },
+    { key: "size", label: "File size", get: (artifact) => artifact.sizeBytes, column: "size" },
+    { key: "age", label: "Age", get: (artifact) => Date.parse(artifact.mtime), defaultDir: "desc", column: "age" },
+    {
+      key: "references",
+      label: "Referenced by",
+      get: (artifact) => artifact.references.map((reference) => reference.runId).join(", "),
+      column: "references",
+    },
+  ],
+  columns: [
+    { key: "sha", label: "SHA", always: true },
+    { key: "kind", label: "Kind" },
+    { key: "size", label: "File size" },
+    { key: "age", label: "Age" },
+    { key: "references", label: "Referenced by" },
+  ],
+  defaults: { sortBy: "age", sortDir: "desc" },
+};
 
 function matchesSearch(artifact: ArtifactInventoryItem, search: string): boolean {
   const term = search.trim().toLowerCase();
@@ -115,7 +156,17 @@ function KindBadge({ kind }: { kind: string }) {
   );
 }
 
-function Metric({ label, value, warning }: { label: string; value: string; warning?: boolean }) {
+function Metric({
+  label,
+  value,
+  caption,
+  warning,
+}: {
+  label: string;
+  value: string;
+  caption?: string;
+  warning?: boolean;
+}) {
   return (
     <div className="min-w-36 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-3">
       <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
@@ -125,6 +176,7 @@ function Metric({ label, value, warning }: { label: string; value: string; warni
       >
         {value}
       </div>
+      {caption && <div className="mt-0.5 text-[11px] text-(--text-faint)">{caption}</div>}
     </div>
   );
 }
@@ -193,6 +245,13 @@ export function Artifacts({
       }),
     [artifacts, filters],
   );
+  const [display, setDisplay] = useDisplayOptions(ARTIFACTS_DISPLAY);
+  const ordered = useMemo(
+    () => sortRows(visible, ARTIFACTS_DISPLAY, display),
+    [visible, display],
+  );
+  const columns = visibleColumns(ARTIFACTS_DISPLAY, display);
+  const shown = useMemo(() => new Set(columns.map((column) => column.key)), [columns]);
 
   const linkedEvents = (eventsQ.data?.events ?? []) as LinkedEvent[];
   const producerRunIds = useMemo(
@@ -269,25 +328,27 @@ export function Artifacts({
 
           <section aria-label="Artifact storage summary" className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
             <Metric label="Stored files" value={summary.files.toLocaleString()} />
-            <Metric label="Disk usage" value={humanSize(summary.bytes)} />
+            <Metric label="Disk usage" value={formatBytes(summary.bytes)} />
             <Metric
               label="Orphans"
-              value={`${summary.orphans.toLocaleString()} · ${humanSize(summary.orphanBytes)}`}
+              value={summary.orphans.toLocaleString()}
+              caption={formatBytes(summary.orphanBytes)}
               warning={summary.orphans > 0}
             />
           </section>
 
           <div className="mt-3 flex flex-wrap items-center gap-2">
-            <div className="flex flex-wrap gap-1" role="group" aria-label="Artifact status facets">
+            <div className="flex flex-wrap gap-1" role="tablist" aria-label="Artifact reference state">
               {([
-                { label: "All", value: null },
-                { label: "Referenced", value: false },
-                { label: "Orphans", value: true },
+                { label: "All", value: null, count: summary.files },
+                { label: "Referenced", value: false, count: summary.files - summary.orphans },
+                { label: "Orphans", value: true, count: summary.orphans },
               ] as const).map((facet) => (
                 <button
                   key={facet.label}
                   type="button"
-                  aria-pressed={filters.orphan === facet.value}
+                  role="tab"
+                  aria-selected={filters.orphan === facet.value}
                   onClick={() => set({ orphan: facet.value })}
                   className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
                     filters.orphan === facet.value
@@ -296,34 +357,30 @@ export function Artifacts({
                   }`}
                 >
                   {facet.label}
+                  <span className="ml-1.5 tabular-nums text-(--text-faint)">{facet.count.toLocaleString()}</span>
                 </button>
               ))}
             </div>
-            <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="group" aria-label="Artifact kind facets">
-              <button
-                type="button"
-                aria-pressed={filters.kind === null}
-                onClick={() => set({ kind: null })}
-                className={`rounded-md px-2 py-1 text-[11px] ${
-                  filters.kind === null ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
-                }`}
+            <span className="ml-auto">
+              <DisplayOptions
+                config={ARTIFACTS_DISPLAY}
+                state={display}
+                onChange={setDisplay}
+                rows={artifacts}
+              />
+            </span>
+            <label className="flex items-center gap-1.5 text-[11px] font-medium text-(--text-dim)">
+              <span>Kind:</span>
+              <select
+                aria-label="Artifact kind"
+                value={filters.kind ?? ""}
+                onChange={(event) => set({ kind: event.target.value || null })}
+                className="cursor-pointer rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent)"
               >
-                Any kind
-              </button>
-              {kinds.map((kind) => (
-                <button
-                  key={kind}
-                  type="button"
-                  aria-pressed={filters.kind === kind}
-                  onClick={() => set({ kind: filters.kind === kind ? null : kind })}
-                  className={`mono rounded-md px-2 py-1 text-[11px] ${
-                    filters.kind === kind ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
-                  }`}
-                >
-                  {kind}
-                </button>
-              ))}
-            </div>
+                <option value="">Any kind</option>
+                {kinds.map((kind) => <option key={kind} value={kind}>{kind}</option>)}
+              </select>
+            </label>
             <FilterInput
               value={filters.search}
               onChange={(search) => set({ search })}
@@ -337,16 +394,26 @@ export function Artifacts({
       <table className="w-full border-separate border-spacing-0 text-[12px]">
         <thead>
           <tr className="text-left text-[11px] text-(--text-faint)">
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">SHA</th>
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Kind</th>
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">File size</th>
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Age / timestamp</th>
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Referenced by</th>
-            <th className="border-b border-(--border-strong) px-3 py-2 font-medium">Orphan</th>
+            {columns.map((column) => {
+              const sort = ARTIFACTS_DISPLAY.sorts.find((field) => field.column === column.key);
+              const isCustom = column.isCustom || column.key.startsWith("custom:");
+              const customPath = column.key.replace(/^custom:/, "");
+              const current = isCustom ? display.sortBy === column.key : sort && display.sortBy === sort.key;
+              return (
+                <Th
+                  key={column.key}
+                  label={column.label}
+                  dir={current ? display.sortDir : null}
+                  naturalDir={sort?.defaultDir ?? "asc"}
+                  onSort={sort || isCustom ? () => setDisplay((state) => cycleColumnSort(ARTIFACTS_DISPLAY, state, column.key)) : undefined}
+                  onRemove={isCustom ? () => setDisplay((state) => removeCustomColumn(state, customPath)) : undefined}
+                />
+              );
+            })}
           </tr>
         </thead>
         <tbody>
-          {visible.map((artifact) => {
+          {ordered.map((artifact) => {
             const artifactKinds = kindsOf(artifact);
             const name = `${artifact.sha256.slice(0, 12)}${artifactKinds[0] ? `.${artifactKinds[0]}` : ""}`;
             return (
@@ -356,73 +423,79 @@ export function Artifacts({
                 aria-selected={artifact.sha256 === selectedSha}
                 className={`cursor-pointer hover:bg-(--surface-1) ${artifact.sha256 === selectedSha ? "row-selected" : ""}`}
               >
-                <td className="mono max-w-40 border-b border-(--border) px-3 py-2 whitespace-nowrap truncate" title={artifact.sha256}>
-                  <a
-                    href={artifactUrl(artifact.sha256, name)}
-                    download={name}
-                    onClick={(event) => event.stopPropagation()}
-                    className="text-(--accent) hover:underline"
-                    aria-label={`Download artifact ${artifact.sha256}`}
-                  >
-                    {artifact.sha256.slice(0, 12)}
-                  </a>
-                </td>
-                <td className="border-b border-(--border) px-3 py-2 whitespace-nowrap">
-                  {artifactKinds.length > 0 ? (
-                    <div className="flex flex-wrap gap-1">
-                      {artifactKinds.map((kind) => <KindBadge key={kind} kind={kind} />)}
-                    </div>
-                  ) : (
-                    <span className="text-(--text-faint)">—</span>
-                  )}
-                </td>
-                <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-2 text-(--text-dim)">
-                  {humanSize(artifact.sizeBytes)}
-                </td>
-                <td className="whitespace-nowrap border-b border-(--border) px-3 py-2">
-                  <div><Ago iso={artifact.mtime} now={now} /></div>
-                  <time dateTime={artifact.mtime} className="mono text-[10px] text-(--text-faint)">
-                    {new Date(artifact.mtime).toLocaleString()}
-                  </time>
-                </td>
-                <td className="border-b border-(--border) px-3 py-2 whitespace-nowrap">
-                  {artifact.references.length > 0 ? (
-                    <div className="flex flex-wrap gap-x-2 gap-y-1">
-                      {artifact.references.map((reference) => (
-                        <JumpLink
-                          key={`${reference.runId}:${reference.kind ?? "unknown"}`}
-                          onClick={() => onJumpRun(reference.runId)}
-                          title={`Open run ${reference.runId}`}
-                        >
-                          {reference.runId}
-                        </JumpLink>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-(--text-faint)">—</span>
-                  )}
-                </td>
-                <td className="border-b border-(--border) px-3 py-2 whitespace-nowrap">
-                  {!artifact.referenced ? (
-                    <span
-                      className="rounded px-1.5 py-0.5 text-[11px] font-medium"
-                      style={{
-                        color: "var(--hue-warn)",
-                        background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
-                      }}
+                <td className="mono max-w-48 border-b border-(--border) px-3 py-1.5 whitespace-nowrap" title={artifact.sha256}>
+                  <span className="inline-flex items-center gap-2">
+                    <a
+                      href={artifactUrl(artifact.sha256, name)}
+                      download={name}
+                      onClick={(event) => event.stopPropagation()}
+                      className="text-(--accent) hover:underline"
+                      aria-label={`Download artifact ${artifact.sha256}`}
                     >
-                      orphan
-                    </span>
-                  ) : (
-                    <span className="text-(--text-faint)">—</span>
-                  )}
+                      {artifact.sha256.slice(0, 12)}
+                    </a>
+                    {!artifact.referenced && (
+                      <span
+                        className="rounded px-1.5 py-0.5 font-sans text-[11px] font-medium"
+                        style={{
+                          color: "var(--hue-warn)",
+                          background: "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
+                        }}
+                      >
+                        orphan
+                      </span>
+                    )}
+                  </span>
                 </td>
+                {shown.has("kind") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                    {artifactKinds.length > 0 ? (
+                      <div className="flex flex-nowrap gap-1">
+                        {artifactKinds.map((kind) => <KindBadge key={kind} kind={kind} />)}
+                      </div>
+                    ) : (
+                      <span className="text-(--text-faint)">—</span>
+                    )}
+                  </td>
+                )}
+                {shown.has("size") && (
+                  <td className="mono whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-dim)">
+                    {formatBytes(artifact.sizeBytes)}
+                  </td>
+                )}
+                {shown.has("age") && (
+                  <td className="whitespace-nowrap border-b border-(--border) px-3 py-1.5" title={new Date(artifact.mtime).toLocaleString()}>
+                    <Ago iso={artifact.mtime} now={now} />
+                  </td>
+                )}
+                {shown.has("references") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                    {artifact.references.length > 0 ? (
+                      <div className="flex flex-nowrap gap-2">
+                        {artifact.references.map((reference) => (
+                          <JumpLink
+                            key={`${reference.runId}:${reference.kind ?? "unknown"}`}
+                            onClick={() => onJumpRun(reference.runId)}
+                            title={reference.runId}
+                          >
+                            {shortId(reference.runId)}
+                          </JumpLink>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-(--text-faint)">—</span>
+                    )}
+                  </td>
+                )}
+                {columns.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
+                  <CustomCell key={column.key} row={artifact} path={column.key} />
+                ))}
               </tr>
             );
           })}
           {visible.length === 0 && (
             <ListEmpty
-              colSpan={6}
+              colSpan={columns.length}
               query={artifactsQ}
               filtered={filtered}
               noun="artifacts"
@@ -475,7 +548,7 @@ export function Artifacts({
         {selected && (
           <>
             <section aria-label="Artifact metadata" className="grid grid-cols-2 gap-2 text-[12px]">
-              <div><span className="text-(--text-faint)">Size</span><div className="mono mt-0.5">{humanSize(selected.sizeBytes)}</div></div>
+              <div><span className="text-(--text-faint)">Size</span><div className="mono mt-0.5">{formatBytes(selected.sizeBytes)}</div></div>
               <div><span className="text-(--text-faint)">Modified</span><div className="mono mt-0.5">{new Date(selected.mtime).toLocaleString()}</div></div>
               <div className="col-span-2">
                 <span className="text-(--text-faint)">Kinds</span>


### PR DESCRIPTION
## Summary
- separate reference tabs from the kind selector and clarify storage metrics
- add persisted Display options, sortable headers, and newest-first default ordering
- compact artifact rows with shortened provenance IDs and inline orphan badges
- add byte-threshold and default-sort coverage

## Verification
- `cd event-runtime/web && bun run build && bun test`

UX critique: required — SHIP; evidence: http://127.0.0.1:7439/#/artifacts and /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/WM-550-artifacts-narrow.png

Follow-up WM-598 tracks the Overview byte formatter because Overview.tsx and the shared formatter are outside this ticket's Owned Paths.

Fixes WM-550