### PR TITLE
chore(hooks): lefthook commit-msg hook enforcing conventional commit + ticket ref (WM-609)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `~/D
 
 **An ad-hoc request gets a ticket too — file it, don't wait to be asked.** A request typed into a chat session is not exempt from the control plane; if it isn't tracked, it is invisible to every other agent and to tomorrow. **The trip wire is your first file edit:** before it, either find the issue that already covers this or create one, and say in one line which it is ("Tracking as OPS-91"). Commits still carry their `(ISSUE-ID)`. Skip the ticket only for ordinary questions, read-only lookups with no actionable finding, and inconsequential edits — and the human can always say "no ticket", which settles it. Sessions drift: one that began as a question and turned into a change trips the wire at that moment, not at the end.
 
+**A local `commit-msg` hook enforces `type(scope): summary (ISSUE-ID)` (WM-609)** — `FACTORY_NO_TICKET=1 git commit …` is the deliberate escape hatch for a commit that genuinely has no ticket.
+
 **Retroactive capture is the backstop, not the plan.** If you notice partway through, or while wrapping up, that work already done has no issue, file it _then_ — with the commits or PR linked and the state set to where the work actually is (`Done` if it is already merged and green), never dressed up as queued work. Before reporting a session finished, check that everything you changed is on a ticket. A late ticket beats an invisible change; both are worse than filing up front.
 
 **Claim before you code.** Set assignee to yourself, state `In Progress`, add `ai:in-progress`, then **re-read the ticket** — if the assignee isn't you, another agent won the race; take the next one. This read-back is the entire concurrency control.

--- a/bin/check-commit-msg.sh
+++ b/bin/check-commit-msg.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# WM-609: lefthook commit-msg hook.
+#
+# Enforces `type(scope): summary (ISSUE-ID)` conventional-commit format
+# locally, matching AGENTS.md / linear.md §6. Dependency-free bash regex —
+# no node_modules, <50ms — per the tier-4 hook rule in
+# docs/guides/code-security.md §4 (heavier checks belong in CI, not here).
+set -euo pipefail
+
+msg_file="${1:?usage: check-commit-msg.sh <path-to-COMMIT_EDITMSG>}"
+
+# The subject is the first line that isn't a `#`-prefixed comment (git
+# strips these itself before the commit lands, but the hook sees the raw
+# COMMIT_EDITMSG file, comments and all).
+subject=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+  case "$line" in
+  \#*) continue ;;
+  esac
+  subject="$line"
+  break
+done <"$msg_file"
+
+# Commits that are never held to the conventional-commit format: merges,
+# reverts, in-progress fixup/squash commits, and Dependabot's own commits
+# (message or author).
+case "$subject" in
+Merge* | Revert* | fixup!* | squash!* | "build(deps"*)
+  exit 0
+  ;;
+esac
+if [[ "${GIT_AUTHOR_NAME:-}" == *dependabot* || "${GIT_AUTHOR_EMAIL:-}" == *dependabot* ]]; then
+  exit 0
+fi
+
+type_re='^(feat|fix|chore|docs|test|refactor|perf|ci|build|style|revert|sec|maint|ui|ui-ux|spike|epic)(\([a-z0-9._/-]+\))?!?: .+'
+if ! [[ "$subject" =~ $type_re ]]; then
+  cat >&2 <<EOF
+commit-msg: subject does not match conventional commit format.
+
+  expected: type(scope): summary (ISSUE-ID)
+  example:  fix(scope): correct off-by-one in scheduler (WM-123)
+  got:      ${subject}
+
+  allowed types: feat fix chore docs test refactor perf ci build style revert sec maint ui ui-ux spike epic
+EOF
+  exit 1
+fi
+
+ticket_re='\((WM|OPS|CLNT|CW|LAB)-[0-9]+\)'
+if ! [[ "$subject" =~ $ticket_re ]]; then
+  if [[ "${FACTORY_NO_TICKET:-}" == "1" ]]; then
+    echo "commit-msg: warning: no ticket ref like (WM-123) in subject — allowed because FACTORY_NO_TICKET=1" >&2
+    exit 0
+  fi
+  cat >&2 <<EOF
+commit-msg: subject is missing a ticket reference.
+
+  fix: append " (WM-123)" to the subject, or export FACTORY_NO_TICKET=1 for a deliberate no-ticket commit
+  got: ${subject}
+EOF
+  exit 1
+fi
+
+exit 0

