### PR TITLE
fix(worker): reload before stale registry claims

### DIFF
--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -117,6 +117,21 @@ export const SPAWN_GRACE_MS = 10_000;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** Flags that shape a worker are passed through unchanged by the pool. */
+export function workerPassthroughArgs(args) {
+  const passthrough = [];
+  for (const flag of ["--adapter-override", "--poll-ms", "--drain-timeout"]) {
+    const v = flagValue(args, flag);
+    if (v !== null && v !== undefined) passthrough.push(flag, v);
+  }
+  if (args.includes("--reload-on-change")) passthrough.push("--reload-on-change");
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--label")
+      passthrough.push("--label", String(args[i + 1] ?? ""));
+  }
+  return passthrough;
+}
+
 /**
  * The pool supervisor: a deterministic loop that maintains
  * `workers.min ≤ pool ≤ workers.max` from observed queue depth. It is its own
@@ -162,15 +177,7 @@ export default async function supervise(args) {
 
   // Whatever shapes a worker gets handed straight through, so a supervised pool
   // is configured exactly like the single worker it replaces.
-  const passthrough = [];
-  for (const flag of ["--adapter-override", "--poll-ms", "--drain-timeout"]) {
-    const v = flagValue(args, flag);
-    if (v !== null && v !== undefined) passthrough.push(flag, v);
-  }
-  for (let i = 0; i < args.length; i += 1) {
-    if (args[i] === "--label")
-      passthrough.push("--label", String(args[i + 1] ?? ""));
-  }
+  const passthrough = workerPassthroughArgs(args);
 
   // One supervisor per run dir. Two would allocate the same slot numbers and
   // silently orphan each other's workers — pidfiles overwritten, processes

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -11,6 +11,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
+import { workerPassthroughArgs } from "./supervise.mjs";
 import {
   CLI,
   DEAD_PORT,
@@ -29,6 +30,30 @@ import {
 } from "./test-helpers.mjs";
 
 describe("supervise (WM-226)", () => {
+  test("passes reload and worker-shaping flags through to every pool slot (WM-613)", () => {
+    expect(
+      workerPassthroughArgs([
+        "--workers",
+        "1:2",
+        "--adapter-override",
+        "fake",
+        "--poll-ms",
+        "50",
+        "--reload-on-change",
+        "--label",
+        "node=lab",
+      ]),
+    ).toEqual([
+      "--adapter-override",
+      "fake",
+      "--poll-ms",
+      "50",
+      "--reload-on-change",
+      "--label",
+      "node=lab",
+    ]);
+  });
+
   test("rejects bounds and intervals it cannot honour, naming the flag", () => {
     expect(runCli(["supervise", "--workers", "3:1", "--once"]).all).toContain(
       "min (3) cannot exceed max (1)",

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -11,6 +11,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
 
 export const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
@@ -279,8 +280,8 @@ export async function seedRun(home, { runId, input = {}, timeoutSeconds = 5 }) {
     inputHash: hashJson(input),
     workspace: { type: "ephemeral", retainOnFailure: false },
     adapter: "fake",
-    promptVersion: "git:test",
-    policyVersion: "git:test",
+    promptVersion: policyVersion(),
+    policyVersion: policyVersion(),
     outputContract: "factory.status-report/v1",
     capabilities: ["linear:read"],
     timeoutSeconds,

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -18,6 +18,7 @@ import { newWorkerId } from "../lib/ids.mjs";
 import { loadRegistry } from "../lib/registry.mjs";
 import {
   claimNext,
+  checkoutPolicyVersion,
   CODE_RELOAD_EXIT,
   codeStamp,
   createReloadWatcher,
@@ -148,9 +149,9 @@ export default async function work(args) {
    * run so the deferral is logged while it is still true, and the loop top is
    * the idle boundary where acting on it is safe.
    */
