### PR TITLE
chore(policy): cursor tiers back to non-fast Grok 4.6 High (WM-603)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -116,14 +116,18 @@ models:
   # levels of one model, not three different models. `-high` is the variant
   # the CLI displays as plain "Cursor Grok 4.6"; `-xhigh` is available if
   # strong should reach higher.
-  # strong/standard use the `-fast` twin (WM-585): merge-scan@2 on cursor
-  # (strong tier) timed out at 900s twice and at 1500s once on 2026.08.17
-  # (run_f8eeb97b, run_7b29aaca, run_4c42f4ce) with 20-25 open PRs on the
-  # non-fast `-high`. `-high-fast` is the same Grok 4.6 High reasoning
-  # effort at a faster serving tier — no capability change, just latency.
+  # WM-585 evidence: merge-scan@2 on cursor (strong tier) timed out at 900s
+  # twice and at 1500s once on 2026.08.17 (run_f8eeb97b, run_7b29aaca,
+  # run_4c42f4ce) with 20-25 open PRs on the non-fast `-high`, and the tiers
+  # were briefly moved to `-high-fast` (same reasoning effort, faster
+  # serving). Decision (operator preference 2026-08-17, WM-603): strong and
+  # standard stay on the non-fast `-high` — the `-fast` twins drain the
+  # Cursor subscription faster; merge-scan timeouts are addressed by scoping
+  # scans per PR (WM-576) rather than by faster serving. light keeps
+  # `-low-fast`.
   cursor:
-    strong: cursor-grok-4.6-high-fast
-    standard: cursor-grok-4.6-high-fast
+    strong: cursor-grok-4.6-high
+    standard: cursor-grok-4.6-high
     light: cursor-grok-4.6-low-fast
 
 limits:


### PR DESCRIPTION
Fixes WM-603

Reverts `models.cursor.strong`/`standard` from `cursor-grok-4.6-high-fast` back to `cursor-grok-4.6-high` (`light` stays `-low-fast`). Operator preference 2026-08-17: the `-fast` twins drain the Cursor subscription faster; merge-scan timeouts (WM-585 evidence retained in the comment) are addressed by per-PR scan scoping (WM-576).

Verification: `bun test event-runtime/lib/planner.test.mjs orchestrator/repos-config.test.mjs` — 44 pass, 0 fail.

## Handoff
UX critique: n/a (config only, no user-facing surface).