### PR TITLE
fix(ci): gitleaks allowlist + diff-based push scan (WM-620)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,11 @@ jobs:
       # PR runs need connected history between base and head so `git log
       # base..head` (gitleaks --log-opts) can walk it — start shallow and
       # deepen only as far as needed to connect the two endpoints.
+      # Push runs (WM-620) do the same against `github.event.before`: in a
+      # depth-1 clone `git log -1` emits the whole tree as added, so gitleaks
+      # scanned ~6 MB per develop push and tripped on pre-existing text.
+      # `before` is all zeros on branch creation and empty on
+      # workflow_dispatch — those fall back to a depth-1 checkout.
       - name: Checkout (no action download)
         shell: bash
         env:
@@ -34,6 +39,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
           rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
@@ -41,6 +47,7 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
 
+          zeros="0000000000000000000000000000000000000000"
           if [ -n "${BASE_SHA:-}" ]; then
             git fetch -q --depth=50 origin "$SHA" "$BASE_SHA"
             git checkout -q "$SHA"
@@ -53,6 +60,22 @@ jobs:
               fi
               depth=$((depth * 4))
               git fetch -q --deepen="$depth" origin "$SHA" "$BASE_SHA"
+            done
+          elif [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "$zeros" ]; then
+            # `before` is normally the parent (or first parent of a merge) of
+            # SHA, so depth 2 covers the common single-commit push; deepen
+            # from SHA only if the pushed range is longer.
+            git fetch -q --depth=2 origin "$SHA"
+            git checkout -q "$SHA"
+            depth=2
+            while ! git rev-parse -q --verify "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; do
+              if [ "$depth" -ge 2000 ]; then
+                echo "::warning::could not reach before $BEFORE_SHA from head $SHA within $depth commits; falling back to full history"
+                git fetch -q --unshallow origin || git fetch -q origin "$SHA" "$BEFORE_SHA"
+                break
+              fi
+              depth=$((depth * 4))
+              git fetch -q --deepen="$depth" origin "$SHA"
             done
           else
             git fetch -q --depth 1 origin "$SHA"
@@ -97,15 +120,23 @@ jobs:
         env:
           GITLEAKS_BIN: ${{ steps.gitleaks-bin.outputs.bin }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # .gitleaks.toml at repo root is auto-loaded by gitleaks if present.
+          # .gitleaks.toml at repo root is auto-loaded by gitleaks if present;
+          # it allowlists the known false positives so the `-1` fallback (a
+          # depth-1 clone, whole tree as one diff) is clean too (WM-620).
+          zeros="0000000000000000000000000000000000000000"
           if [ -n "${BASE_SHA:-}" ]; then
             log_opts="${BASE_SHA}..${SHA}"
+          elif [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "$zeros" ] \
+            && git rev-parse -q --verify "${BEFORE_SHA}^{commit}" >/dev/null 2>&1; then
+            log_opts="${BEFORE_SHA}..${SHA}"
           else
             log_opts="-1"
           fi
+          echo "gitleaks log opts: $log_opts"
           "$GITLEAKS_BIN" git --no-banner --redact --log-opts="$log_opts"
 
   semgrep:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,26 @@
+# Gitleaks config (WM-620). Auto-loaded by `gitleaks git` from the repo root
+# and by the Security workflow (.github/workflows/security.yml).
+#
+# Keep the default ruleset; only allowlist known false positives so a
+# full-tree scan (e.g. a depth-1 clone where `-1` emits every file as added)
+# stays clean. Add new entries with a comment saying what the match is.
+
+title = "factory"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known false positives"
+# Match against the full rule match (context included), not just the
+# extracted secret group — the metrics.mjs entry needs the surrounding text.
+regexTarget = "match"
+regexes = [
+  # docs/eval-gondolin-sandbox.md: truncated illustrative Linear key in a
+  # JSON example (`lin_api_<12 chars>...`) — not a real credential.
+  '''lin_api_[A-Za-z0-9]{12}\.\.\.''',
+  # event-runtime/lib/metrics.mjs: VALID_BREAKDOWN_METRICS list — the string
+  # literal "tokens" adjacent to "p95_execution" trips the generic-api-key
+  # rule keyed on the word "token".
+  '''tokens",\s*"p95_execution"''',
+]


### PR DESCRIPTION
Fixes WM-620

## Problem
Security / Gitleaks was red on develop push runs (run 32049939721): the push path fetches depth 1 and scans `--log-opts=-1`, which in a shallow clone emits the whole tree as added (~6 MB) and flagged two pre-existing false positives (`docs/eval-gondolin-sandbox.md:291` truncated doc example, `event-runtime/lib/metrics.mjs:38` `"tokens"` next to `"p95_execution"`). No real credential.

## Fix
- `.gitleaks.toml`: extend default rules, allowlist those two matches (`regexTarget = "match"`), commented.
- `security.yml`: on push, fetch depth 2 from SHA and deepen until `github.event.before` is present (all-zeros / empty guarded), scan `before..sha` like the PR path; `-1` remains the fallback and is now clean thanks to the toml. Still no `uses:` steps.

## Verification
- `actionlint .github/workflows/security.yml` clean
- depth-1 clone + toml, `gitleaks git --log-opts=-1`: no leaks (control without toml: 2)
- full checkout `gitleaks git --log-opts=-30`: no leaks; `gitleaks dir .`: no leaks
- depth-2 clone `before..HEAD` simulation: no leaks

## Handoff
UX critique: n/a (CI only)
