### PR TITLE
chore(ci): add security.yml — Semgrep + Gitleaks + Actionlint on PRs (WM-608)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint config (WM-608). Declares the repo's custom self-hosted runner
+# labels so `runs-on: [self-hosted, shadow]` / `[self-hosted, smoke-test]`
+# don't flag as "unknown label" — see docs/ci.md and
+# ~/Develop/hdkiller/docs/guides/github-runners.md for what they map to.
+self-hosted-runner:
+  labels:
+    - shadow
+    - smoke-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
           git init -q "$GITHUB_WORKSPACE"
           cd "$GITHUB_WORKSPACE"
           git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
@@ -192,7 +192,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.[!.]* 2>/dev/null || true
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
           git init -q "$GITHUB_WORKSPACE"
           cd "$GITHUB_WORKSPACE"
           git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
@@ -331,6 +331,7 @@ jobs:
           trap cleanup EXIT
 
           ready=0
+          # shellcheck disable=SC2034 # bounded retry counter; loop body doesn't need the index
           for i in $(seq 50); do
             if kill -0 "$SERVE_PID" 2>/dev/null && \
               HEALTH="$(curl -sf "http://127.0.0.1:$PORT/health")" && \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,196 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: ["develop", "main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    # Self-hosted per project-conventions PC-03 / PC-22.
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 15
+    steps:
+      # No `uses:` steps in this workflow on purpose (WM-573, mirrors ci.yml):
+      # every marketplace action is fetched from codeload.github.com at "Set
+      # up job", and the shadow fleet (eight runners, one egress IP, no action
+      # archive cache) has hit 429 Too Many Requests on actions/checkout.
+      # PR runs need connected history between base and head so `git log
+      # base..head` (gitleaks --log-opts) can walk it — start shallow and
+      # deepen only as far as needed to connect the two endpoints.
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
+          if [ -n "${BASE_SHA:-}" ]; then
+            git fetch -q --depth=50 origin "$SHA" "$BASE_SHA"
+            git checkout -q "$SHA"
+            depth=50
+            while ! git merge-base "$BASE_SHA" "$SHA" >/dev/null 2>&1; do
+              if [ "$depth" -ge 2000 ]; then
+                echo "::warning::could not connect base $BASE_SHA to head $SHA within $depth commits; falling back to full history"
+                git fetch -q --unshallow origin || git fetch -q origin "$BASE_SHA" "$SHA"
+                break
+              fi
+              depth=$((depth * 4))
+              git fetch -q --deepen="$depth" origin "$SHA" "$BASE_SHA"
+            done
+          else
+            git fetch -q --depth 1 origin "$SHA"
+            git checkout -q FETCH_HEAD
+          fi
+          git log -1 --oneline
+
+      - name: Resolve gitleaks binary
+        id: gitleaks-bin
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if command -v gitleaks >/dev/null 2>&1; then
+            echo "bin=gitleaks" >> "$GITHUB_OUTPUT"
+          elif [ -x "$HOME/.local/bin/gitleaks" ]; then
+            echo "bin=$HOME/.local/bin/gitleaks" >> "$GITHUB_OUTPUT"
+          else
+            # Releases download, not codeload — resolve the current tag via the
+            # GitHub API (versioned asset name, so a hardcoded URL goes stale)
+            # then fetch the linux_x64 tarball straight from
+            # objects.githubusercontent.com, no actions/* download involved.
+            tag="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+              https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+              | grep -m1 '"tag_name"' | cut -d '"' -f4)"
+            ver="${tag#v}"
+            mkdir -p "$HOME/.local/bin"
+            curl -fsSL -o "$RUNNER_TEMP/gitleaks.tar.gz" \
+              "https://github.com/gitleaks/gitleaks/releases/download/${tag}/gitleaks_${ver}_linux_x64.tar.gz"
+            tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$HOME/.local/bin" gitleaks
+            chmod +x "$HOME/.local/bin/gitleaks"
+            echo "bin=$HOME/.local/bin/gitleaks" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gitleaks scan
+        shell: bash
+        env:
+          GITLEAKS_BIN: ${{ steps.gitleaks-bin.outputs.bin }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # .gitleaks.toml at repo root is auto-loaded by gitleaks if present.
+          if [ -n "${BASE_SHA:-}" ]; then
+            log_opts="${BASE_SHA}..${SHA}"
+          else
+            log_opts="-1"
+          fi
+          "$GITLEAKS_BIN" git --no-banner --redact --log-opts="$log_opts"
+
+  semgrep:
+    name: Semgrep
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
+
+      # uv is on the runner host per code-security.md §4 tier 2b; only install
+      # (from astral.sh, not codeload) if it is missing.
+      - name: Setup uv (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v uvx >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/uvx" ]; then
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+          fi
+          if [ -x "$HOME/.local/bin/uvx" ]; then
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+          uvx --version
+
+      - name: Semgrep scan
+        run: uvx semgrep scan --config p/security-audit --error --metrics=off .
+
+  actionlint:
+    name: Actionlint
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
+
+      - name: Resolve actionlint binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v actionlint >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/actionlint" ]; then
+            bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/.local/bin"
+          fi
+          if [ -x "$HOME/.local/bin/actionlint" ]; then
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+          actionlint -version
+
+      - name: Actionlint
+        run: actionlint -color .github/workflows/*.yml
+
+  codeql:
+    name: CodeQL
+    # Gated: this repo is private with no GitHub Advanced Security, so
+    # `gh api repos/watt-mind/factory/code-scanning/default-setup` returns 403
+    # "Advanced Security must be enabled" (project-conventions.md §3D). Real
+    # CodeQL steps need `github/codeql-action/init` + `.../analyze`, which are
+    # `uses:` marketplace steps — acceptable here specifically because they
+    # only run once GHAS unlocks the codeload path for this repo. Flip the
+    # `CODEQL_ENABLED` repo variable to `true` and replace this placeholder
+    # with the real init/analyze steps at that point.
+    if: ${{ vars.CODEQL_ENABLED == 'true' }}
+    runs-on: [self-hosted, shadow]
+    timeout-minutes: 15
+    steps:
+      - name: CodeQL gated placeholder
+        run: echo "CodeQL is gated behind vars.CODEQL_ENABLED; this repo has no GHAS yet (project-conventions.md §3D)."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,9 +76,13 @@ jobs:
             # GitHub API (versioned asset name, so a hardcoded URL goes stale)
             # then fetch the linux_x64 tarball straight from
             # objects.githubusercontent.com, no actions/* download involved.
-            tag="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-              https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-              | grep -m1 '"tag_name"' | cut -d '"' -f4)"
+            # Capture the full response before grepping it: piping curl
+            # straight into `grep -m1` lets grep exit after the first match
+            # while curl is still writing, which curl reports as exit 23
+            # ("Failure writing output to destination").
+            resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+              https://api.github.com/repos/gitleaks/gitleaks/releases/latest)"
+            tag="$(printf '%s' "$resp" | grep -m1 '"tag_name"' | cut -d '"' -f4)"
             ver="${tag#v}"
             mkdir -p "$HOME/.local/bin"
             curl -fsSL -o "$RUNNER_TEMP/gitleaks.tar.gz" \
@@ -134,10 +138,15 @@ jobs:
           if ! command -v uvx >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/uvx" ]; then
             curl -LsSf https://astral.sh/uv/install.sh | sh
           fi
+          # $GITHUB_PATH only takes effect starting the *next* step, not this
+          # one — resolve the binary directly here rather than relying on PATH.
           if [ -x "$HOME/.local/bin/uvx" ]; then
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+            uvx_bin="$HOME/.local/bin/uvx"
+          else
+            uvx_bin="uvx"
           fi
-          uvx --version
+          "$uvx_bin" --version
 
       - name: Semgrep scan
         run: uvx semgrep scan --config p/security-audit --error --metrics=off .
@@ -170,10 +179,15 @@ jobs:
           if ! command -v actionlint >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/actionlint" ]; then
             bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/.local/bin"
           fi
+          # $GITHUB_PATH only takes effect starting the *next* step, not this
+          # one — resolve the binary directly here rather than relying on PATH.
           if [ -x "$HOME/.local/bin/actionlint" ]; then
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+            actionlint_bin="$HOME/.local/bin/actionlint"
+          else
+            actionlint_bin="actionlint"
           fi
-          actionlint -version
+          "$actionlint_bin" -version
 
       - name: Actionlint
         run: actionlint -color .github/workflows/*.yml

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,10 @@
+# Semgrep already respects .gitignore; this file adds paths that are tracked
+# (or occasionally present) but not source to scan: generated output, vendor
+# trees, fixtures, and lockfiles. See docs/ci.md "Security scans".
+node_modules/
+**/node_modules/
+dist/
+graphify-out/
+evals/**/fixtures/
+bun.lock
+deploy/launchd/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,3 +213,7 @@ factory linear queue --team CLNT                         # what is dispatchable
 
 Never print, echo, commit, or paste an API key, token, or `.env` file — not into a transcript, a PR, a Linear comment, or a log. Scripts read credentials themselves. If a secret appears in a diff, that's an escalation, not a cleanup.
 <!-- FACTORY:FLOOR:END -->
+
+## Repo-specific notes
+
+Run `factory security` (Gitleaks + Semgrep + Actionlint, `lib/security-check.sh`) before pushing — `.github/workflows/security.yml` runs the same three tools in CI on every PR and on pushes to `develop`/`main` (see `docs/ci.md` "Security scans").

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,3 +43,14 @@ After changing the workflow:
 3. For each relevant run, inspect step timestamps with `gh run view <RUN_ID>` and confirm the interval from `Acquire host verify lock` completing through `Release host verify lock` does not overlap that interval in either test job from another Factory workflow run.
 
 A failed or cancelled test job breaks the streak. Record the five develop run URLs in the validating ticket or merge handoff.
+
+## Security scans
+
+`.github/workflows/security.yml` runs on `pull_request`, `push` to `develop`/`main`, and `workflow_dispatch`, on `[self-hosted, shadow]` with the same no-`uses:` git-fetch checkout pattern as `ci.yml` (WM-573). Four jobs:
+
+- **Gitleaks** — `gitleaks git --no-banner --redact` over the PR's base..head range (or the last commit on a branch push). Honours a repo-root `.gitleaks.toml` if one is added. Binary resolves from PATH, then `~/.local/bin/gitleaks`, then a GitHub Releases download (not a marketplace action) on first use per runner host.
+- **Semgrep** — `uvx semgrep scan --config p/security-audit --error --metrics=off .`, scoped by `.semgrepignore` (generated output, vendor trees, fixtures, lockfiles). `uv`/`uvx` installs from astral.sh if missing on the host.
+- **Actionlint** — `actionlint -color .github/workflows/*.yml`. `.github/actionlint.yaml` declares the repo's custom self-hosted runner labels (`shadow`, `smoke-test`) so they don't flag as unknown; real shellcheck findings on `run:` blocks get fixed or suppressed inline with a reason, never blanket-disabled.
+- **CodeQL** — gated behind `if: ${{ vars.CODEQL_ENABLED == 'true' }}` and currently a placeholder: this repo is private with no GitHub Advanced Security (`code-scanning/default-setup` returns 403). Flip the `CODEQL_ENABLED` repository variable and replace the placeholder step with `github/codeql-action` init/analyze once GHAS is available (project-conventions.md §3D).
+
+Run the same tools locally before pushing with `factory security` (Gitleaks + Semgrep + Actionlint, plus Ruff/pip-audit when a repo has adopted the Python tier) — see `lib/security-check.sh`. Local and CI use identical tool invocations and config files (`.gitleaks.toml`, `.semgrepignore`) so a clean local run predicts a clean CI run.


### PR DESCRIPTION
Fixes WM-608

## Summary
- Adds `.github/workflows/security.yml`: `Gitleaks`, `Semgrep`, `Actionlint` jobs plus a `CodeQL` placeholder gated on `vars.CODEQL_ENABLED` (this repo has no GHAS — `code-scanning/default-setup` returns 403). Triggers on `pull_request`, `push` to `develop`/`main`, and `workflow_dispatch`; `permissions: contents: read`; per-run concurrency group matching `ci.yml`'s pattern.
- No `uses:` marketplace steps, mirroring `ci.yml`'s shell git-fetch checkout (WM-573 codeload-429 avoidance). `Gitleaks` uses a history-deepening checkout so `git log base..head` can walk the PR range; `Semgrep`/`Actionlint` use the plain depth-1 checkout. Each tool self-installs into `~/.local/bin` from GitHub Releases / astral.sh only if missing on the runner host (persists across runs on the self-hosted host).
- Fixes every actionlint finding on `ci.yml` (never previously linted): adds `.github/actionlint.yaml` declaring the repo's custom self-hosted runner labels (`shadow`, `smoke-test`) so they don't flag as unknown, guards two `rm -rf "$GITHUB_WORKSPACE"/*` expansions with `${VAR:?}` (shellcheck SC2115), and suppresses one false-positive SC2034 on a bounded retry-loop counter with an inline reason.
- Adds `.semgrepignore` (generated output, vendor trees, fixtures, lockfiles) — local `uvx semgrep scan --config p/security-audit --error --metrics=off .` ran clean, 0 findings, no triage needed.
- Documents the new workflow in `docs/ci.md` ("Security scans") and adds a one-line pointer in `AGENTS.md` (outside the generated floor block, so it survives `--sync-floor`).

## Test plan
- [x] `actionlint .github/workflows/*.yml` — clean
- [x] `gitleaks git --no-banner --redact --log-opts="origin/develop..HEAD"` — no leaks found
- [x] `uvx semgrep scan --config p/security-audit --error --metrics=off .` — 0 findings
- [ ] `gh pr checks --watch --fail-fast` on this PR (CI + new Security workflow both green)