### PR TITLE
fix(event-runtime-web): clarify inbox row references (WM-617)

### DIFF
--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -6,10 +6,13 @@ import {
   Inbox,
   deliveryState,
   deliveryText,
+  displayTitle,
   groupItems,
   groupOf,
+  inboxAge,
   itemStatus,
   matchesTab,
+  prHref,
   sourceRunId,
 } from "./Inbox";
 import { api } from "../api";
@@ -86,6 +89,52 @@ describe("inbox pure helpers", () => {
     expect(sourceRunId("serve:notify")).toBeNull();
     expect(sourceRunId("cli")).toBeNull();
   });
+
+  test("displayTitle removes redundant kind and visible issue/PR prefixes", () => {
+    expect(displayTitle(item({
+      id: "blocked",
+      kind: "BLOCKED",
+      title: "BLOCKED WM-303: expand Owned Paths to include the fixture",
+      refs: { issue: "WM-303" },
+    }))).toBe("expand Owned Paths to include the fixture");
+    expect(displayTitle(item({
+      id: "human",
+      kind: "human_needed",
+      title: "BLOCKED factory.ticket.reaped reap:CLNT-1393:1786698035",
+    }))).toBe("factory.ticket.reaped reap:CLNT-1393:1786698035");
+    expect(displayTitle(item({
+      id: "ci",
+      kind: "CI RED",
+      title: "CI RED PR#398/WM-398: Verify run failed",
+      refs: { issue: "WM-398", pr: "PR#398" },
+    }))).toBe("Verify run failed");
+    expect(displayTitle(item({
+      id: "escalated",
+      kind: "ESCALATED",
+      title: "escalated CLNT-12/PR#7: choose a release",
+      refs: { issue: "CLNT-12", pr: "#7", repo: "bj29" },
+    }))).toBe("choose a release");
+  });
+
+  test("displayTitle keeps a ref prefix that has no matching chip", () => {
+    const row = item({ id: "a", kind: "BLOCKED", title: "BLOCKED WM-303: expand paths", refs: {} });
+    expect(displayTitle(row)).toBe("WM-303: expand paths");
+    expect(row.title).toBe("BLOCKED WM-303: expand paths");
+  });
+
+  test("PR refs resolve only with an absolute URL or a known repository", () => {
+    expect(prHref(item({ id: "url", kind: "CI RED", refs: { pr: "https://github.com/watt-mind/factory/pull/9" } })))
+      .toBe("https://github.com/watt-mind/factory/pull/9");
+    expect(prHref(item({ id: "repo", kind: "CI RED", refs: { pr: "PR#123", repo: "factory" } })))
+      .toBe("https://github.com/watt-mind/factory/pull/123");
+    expect(prHref(item({ id: "issue", kind: "CI RED", refs: { pr: "#124", issue: "WM-617" } })))
+      .toBe("https://github.com/watt-mind/factory/pull/124");
+    expect(prHref(item({ id: "bare", kind: "CI RED", refs: { pr: "PR#125" } }))).toBeNull();
+  });
+
+  test("Inbox age preserves hour precision after 24 hours", () => {
+    expect(inboxAge("2026-08-16T05:30:00.000Z", Date.parse("2026-08-17T10:00:00.000Z"))).toBe("1d 4h ago");
+  });
 });
 
 const origInbox = api.inbox;
