### PR TITLE
fix(web): align worker summary cards (WM-564)

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -950,6 +950,38 @@ export function StateBadge({
   );
 }
 
+export function StatCard({
+  label,
+  value,
+  suffix,
+  caption,
+  hue,
+  compact = false,
+}: {
+  label: string;
+  value: ReactNode;
+  suffix?: ReactNode;
+  caption?: ReactNode;
+  hue?: string;
+  compact?: boolean;
+}) {
+  return (
+    <div
+      data-stat-card
+      className={`${compact ? "min-w-0 rounded-md px-3 py-2" : "min-w-36 rounded-lg px-3.5 py-3"} border border-(--border) bg-(--surface-1)`}
+    >
+      <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
+      <div className={`display font-semibold tabular-nums ${compact ? "mt-0.5 text-lg" : "mt-1 text-xl"}`}>
+        <span data-stat-value style={hue ? { color: hue } : undefined}>{value}</span>
+        {suffix}
+      </div>
+      {caption != null && (
+        <div className={`${compact ? "text-[10px]" : "text-[11px]"} mt-0.5 text-(--text-faint)`}>{caption}</div>
+      )}
+    </div>
+  );
+}
+
 export function StatTile({
   label,
   value,

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -11,6 +11,7 @@ import {
   JumpLink,
   ListEmpty,
   ListPane,
+  StatCard,
   Th,
   copyText,
   shortId,
@@ -153,31 +154,6 @@ function KindBadge({ kind }: { kind: string }) {
     >
       {kind}
     </span>
-  );
-}
-
-function Metric({
-  label,
-  value,
-  caption,
-  warning,
-}: {
-  label: string;
-  value: string;
-  caption?: string;
-  warning?: boolean;
-}) {
-  return (
-    <div className="min-w-36 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-3">
-      <div className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
-      <div
-        className="display mt-1 text-xl font-semibold tabular-nums"
-        style={warning ? { color: "var(--hue-warn)" } : undefined}
-      >
-        {value}
-      </div>
-      {caption && <div className="mt-0.5 text-[11px] text-(--text-faint)">{caption}</div>}
-    </div>
   );
 }
 
@@ -327,13 +303,13 @@ export function Artifacts({
           </div>
 
           <section aria-label="Artifact storage summary" className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
-            <Metric label="Stored files" value={summary.files.toLocaleString()} />
-            <Metric label="Disk usage" value={formatBytes(summary.bytes)} />
-            <Metric
+            <StatCard label="Stored files" value={summary.files.toLocaleString()} />
+            <StatCard label="Disk usage" value={formatBytes(summary.bytes)} />
+            <StatCard
               label="Orphans"
               value={summary.orphans.toLocaleString()}
               caption={formatBytes(summary.orphanBytes)}
-              warning={summary.orphans > 0}
+              hue={summary.orphans > 0 ? "var(--hue-warn)" : undefined}
             />
           </section>
 

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  CapacityBand,
   Workers,
   capacityFromWorkers,
   defaultWorkerTab,
@@ -104,7 +105,40 @@ describe("worker capacity and draining state (WM-228)", () => {
     expect(workerDisplayState({ ...stubWorker("w_stale", "busy", true), draining: true })).toBe("stale");
   });
 
-  test("shows running/capacity, queue limiter, class caps, and an explicit draining row", async () => {
+  test("uses worker-health hues on the running number only", () => {
+    const capacity: WorkerCapacity = {
+      running: 1,
+      capacity: 2,
+      queued: 0,
+      live: 2,
+      idle: 1,
+      draining: 0,
+      target: 2,
+      min: 1,
+      max: 2,
+      supervisor: "active",
+      source: "worker-policy",
+      limitingFactor: null,
+      classes: [],
+    };
+    const view = render(<CapacityBand capacity={capacity} />);
+    const runningValue = () => view.container.querySelector("[data-stat-value]");
+
+    expect(runningValue()?.textContent).toBe("1");
+    expect(runningValue()?.getAttribute("style")).toContain("var(--hue-ok)");
+    expect(runningValue()?.nextElementSibling?.textContent).toBe(" / 2");
+    expect(runningValue()?.nextElementSibling?.getAttribute("style")).toBeNull();
+
+    view.rerender(
+      <CapacityBand capacity={{ ...capacity, queued: 1, limitingFactor: "at worker max" }} />,
+    );
+    expect(runningValue()?.getAttribute("style")).toContain("var(--hue-warn)");
+
+    view.rerender(<CapacityBand capacity={{ ...capacity, supervisor: "stopped" }} />);
+    expect(runningValue()?.getAttribute("style")).toContain("var(--hue-err)");
+  });
+
+  test("shows four capacity stat cells, queue limiter, class caps, and an explicit draining row", async () => {
     const worker = {
       ...stubWorker("w_drain", "busy"),
       draining: true,
@@ -127,9 +161,20 @@ describe("worker capacity and draining state (WM-228)", () => {
       classes: [{ name: "heavy", running: 1, capacity: 2 }],
     };
     await withWorkers([worker], async () => {
-      const { getByText, getAllByText, getByTitle } = renderWorkers();
-      await waitFor(() => expect(getByText("1 running / 2 capacity")).toBeTruthy());
-      expect(getByText("4 queued runs")).toBeTruthy();
+      const { getByText, getAllByText, getByTitle, getByRole } = renderWorkers();
+      const summary = await waitFor(() => getByRole("region", { name: "Worker pool capacity" }));
+      const statCells = summary.querySelectorAll("[data-stat-card]");
+      expect(statCells).toHaveLength(4);
+      expect(Array.from(statCells).map((cell) => cell.textContent)).toEqual([
+        "Running1 / 2",
+        "Queued4",
+        "Idle0",
+        "Target0supervisor active",
+      ]);
+      expect(statCells[0]?.querySelector("[data-stat-value]")?.textContent).toBe("1");
+      expect(statCells[0]?.querySelector("[data-stat-value]")?.getAttribute("style")).toContain(
+        "var(--hue-warn)",
+      );
       expect(getByText("at worker max")).toBeTruthy();
       expect(getByText("heavy 1/2")).toBeTruthy();
       expect(getAllByText("draining").length).toBeGreaterThan(0);

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -43,6 +43,7 @@ import {
   GroupHeaderRow,
   Section,
   StateBadge,
+  StatCard,
   Th,
   copyLink,
   copyText,
@@ -310,33 +311,34 @@ const openRun = (runId: string) => {
 };
 
 export function CapacityBand({ capacity }: { capacity: WorkerCapacity }) {
-  const constrained = capacity.queued > 0 && capacity.limitingFactor;
-  const hue = constrained ? "var(--hue-warn)" : "var(--hue-ok)";
+  const constrained = capacity.queued > 0 && Boolean(capacity.limitingFactor);
+  const runningHue =
+    capacity.supervisor === "stopped"
+      ? WORKER_HUES.stale
+      : constrained
+        ? WORKER_HUES.busy
+        : WORKER_HUES.idle;
+  const targetCaption =
+    capacity.source === "worker-policy"
+      ? "supervisor active"
+      : `${capacity.supervisor === "stopped" ? "supervisor stopped · " : ""}live-worker fallback${capacity.max != null ? ` · policy max ${capacity.max}` : ""}`;
   return (
-    <section
-      aria-label="Worker pool capacity"
-      className="mb-3 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-3"
-    >
-      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5">
-        <div className="flex items-baseline gap-2">
-          <span className="display text-xl font-semibold tabular-nums" style={{ color: hue }}>
-            {capacity.running} running / {capacity.capacity} capacity
-          </span>
-          <span className="mono text-[12px] text-(--text-dim)">
-            {capacity.queued} queued run{capacity.queued === 1 ? "" : "s"}
-          </span>
-        </div>
-        <span className="text-[11px] text-(--text-faint)">
-          {capacity.live} live · {capacity.idle} idle
-          {capacity.draining > 0 ? ` · ${capacity.draining} draining` : ""}
-          {capacity.source === "worker-policy"
-            ? ` · target ${capacity.target} · supervisor active`
-            : ` · ${capacity.supervisor === "stopped" ? "supervisor stopped · " : ""}live-worker fallback${capacity.max != null ? ` · policy max ${capacity.max}` : ""}`}
-        </span>
+    <section aria-label="Worker pool capacity" className="mb-3">
+      <div className="grid grid-cols-4 gap-2">
+        <StatCard
+          compact
+          label="Running"
+          value={capacity.running}
+          suffix={<span className="text-(--text-dim)"> / {capacity.capacity}</span>}
+          hue={runningHue}
+        />
+        <StatCard compact label="Queued" value={capacity.queued} />
+        <StatCard compact label="Idle" value={capacity.idle} />
+        <StatCard compact label="Target" value={capacity.target} caption={targetCaption} />
       </div>
       {constrained && (
-        <div className="mt-2 flex items-center gap-2 text-[12px]" style={{ color: hue }}>
-          <span className="size-1.5 rounded-full" style={{ background: hue }} />
+        <div className="mt-2 flex items-center gap-2 text-[12px]" style={{ color: WORKER_HUES.busy }}>
+          <span className="size-1.5 rounded-full" style={{ background: WORKER_HUES.busy }} />
           <span>
             Queue is waiting: <strong>{capacity.limitingFactor}</strong>
           </span>


### PR DESCRIPTION
## Summary
- extract the Artifacts KPI treatment into a shared `StatCard` with a compact variant
- render Workers capacity as RUNNING, QUEUED, IDLE, and TARGET KPI cells
- apply worker-health color to the running number only and cover all health hues

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass, 694 tests

UX critique: skipped — isolated summary-card styling with no user-completable flow or interaction change

Fixes WM-564