-  function reloadWanted() {
+  function reloadWanted({ force = false } = {}) {
     if (!watcher || draining) return false;
-    const r = watcher.check(inFlight);
+    const r = watcher.check(inFlight, { force });
     if (r.action === "deferred") {
       if (r.first)
         log(
@@ -186,11 +187,22 @@ export default async function work(args) {
         const claim = claimNext(db, {
           owner: workerId,
           policyVersion: pv,
+          registryVersion: pv,
+          currentRegistryVersion: checkoutPolicyVersion,
           labels,
           adapters: adapterOverride ? null : adapterNames,
           ...(adapterOverride ? { adapterOverride } : {}),
         });
         if (!claim) {
+          await new Promise((resolve) => setTimeout(resolve, pollMs));
+          continue;
+        }
+        if (claim.refused) {
+          log(
+            `refused ${claim.runId} (${claim.reasonCode}, retryable): worker registry ${claim.workerRegistryVersion}, checkout registry ${claim.checkoutRegistryVersion}, run prompt ${claim.spec.promptVersion}, run policy ${claim.spec.policyVersion}`,
+          );
+          if (claim.reloadRequired)
+            return finish("registry_stale", CODE_RELOAD_EXIT);
           await new Promise((resolve) => setTimeout(resolve, pollMs));
           continue;
         }
@@ -207,6 +219,12 @@ export default async function work(args) {
         log(
           `${claim.runId} → ${summary?.terminalState ?? "?"} (${summary?.reasonCode ?? "-"})`,
         );
+        // Force a fresh code stamp after every completed run. Without this,
+        // an interval-gated check can immediately claim from a hot queue using
+        // the registry snapshot from before the checkout changed.
+        inFlight = null;
+        if (reloadWanted({ force: true }))
+          return finish("code_reload", CODE_RELOAD_EXIT);
       } catch (err) {
         log(`worker error: ${err.message}`);
         await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
 import {
   CLI,
@@ -27,6 +28,8 @@ import {
   spawnWorker,
   waitFor,
 } from "./test-helpers.mjs";
+
+const WORKER_POLICY_VERSION = policyVersion();
 
 describe("work command", () => {
   test("work rejects an unsafe idle poll interval", () => {
@@ -164,8 +167,8 @@ describe("work command", () => {
       inputHash: hashJson(input),
       workspace: { type: "ephemeral", retainOnFailure: true },
       adapter: "command", // real adapter that lacks command template for status-report
-      promptVersion: "git:test",
-      policyVersion: "git:test",
+      promptVersion: WORKER_POLICY_VERSION,
+      policyVersion: WORKER_POLICY_VERSION,
       outputContract: "factory.status-report/v1",
       capabilities: ["linear:read"],
       timeoutSeconds: 5,
@@ -679,8 +682,8 @@ describe("work --reload-on-change (WM-213)", () => {
       inputHash: hashJson(input),
       workspace: { type: "ephemeral", retainOnFailure: false },
       adapter: "fake",
-      promptVersion: "git:test",
-      policyVersion: "git:test",
+      promptVersion: WORKER_POLICY_VERSION,
+      policyVersion: WORKER_POLICY_VERSION,
       outputContract: "factory.status-report/v1",
       capabilities: ["linear:read"],
       timeoutSeconds: 4,
@@ -710,6 +713,12 @@ describe("work --reload-on-change (WM-213)", () => {
       now: Date.now(),
     });
     db.close();
+    // Keep the queue non-empty when the first run finishes. The worker must
+    // reload at that boundary rather than claiming this run with old code.
+    await seedRun(home, {
+      runId: "run_reload_waiting",
+      input: { repos: ["ok"] },
+    });
 
     const box = spawnWorker(
       ["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"],
@@ -737,6 +746,7 @@ describe("work --reload-on-change (WM-213)", () => {
       expect(box.out.indexOf("run_reload_busy → ")).toBeLessThan(
         box.out.indexOf("reloading worker"),
       );
+      expect(box.out).not.toContain("claimed run_reload_waiting");
       // And exactly one deferral line, however many intervals it spanned.
       expect(box.out.split("reload deferred until").length - 1).toBe(1);
     } finally {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -59,7 +59,12 @@ function workerSubprocessTimeoutMs() {
     : DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS;
 }
 
-const ENVIRONMENT_FAILURES = new Set(["adapter_error", "lease_expired", "linear_unconfigured"]);
+const ENVIRONMENT_FAILURES = new Set([
+  "adapter_error",
+  "lease_expired",
+  "linear_unconfigured",
+  "registry_stale",
+]);
 const AGENT_FAILURES = new Set(["contract_violation"]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
@@ -193,9 +198,18 @@ function originatingEvent(db, runId) {
  * Claim the oldest QUEUED run: bump the attempt counter, take a lease with a
  * fresh fencing token, and move it to LEASED — all in one transaction.
  *
- * @returns {{ runId: string, attempt: number, fencingToken: number, spec: object } | null}
+ * @returns {{ runId: string, attempt: number, fencingToken: number, spec: object } | { runId: string, spec: object, refused: true, retryable: true, reloadRequired: boolean, reasonCode: "registry_stale", workerRegistryVersion: string, checkoutRegistryVersion: string } | null}
  */
-export function claimNext(db, { owner, now = () => Date.now(), policyVersion = "unknown", labels = {}, adapters = null, adapterOverride } = {}) {
+export function claimNext(db, {
+  owner,
+  now = () => Date.now(),
+  policyVersion = "unknown",
+  registryVersion = null,
+  currentRegistryVersion = null,
+  labels = {},
+  adapters = null,
+  adapterOverride,
+} = {}) {
   // BEGIN IMMEDIATE, not the default deferred transaction: two workers must
   // not both read the same QUEUED row before either writes (OPS-233).
   return txImmediate(db, () => {
@@ -218,17 +232,55 @@ export function claimNext(db, { owner, now = () => Date.now(), policyVersion = "
       .all();
     let row = null;
     let spec = null;
+    let staleRefusal = null;
+    let checkoutVersion;
+    const resolveCheckoutVersion = () => {
+      if (checkoutVersion !== undefined) return checkoutVersion;
+      checkoutVersion = typeof currentRegistryVersion === "function"
+        ? currentRegistryVersion()
+        : currentRegistryVersion;
+      return checkoutVersion;
+    };
     for (const candidate of candidates) {
       const backoff = /^(?:claim_lock_contention:\d+|dispatch_gate_transient:[^:]+:\d+):backoff_(\d+)ms$/.exec(candidate.queue_reason ?? "");
       if (backoff && Date.parse(candidate.queued_at) + Number(backoff[1]) > claimNow) continue;
       const candidateSpec = JSON.parse(candidate.spec_json);
       if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
       if (adapters && !adapterOverride && !adapters.includes(candidateSpec.adapter)) continue;
+      // The worker snapshots the registry and policy at startup. A run planned
+      // against another checkout must stay QUEUED; leasing it would execute and
+      // validate with incompatible definitions. Compare the live checkout too
+      // so only an actually stale worker reloads — an older queued spec must not
+      // put a fresh supervisor into an endless exit-75 loop.
+      if (
+        registryVersion &&
+        (candidateSpec.promptVersion !== registryVersion ||
+          candidateSpec.policyVersion !== registryVersion)
+      ) {
+        const current = resolveCheckoutVersion();
+        const reloadRequired =
+          candidateSpec.promptVersion === current &&
+          candidateSpec.policyVersion === current &&
+          registryVersion !== current;
+        const refusal = {
+          runId: candidate.run_id,
+          spec: candidateSpec,
+          refused: true,
+          retryable: true,
+          reloadRequired,
+          reasonCode: "registry_stale",
+          workerRegistryVersion: registryVersion,
+          checkoutRegistryVersion: current,
+        };
+        if (reloadRequired) return refusal;
+        staleRefusal ??= refusal;
+        continue;
+      }
       row = candidate;
       spec = candidateSpec;
       break;
     }
-    if (!row) return null;
+    if (!row) return staleRefusal;
     const attempt = row.attempts + 1;
     const fencingToken = nextCounter(db, "fencing");
     const leaseExpiresAt = iso(claimNow + (spec.timeoutSeconds + LEASE_GRACE_SECONDS) * 1000);
@@ -397,6 +449,21 @@ function contradictsPlanTimeOwnedPaths(spec, gateResult) {
  */
 export const CODE_RELOAD_EXIT = 75;
 
+/** Uncached checkout provenance, used to distinguish a stale worker from a stale queued spec. */
+export function checkoutPolicyVersion(repoRoot = FACTORY_ROOT) {
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: workerSubprocessTimeoutMs(),
+    }).trim();
+    return `git:${sha}`;
+  } catch {
+    return "unknown";
+  }
+}
+
 /** What "the worker's code" is: everything the claim loop actually executes. */
 export const CODE_STAMP_PATHS = ["event-runtime/lib", "event-runtime/cli.mjs"];
 
@@ -465,8 +532,8 @@ export function codeStamp(repoRoot = codeStampRoot(), paths = CODE_STAMP_PATHS) 
 }
 
 /**
- * Poll-boundary reload detection. `check(inFlight)` is called by the claim
- * loop *between* claims and returns one of:
+ * Poll-boundary reload detection. `check(inFlight, { force })` is called by
+ * the claim loop *between* claims and returns one of:
  *
  *   none      nothing changed (or it is not time to re-stamp yet)
  *   deferred  code changed but this worker holds a lease — keep going
@@ -492,10 +559,13 @@ export function createReloadWatcher({
 
   return {
     from,
-    check(inFlight = null) {
+    check(inFlight = null, { force = false } = {}) {
       if (!pending) {
         const at = now();
-        if (at - lastCheck < intervalMs) return { action: "none", from, to: from };
+        // A completed run is a mandatory freshness boundary: force bypasses
+        // only the cadence gate so a hot queue cannot hide a recent edit.
+        if (!force && at - lastCheck < intervalMs)
+          return { action: "none", from, to: from };
         lastCheck = at;
         const to = stamp();
         if (to === from) return { action: "none", from, to };
@@ -1450,10 +1520,10 @@ export function reapExpiredLeases(db, { now = () => Date.now(), policyVersion = 
   });
 }
 
-/** Claim and execute one run, or null when nothing is QUEUED. */
+/** Claim and execute one run, or return a typed refusal/null without execution. */
 export async function runOnce(db, registry, adapters, opts = {}) {
   const claim = claimNext(db, opts);
-  if (!claim) return null;
+  if (!claim || claim.refused) return claim;
   return executeClaimed(db, registry, adapters, claim, opts);
 }
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -774,6 +774,7 @@ describe("worker", () => {
     expect(classifyFailureCause("adapter_error")).toBe("environment");
     expect(classifyFailureCause("lease_expired")).toBe("environment");
     expect(classifyFailureCause("linear_unconfigured")).toBe("environment");
+    expect(classifyFailureCause("registry_stale")).toBe("environment");
     expect(classifyFailureCause("agent_exit_1")).toBe("agent_error");
     expect(classifyFailureCause("contract_violation")).toBe("agent_error");
     for (const reason of [
@@ -1026,6 +1027,81 @@ describe("worker", () => {
     expect(Date.parse(verifying.at)).toBeLessThan(Date.parse(completed.at));
     expect(attempt.started_at).toBe(running.at);
     expect(attempt.finished_at).toBe(completed.at);
+  });
+
+  test("claimNext refuses a stale worker before leasing and requires reload (WM-613)", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({
+      promptVersion: "git:current",
+      policyVersion: "git:current",
+    }));
+
+    const refusal = claimNext(db, {
+      ...opts(),
+      policyVersion: "git:stale",
+      registryVersion: "git:stale",
+      currentRegistryVersion: "git:current",
+    });
+
+    expect(refusal).toMatchObject({
+      runId: spec.runId,
+      refused: true,
+      retryable: true,
+      reloadRequired: true,
+      reasonCode: "registry_stale",
+      workerRegistryVersion: "git:stale",
+      checkoutRegistryVersion: "git:current",
+    });
+    expect(runState(db, spec.runId)).toBe("QUEUED");
+    expect(db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId).attempts).toBe(0);
+    expect(db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId)).toHaveLength(0);
+  });
+
+  test("claimNext does not restart-loop a fresh worker on an older queued spec (WM-613)", () => {
+    const db = openDb(":memory:");
+    const staleSpec = queueRun(db, makeSpec({
+      promptVersion: "git:old",
+      policyVersion: "git:old",
+    }));
+
+    const refusal = claimNext(db, {
+      ...opts(),
+      policyVersion: "git:current",
+      registryVersion: "git:current",
+      currentRegistryVersion: "git:current",
+    });
+
+    expect(refusal).toMatchObject({
+      runId: staleSpec.runId,
+      refused: true,
+      retryable: true,
+      reloadRequired: false,
+      reasonCode: "registry_stale",
+    });
+    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+  });
+
+  test("claimNext skips an incompatible old spec and claims compatible queued work (WM-613)", () => {
+    const db = openDb(":memory:");
+    const staleSpec = queueRun(db, makeSpec({
+      promptVersion: "git:old",
+      policyVersion: "git:old",
+    }), T0);
+    const compatibleSpec = queueRun(db, makeSpec({
+      promptVersion: "git:current",
+      policyVersion: "git:current",
+    }), T0 + 1000);
+
+    const claim = claimNext(db, {
+      ...opts(),
+      policyVersion: "git:current",
+      registryVersion: "git:current",
+      currentRegistryVersion: "git:current",
+    });
+
+    expect(claim.runId).toBe(compatibleSpec.runId);
+    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+    expect(runState(db, compatibleSpec.runId)).toBe("LEASED");
   });
 
   test("claimNext unconstrained candidate query: 60 unsatisfiable placement runs do not starve matching run (OPS-454)", () => {
@@ -2528,6 +2604,19 @@ describe("reload watcher (WM-213)", () => {
     expect(r.action).toBe("reload");
     expect(r.from).toBe("a");
     expect(r.to).toBe("b");
+  });
+
+  test("forced between-runs check detects a change before the normal interval (WM-613)", () => {
+    const h = harness();
+    h.change("b");
+    h.advance(1);
+
+    expect(h.watcher.check(null).action).toBe("none");
+    expect(h.watcher.check(null, { force: true })).toMatchObject({
+      action: "reload",
+      from: "a",
+      to: "b",
+    });
   });
 
   test("in-flight run defers the reload, then reloads at the next idle check", () => {


### PR DESCRIPTION
## Summary
- force a code-stamp check after every completed run before the next claim
- refuse incompatible registry/policy claims with retryable `registry_stale` and reload only stale workers
- forward reload mode through pool supervision and cover continuous-queue behavior

## Verification
- `bun test event-runtime/lib/worker.test.mjs event-runtime/cli/supervise.test.mjs event-runtime/cli/work.test.mjs` — 108 pass, 0 fail

UX critique: skipped — backend worker-runtime change with no user-facing flow

Fixes WM-613