--- a/bin/check-commit-msg.test.mjs
+++ b/bin/check-commit-msg.test.mjs
@@ -1,0 +1,111 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+const SCRIPT = path.resolve(import.meta.dir, "check-commit-msg.sh");
+
+const WORK_DIR = mkdtempSync(path.join(tmpdir(), "wm-609-check-commit-msg-"));
+let fileCount = 0;
+
+afterAll(() => {
+  rmSync(WORK_DIR, { recursive: true, force: true });
+});
+
+function run(message, extraEnv = {}) {
+  const file = path.join(WORK_DIR, `msg-${fileCount++}.txt`);
+  writeFileSync(file, message);
+  const result = Bun.spawnSync({
+    cmd: ["bash", SCRIPT, file],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+test("valid conventional commit with ticket ref passes", () => {
+  const r = run("fix(scope): thing (WM-1)\n");
+  expect(r.status).toBe(0);
+});
+
+test("missing type is rejected", () => {
+  const r = run("random text (WM-1)\n");
+  expect(r.status).toBe(1);
+  expect(r.stderr).toContain("does not match conventional commit format");
+});
+
+test("missing ticket ref is rejected", () => {
+  const r = run("fix: thing\n");
+  expect(r.status).toBe(1);
+  expect(r.stderr).toContain("missing a ticket reference");
+  expect(r.stderr).toContain("FACTORY_NO_TICKET=1");
+});
+
+test("missing ticket ref passes with FACTORY_NO_TICKET=1 and warns on stderr", () => {
+  const r = run("fix: thing\n", { FACTORY_NO_TICKET: "1" });
+  expect(r.status).toBe(0);
+  expect(r.stderr).toContain("warning");
+  expect(r.stderr).toContain("FACTORY_NO_TICKET=1");
+});
+
+test("merge commit is skipped", () => {
+  const r = run("Merge branch 'feature/x' into develop\n");
+  expect(r.status).toBe(0);
+});
+
+test("revert commit is skipped", () => {
+  const r = run('Revert "fix(scope): thing (WM-1)"\n');
+  expect(r.status).toBe(0);
+});
+
+test("fixup and squash commits are skipped", () => {
+  expect(run("fixup! fix(scope): thing (WM-1)\n").status).toBe(0);
+  expect(run("squash! fix(scope): thing (WM-1)\n").status).toBe(0);
+});
+
+test("dependabot build(deps commit is skipped by message", () => {
+  const r = run("build(deps): bump lodash from 4.17.20 to 4.17.21\n");
+  expect(r.status).toBe(0);
+});
+
+test("dependabot author is skipped even without a build(deps) subject", () => {
+  const r = run("chore: bump some dep\n", {
+    GIT_AUTHOR_NAME: "dependabot[bot]",
+    GIT_AUTHOR_EMAIL: "49699333+dependabot[bot]@users.noreply.github.com",
+  });
+  expect(r.status).toBe(0);
+});
+
+test("scope with slash and dot characters is accepted", () => {
+  const r = run("chore(event-runtime/web): x (OPS-12)\n");
+  expect(r.status).toBe(0);
+});
+
+test("breaking-change marker before the colon is accepted", () => {
+  const r = run("feat(api)!: x (WM-2)\n");
+  expect(r.status).toBe(0);
+});
+
+test("comment lines above the subject are skipped", () => {
+  const r = run("# Please enter the commit message for your changes.\n# Lines starting with '#' will be ignored.\nfix(scope): thing (WM-1)\n#\n# On branch develop\n");
+  expect(r.status).toBe(0);
+});
+
+test("every allowed type is accepted with a ticket ref", () => {
+  const types = ["feat", "fix", "chore", "docs", "test", "refactor", "perf", "ci", "build", "style", "revert", "sec", "maint", "ui", "ui-ux", "spike", "epic"];
+  for (const type of types) {
+    const r = run(`${type}: something (WM-1)\n`);
+    expect(r.status).toBe(0);
+  }
+});
+
+test("unknown ticket prefix is rejected", () => {
+  const r = run("fix(scope): thing (XX-1)\n");
+  expect(r.status).toBe(1);
+  expect(r.stderr).toContain("missing a ticket reference");
+});

--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -16,6 +16,8 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `~/D
 
 **An ad-hoc request gets a ticket too — file it, don't wait to be asked.** A request typed into a chat session is not exempt from the control plane; if it isn't tracked, it is invisible to every other agent and to tomorrow. **The trip wire is your first file edit:** before it, either find the issue that already covers this or create one, and say in one line which it is ("Tracking as OPS-91"). Commits still carry their `(ISSUE-ID)`. Skip the ticket only for ordinary questions, read-only lookups with no actionable finding, and inconsequential edits — and the human can always say "no ticket", which settles it. Sessions drift: one that began as a question and turned into a change trips the wire at that moment, not at the end.
 
+**A local `commit-msg` hook enforces `type(scope): summary (ISSUE-ID)` (WM-609)** — `FACTORY_NO_TICKET=1 git commit …` is the deliberate escape hatch for a commit that genuinely has no ticket.
+
 **Retroactive capture is the backstop, not the plan.** If you notice partway through, or while wrapping up, that work already done has no issue, file it _then_ — with the commits or PR linked and the state set to where the work actually is (`Done` if it is already merged and green), never dressed up as queued work. Before reporting a session finished, check that everything you changed is on a ticket. A late ticket beats an invisible change; both are worse than filing up front.
 
 **Claim before you code.** Set assignee to yourself, state `In Progress`, add `ai:in-progress`, then **re-read the ticket** — if the assignee isn't you, another agent won the race; take the next one. This read-back is the entire concurrency control.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,3 +7,10 @@ pre-commit:
   commands:
     gitleaks:
       run: gitleaks git --pre-commit --staged --no-banner --redact
+
+# WM-609: enforce `type(scope): summary (ISSUE-ID)` locally (dependency-free
+# bash regex, same tier-4 rule as pre-commit above).
+commit-msg:
+  commands:
+    check-commit-msg:
+      run: bin/check-commit-msg.sh {1}

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -16,6 +16,8 @@ Non-negotiable for every agent in this repo, in any harness. Full protocol: `~/D
 
 **An ad-hoc request gets a ticket too — file it, don't wait to be asked.** A request typed into a chat session is not exempt from the control plane; if it isn't tracked, it is invisible to every other agent and to tomorrow. **The trip wire is your first file edit:** before it, either find the issue that already covers this or create one, and say in one line which it is ("Tracking as OPS-91"). Commits still carry their `(ISSUE-ID)`. Skip the ticket only for ordinary questions, read-only lookups with no actionable finding, and inconsequential edits — and the human can always say "no ticket", which settles it. Sessions drift: one that began as a question and turned into a change trips the wire at that moment, not at the end.
 
+**A local `commit-msg` hook enforces `type(scope): summary (ISSUE-ID)` (WM-609)** — `FACTORY_NO_TICKET=1 git commit …` is the deliberate escape hatch for a commit that genuinely has no ticket.
+
 **Retroactive capture is the backstop, not the plan.** If you notice partway through, or while wrapping up, that work already done has no issue, file it _then_ — with the commits or PR linked and the state set to where the work actually is (`Done` if it is already merged and green), never dressed up as queued work. Before reporting a session finished, check that everything you changed is on a ticket. A late ticket beats an invisible change; both are worse than filing up front.
 
 **Claim before you code.** Set assignee to yourself, state `In Progress`, add `ai:in-progress`, then **re-read the ticket** — if the assignee isn't you, another agent won the race; take the next one. This read-back is the entire concurrency control.


### PR DESCRIPTION
Fixes WM-609

Adds a lefthook `commit-msg` hook that enforces `type(scope): summary (ISSUE-ID)` locally, per `project-conventions.md` §7 PC-10 — the pre-commit gitleaks hook existed but the commit format wasn't locally enforced.

- `bin/check-commit-msg.sh`: dependency-free bash (`set -euo pipefail`, no node), validates the first non-comment line against `^(feat|fix|chore|docs|test|refactor|perf|ci|build|style|revert|sec|maint|ui|ui-ux|spike|epic)(\([a-z0-9._/-]+\))?!?: .+` and requires a `(WM|OPS|CLNT|CW|LAB)-<n>` ticket ref. Skips merge/revert/fixup!/squash!/`build(deps`/dependabot-authored commits. `FACTORY_NO_TICKET=1` is the deliberate no-ticket escape hatch (prints a warning to stderr, exits 0).
- `lefthook.yml`: new `commit-msg` section wired to the script, alongside the existing `pre-commit` gitleaks block.
- `bin/check-commit-msg.test.mjs`: bun test, 14 tests covering valid/invalid subjects, every allowed type, missing type, missing ticket (with and without the escape hatch), merge/revert/fixup!/squash!, dependabot by message and by author, scope with slash/dot, breaking-change `!`, and comment-line skipping.
- `AGENTS.md` / `shared/floor.md` / `dist/AGENTS.floor.md`: one-line note in the floor naming the hook and the escape hatch. AGENTS.md is generated from `shared/floor.md` (splice-in-repos build step), so the source was edited and `bun run emit` was re-run to keep `dist/AGENTS.floor.md` in sync — a legitimate Owned-Paths exception beyond the ticket's four listed paths, since AGENTS.md itself is generated-tree output.

## Test plan
- [x] `bun test bin/check-commit-msg.test.mjs && bash -n bin/check-commit-msg.sh` — 14 pass, syntax clean
- [x] Negative test: tests observed failing against a stub script that always exits 0 (proves they're not vacuous), then passing again against the real implementation
- [x] `bun run check` — generated tree matches `shared/`, exit 0 (pre-existing floor-delivery staleness in *other* checkouts on this machine is unrelated and non-blocking, per the script's own design)
- [x] `bunx prettier --check AGENTS.md` — clean
- [x] `lefthook install` run locally; a bad commit message (`this is not a conventional commit message`) was blocked (exit 1) with the expected-format message; this PR's own commit passed the hook