### PR TITLE
feat(event-runtime): artifact-view v1 sidecar contract — validator, registry loading with drift check, /agents.outputView; views for triage-scan + merge-scan (WM-454)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -360,6 +360,14 @@ mutating: false
 A definition is admitted only when its adapter can prove the required
 capabilities. Adapter support is a contract, not a hopeful command-line flag.
 
+**Artifact-view sidecar (`agents/<name>.view.json`, WM-454).** An optional
+`factory.artifact-view/v1` document beside the definition annotates pointers
+into the output schema with rendering hints ([event-runtime-artifact-views.md](event-runtime-artifact-views.md)
+§2); it is validated against the output schema at load, is not part of the
+definition pin, is served as `GET /agents[].outputView`, and a view that does
+not fit its schema is a `/status.anomalies.configuration` entry — the agent
+still loads, without a view.
+
 **Per-agent repo scoping (`repos`, WM-64).** A definition may declare an
 optional top-level `"repos": ["bj29", "cw-app"]` — a closed set of repos the
 agent may run over, the repo analogue of the actions adapter's per-definition

--- a/event-runtime/agents/merge-scan.view.json
+++ b/event-runtime/agents/merge-scan.view.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "title": "Merge plan",
+  "summary": "/summary",
+  "status": {
+    "path": "/recommendation",
+    "tone": { "MERGE": "ok", "FIX": "warn", "ESCALATE": "error", "NOOP": "neutral" }
+  },
+  "sections": [
+    {
+      "path": "/plan",
+      "as": "table",
+      "label": "Merge",
+      "columns": ["pr", "ticket", "headRef", "reason"],
+      "formats": { "pr": "pr", "ticket": "issue", "headSha": "sha", "baseSha": "sha" },
+      "expand": ["headSha", "baseSha", "sensitive", "ambiguous"]
+    },
+    {
+      "path": "/fix",
+      "as": "table",
+      "label": "Fix",
+      "columns": ["pr", "ticket", "round", "mechanical", "finding"],
+      "formats": { "pr": "pr", "ticket": "issue", "round": "count", "headSha": "sha", "baseSha": "sha" },
+      "tone": {
+        "mechanical": { "true": "ok", "false": "warn" },
+        "withinOwnedPaths": { "true": "ok", "false": "error" }
+      },
+      "expand": ["headRef", "headSha", "baseSha", "withinOwnedPaths", "ownedPaths", "findingHash"]
+    },
+    {
+      "path": "/escalate",
+      "as": "table",
+      "label": "Escalate",
+      "columns": ["pr", "ticket", "reason"],
+      "formats": { "pr": "pr", "ticket": "issue", "headSha": "sha" },
+      "expand": ["headSha"]
+    },
+    {
+      "path": "",
+      "as": "keyvalue",
+      "label": "Repo",
+      "keys": ["repo", "github", "base", "deployBranch", "noopReason"],
+      "formats": { "repo": "repo" },
+      "tone": { "noopReason": { "no_open_prs": "muted", "all_prs_held": "warn" } }
+    }
+  ]
+}

--- a/event-runtime/agents/triage-scan.view.json
+++ b/event-runtime/agents/triage-scan.view.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "factory.artifact-view/v1",
+  "title": "Triage plan",
+  "summary": "/summary",
+  "status": {
+    "path": "/recommendation",
+    "tone": { "TRIAGE": "ok", "NOOP": "neutral" }
+  },
+  "sections": [
+    {
+      "path": "/plan",
+      "as": "table",
+      "label": "Plan",
+      "columns": ["issueId", "action", "reason"],
+      "groupBy": "action",
+      "formats": { "issueId": "issue" },
+      "tone": {
+        "action": {
+          "label-agent-ready": "ok",
+          "move-to-todo": "ok",
+          "write-detail": "neutral",
+          "needs-detail": "warn",
+          "mark-duplicate": "muted",
+          "needs-human": "warn"
+        }
+      },
+      "expand": ["detail", "ownedPaths", "verificationCommand", "acceptanceCriteria"]
+    },
+    {
+      "path": "/repo",
+      "as": "keyvalue",
+      "label": "Repo",
+      "formats": { "": "repo" }
+    }
+  ]
+}

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -1,6 +1,6 @@
 /** Agent and repository registry endpoints. */
 import { readFileSync } from "node:fs";