@@ -142,8 +191,8 @@ function renderInbox(props: Partial<React.ComponentProps<typeof Inbox>> = {}) {
 describe("Inbox view", () => {
   test("Open tab shows open items grouped, with counts on every tab", async () => {
     const { view } = renderInbox();
-    await waitFor(() => view.getByText("BLOCKED WM-1: decide X"));
-    expect(view.getByText("CI RED WM-2/PR #9")).toBeTruthy();
+    await waitFor(() => view.getByText("decide X"));
+    expect(view.getByText("WM-2/PR #9")).toBeTruthy();
     expect(view.queryByText("ESCALATED merge")).toBeNull();
     const tabs = view.getAllByRole("tab").map((t) => t.textContent);
     expect(tabs[0]).toContain("Open");
@@ -168,14 +217,46 @@ describe("Inbox view", () => {
   test("ref chips jump without selecting the row", async () => {
     const onSelectItem = mock(() => {});
     const { view, jumps } = renderInbox({ onSelectItem });
-    await waitFor(() => view.getByText("BLOCKED WM-1: decide X"));
+    await waitFor(() => view.getByText("decide X"));
     fireEvent.click(view.getByTitle("run_a"));
     expect(jumps.onJumpRun).toHaveBeenCalledWith("run_a");
     expect(onSelectItem).not.toHaveBeenCalled();
     const issue = view.getByText("WM-1") as HTMLAnchorElement;
     expect(issue.getAttribute("href")).toBe("https://linear.app/watt-mind/issue/WM-1");
-    const pr = view.getByText("PR") as HTMLAnchorElement;
+    const pr = view.getByTitle("Open pull request") as HTMLAnchorElement;
     expect(pr.getAttribute("href")).toBe("https://github.com/watt-mind/factory/pull/9");
+  });
+
+  test("ref chips shorten events and cap the row at three with a remainder tooltip", async () => {
+    ledger = [item({
+      id: "many_refs",
+      kind: "BLOCKED",
+      title: "BLOCKED inspect refs",
+      refs: {
+        runId: "run_1234567890",
+        eventSource: "github",
+        eventId: "event_abcdefghijk",
+        issue: "WM-617",
+        pr: "PR#42",
+        repo: "factory",
+      },
+    })];
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("inspect refs"));
+    expect(view.getByText("event_abcdefgh").getAttribute("title")).toBe("event_abcdefghijk");
+    expect(view.getByText("WM-617")).toBeTruthy();
+    expect(view.queryByText("PR#42")).toBeNull();
+    const more = view.getByText("+1");
+    expect(more.getAttribute("title")).toBe("pull request PR#42");
+  });
+
+  test("an unresolved PR shorthand renders as text, never a relative link", async () => {
+    ledger = [item({ id: "bare_pr", kind: "CI RED", title: "CI RED inspect PR", refs: { pr: "PR#88" } })];
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("inspect PR"));
+    const ref = view.getByText("PR#88");
+    expect(ref.tagName).toBe("SPAN");
+    expect(ref.closest("a")).toBeNull();
   });
 
   test("deep link selects the item and follows it onto the tab that has it", async () => {
@@ -191,7 +272,7 @@ describe("Inbox view", () => {
     const { view } = renderInbox({ focusItemId: "inbox_nope" });
     await waitFor(() => view.getByRole("status"));
     expect(view.getByRole("status").textContent).toContain("No inbox item");
-    expect(view.getByText("BLOCKED WM-1: decide X")).toBeTruthy();
+    expect(view.getByText("decide X")).toBeTruthy();
   });
 
   test("a acks the selected item and the ledger, not the UI, flips its status", async () => {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -128,6 +128,98 @@ export function sourceRunId(source: string): string | null {
 
 const LINEAR_ISSUE_URL = "https://linear.app/watt-mind/issue/";
 
+const REPO_GITHUB: Record<string, string> = {
+  bj29: "watt-mind/bakonszegi-coaching",
+  "wm-home": "watt-mind/wm-home",
+  "coach-wattz": "watt-mind/coach",
+  "watts-mobile": "watt-mind/watts-mobile",
+  legalease: "watt-mind/legalease",
+  cashsaas: "hdkiller/cashsaas",
+  proxies: "watt-mind/proxies",
+  hdkiller: "hdkiller/hdkiller",
+  "eslint-config": "watt-mind/eslint-config",
+  factory: "watt-mind/factory",
+};
+
+// Only unambiguous team prefixes belong here. CLNT, CW, and OPS each route to
+// multiple repositories, so a bare issue from those teams must not guess.
+const ISSUE_PREFIX_GITHUB: Record<string, string> = {
+  WM: "watt-mind/factory",
+  LAB: "watt-mind/proxies",
+};
+
+function prNumber(ref: string | undefined): string | null {
+  if (!ref) return null;
+  return /^(?:PR\s*)?#(\d+)$/i.exec(ref.trim())?.[1] ?? /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref)?.[1] ?? null;
+}
+
+function githubRepo(item: InboxItem): string | null {
+  const repo = item.refs.repo?.trim();
+  if (repo) {
+    if (/^[^/\s]+\/[^/\s]+$/.test(repo)) return repo;
+    if (REPO_GITHUB[repo]) return REPO_GITHUB[repo];
+  }
+  const team = /^([A-Z][A-Z0-9]+)-\d+$/i.exec(item.refs.issue ?? "")?.[1]?.toUpperCase();
+  return team ? (ISSUE_PREFIX_GITHUB[team] ?? null) : null;
+}
+
+/** Resolve only real absolute URLs or PR shorthands with a known repository. */
+export function prHref(item: InboxItem): string | null {
+  const ref = item.refs.pr?.trim();
+  if (!ref) return null;
+  if (/^https?:\/\/[^\s]+$/i.test(ref)) return ref;
+  const number = prNumber(ref);
+  const repo = githubRepo(item);
+  return number && repo ? `https://github.com/${repo}/pull/${number}` : null;
+}
+
+function refPrefixIsVisible(prefix: string, item: InboxItem): boolean {
+  const tokens = prefix.split(/\s*\/\s*/);
+  return tokens.every((token) => {
+    if (/^[A-Z][A-Z0-9]+-\d+$/i.test(token)) {
+      return item.refs.issue?.toUpperCase() === token.toUpperCase();
+    }
+    const number = /^(?:PR\s*)?#(\d+)$/i.exec(token)?.[1];
+    return number != null && prNumber(item.refs.pr) === number;
+  });
+}
+
+/** Keep the row focused on the action by removing labels already shown beside it. */
+export function displayTitle(item: InboxItem): string {
+  let title = item.title.trimStart();
+  const knownKinds = [...new Set([item.kind, ...INBOX_GROUPS.flatMap((group) => group.kinds)])]
+    .sort((a, b) => b.length - a.length);
+  for (const kind of knownKinds) {
+    const plain = kind.toLowerCase();
+    const bracketed = `[${plain}]`;
+    const lower = title.toLowerCase();
+    const matched = lower.startsWith(`${plain} `)
+      ? plain.length
+      : lower.startsWith(`${bracketed} `)
+        ? bracketed.length
+        : 0;
+    if (matched) {
+      title = title.slice(matched).trimStart();
+      break;
+    }
+  }
+
+  const refPrefix = /^((?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+))(?:\s*\/\s*(?:(?:[A-Z][A-Z0-9]+-\d+)|(?:(?:PR\s*)?#\d+)))?)\s*:\s*/i.exec(title);
+  if (refPrefix && refPrefixIsVisible(refPrefix[1], item)) title = title.slice(refPrefix[0].length);
+  return title || item.title;
+}
+
+/** WM-559 will move this precision into shared `Ago`; keep the Inbox local until then. */
+export function inboxAge(iso: string, now: number): string {
+  const seconds = Math.max(0, Math.floor((now - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  return `${days}d ${hours}h ago`;
+}
+
 const isTypingTarget = (target: EventTarget | null): boolean =>
   target instanceof HTMLElement && Boolean(target.closest("input, textarea, select, [contenteditable=true]"));
 
@@ -459,9 +551,7 @@ export function Inbox({
               {sel.refs.issue && (
                 <KV k="issue" v={<JumpLink href={`${LINEAR_ISSUE_URL}${encodeURIComponent(sel.refs.issue)}`} title="Open in Linear">{sel.refs.issue}</JumpLink>} />
               )}
-              {sel.refs.pr && (
-                <KV k="pr" v={<JumpLink href={sel.refs.pr} title="Open pull request">{sel.refs.pr.replace(/^https?:\/\/(www\.)?github\.com\//, "")}</JumpLink>} />
-              )}
+              {sel.refs.pr && <KV k="pr" v={<PrRef item={sel} />} />}
               {sel.refs.repo && <KV k="repo" v={sel.refs.repo} />}
             </Section>
           )}
@@ -549,12 +639,12 @@ function GroupRows({
                 shrink-to-fit, `min-w-40` stops it collapsing to a glyph when
                 the pane opens at ~1100px — Refs gives up width first. */}
             <td className={`${tdCls} min-w-40 max-w-0`}>
-              <div className="truncate text-(--text)" title={item.title}>{item.title}</div>
+              <div className="truncate text-(--text)" title={item.title}>{displayTitle(item)}</div>
             </td>
             <td className={`${tdCls} w-16 text-(--text-faint)`}>
-              <Ago iso={item.createdAt} now={now} />
+              <span className="tabular-nums" title={item.createdAt}>{inboxAge(item.createdAt, now)}</span>
             </td>
-            <td className={`${tdCls} w-40 max-w-40`}>
+            <td className={`${tdCls} w-72 max-w-72`}>
               <RefChips item={item} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpEvent={onJumpEvent} />
             </td>
             <td className={`${tdCls} w-12`}>
@@ -573,6 +663,17 @@ function GroupRows({
   );
 }
 
+function PrRef({ item, className }: { item: InboxItem; className?: string }) {
+  const ref = item.refs.pr!;
+  const href = prHref(item);
+  const label = ref.replace(/^https?:\/\/(www\.)?github\.com\//, "");
+  return href ? (
+    <JumpLink className={className} href={href} title="Open pull request">{label}</JumpLink>
+  ) : (
+    <span className={`mono ${className ?? ""}`} title={ref}>{ref}</span>
+  );
+}
+
 /** Every ref is one click from the thing it is about; nothing here selects the row. */
 function RefChips({
   item,
@@ -586,14 +687,29 @@ function RefChips({
   onJumpEvent: (source: string, eventId: string) => void;
 }) {
   const r = item.refs;
-  const chip = "rounded border border-(--border) bg-(--surface-1) px-1 text-[10px]";
-  const chips: React.ReactNode[] = [];
-  if (r.runId) chips.push(<JumpLink key="run" className={chip} onClick={() => onJumpRun(r.runId!)} title={r.runId}>{shortId(r.runId)}</JumpLink>);
-  if (r.proposalId) chips.push(<JumpLink key="prop" className={chip} onClick={() => onJumpProposal(r.proposalId!)} title={r.proposalId}>{shortId(r.proposalId)}</JumpLink>);
-  if (r.eventId && r.eventSource) chips.push(<JumpLink key="event" className={chip} onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title={r.eventId}>{shortId(r.eventId)}</JumpLink>);
-  if (r.issue) chips.push(<JumpLink key="issue" className={chip} href={`${LINEAR_ISSUE_URL}${encodeURIComponent(r.issue)}`} title="Open in Linear">{r.issue}</JumpLink>);
-  if (r.pr) chips.push(<JumpLink key="pr" className={chip} href={r.pr} title={r.pr}>PR</JumpLink>);
+  const chip = "inline-block max-w-20 truncate rounded border border-(--border) bg-(--surface-1) px-1 align-bottom text-[10px]";
+  const chips: { key: string; description: string; node: React.ReactNode }[] = [];
+  if (r.runId) chips.push({ key: "run", description: `run ${r.runId}`, node: <JumpLink className={chip} onClick={() => onJumpRun(r.runId!)} title={r.runId}>{shortId(r.runId)}</JumpLink> });
+  if (r.proposalId) chips.push({ key: "prop", description: `proposal ${r.proposalId}`, node: <JumpLink className={chip} onClick={() => onJumpProposal(r.proposalId!)} title={r.proposalId}>{shortId(r.proposalId)}</JumpLink> });
+  if (r.eventId) {
+    const event = r.eventSource
+      ? <JumpLink className={chip} onClick={() => onJumpEvent(r.eventSource!, r.eventId!)} title={r.eventId}>{shortId(r.eventId)}</JumpLink>
+      : <span className={`mono ${chip}`} title={r.eventId}>{shortId(r.eventId)}</span>;
+    chips.push({ key: "event", description: `event ${r.eventId}`, node: event });
+  }
+  if (r.issue) chips.push({ key: "issue", description: `issue ${r.issue}`, node: <JumpLink className={chip} href={`${LINEAR_ISSUE_URL}${encodeURIComponent(r.issue)}`} title="Open in Linear">{r.issue}</JumpLink> });
+  if (r.pr) chips.push({ key: "pr", description: `pull request ${r.pr}`, node: <PrRef item={item} className={chip} /> });
   if (chips.length === 0) return <span className="text-(--text-faint)">-</span>;
-  // One line, clipped: a row must stay one row high; the pane lists every ref in full.
-  return <div className="flex gap-1 overflow-hidden whitespace-nowrap [&>*]:shrink-0">{chips}</div>;
+  const visible = chips.slice(0, 3);
+  const hidden = chips.slice(3);
+  return (
+    <div className="flex gap-1 overflow-hidden whitespace-nowrap [&>*]:shrink-0">
+      {visible.map(({ key, node }) => <span key={key} className="contents">{node}</span>)}
+      {hidden.length > 0 && (
+        <span className={`mono ${chip} text-(--text-faint)`} title={hidden.map((ref) => ref.description).join(", ")}>
+          +{hidden.length}
+        </span>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- remove redundant kind and visible issue/PR prefixes from Inbox row titles while retaining the original detail/tooltip text
- resolve PR shorthands only when a repository is known, shorten/cap reference chips, and preserve hidden refs in the pane
- show day-and-hour precision for Inbox rows older than 24 hours

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (716 tests)

UX critique: required — SHIP after 2 rounds; evidence: http://127.0.0.1:7599/#/inbox and `/Users/hdkiller/.factory/event-runtime/workspaces/run_fbc61fd2-e54a-4b96-8932-e1816eac7e97-a1/wm-617-ux-round2-inbox-1200.png`

Fixes WM-617