### PR TITLE
fix(event-runtime-web): align list view consistency (WM-219)

### DIFF
--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -63,6 +63,62 @@ function removeTokensFromQuery(filter: string, tokens: readonly FilterToken[]): 
   return next.replace(/\s+/g, " ").trim();
 }
 
+const FACET_PREVIEW_LIMIT = 2;
+
+function FacetChoice({
+  value,
+  count,
+  active,
+  mono = false,
+  onClick,
+}: {
+  value: string;
+  count: number;
+  active: boolean;
+  mono?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      title={value}
+      onClick={onClick}
+      className={`inline-flex min-w-0 max-w-44 items-center rounded-md px-2 py-0.5 text-[11px] transition-colors ${
+        mono ? "mono" : ""
+      } ${
+        active
+          ? "bg-(--surface-3) font-medium text-(--text)"
+          : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+      }`}
+    >
+      <span className="min-w-0 truncate">{value}</span>
+      {count > 0 && (
+        <span className={`${mono ? "font-sans" : ""} ml-1.5 shrink-0 tabular-nums text-(--text-faint)`}>
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function FacetOverflow({ children, count, label }: { children: React.ReactNode; count: number; label: string }) {
+  if (count === 0) return null;
+  return (
+    <details className="relative shrink-0">
+      <summary
+        className="cursor-pointer list-none rounded-md px-2 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text) [&::-webkit-details-marker]:hidden"
+        title={`Show ${count} more ${label.toLowerCase()}`}
+      >
+        +{count} more
+      </summary>
+      <div className="absolute top-full right-0 z-30 mt-1 flex min-w-56 max-w-80 flex-col items-stretch gap-1 rounded-md border border-(--border-strong) bg-(--surface-1) p-1 shadow-xl">
+        {children}
+      </div>
+    </details>
+  );
+}
+
 function toggleFacetInQuery(filter: string, key: "type" | "source", value: string): string {
   const parsed = parseFilterQuery(filter, EVENT_FACETS);
   const existingTokens = parsed.tokens.filter(
@@ -306,7 +362,6 @@ export function Events({
     [sections, display.collapsed],
   );
   const cols = visibleColumns(displayConfig, display);
-  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
 
   const selectedKey =
     focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
@@ -320,6 +375,13 @@ export function Events({
     () => (selectedKey ? (visible.find((e) => keyOf(e) === selectedKey) ?? null) : null),
     [visible, selectedKey],
   );
+  // The detail pane leaves a compact triage list. Keep the columns needed to
+  // identify and compare events; the complete row remains in Display when the
+  // pane closes, and every field remains available in the pane itself.
+  const listCols = sel
+    ? cols.filter((c) => ["event", "type", "subject", "status", "admitted"].includes(c.key))
+    : cols;
+  const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -593,61 +655,69 @@ export function Events({
         </div>
 
         {(types.length > 1 || sources.length > 1) && (
-          <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px]">
+          <div className="mb-2 flex min-w-0 items-center gap-x-4 whitespace-nowrap text-[11px]">
             {types.length > 1 && (
-              <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event types">
-                <span className="text-[11px] font-medium text-(--text-dim)">Type:</span>
-                {types.map((t) => {
+              <div className="flex min-w-0 flex-1 items-center gap-1.5" role="group" aria-label="Event types">
+                <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">Type:</span>
+                {types.slice(0, FACET_PREVIEW_LIMIT).map((t) => {
                   const isPressed = activeTypes.has(t.toLowerCase());
-                  const count = typeCounts[t] ?? 0;
                   return (
-                    <button
+                    <FacetChoice
                       key={t}
-                      type="button"
-                      aria-pressed={isPressed}
+                      value={t}
+                      count={typeCounts[t] ?? 0}
+                      active={isPressed}
                       onClick={() => {
-                        const next = isPressed ? null : t;
                         setFilter((cur) => toggleFacetInQuery(cur, "type", t));
-                        onSelectType(next);
+                        onSelectType(isPressed ? null : t);
                       }}
-                      className={`rounded-md px-2 py-0.5 text-[11px] transition-colors ${
-                        isPressed
-                          ? "bg-(--surface-3) text-(--text) font-medium"
-                          : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                      }`}
-                    >
-                      <span>{t}</span>
-                      {count > 0 && <span className="ml-1.5 tabular-nums text-(--text-faint)">{count}</span>}
-                    </button>
+                    />
                   );
                 })}
+                <FacetOverflow count={Math.max(0, types.length - FACET_PREVIEW_LIMIT)} label="event types">
+                  {types.slice(FACET_PREVIEW_LIMIT).map((t) => {
+                    const isPressed = activeTypes.has(t.toLowerCase());
+                    return (
+                      <FacetChoice
+                        key={t}
+                        value={t}
+                        count={typeCounts[t] ?? 0}
+                        active={isPressed}
+                        onClick={() => {
+                          setFilter((cur) => toggleFacetInQuery(cur, "type", t));
+                          onSelectType(isPressed ? null : t);
+                        }}
+                      />
+                    );
+                  })}
+                </FacetOverflow>
               </div>
             )}
             {sources.length > 1 && (
-              <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Event sources">
-                <span className="text-[11px] font-medium text-(--text-dim)">Source:</span>
-                {sources.map((s) => {
-                  const isPressed = activeSources.has(s.toLowerCase());
-                  const count = sourceCounts[s] ?? 0;
-                  return (
-                    <button
+              <div className="flex min-w-0 flex-1 items-center gap-1.5" role="group" aria-label="Event sources">
+                <span className="shrink-0 text-[11px] font-medium text-(--text-dim)">Source:</span>
+                {sources.slice(0, FACET_PREVIEW_LIMIT).map((s) => (
+                  <FacetChoice
+                    key={s}
+                    value={s}
+                    count={sourceCounts[s] ?? 0}
+                    active={activeSources.has(s.toLowerCase())}
+                    mono
+                    onClick={() => setFilter((cur) => toggleFacetInQuery(cur, "source", s))}
+                  />
+                ))}
+                <FacetOverflow count={Math.max(0, sources.length - FACET_PREVIEW_LIMIT)} label="event sources">
+                  {sources.slice(FACET_PREVIEW_LIMIT).map((s) => (
+                    <FacetChoice
                       key={s}
-                      type="button"
-                      aria-pressed={isPressed}
-                      onClick={() => {
-                        setFilter((cur) => toggleFacetInQuery(cur, "source", s));
-                      }}
-                      className={`rounded-md px-2 py-0.5 mono text-[11px] transition-colors ${
-                        isPressed
-                          ? "bg-(--surface-3) text-(--text) font-medium"
-                          : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                      }`}
-                    >
-                      <span>{s}</span>
-                      {count > 0 && <span className="ml-1.5 font-sans tabular-nums text-(--text-faint)">{count}</span>}
-                    </button>
-                  );
-                })}
+                      value={s}
+                      count={sourceCounts[s] ?? 0}
+                      active={activeSources.has(s.toLowerCase())}
+                      mono
+                      onClick={() => setFilter((cur) => toggleFacetInQuery(cur, "source", s))}
+                    />
+                  ))}
+                </FacetOverflow>
               </div>
             )}
           </div>
@@ -678,10 +748,10 @@ export function Events({
         }
       >
 
-        <table className="w-full border-separate border-spacing-0">
+        <table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              {cols.map((c) => {
+              {listCols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
@@ -730,27 +800,25 @@ export function Events({
                       </td>
                     )}
                     {show.has("status") && (
-                      <td className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                        <div className="flex items-center whitespace-nowrap">
-                          <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                      <td
+                        className="max-w-44 overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
+                        title={e.lastPlanError ?? proposalReason ?? undefined}
+                      >
+                        <div className="flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
+                          <span className="shrink-0">
+                            <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                          </span>
                           {e.planFailures > 0 && (
-                            <span className="ml-2 whitespace-nowrap text-[11px] text-(--hue-err)">
-                              {e.planFailures} plan failure{e.planFailures === 1 ? "" : "s"}
+                            <span className="shrink-0 text-[11px] text-(--hue-err)">
+                              {e.planFailures} failure{e.planFailures === 1 ? "" : "s"}
+                            </span>
+                          )}
+                          {(e.lastPlanError || proposalReason) && (
+                            <span className="mono min-w-0 truncate text-(--text-dim)">
+                              {e.lastPlanError ?? proposalReason}
                             </span>
                           )}
                         </div>
-                        {/* Why the event is parked, on the row: `.mono` carries its own
-                            11.5px, so no size utility (it is unlayered and would win).
-                            The detail pane keeps the untruncated error. */}
-                        {e.lastPlanError ? (
-                          <div className="mono mt-0.5 truncate whitespace-nowrap text-(--text-dim)" title={e.lastPlanError}>
-                            {e.lastPlanError}
-                          </div>
-                        ) : proposalReason ? (
-                          <div className="mono mt-0.5 truncate whitespace-nowrap text-(--text-dim)" title={proposalReason}>
-                            {proposalReason}
-                          </div>
-                        ) : null}
                       </td>
                     )}
                     {show.has("admitted") && (
@@ -758,7 +826,7 @@ export function Events({
                         <Ago iso={e.admittedAt} now={now} />
                       </td>
                     )}
-                    {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                    {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
                       <CustomCell key={c.key} row={e} path={c.key.replace(/^custom:/, "")} />
                     ))}
                   </tr>
@@ -770,7 +838,7 @@ export function Events({
                 return (
                   <Fragment key={s.key}>
                     <GroupHeaderRow
-                      colSpan={cols.length}
+                      colSpan={listCols.length}
                       section={s}
                       collapsed={closed}
                       onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
@@ -782,7 +850,7 @@ export function Events({
                             return (
                               <Fragment key={child.key}>
                                 <GroupHeaderRow
-                                  colSpan={cols.length}
+                                  colSpan={listCols.length}
                                   section={child}
                                   collapsed={childClosed}
                                   onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
@@ -799,7 +867,7 @@ export function Events({
             })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={cols.length}
+                colSpan={listCols.length}
                 query={list}
                 filtered={tabScoped.length > 0}
                 onClear={

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -421,7 +421,6 @@ export function Proposals({
     [sections, display.collapsed],
   );
   const cols = visibleColumns(displayConfig, display);
-  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
 
   const selectedId = focusProposalId;
   // Keyboard index walks the open sections; the detail pane keys off the row
@@ -431,6 +430,12 @@ export function Proposals({
     () => (selectedId ? (visible.find((p) => p.id === selectedId) ?? null) : null),
     [visible, selectedId],
   );
+  // Keep the selected-row list as a compact audit rail. Open and History expose
+  // different columns, so this union leaves four useful columns in either tab.
+  const listCols = sel
+    ? cols.filter((c) => ["agent", "decision", "ttl", "status", "decided", "origin"].includes(c.key))
+    : cols;
+  const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
   /** Agent behind the selected proposal — feeds the shared safety card / approve dialog. */
   const selAgent = useMemo(
@@ -824,7 +829,7 @@ export function Proposals({
         }
       >
 
-        <table className="w-full border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
+        <table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
               {tab === "open" && (
@@ -840,7 +845,7 @@ export function Proposals({
                   />
                 </th>
               )}
-              {cols.map((c) => {
+              {listCols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
@@ -860,7 +865,7 @@ export function Proposals({
           </thead>
           <tbody>
             {(() => {
-              const totalColSpan = cols.length + (tab === "open" ? 1 : 0);
+              const totalColSpan = listCols.length + (tab === "open" ? 1 : 0);
               const tdCls = "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
               const renderRow = (p: Proposal) => (
                 <tr
@@ -958,7 +963,7 @@ export function Proposals({
                       {p.reason ?? "-"}
                     </td>
                   )}
-                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                  {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
                     <CustomCell key={c.key} row={p} path={c.key.replace(/^custom:/, "")} />
                   ))}
                 </tr>
@@ -998,7 +1003,7 @@ export function Proposals({
             })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={cols.length + (tab === "open" ? 1 : 0)}
+                colSpan={listCols.length + (tab === "open" ? 1 : 0)}
                 query={tab === "open" ? query : history}
                 filtered={unfilteredCount > 0}
                 onClear={

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -327,7 +327,6 @@ export function Runs({
     [sections, display.collapsed],
   );
   const cols = visibleColumns(displayConfig, display);
-  const show = useMemo(() => new Set(cols.map((c) => c.key)), [cols]);
 
   const selectedId = focusRunId;
   // Keyboard index walks the open sections; the detail pane keys off the row
@@ -421,6 +420,13 @@ export function Runs({
     () => (selectedId ? (visible.find((r) => r.runId === selectedId) ?? null) : null),
     [visible, selectedId],
   );
+  // A side pane turns the list into a compact comparison rail. Keep the five
+  // decision-bearing columns instead of forcing a horizontal scrollbar; the
+  // pane and the unselected list retain every configured column.
+  const listCols = sel
+    ? cols.filter((c) => ["run", "state", "reason", "origin", "updated"].includes(c.key))
+    : cols;
+  const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
   useEffect(() => {
     document.querySelector("tr.row-selected")?.scrollIntoView({ block: "nearest" });
@@ -700,10 +706,10 @@ export function Runs({
         }
       >
 
-        <table className="w-full border-separate border-spacing-0">
+        <table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
             <tr className="text-left text-[11px] text-(--text-faint)">
-              {cols.map((c) => {
+              {listCols.map((c) => {
                 const sort = displayConfig.sorts.find((s) => s.column === c.key);
                 const isCustom = c.isCustom || c.key.startsWith("custom:");
                 const customPath = c.key.replace(/^custom:/, "");
@@ -741,8 +747,8 @@ export function Runs({
                     to its content instead, which keeps the link fully rendered.
                   */}
                   {show.has("state") && (
-                    <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <div className="flex items-center gap-1.5 whitespace-nowrap">
+                    <td className="overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
+                      <div className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
                         <StateBadge state={r.state} />
                         {r.state === "PROPOSED" && (() => {
                           const prop = proposalByRunId.get(r.runId);
@@ -819,7 +825,7 @@ export function Runs({
                       <Ago iso={r.updated_at} now={now} />
                     </td>
                   )}
-                  {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
+                  {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
                     <CustomCell key={c.key} row={r} path={c.key.replace(/^custom:/, "")} />
                   ))}
                 </tr>
@@ -830,7 +836,7 @@ export function Runs({
                 return (
                   <Fragment key={s.key}>
                     <GroupHeaderRow
-                      colSpan={cols.length}
+                      colSpan={listCols.length}
                       section={s}
                       collapsed={closed}
                       onToggle={() => setDisplay((st) => toggleCollapsed(st, s.key))}
@@ -842,7 +848,7 @@ export function Runs({
                             return (
                               <Fragment key={child.key}>
                                 <GroupHeaderRow
-                                  colSpan={cols.length}
+                                  colSpan={listCols.length}
                                   section={child}
                                   collapsed={childClosed}
                                   onToggle={() => setDisplay((st) => toggleCollapsed(st, child.key))}
@@ -859,7 +865,7 @@ export function Runs({
             })()}
             {visible.length === 0 && (
               <ListEmpty
-                colSpan={cols.length}
+                colSpan={listCols.length}
                 query={list}
                 filtered={byTab.length > 0}
                 onClear={filter.trim() ? () => setFilter("") : undefined}


### PR DESCRIPTION
Align the Events, Proposals, and Runs list surfaces with the shared dense-table grammar:

- keep Events facets on one line with accessible `+n more` overflow menus
- use fixed table layouts and compact decision-bearing columns while detail panes are open
- keep Events status/reason rows constant-height with full reasons preserved in titles and panes

Verification: `bun test event-runtime/web` — 692 pass, 0 fail

UX critique: required — SHIP (round 2)
Evidence: http://127.0.0.1:7645/#/events/demo-seed/demo-dead-letter, http://127.0.0.1:7645/#/proposals/prop_8fd40db8-ec54-4a90-9c38-e8215e71ba76, http://127.0.0.1:7645/#/runs/run_b57cd2da-a1e7-45dc-81e6-befad4354e8e

Fixes WM-219