-import { resolveModel } from "./registry.mjs";
+import { getArtifactView, resolveModel } from "./registry.mjs";
 import { RepoError, reposView } from "./repos.mjs";
 
 export function agentsView(registry) {
@@ -20,6 +20,10 @@ export function agentsView(registry) {
       inputSchema: def.inputSchema,
       outputSchemaFile: def.output_schema,
       outputSchema: def.outputSchema,
+      // Artifact-view sidecar (WM-454): null when the agent has none or its
+      // view failed the drift check (then /status names the anomaly).
+      outputViewFile: getArtifactView(registry, def.ref).file,
+      outputView: getArtifactView(registry, def.ref).view,
       pins: def.pins,
       command: def.command ?? null,
       actionRegistry: def.actionRegistry ?? null,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -34,6 +34,7 @@ import {
   utimesSync,
   writeFileSync,
 } from "./api-test-helpers.mjs";
+import { cpSync } from "node:fs";
 import { emitDueTicks } from "./schedules.mjs";
 
 describe("schedule trigger metadata (WM-259)", () => {
@@ -86,6 +87,66 @@ describe("schedule trigger metadata (WM-259)", () => {
       });
     } finally {
       s.close();
+    }
+  });
+});
+
+describe("artifact-view sidecar on GET /agents (WM-454)", () => {
+  test("every agent item carries outputView/outputViewFile; views are objects where a sidecar exists, null elsewhere", async () => {
+    const { server, port } = await makeServer();
+    const client = apiClient({ port });
+    try {
+      const { agents: defs } = await client.agents();
+      for (const def of defs) {
+        expect(def).toHaveProperty("outputView");
+        expect(def).toHaveProperty("outputViewFile");
+      }
+      const merge = defs.find((d) => d.ref === "merge-scan@2");
+      expect(merge.outputViewFile).toBe("agents/merge-scan.view.json");
+      expect(merge.outputView.schemaVersion).toBe("factory.artifact-view/v1");
+      expect(merge.outputView.status.path).toBe("/recommendation");
+      const triage = defs.find((d) => d.ref === "triage-scan@1");
+      expect(triage.outputView.summary).toBe("/summary");
+      const bare = defs.find((d) => d.ref === "reconcile@1");
+      expect(bare.outputView).toBeNull();
+      expect(bare.outputViewFile).toBeNull();
+      // Not part of the pinned identity.
+      expect(Object.keys(merge.pins)).not.toContain("agents/merge-scan.view.json");
+      // web/src/types.ts AgentDef names both fields (kept in step by hand;
+      // AgentDef is not pinned by the OPS-284 parity test).
+      const typesSrc = readFileSync(path.resolve(import.meta.dir, "../web/src/types.ts"), "utf8");
+      const agentDef = typesSrc.slice(typesSrc.indexOf("export interface AgentDef {"));
+      expect(agentDef).toContain("outputViewFile?");
+      expect(agentDef).toContain("outputView?");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("a drifted view is served as null and named in /status.anomalies.configuration", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-view-"));
+    for (const dir of ["agents", "schemas"]) {
+      cpSync(path.join(registry.root, dir), path.join(root, dir), { recursive: true });
+    }
+    cpSync(path.join(registry.root, "event-types.json"), path.join(root, "event-types.json"));
+    const viewFile = path.join(root, "agents", "triage-scan.view.json");
+    const view = JSON.parse(readFileSync(viewFile, "utf8"));
+    view.summary = "/tldr";
+    writeFileSync(viewFile, JSON.stringify(view));
+    const drifted = loadRegistry({ root, modelTiers: registry.modelTiers });
+    const { server, port } = await makeServer({ registry: drifted });
+    const client = apiClient({ port });
+    try {
+      const { agents: defs } = await client.agents();
+      const triage = defs.find((d) => d.ref === "triage-scan@1");
+      expect(triage.outputView).toBeNull();
+      expect(triage.outputViewFile).toBe("agents/triage-scan.view.json");
+      const status = await client.status();
+      const anomaly = status.anomalies.configuration.find((a) => a.includes("triage-scan@1"));
+      expect(anomaly).toContain("agents/triage-scan.view.json");
+      expect(anomaly).toMatch(/"\/tldr" does not resolve/);
+    } finally {
+      server.close();
     }
   });
 });

--- a/event-runtime/lib/artifact-view.mjs
+++ b/event-runtime/lib/artifact-view.mjs
@@ -1,0 +1,196 @@
+/**
+ * Artifact views — `factory.artifact-view/v1` (docs/event-runtime-artifact-views.md §2).
+ *
+ * A sidecar `agents/<name>.view.json` annotates JSON pointers into an agent's
+ * output schema with a closed hint vocabulary so a generic renderer can draw
+ * the artifact. Two checks, both fail closed and both here rather than in the
+ * renderer: the document must match the v1 schema (lib/schema.mjs, the same
+ * validator every contract goes through), and every pointer it names must
+ * resolve to a property of the agent's output schema — a view cannot drift
+ * from the contract it describes (§2.3). Pointer resolution against a
+ * concrete document (`resolvePointer`) is shared with the presentation layer
+ * (WM-456).
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { RUNTIME_ROOT } from "./config.mjs";
+import { validate } from "./schema.mjs";
+
+export const ARTIFACT_VIEW_SCHEMA_VERSION = "factory.artifact-view/v1";
+export const ARTIFACT_VIEW_SCHEMA = JSON.parse(
+  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.artifact-view.v1.json"), "utf8"),
+);
+
+export const SECTION_KINDS = ["table", "keyvalue", "list", "badge", "code", "prose"];
+export const FORMATS = ["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"];
+export const TONES = ["ok", "warn", "error", "muted", "neutral"];
+
+/** Keys every section may carry, plus the per-`as` keys (design §2.2 `as` row). */
+const COMMON_SECTION_KEYS = new Set(["path", "as", "label"]);
+const KEYS_BY_KIND = {
+  table: new Set(["columns", "groupBy", "expand", "formats", "tone"]),
+  keyvalue: new Set(["keys", "formats", "tone"]),
+  list: new Set(["itemLabel", "formats", "tone"]),
+  badge: new Set(["tone"]),
+  code: new Set(["language"]),
+  prose: new Set(),
+};
+const REQUIRED_BY_KIND = { table: ["columns"] };
+
+const isObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+const hasOwn = (obj, key) => isObject(obj) && Object.prototype.hasOwnProperty.call(obj, key);
+
+/** RFC 6901: split a pointer into unescaped reference tokens; null when malformed. */
+export function parsePointer(pointer) {
+  if (typeof pointer !== "string") return null;
+  if (pointer === "") return [];
+  if (!pointer.startsWith("/")) return null;
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+/**
+ * Resolve an RFC 6901 pointer against a document. Returns `undefined` when
+ * the pointer is malformed or any step is absent — never throws, never
+ * invents a value.
+ */
+export function resolvePointer(doc, pointer) {
+  const tokens = parsePointer(pointer);
+  if (tokens === null) return undefined;
+  let node = doc;
+  for (const token of tokens) {
+    if (Array.isArray(node)) {
+      if (!/^(0|[1-9][0-9]*)$/.test(token)) return undefined;
+      const index = Number(token);
+      if (index >= node.length) return undefined;
+      node = node[index];
+    } else if (isObject(node)) {
+      if (!hasOwn(node, token)) return undefined;
+      node = node[token];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+/**
+ * Walk a JSON Schema (the subset lib/schema.mjs supports) along a pointer's
+ * tokens: an object step follows `properties.<token>`, an array step (an
+ * index token or `-`) follows `items`. Returns the schema node or `undefined`.
+ */
+export function resolveSchemaPointer(schema, pointer) {
+  const tokens = parsePointer(pointer);
+  if (tokens === null) return undefined;
+  return walkSchema(schema, tokens);
+}
+
+function walkSchema(schema, tokens) {
+  let node = schema;
+  for (const token of tokens) {
+    if (!isObject(node)) return undefined;
+    if (isObject(node.properties) && hasOwn(node.properties, token)) {
+      node = node.properties[token];
+    } else if (hasOwn(node, "items") && isObject(node.items) && /^(0|[1-9][0-9]*|-)$/.test(token)) {
+      node = node.items;
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+/** The node a section's relative keys are resolved against: an array's `items`, else the node itself. */
+function itemNode(node) {
+  if (isObject(node) && hasOwn(node, "items") && isObject(node.items)) return node.items;
+  return node;
+}
+
+function relativeNode(base, key) {
+  // Keys are plain property names or pointer-ish paths ("a/b", "/a/b").
+  const tokens = key.startsWith("/") ? parsePointer(key) : key.split("/");
+  if (!tokens || tokens.length === 0) return undefined;
+  return walkSchema(base, tokens);
+}
+
+/**
+ * Validate a view document against the v1 schema AND against the agent's
+ * output schema (pointer drift). Never throws.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateArtifactView(view, outputSchema) {
+  const schemaCheck = validate(ARTIFACT_VIEW_SCHEMA, view, "view");
+  if (!schemaCheck.valid) return { valid: false, errors: schemaCheck.errors };
+  if (!isObject(outputSchema)) {
+    return { valid: false, errors: ["view: output schema is missing — nothing to resolve pointers against"] };
+  }
+  const errors = [];
+
+  if (hasOwn(view, "summary") && resolveSchemaPointer(outputSchema, view.summary) === undefined) {
+    errors.push(`view.summary: pointer "${view.summary}" does not resolve in the output schema`);
+  }
+  if (hasOwn(view, "status") && resolveSchemaPointer(outputSchema, view.status.path) === undefined) {
+    errors.push(`view.status.path: pointer "${view.status.path}" does not resolve in the output schema`);
+  }
+
+  view.sections.forEach((section, i) => {
+    const at = `view.sections[${i}]`;
+    const kind = section.as;
+    const allowed = KEYS_BY_KIND[kind];
+    for (const key of Object.keys(section)) {
+      if (!COMMON_SECTION_KEYS.has(key) && !allowed.has(key)) {
+        errors.push(`${at}: "${key}" is not a key of as=${kind}`);
+      }
+    }
+    for (const key of REQUIRED_BY_KIND[kind] ?? []) {
+      if (!hasOwn(section, key)) errors.push(`${at}: as=${kind} requires "${key}"`);
+    }
+
+    const node = resolveSchemaPointer(outputSchema, section.path);
+    if (node === undefined) {
+      errors.push(`${at}.path: pointer "${section.path}" does not resolve in the output schema`);
+      return;
+    }
+    if ((kind === "table" || kind === "list") && !(hasOwn(node, "items") && isObject(node.items))) {
+      errors.push(`${at}.path: as=${kind} needs an array schema at "${section.path}"`);
+    }
+    const base = itemNode(node);
+    const checkKey = (field, key) => {
+      if (key === "") return;
+      if (relativeNode(base, key) === undefined) {
+        errors.push(`${at}.${field}: "${key}" does not resolve under "${section.path}" in the output schema`);
+      }
+    };
+    for (const field of ["columns", "expand", "keys"]) {
+      if (Array.isArray(section[field])) for (const key of section[field]) checkKey(field, key);
+    }
+    if (typeof section.groupBy === "string") checkKey("groupBy", section.groupBy);
+    if (typeof section.itemLabel === "string") checkKey("itemLabel", section.itemLabel);
+    if (isObject(section.formats)) for (const key of Object.keys(section.formats)) checkKey("formats", key);
+
+    if (isObject(section.tone)) {
+      for (const [key, value] of Object.entries(section.tone)) {
+        if (kind === "badge") {
+          if (!TONES.includes(value)) {
+            errors.push(`${at}.tone.${key}: badge tone must be one of ${TONES.join("|")}`);
+          }
+          continue;
+        }
+        checkKey("tone", key);
+        if (!isObject(value)) {
+          errors.push(`${at}.tone.${key}: as=${kind} tone maps a column/key to a (value → tone) object`);
+          continue;
+        }
+        for (const [v, tone] of Object.entries(value)) {
+          if (!TONES.includes(tone)) {
+            errors.push(`${at}.tone.${key}.${v}: tone must be one of ${TONES.join("|")}`);
+          }
+        }
+      }
+    }
+  });
+
+  return { valid: errors.length === 0, errors };
+}

--- a/event-runtime/lib/artifact-view.test.mjs
+++ b/event-runtime/lib/artifact-view.test.mjs
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { RUNTIME_ROOT } from "./config.mjs";
+import {
+  ARTIFACT_VIEW_SCHEMA,
+  ARTIFACT_VIEW_SCHEMA_VERSION,
+  FORMATS,
+  SECTION_KINDS,
+  TONES,
+  parsePointer,
+  resolvePointer,
+  resolveSchemaPointer,
+  validateArtifactView,
+} from "./artifact-view.mjs";
+import { validate } from "./schema.mjs";
+
+/** A small output schema shaped like the real scans: enum status, array of objects, nested array. */
+const OUTPUT_SCHEMA = {
+  type: "object",
+  required: ["recommendation", "plan", "summary"],
+  additionalProperties: false,
+  properties: {
+    recommendation: { enum: ["GO", "NOOP"] },
+    repo: { type: "string" },
+    summary: { type: "string" },
+    "a/b": { type: "string" },
+    "t~e": { type: "string" },
+    plan: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          issueId: { type: "string" },
+          action: { enum: ["one", "two"] },
+          reason: { type: "string" },
+          criteria: {
+            type: "array",
+            items: { type: "object", properties: { text: { type: "string" } } },
+          },
+        },
+      },
+    },
+    log: { type: "string" },
+  },
+};
+
+const VIEW = {
+  schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION,
+  title: "Plan",
+  summary: "/summary",
+  status: { path: "/recommendation", tone: { GO: "ok", NOOP: "neutral" } },
+  sections: [
+    {
+      path: "/plan",
+      as: "table",
+      label: "Plan",
+      columns: ["issueId", "action", "reason"],
+      groupBy: "action",
+      formats: { issueId: "issue" },
+      tone: { action: { one: "ok", two: "warn" } },
+      expand: ["criteria"],
+    },
+    { path: "/repo", as: "keyvalue", label: "Repo", formats: { "": "repo" } },
+    { path: "/plan", as: "list", itemLabel: "/reason", formats: { issueId: "issue" } },
+    { path: "/recommendation", as: "badge", tone: { GO: "ok" } },
+    { path: "/log", as: "code", language: "text" },
+    { path: "/summary", as: "prose" },
+  ],
+};
+
+const clone = (v) => JSON.parse(JSON.stringify(v));
+
+describe("factory.artifact-view/v1 schema (WM-454)", () => {
+  test("uses only lib/schema.mjs's supported keyword subset — the schema itself validates a document", () => {
+    // schema.mjs fails closed on any unsupported keyword; a keyword slip in the
+    // contract would surface here as an "unsupported schema keyword" error.
+    const { valid, errors } = validate(ARTIFACT_VIEW_SCHEMA, VIEW);
+    expect(errors).toEqual([]);
+    expect(valid).toBe(true);
+  });
+
+  test("encodes the closed vocabularies from design §2.2", () => {
+    expect(ARTIFACT_VIEW_SCHEMA.properties.schemaVersion.const).toBe("factory.artifact-view/v1");
+    expect(ARTIFACT_VIEW_SCHEMA.properties.title.maxLength).toBe(60);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.sections.minItems).toBe(1);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.sections.maxItems).toBe(12);
+    const section = ARTIFACT_VIEW_SCHEMA.properties.sections.items;
+    expect(section.properties.as.enum).toEqual(SECTION_KINDS);
+    expect(SECTION_KINDS).toEqual(["table", "keyvalue", "list", "badge", "code", "prose"]);
+    expect(section.properties.columns.minItems).toBe(1);
+    expect(section.properties.columns.maxItems).toBe(8);
+    expect(section.properties.formats.additionalProperties.enum).toEqual(FORMATS);
+    expect(FORMATS).toEqual(["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"]);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.status.properties.tone.additionalProperties.enum).toEqual(TONES);
+    expect(TONES).toEqual(["ok", "warn", "error", "muted", "neutral"]);
+    // additionalProperties: false throughout the object shapes.
+    expect(ARTIFACT_VIEW_SCHEMA.additionalProperties).toBe(false);
+    expect(ARTIFACT_VIEW_SCHEMA.properties.status.additionalProperties).toBe(false);
+    expect(section.additionalProperties).toBe(false);
+  });
+
+  test("a well-formed view passes schema and drift checks", () => {
+    expect(validateArtifactView(VIEW, OUTPUT_SCHEMA)).toEqual({ valid: true, errors: [] });
+  });
+
+  test("schema failures: wrong version, unknown as/format/tone, bounds, unknown keys", () => {
+    const fails = (mutate, needle) => {
+      const view = clone(VIEW);
+      mutate(view);
+      const { valid, errors } = validateArtifactView(view, OUTPUT_SCHEMA);
+      expect(valid).toBe(false);
+      expect(errors.join("\n")).toMatch(needle);
+    };
+    fails((v) => (v.schemaVersion = "factory.artifact-view/v2"), /schemaVersion: expected const/);
+    fails((v) => (v.title = "x".repeat(61)), /title: longer than maxLength 60/);
+    fails((v) => (v.sections = []), /fewer than minItems 1/);
+    fails((v) => (v.sections = Array.from({ length: 13 }, () => clone(VIEW.sections[5]))), /more than minItems|more than maxItems 12/);
+    fails((v) => (v.sections[0].as = "chart"), /as: value not in enum/);
+    fails((v) => (v.sections[0].formats.issueId = "money"), /formats.issueId: value not in enum/);
+    fails((v) => (v.status.tone.GO = "green"), /status.tone.GO: value not in enum/);
+    fails((v) => (v.sections[0].columns = Array.from({ length: 9 }, (_, i) => `c${i}`)), /columns: more than maxItems 8/);
+    fails((v) => (v.sections[0].width = 12), /unknown property "width"/);
+    fails((v) => (v.extra = true), /unknown property "extra"/);
+    fails((v) => delete v.sections[0].path, /missing required property "path"/);
+    fails((v) => (v.summary = "summary"), /summary: does not match pattern/);
+    // Nested tone values are checked in code (schema.mjs has no conditional keywords).
+    fails((v) => (v.sections[0].tone.action.one = "purple"), /tone.action.one: tone must be one of/);
+    fails((v) => (v.sections[3].tone.GO = "purple"), /badge tone must be one of/);
+    fails((v) => (v.sections[0].tone.action = "ok"), /tone maps a column\/key to a \(value → tone\) object/);
+  });
+
+  test("per-as keys: a key from another kind is refused, table requires columns", () => {
+    const fails = (mutate, needle) => {
+      const view = clone(VIEW);
+      mutate(view);
+      const { valid, errors } = validateArtifactView(view, OUTPUT_SCHEMA);
+      expect(valid).toBe(false);
+      expect(errors.join("\n")).toMatch(needle);
+    };
+    fails((v) => (v.sections[1].columns = ["repo"]), /"columns" is not a key of as=keyvalue/);
+    fails((v) => (v.sections[0].language = "json"), /"language" is not a key of as=table/);
+    fails((v) => (v.sections[5].tone = { x: "ok" }), /"tone" is not a key of as=prose/);
+    fails((v) => (v.sections[3].keys = ["x"]), /"keys" is not a key of as=badge/);
+    fails((v) => delete v.sections[0].columns, /as=table requires "columns"/);
+    fails((v) => (v.sections[0].path = "/summary"), /as=table needs an array schema/);
+  });
+
+  test("drift: every pointer must resolve in the output schema", () => {
+    const fails = (mutate, needle) => {
+      const view = clone(VIEW);
+      mutate(view);
+      const { valid, errors } = validateArtifactView(view, OUTPUT_SCHEMA);
+      expect(valid).toBe(false);
+      expect(errors.join("\n")).toMatch(needle);
+    };
+    fails((v) => (v.summary = "/gone"), /summary: pointer "\/gone" does not resolve/);
+    fails((v) => (v.status.path = "/verdict"), /status.path: pointer "\/verdict" does not resolve/);
+    fails((v) => (v.sections[0].path = "/rows"), /sections\[0\].path: pointer "\/rows" does not resolve/);
+    fails((v) => v.sections[0].columns.push("owner"), /sections\[0\].columns: "owner" does not resolve under "\/plan"/);
+    fails((v) => (v.sections[0].groupBy = "kind"), /groupBy: "kind" does not resolve/);
+    fails((v) => v.sections[0].expand.push("detail"), /expand: "detail" does not resolve/);
+    fails((v) => (v.sections[0].formats.pr = "pr"), /formats: "pr" does not resolve/);
+    fails((v) => (v.sections[0].tone.state = { x: "ok" }), /tone: "state" does not resolve/);
+    fails((v) => (v.sections[2].itemLabel = "/title"), /itemLabel: "\/title" does not resolve/);
+    fails((v) => (v.sections[1].keys = ["nope"]), /keys: "nope" does not resolve under "\/repo"/);
+    // A missing output schema is a validation failure, not a crash.
+    expect(validateArtifactView(VIEW, undefined).valid).toBe(false);
+    // Section pointers may reach through arrays with an index token, and
+    // relative keys may be nested pointers.
+    const ok = clone(VIEW);
+    ok.sections[2] = { path: "/plan/0/criteria", as: "list", itemLabel: "/text" };
+    ok.sections[0].expand = ["criteria/0/text"];
+    expect(validateArtifactView(ok, OUTPUT_SCHEMA)).toEqual({ valid: true, errors: [] });
+    // ...but an array is not stepped through by a property name.
+    const bad = clone(VIEW);
+    bad.sections[0].path = "/plan/issueId";
+    expect(validateArtifactView(bad, OUTPUT_SCHEMA).valid).toBe(false);
+  });
+
+  test("validateArtifactView never throws on garbage input", () => {
+    for (const junk of [null, undefined, 42, "view", [], {}, { schemaVersion: 1 }]) {
+      const result = validateArtifactView(junk, OUTPUT_SCHEMA);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolvePointer (RFC 6901)", () => {
+  const doc = {
+    a: { b: [{ c: 1 }, { c: 2 }] },
+    "x/y": "slash",
+    "m~n": "tilde",
+    "": "empty-key",
+    zero: 0,
+    nul: null,
+  };
+
+  test("resolves objects, arrays and the whole document", () => {
+    expect(resolvePointer(doc, "")).toBe(doc);
+    expect(resolvePointer(doc, "/a/b/1/c")).toBe(2);
+    expect(resolvePointer(doc, "/a/b/0")).toEqual({ c: 1 });
+    expect(resolvePointer(doc, "/zero")).toBe(0);
+    expect(resolvePointer(doc, "/nul")).toBeNull();
+    expect(resolvePointer(doc, "/")).toBe("empty-key");
+  });
+
+  test("unescapes ~1 then ~0", () => {
+    expect(parsePointer("/x~1y")).toEqual(["x/y"]);
+    expect(parsePointer("/m~0n")).toEqual(["m~n"]);
+    expect(parsePointer("/~01")).toEqual(["~1"]);
+    expect(resolvePointer(doc, "/x~1y")).toBe("slash");
+    expect(resolvePointer(doc, "/m~0n")).toBe("tilde");
+  });
+
+  test("returns undefined when absent, malformed, or stepping through a scalar", () => {
+    expect(resolvePointer(doc, "/a/missing")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b/2")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b/c")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b/01")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b/-")).toBeUndefined();
+    expect(resolvePointer(doc, "/zero/x")).toBeUndefined();
+    expect(resolvePointer(doc, "a/b")).toBeUndefined();
+    expect(resolvePointer(doc, 7)).toBeUndefined();
+    expect(resolvePointer(undefined, "/a")).toBeUndefined();
+    expect(parsePointer("a")).toBeNull();
+  });
+
+  test("resolveSchemaPointer walks properties and items, and unescapes too", () => {
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/0/criteria/3/text")).toEqual({ type: "string" });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/-/issueId")).toEqual({ type: "string" });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/a~1b")).toEqual({ type: "string" });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/t~0e")).toEqual({ type: "string" });
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "")).toBe(OUTPUT_SCHEMA);
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/plan/issueId")).toBeUndefined();
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "/summary/x")).toBeUndefined();
+    expect(resolveSchemaPointer(OUTPUT_SCHEMA, "nope")).toBeUndefined();
+  });
+});
+
+describe("committed views fit their agents' output schemas (drift gate, design §2.3)", () => {
+  const agentsDir = path.join(RUNTIME_ROOT, "agents");
+  const viewFiles = readdirSync(agentsDir)
+    .filter((n) => n.endsWith(".view.json"))
+    .sort();
+
+  test("the first two views ship with the contract (§2.5)", () => {
+    expect(viewFiles).toEqual(expect.arrayContaining(["merge-scan.view.json", "triage-scan.view.json"]));
+  });
+
+  for (const name of viewFiles) {
+    test(`agents/${name} resolves every pointer against its output schema`, () => {
+      const defFile = path.join(agentsDir, name.replace(/\.view\.json$/, ".json"));
+      const def = JSON.parse(readFileSync(defFile, "utf8"));
+      const outputSchema = JSON.parse(readFileSync(path.join(RUNTIME_ROOT, def.output_schema), "utf8"));
+      const view = JSON.parse(readFileSync(path.join(agentsDir, name), "utf8"));
+      expect(validateArtifactView(view, outputSchema)).toEqual({ valid: true, errors: [] });
+    });
+  }
+
+  test("triage-scan and merge-scan views carry the hints the operator reads first", () => {
+    const triage = JSON.parse(readFileSync(path.join(agentsDir, "triage-scan.view.json"), "utf8"));
+    expect(triage.summary).toBe("/summary");
+    expect(triage.status.path).toBe("/recommendation");
+    const plan = triage.sections.find((s) => s.path === "/plan");
+    expect(plan.as).toBe("table");
+    expect(plan.groupBy).toBe("action");
+    expect(plan.formats.issueId).toBe("issue");
+    expect(plan.expand).toEqual(["detail", "ownedPaths", "verificationCommand", "acceptanceCriteria"]);
+
+    const merge = JSON.parse(readFileSync(path.join(agentsDir, "merge-scan.view.json"), "utf8"));
+    expect(merge.status.path).toBe("/recommendation");
+    for (const p of ["/plan", "/fix", "/escalate"]) {
+      const section = merge.sections.find((s) => s.path === p);
+      expect(section.as).toBe("table");
+      expect(section.formats.pr).toBe("pr");
+      expect(section.columns).toContain("pr");
+    }
+    expect(merge.sections.find((s) => s.path === "/escalate").columns).toContain("reason");
+    expect(merge.sections.find((s) => s.path === "/plan").columns).toContain("reason");
+    expect(merge.sections.find((s) => s.path === "/fix").columns).toContain("finding");
+  });
+});

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -14,6 +14,7 @@ import { hashBytes } from "./canonical.mjs";
 import { APPROVAL_MODES, CATCH_UP_MODES, parseCadence } from "./schedules.mjs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import { reposRoot } from "./repos.mjs";
+import { validateArtifactView } from "./artifact-view.mjs";
 
 export class RegistryError extends Error {
   constructor(message) {
@@ -23,6 +24,41 @@ export class RegistryError extends Error {
 }
 
 const PINNED_FIELDS = ["prompt", "input_schema", "output_schema"];
+
+/** Agent definition files: every `agents/*.json` except the view sidecars. */
+const VIEW_SUFFIX = ".view.json";
+const isDefinitionFile = (name) => name.endsWith(".json") && !name.endsWith(VIEW_SUFFIX);
+
+/**
+ * Artifact-view sidecar (WM-454, docs/event-runtime-artifact-views.md §2):
+ * `agents/<name>.view.json` beside `agents/<name>.json`, optional. Loaded
+ * and validated against the definition's output schema; a view that does
+ * not parse or does not fit its schema is a configuration anomaly (surfaced
+ * in /status.anomalies.configuration) and the agent is served WITHOUT a
+ * view — never a load failure, never a rendering crash. Views are not part
+ * of the definition pin (§2.3): a rendering tweak is not a contract change.
+ * @returns {{ file: string|null, view: object|null, anomaly: string|null }}
+ */
+function loadArtifactView(root, defFile, def) {
+  const rel = path.relative(root, defFile).replace(/\.json$/, VIEW_SUFFIX);
+  const abs = path.join(root, rel);
+  if (!existsSync(abs)) return { file: null, view: null, anomaly: null };
+  let view;
+  try {
+    view = JSON.parse(readFileSync(abs, "utf8"));
+  } catch (err) {
+    return { file: rel, view: null, anomaly: `artifact view ${rel} for ${def.ref} is unparseable: ${err.message}` };
+  }
+  const check = validateArtifactView(view, def.outputSchema);
+  if (!check.valid) {
+    return {
+      file: rel,
+      view: null,
+      anomaly: `artifact view ${rel} for ${def.ref} does not fit ${def.output_schema} (served without a view): ${check.errors.join("; ")}`,
+    };
+  }
+  return { file: rel, view, anomaly: null };
+}
 
 // ---------------------------------------------------------------------------
 // Model-tier routing (WM-135). Definitions declare INTENT — a tier from a
@@ -199,11 +235,19 @@ function loadAgentDef(root, file) {
  */
 export function loadRegistry({ root = RUNTIME_ROOT, modelTiers = loadModelTierMap() } = {}) {
   const agents = new Map();
+  const views = new Map();
+  const anomalies = [];
   const agentsDir = path.join(root, "agents");
-  for (const name of readdirSync(agentsDir).filter((n) => n.endsWith(".json")).sort()) {
-    const def = loadAgentDef(root, path.join(agentsDir, name));
+  for (const name of readdirSync(agentsDir).filter(isDefinitionFile).sort()) {
+    const defFile = path.join(agentsDir, name);
+    const def = loadAgentDef(root, defFile);
     if (agents.has(def.ref)) throw new RegistryError(`duplicate agent definition ${def.ref}`);
     agents.set(def.ref, def);
+    const { file, view, anomaly } = loadArtifactView(root, defFile, def);
+    if (anomaly) anomalies.push(anomaly);
+    // Kept off the definition object so receipts' defHash and the pinned
+    // identity never see the view (§2.3).
+    views.set(def.ref, { file, view });
   }
 
   const eventTypes = JSON.parse(readFileSync(path.join(root, "event-types.json"), "utf8"));
@@ -341,7 +385,12 @@ export function loadRegistry({ root = RUNTIME_ROOT, modelTiers = loadModelTierMa
     }
   }
 
-  return { root, agents, eventTypes, schemas, edges, schedules, modelTiers };
+  return { root, agents, views, anomalies, eventTypes, schemas, edges, schedules, modelTiers };
+}
+
+/** The artifact view for a registered agent: `{ file, view }`, both null when the agent has none. */
+export function getArtifactView(registry, ref) {
+  return registry.views?.get(ref) ?? { file: null, view: null };
 }
 
 export function getAgent(registry, ref) {
@@ -358,7 +407,7 @@ export function getEventType(registry, type) {
 export function updatePins({ root = RUNTIME_ROOT } = {}) {
   const changed = [];
   const agentsDir = path.join(root, "agents");
-  for (const name of readdirSync(agentsDir).filter((n) => n.endsWith(".json")).sort()) {
+  for (const name of readdirSync(agentsDir).filter(isDefinitionFile).sort()) {
     const file = path.join(agentsDir, name);
     const def = JSON.parse(readFileSync(file, "utf8"));
     const pins = {};

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -6,8 +6,10 @@ import { cpSync } from "node:fs";
 import { mkdirSync } from "node:fs";
 import { RUNTIME_ROOT } from "./config.mjs";
 import {
-  DEFAULT_MODEL, RegistryError, getAgent, getEventType, loadModelTierMap, loadRegistry, resolveModel, updatePins,
+  DEFAULT_MODEL, RegistryError, getAgent, getArtifactView, getEventType, loadModelTierMap, loadRegistry, resolveModel,
+  updatePins,
 } from "./registry.mjs";
+import { computeDefHash } from "./receipts.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
 function tempRegistry() {
@@ -234,5 +236,56 @@ describe("registry", () => {
       JSON.stringify({ "x.y": { agent: "ghost@9", idempotencyScope: ["correlationId"] } }),
     );
     expect(() => loadRegistry({ root })).toThrow(/unregistered agent/);
+  });
+
+  test("artifact-view sidecars load beside their definition and are served off the pinned identity (WM-454)", () => {
+    const registry = loadRegistry();
+    // The committed views: present, validated, keyed by ref, not on the def.
+    const merge = getArtifactView(registry, "merge-scan@2");
+    expect(merge.file).toBe("agents/merge-scan.view.json");
+    expect(merge.view.schemaVersion).toBe("factory.artifact-view/v1");
+    expect(getArtifactView(registry, "triage-scan@1").view.status.path).toBe("/recommendation");
+    expect(getArtifactView(registry, "reconcile@1")).toEqual({ file: null, view: null });
+    expect(getArtifactView(registry, "ghost@9")).toEqual({ file: null, view: null });
+    expect(registry.anomalies).toEqual([]);
+    // Views are not part of the definition pin nor of the receipt defHash:
+    // the def object never carries them, and the sidecar has no pin entry.
+    const def = getAgent(registry, "merge-scan@2");
+    expect(def.outputView).toBeUndefined();
+    expect(Object.keys(def.pins)).not.toContain("agents/merge-scan.view.json");
+    const { promptPath, inputSchema, outputSchema, ...pinnedIdentity } = def;
+    expect(computeDefHash(def)).toBe(computeDefHash({ ...pinnedIdentity, promptPath, inputSchema, outputSchema }));
+    // A .view.json file is never mistaken for a definition, and re-pinning
+    // leaves it alone.
+    expect([...registry.agents.keys()].some((ref) => ref.includes(".view"))).toBe(false);
+    const root = tempRegistry();
+    expect(updatePins({ root })).toEqual([]);
+  });
+
+  test("a view that drifts from its schema is a configuration anomaly, not a load error (WM-454)", () => {
+    const root = tempRegistry();
+    const viewFile = path.join(root, "agents", "merge-scan.view.json");
+    const view = JSON.parse(readFileSync(viewFile, "utf8"));
+    view.sections[0].columns.push("owner");
+    view.status.path = "/verdict";
+    writeFileSync(viewFile, JSON.stringify(view));
+    const registry = loadRegistry({ root, modelTiers: PI_TIERS });
+    // Served without a view; the anomaly names the agent, the file and the errors.
+    expect(getArtifactView(registry, "merge-scan@2")).toEqual({ file: "agents/merge-scan.view.json", view: null });
+    expect(registry.anomalies).toHaveLength(1);
+    expect(registry.anomalies[0]).toContain("merge-scan@2");
+    expect(registry.anomalies[0]).toContain("agents/merge-scan.view.json");
+    expect(registry.anomalies[0]).toMatch(/"owner" does not resolve/);
+    expect(registry.anomalies[0]).toMatch(/"\/verdict" does not resolve/);
+    // Other agents' views are unaffected.
+    expect(getArtifactView(registry, "triage-scan@1").view).not.toBeNull();
+    // Unparseable JSON is the same class of anomaly.
+    writeFileSync(viewFile, "{ not json");
+    const again = loadRegistry({ root, modelTiers: PI_TIERS });
+    expect(getArtifactView(again, "merge-scan@2").view).toBeNull();
+    expect(again.anomalies[0]).toMatch(/unparseable/);
+    // A schema-invalid document (bad `as`) is refused the same way.
+    writeFileSync(viewFile, JSON.stringify({ ...view, sections: [{ path: "/plan", as: "chart" }] }));
+    expect(loadRegistry({ root, modelTiers: PI_TIERS }).anomalies[0]).toMatch(/not in enum/);
   });
 });

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -255,6 +255,9 @@ export function statusView(
   if (policyVersion === "unknown")
     configAnomalies.push("policyVersion is unknown");
   if (fleet.policyError) configAnomalies.push(fleet.policyError);
+  // Registry-load anomalies that are deliberately not load errors — today
+  // only artifact-view sidecars that do not fit their schema (WM-454).
+  configAnomalies.push(...(registry?.anomalies ?? []));
 
   return {
     events: eventCounts(db),

--- a/event-runtime/schemas/factory.artifact-view.v1.json
+++ b/event-runtime/schemas/factory.artifact-view.v1.json
@@ -1,0 +1,90 @@
+{
+  "title": "factory.artifact-view/v1 — sidecar rendering hints over an agent's output schema (docs/event-runtime-artifact-views.md §2.2)",
+  "description": "A closed hint vocabulary, not a layout language. Per-`as` key applicability (table→columns/groupBy/expand, keyvalue→keys, list→itemLabel, code→language) and the pointer→schema drift check are enforced by lib/artifact-view.mjs, because lib/schema.mjs has no conditional keywords.",
+  "type": "object",
+  "required": ["schemaVersion", "sections"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.artifact-view/v1" },
+    "title": { "type": "string", "minLength": 1, "maxLength": 60 },
+    "summary": {
+      "type": "string",
+      "pattern": "^(/|$)",
+      "description": "RFC 6901 pointer into the artifact to a string rendered first, as prose"
+    },
+    "status": {
+      "type": "object",
+      "required": ["path", "tone"],
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string", "pattern": "^/" },
+        "tone": {
+          "type": "object",
+          "description": "artifact value → tone",
+          "additionalProperties": { "enum": ["ok", "warn", "error", "muted", "neutral"] }
+        }
+      }
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 12,
+      "items": {
+        "type": "object",
+        "required": ["path", "as"],
+        "additionalProperties": false,
+        "properties": {
+          "path": { "type": "string", "pattern": "^(/|$)" },
+          "as": { "enum": ["table", "keyvalue", "list", "badge", "code", "prose"] },
+          "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "columns": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 8,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "table only: item properties shown as columns, in order"
+          },
+          "groupBy": {
+            "type": "string",
+            "minLength": 1,
+            "description": "table only: item property whose value groups the rows"
+          },
+          "expand": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "table only: item properties shown only in the row's expanded state"
+          },
+          "keys": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "keyvalue only: subset of the object's properties, in order"
+          },
+          "itemLabel": {
+            "type": "string",
+            "minLength": 1,
+            "description": "list only: pointer relative to each item naming the text shown"
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1,
+            "description": "code only: syntax hint"
+          },
+          "formats": {
+            "type": "object",
+            "description": "column/key (or \"\" for the section value itself) → format",
+            "additionalProperties": {
+              "enum": ["issue", "pr", "url", "sha", "repo", "run", "duration", "datetime", "state", "bytes", "count"]
+            }
+          },
+          "tone": {
+            "type": "object",
+            "description": "table/keyvalue/list: column/key → (value → tone); badge: value → tone",
+            "additionalProperties": { "type": ["string", "object"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -332,6 +332,9 @@ export interface AgentDef {
   inputSchema: unknown;
   outputSchemaFile: string;
   outputSchema: unknown;
+  /** Artifact-view sidecar (WM-454), null when the agent ships none. */
+  outputViewFile?: string | null;
+  outputView?: unknown;
   pins: Record<string, string>;
   /** Closed-execution shape: fixed argv (command adapter) or action registry. */
   command: string[] | null;


### PR DESCRIPTION
Fixes WM-454

Layer A of the artifact-views epic (WM-452, design `docs/event-runtime-artifact-views.md` §2.1–2.5): a sidecar `agents/<name>.view.json` annotates JSON pointers into an agent's output schema with a closed hint vocabulary so a generic renderer (WM-455) can draw the artifact. Sidecar, not `x-ui`, because `lib/schema.mjs` fails closed on unknown keywords and output schemas are pinned.

## What
- `schemas/factory.artifact-view.v1.json` — the §2.2 contract using only `lib/schema.mjs`'s keyword subset, `additionalProperties: false` throughout. Since the validator has no conditional keywords, per-`as` key applicability (table→columns/groupBy/expand, keyvalue→keys, list→itemLabel, code→language) and nested tone leaves are enforced in code.
- `lib/artifact-view.mjs` — `validateArtifactView(view, outputSchema)` → `{valid, errors}` (schema-valid AND every pointer — `summary`, `status.path`, section `path`, and each section's `columns`/`keys`/`expand`/`itemLabel`/`groupBy`/`formats`/`tone` keys relative to the section node — resolves through `properties`/`items` in the output schema); `resolvePointer(doc, pointer)` (RFC 6901 incl. `~0`/`~1`, `undefined` when absent — shared with WM-456); `resolveSchemaPointer`.
- `lib/registry.mjs` — loads `agents/<name>.view.json` beside each definition (view sidecars are excluded from definition enumeration and from `update-pins`), validates against the def's `outputSchema`; a bad view becomes `registry.anomalies[]` (naming agent, file, errors) and the agent is served without a view — never a load throw. Views live in `registry.views` (Map by ref), NOT on the def object, so receipts' `defHash` and the pinned identity never see them. New `getArtifactView(registry, ref)`.
- `lib/api-registry.mjs` — `GET /agents` items gain `outputView` (object|null) and `outputViewFile` (path|null).
- `lib/status-view.mjs` — `/status.anomalies.configuration` includes `registry.anomalies`.
- `agents/triage-scan.view.json`, `agents/merge-scan.view.json` — first two views, adjusted to the real schemas (triage: `/summary`, status on `/recommendation`, plan table grouped by `action`, `issueId` as issue chips, expand `detail/ownedPaths/verificationCommand/acceptanceCriteria`; merge: status on `/recommendation`, tables for `plan`/`fix`/`escalate` with `pr` chips and reason/finding visible, keyvalue for repo/github/base/deployBranch/noopReason).
- `docs/event-runtime.md` §6 — one paragraph on the sidecar.
- Tests: `lib/artifact-view.test.mjs` (schema pass/fail, per-as keys, pointer resolution incl. arrays/escapes, drift cases, sweep over every `agents/*.view.json` = the drift gate), `lib/registry.test.mjs` (+2), `lib/api.test.mjs` (+2: field presence on every `/agents` item incl. the two committed views, drifted view → null + `/status` anomaly).

## Outside Owned Paths (minimal, named)
- `event-runtime/lib/status-view.mjs`: one line pushing `registry.anomalies` into `configAnomalies` — the only way to surface a load-time anomaly in `/status.anomalies.configuration` without a load throw.
- `event-runtime/web/src/types.ts`: two optional fields on `AgentDef` (`outputViewFile?`, `outputView?`) so WM-455 has the type; `AgentDef` is not pinned by the OPS-284 parity test, so `api.test.mjs` asserts the names by string instead.
- `event-runtime/lib/api-registry.mjs` (the `/agents` route moved there in WM-290 — the ticket names `api.mjs` "or the split file").

## Verification
`bun test event-runtime/lib/artifact-view.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/api.test.mjs && bun test && bun build/emit.mjs --check && bun run format:check`
- named files: 39 pass, 0 fail
- full `bun test` (after installing `event-runtime/web` deps in the worktree): 2183 pass / 6 skip / 4 fail — 3 are `bin/worktree-checkout.test.mjs` commits rejected by the new WM-609 `commit-msg` hook on develop (pre-existing, filed WM-619), 1 is the known load flake `high concurrency race of 8 parallel locked_bun_install` (passes in isolation).
- `bun build/emit.mjs --check`: ok (exit 0; floor-delivery notice is pre-existing/informational)
- `bun run format:check`: clean
- `cd event-runtime/web && bun run build`: ok
