### PR TITLE
feat(event-runtime-web): add ticket journey view

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -105,6 +105,205 @@ function eventsView(db, status) {
   });
 }
 
+const TICKET_ID = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
+
+function objectNamesTicket(value, ticket) {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some((entry) => objectNamesTicket(entry, ticket));
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      /^(ticket|ticketId|issue|issueId|linearId)$/i.test(key) &&
+      typeof entry === "string" &&
+      entry.toUpperCase() === ticket
+    )
+      return true;
+    if (entry && typeof entry === "object" && objectNamesTicket(entry, ticket))
+      return true;
+  }
+  return false;
+}
+
+function parseObject(json) {
+  try {
+    const value = JSON.parse(json);
+    return value && typeof value === "object" ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function collectPrRefs(value, refs = { numbers: new Set(), urls: new Set() }) {
+  if (!value || typeof value !== "object") return refs;
+  if (Array.isArray(value)) {
+    for (const entry of value) collectPrRefs(entry, refs);
+    return refs;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "string") {
+      const match = entry.match(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)(?:$|[/?#])/);
+      if (match) {
+        refs.urls.add(entry);
+        refs.numbers.add(Number(match[1]));
+      }
+    }
+    if (/^(pr|prNumber|pullRequest|pullRequestNumber)$/i.test(key)) {
+      const number = Number(entry);
+      if (Number.isInteger(number) && number > 0) refs.numbers.add(number);
+    }
+    if (entry && typeof entry === "object") collectPrRefs(entry, refs);
+  }
+  return refs;
+}
+
+function hasPrRef(value, refs) {
+  const own = collectPrRefs(value);
+  for (const number of own.numbers) if (refs.numbers.has(number)) return true;
+  for (const url of own.urls) if (refs.urls.has(url)) return true;
+  return false;
+}
+
+function namedString(values, names) {
+  for (const value of values) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    for (const name of names) {
+      if (typeof value[name] === "string" && value[name].trim()) return value[name].trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Everything the ticket journey needs in one bounded server-side join. The
+ * existing `/runs` route carries `?ticket=` so this stays inside the run API
+ * module and does not add another top-level router branch. Matching starts on
+ * explicit ticket fields (never arbitrary prose), then closes over linked
+ * event/proposal/run ids and PR references emitted by dispatch/merge results.
+ */
+export function ticketJourneyView(db, rawTicket, options = {}) {
+  const ticket = String(rawTicket ?? "").trim().toUpperCase();
+  if (!TICKET_ID.test(ticket)) return null;
+
+  const eventRows = db.query(`SELECT * FROM events ORDER BY admitted_at, rowid`).all();
+  const proposalRows = db.query(`SELECT * FROM proposals ORDER BY created_at, rowid`).all();
+  const runRows = db.query(`SELECT * FROM runs ORDER BY created_at, rowid`).all();
+  const resultRows = db.query(`SELECT * FROM results ORDER BY rowid`).all();
+  const resultByRun = new Map();
+  for (const row of resultRows) {
+    const result = parseObject(row.result_json);
+    if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
+    resultByRun.get(row.run_id).push(result);
+  }
+
+  const events = new Set();
+  const proposals = new Set();
+  const runs = new Set();
+  for (const row of eventRows) {
+    const envelope = parseObject(row.envelope_json);
+    if (
+      String(row.subject ?? "").toUpperCase() === ticket ||
+      objectNamesTicket(envelope, ticket)
+    )
+      events.add(`${row.source}\0${row.event_id}`);
+  }
+  for (const row of proposalRows) {
+    const spec = parseObject(row.spec_json);
+    if (objectNamesTicket(spec.input, ticket)) proposals.add(row.id);
+  }
+  for (const row of runRows) {
+    const spec = parseObject(row.spec_json);
+    const results = resultByRun.get(row.run_id) ?? [];
+    if (
+      objectNamesTicket(spec.input, ticket) ||
+      results.some((result) => objectNamesTicket(result, ticket))
+    )
+      runs.add(row.run_id);
+  }
+
+  // Link closure catches runs that name only their proposal/event and events
+  // whose payload names only a PR emitted by the original dispatch attempt.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of proposalRows) {
+      const eventKey = `${row.event_source}\0${row.event_id}`;
+      if (
+        proposals.has(row.id) ||
+        events.has(eventKey) ||
+        (row.run_id && runs.has(row.run_id))
+      ) {
+        if (!proposals.has(row.id)) { proposals.add(row.id); changed = true; }
+        if (!events.has(eventKey)) { events.add(eventKey); changed = true; }
+        if (row.run_id && !runs.has(row.run_id)) { runs.add(row.run_id); changed = true; }
+      }
+    }
+  }
+
+  const prRefs = { numbers: new Set(), urls: new Set() };
+  for (const runId of runs) {
+    for (const result of resultByRun.get(runId) ?? []) collectPrRefs(result, prRefs);
+  }
+  if (prRefs.numbers.size || prRefs.urls.size) {
+    for (const row of runRows) {
+      const spec = parseObject(row.spec_json);
+      const results = resultByRun.get(row.run_id) ?? [];
+      if (hasPrRef(spec.input, prRefs) || results.some((result) => hasPrRef(result, prRefs)))
+        runs.add(row.run_id);
+    }
+    for (const row of eventRows) {
+      if (hasPrRef(parseObject(row.envelope_json), prRefs))
+        events.add(`${row.source}\0${row.event_id}`);
+    }
+  }
+
+  const matchedEvents = eventsView(db).filter((event) =>
+    events.has(`${event.source}\0${event.eventId}`),
+  );
+  const matchedProposals = proposalHistory(db).filter((proposal) => proposals.has(proposal.id));
+  const matchedRuns = [...runs]
+    .map((runId) => runView(db, runId, options))
+    .filter(Boolean)
+    .sort((a, b) => a.run.created_at.localeCompare(b.run.created_at));
+
+  const metadata = [
+    ...matchedEvents.map((event) => event.envelope?.payload),
+    ...matchedProposals.map((proposal) => proposal.spec?.input),
+    ...matchedRuns.map((run) => run.run.spec?.input),
+    ...matchedRuns.map((run) => run.result?.artifact),
+  ];
+  const title = namedString(metadata, ["ticketTitle", "linearTitle", "issueTitle"]);
+  const recordedState = namedString(metadata, ["ticketState", "linearState", "issueState"]);
+  const createdAt = namedString(metadata, ["ticketCreatedAt", "linearCreatedAt", "issueCreatedAt"]);
+  const active = matchedRuns.find((run) =>
+    ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(run.run.state),
+  );
+  const merged = matchedRuns.some((run) =>
+    /merged/i.test(JSON.stringify(run.result?.artifact ?? {})),
+  );
+  const inferredState = merged
+    ? "Done"
+    : active
+      ? "In Progress"
+      : matchedProposals.some((proposal) => proposal.decision === "noop")
+        ? "Todo"
+        : matchedRuns.length
+          ? "In Review"
+          : null;
+
+  return {
+    ticket: {
+      id: ticket,
+      title,
+      state: recordedState ?? inferredState,
+      createdAt,
+      url: `https://linear.app/watt-mind/issue/${encodeURIComponent(ticket)}`,
+    },
+    activity: matchedEvents.length > 0 || matchedProposals.length > 0 || matchedRuns.length > 0,
+    events: matchedEvents,
+    proposals: matchedProposals,
+    runs: matchedRuns,
+  };
+}
+
 function runsView(db, state) {
   const where = state ? `WHERE r.state = ?` : ``;
   const rows = db
@@ -390,6 +589,12 @@ export async function handleRunApiRoute({
   }
 
   if (route === "GET /runs") {
+    const ticket = url.searchParams.get("ticket");
+    if (ticket) {
+      const journey = ticketJourneyView(db, ticket, { artifactsDir });
+      if (!journey) return send(422, { error: "ticket must look like WM-123" });
+      return send(200, journey);
+    }
     return send(200, { runs: runsView(db, url.searchParams.get("state")) });
   }
 

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -85,6 +85,116 @@ describe("list views carry repos[] (OPS-356)", () => {
   });
 });
 
+describe("ticket journey join (WM-595)", () => {
+  test("GET /runs?ticket= joins explicit ticket activity and PR-linked merge runs", async () => {
+    const s = await makeServer();
+    try {
+      await s.client.replay(
+        envelope({
+          eventId: "ticket-dispatch",
+          subject: "WM-595",
+          payload: {
+            repo: "factory",
+            ticket: "WM-595",
+            ticketTitle: "Ticket journey",
+            ticketState: "In Review",
+            ticketCreatedAt: "2026-01-01T09:00:00.000Z",
+          },
+        }),
+      );
+      const spec = (input, agent = "dispatch@1") =>
+        JSON.stringify({
+          schemaVersion: "factory.run-spec/v1",
+          runId: "ignored",
+          agent,
+          input,
+          inputHash: "sha256:input",
+          workspace: { type: "none" },
+          adapter: "fake",
+          promptVersion: "test",
+          policyVersion: PV,
+          outputContract: "test/v1",
+          capabilities: [],
+          timeoutSeconds: 60,
+          maxAttempts: 1,
+          idempotencyKey: "ignored",
+        });
+      s.db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      ).run(
+        "run_ticket",
+        "ticket-key",
+        spec({ repo: "factory", ticket: "WM-595" }),
+        "sha256:ticket",
+        "COMPLETED",
+        "2026-01-01T10:00:00.000Z",
+        "2026-01-01T10:10:00.000Z",
+      );
+      s.db.query(
+        `INSERT INTO results
+           (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, ?, '{}', '{}', ?)`,
+      ).run(
+        "run_ticket",
+        JSON.stringify({
+          terminalState: "completed",
+          artifact: {
+            outcome: "PR_OPEN",
+            ticket: "WM-595",
+            prUrl: "https://github.com/watt-mind/factory/pull/595",
+          },
+        }),
+        "sha256:result-ticket",
+        "2026-01-01T10:10:00.000Z",
+      );
+      s.db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      ).run(
+        "run_merge",
+        "merge-key",
+        spec({ repo: "factory", pr: 595 }, "merge-apply@1"),
+        "sha256:merge",
+        "COMPLETED",
+        "2026-01-01T11:00:00.000Z",
+        "2026-01-01T11:01:00.000Z",
+      );
+      s.db.query(
+        `INSERT INTO results
+           (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, ?, '{}', '{}', ?)`,
+      ).run(
+        "run_merge",
+        JSON.stringify({ terminalState: "completed", artifact: { pr: 595, outcome: "MERGED" } }),
+        "sha256:result-merge",
+        "2026-01-01T11:01:00.000Z",
+      );
+
+      const response = await fetch(s.url("/runs?ticket=WM-595"));
+      expect(response.status).toBe(200);
+      const journey = await response.json();
+      expect(journey.ticket).toEqual({
+        id: "WM-595",
+        title: "Ticket journey",
+        state: "In Review",
+        createdAt: "2026-01-01T09:00:00.000Z",
+        url: "https://linear.app/watt-mind/issue/WM-595",
+      });
+      expect(journey.events.map((event) => event.eventId)).toContain("ticket-dispatch");
+      expect(journey.runs.map((run) => run.run.runId)).toEqual(["run_ticket", "run_merge"]);
+      expect(journey.activity).toBe(true);
+
+      const unknown = await fetch(s.url("/runs?ticket=WM-999"));
+      expect((await unknown.json()).activity).toBe(false);
+      const invalid = await fetch(s.url("/runs?ticket=not-a-ticket"));
+      expect(invalid.status).toBe(422);
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("watched flow and operator verbs (§12, §13, §15)", () => {
   let s;
   let flowProposalId;

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -81,6 +81,16 @@ beforeEach(() => {
       });
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
+    if (url.includes("/api/runs?ticket=")) {
+      const ticket = new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
+      return jsonResponse({
+        ticket: { id: ticket, title: null, state: null, createdAt: null, url: `https://linear.app/watt-mind/issue/${ticket}` },
+        activity: false,
+        events: [],
+        proposals: [],
+        runs: [],
+      });
+    }
     // Views poll their own endpoints; an empty list keeps them quiet.
     return jsonResponse([]);
   }) as typeof fetch;
@@ -315,7 +325,7 @@ describe("context strip fast jump chords (WM-235)", () => {
     expect(utils.queryByPlaceholderText(/search event types/i)).toBeNull();
   });
 
-  test("view chords (g o, g e, g p, g r) still work alongside context chords", async () => {
+  test("view chords (including g k ticket picker) still work alongside context chords", async () => {
     window.location.hash = "#/overview";
     const utils = renderApp();
     await waitFor(() => {
@@ -341,6 +351,14 @@ describe("context strip fast jump chords (WM-235)", () => {
       fireEvent.keyDown(document.body, { key: "r" });
     });
     expect(window.location.hash).toBe("#/runs");
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: "g" });
+      fireEvent.keyDown(document.body, { key: "k" });
+    });
+    expect(window.location.hash).toBe("#/tickets");
+    const ticketInput = await utils.findByRole("textbox", { name: "Ticket id" });
+    expect(document.activeElement === ticketInput).toBe(true);
   });
 
   test("`g` prefix arms and displays GoPrefixHint legend with context chords", async () => {
@@ -360,6 +378,42 @@ describe("context strip fast jump chords (WM-235)", () => {
     expect(utils.container.textContent).toContain("0 All");
     expect(utils.container.textContent).toContain("1–9 repos");
     expect(utils.container.textContent).toContain("i In flight");
+  });
+});
+
+describe("ticket journey navigation (WM-595)", () => {
+  test("exact ticket-id chips in detail panes navigate to the ticket journey", async () => {
+    const utils = renderApp();
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.title = "WM-542";
+    chip.textContent = "WM-542";
+    utils.getByRole("main").appendChild(chip);
+
+    await waitFor(() => {
+      fireEvent.click(chip);
+      expect(window.location.hash).toBe("#/tickets/WM-542");
+    });
+  });
+
+  test("exact ticket values in JSON are exposed as keyboard-navigable journey links", async () => {
+    const utils = renderApp();
+    const value = document.createElement("span");
+    value.textContent = '"WM-400"';
+    utils.getByRole("main").appendChild(value);
+    const link = await utils.findByRole("link", { name: "Open ticket WM-400" });
+    fireEvent.keyDown(link, { key: "Enter" });
+    expect(window.location.hash).toBe("#/tickets/WM-400");
+  });
+
+  test("typing a ticket id in the command palette offers its journey", async () => {
+    const utils = renderApp();
+    fireEvent.keyDown(document.body, { key: "k", metaKey: true });
+    const input = utils.getByPlaceholderText("Type a command…");
+    fireEvent.input(input, { target: { value: "WM-595" } });
+    const command = await utils.findByText("WM-595", { selector: "span.mono" });
+    fireEvent.click(command.closest("[cmdk-item]")!);
+    expect(window.location.hash).toBe("#/tickets/WM-595");
   });
 });
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -59,6 +59,7 @@ const Schedules = lazy(() => import("./views/Schedules").then((m) => ({ default:
 const Proposals = lazy(() => import("./views/Proposals").then((m) => ({ default: m.Proposals })));
 const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
 const RunFull = lazy(() => import("./views/RunFull").then((m) => ({ default: m.RunFull })));
+const Ticket = lazy(() => import("./views/Ticket").then((m) => ({ default: m.Ticket })));
 const Workers = lazy(() => import("./views/Workers").then((m) => ({ default: m.Workers })));
 const ShortcutsDialog = lazy(() =>
   import("./components/ShortcutsDialog").then((m) => ({ default: m.ShortcutsDialog })),
@@ -136,7 +137,22 @@ export function App() {
   const mainRef = useRef<HTMLElement>(null);
   const previousViewRef = useRef(view);
 
+  useEffect(() => {
+    const root = mainRef.current;
+    if (!root) return;
+    let disposed = false;
+    let uninstall = () => {};
+    void import("./ticketJourney").then(({ installTicketJourneyLinks }) => {
+      if (!disposed) uninstall = installTicketJourneyLinks(root, jumpToTicket);
+    });
+    return () => {
+      disposed = true;
+      uninstall();
+    };
+  }, []);
+
   const focusRunId = view === "runs" ? (route[1] ?? null) : null;
+  const focusTicketId = view === "tickets" ? (route[1] ?? null) : null;
   // `#/run/:id` is the full-page run view — a distinct first segment, so
   // crossing from `#/runs/:id` pushes history and Back restores the panel.
   const fullRunId = view === "run" ? (route[1] ?? null) : null;
@@ -184,6 +200,7 @@ export function App() {
     navigate(hashPath("runs", runId));
   };
   const openRunFull = (runId: string) => navigate(hashPath("run", runId));
+  const jumpToTicket = (ticketId: string) => navigate(hashPath("tickets", ticketId));
   const jumpToRuns = (state?: string) => {
     if (state) setFocusRunState(state);
     setRejumpEpoch((n) => n + 1);
@@ -262,6 +279,7 @@ export function App() {
     events: { count: scopedNav ? 0 : eventAttention, hue: "var(--accent)" },
     proposals: { count: scopedNav ? 0 : openProposals, hue: "var(--accent)" },
     runs: { count: scopedRunsNav ? 0 : activeRuns, hue: "var(--accent)" },
+    tickets: { count: 0, hue: "var(--accent)" },
     projects: { count: 0, hue: "var(--accent)" },
     agents: { count: 0, hue: "var(--accent)" },
     artifacts: {
@@ -603,6 +621,10 @@ export function App() {
               onJumpProposal={jumpToProposal}
               rejumpEpoch={rejumpEpoch}
             />
+          ) : view === "tickets" ? (
+            <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading ticket journey…</div>}>
+              <Ticket ticketId={focusTicketId} onNavigate={jumpToTicket} />
+            </Suspense>
           ) : view === "projects" ? (
             <Suspense fallback={<div className="p-5 text-(--text-faint)">Loading projects…</div>}>
               <Projects
@@ -783,6 +805,7 @@ export function App() {
         onJumpAgent={jumpToAgent}
         onJumpWorker={jumpToWorker}
         onJumpProject={jumpToProject}
+        onJumpTicket={jumpToTicket}
       />
       {injectOpen && (
         <Suspense fallback={null}>

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -27,6 +27,7 @@ export function CommandPalette({
   onJumpAgent,
   onJumpWorker,
   onJumpProject,
+  onJumpTicket,
 }: {
   actions: PaletteAction[];
   onJumpRun: (runId: string) => void;
@@ -35,11 +36,14 @@ export function CommandPalette({
   onJumpAgent: (ref: string) => void;
   onJumpWorker: (id: string) => void;
   onJumpProject?: (name: string) => void;
+  onJumpTicket?: (ticketId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const [hasMoreBelow, setHasMoreBelow] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const wasOpenRef = useRef(false);
   const contextActions = useContextActions();
@@ -65,8 +69,12 @@ export function CommandPalette({
   const agents = useQuery({ queryKey: ["agents"], queryFn: api.agents, enabled: open });
   const workers = useQuery({ queryKey: ["workers"], queryFn: api.workers, enabled: open });
   const repos = useQuery({ queryKey: ["repos"], queryFn: api.repos, enabled: open });
+  const typedTicket = /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(search.trim().toUpperCase())
+    ? search.trim().toUpperCase()
+    : null;
   const resultCount =
     actions.length +
+    (typedTicket ? 1 : 0) +
     contextActions.length +
     (runs.data?.runs?.length ?? 0) +
     (proposals.data?.proposals?.length ?? 0) +
@@ -96,6 +104,10 @@ export function CommandPalette({
   }, [open, resultCount, updateOverflow]);
 
   useEffect(() => {
+    if (!open) setSearch("");
+  }, [open]);
+
+  useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key !== "k" || !(e.metaKey || e.ctrlKey)) return;
       e.preventDefault();
@@ -108,6 +120,14 @@ export function CommandPalette({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const input = searchRef.current;
+    const syncSearch = () => setSearch(input?.value ?? "");
+    input?.addEventListener("input", syncSearch);
+    return () => input?.removeEventListener("input", syncSearch);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -163,7 +183,10 @@ export function CommandPalette({
           className="outline-none focus:outline-none focus-visible:outline-none"
         >
         <Command.Input
+          ref={searchRef}
           autoFocus
+          value={search}
+          onValueChange={setSearch}
           placeholder="Type a command…"
           className="w-full border-0 border-b border-(--border) bg-transparent px-4 py-3 text-[14px] text-(--text) outline-none ring-0 placeholder:text-(--text-faint) focus:border-(--accent) focus:outline-none focus:ring-0"
         />
@@ -223,6 +246,22 @@ export function CommandPalette({
                 </Command.Item>
               ))}
           </Command.Group>
+          {typedTicket && onJumpTicket && (
+            <Command.Group heading="Tickets">
+              <Command.Item
+                value={`ticket ${typedTicket} open journey`}
+                onSelect={() => {
+                  setOpen(false);
+                  setSearch("");
+                  onJumpTicket(typedTicket);
+                }}
+                className={PALETTE_ITEM_CLASS}
+              >
+                <span>Open ticket <span className="mono">{typedTicket}</span></span>
+                <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">ticket journey</span>
+              </Command.Item>
+            </Command.Group>
+          )}
           {(proposals.data?.proposals ?? []).length > 0 && (
             <Command.Group heading="Proposals">
           {(proposals.data?.proposals ?? []).map((p) => (

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -5,8 +5,9 @@
  * `#/overview` `#/events` `#/events?type=` `#/events/:source/:eventId`
  * `#/proposals` `#/proposals/:id` `#/runs` `#/runs/:id` `#/run/:id` (the
  * full-page run view — distinct first segment so expand/back get push
- * semantics) `#/agents` `#/agents/:ref` `#/artifacts` `#/artifacts?kind=…`
- * `#/workers` `#/workers/:id` `#/graph` `#/graph/:nodeId`
+ * semantics) `#/tickets` `#/tickets/:id` (the ticket journey; an id-less
+ * route presents the ticket picker) `#/agents` `#/agents/:ref` `#/artifacts`
+ * `#/artifacts?kind=…` `#/workers` `#/workers/:id` `#/graph` `#/graph/:nodeId`
  * `#/chain/:correlationId` `#/chain/:correlationId/:nodeId` (the chain trace,
  * WM-527 — a drill-in like `#/run/:id`, not a nav item)
  *

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -7,6 +7,7 @@ export const NAV = [
   { key: "events", label: "Events", go: "e" },
   { key: "proposals", label: "Proposals", go: "p" },
   { key: "runs", label: "Runs", go: "r" },
+  { key: "tickets", label: "Tickets", go: "k" },
   { key: "projects", label: "Projects", go: "f" },
   { key: "agents", label: "Agents", go: "t" },
   { key: "artifacts", label: "Artifacts", go: "y" },

--- a/event-runtime/web/src/ticketJourney.test.ts
+++ b/event-runtime/web/src/ticketJourney.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildTicketJourney,
+  formatDuration,
+  humanizeReason,
+  ticketIdsIn,
+  type JourneyRun,
+  type TicketJourneySource,
+} from "./ticketJourney";
+
+const lifecycle = (runId: string, start: string, end: string) => [
+  {
+    seq: 1,
+    run_id: runId,
+    from_state: null,
+    to_state: "QUEUED",
+    actor: "planner",
+    reason: null,
+    attempt: null,
+    at: start,
+  },
+  {
+    seq: 2,
+    run_id: runId,
+    from_state: "QUEUED",
+    to_state: "COMPLETED",
+    actor: "worker_demo",
+    reason: "ok",
+    attempt: 1,
+    at: end,
+  },
+];
+
+function run(
+  id: string,
+  created: string,
+  finished: string,
+  cost: number | null,
+  artifact: Record<string, unknown> = {},
+): JourneyRun {
+  return {
+    run: {
+      runId: id,
+      state: "COMPLETED",
+      attempts: 1,
+      created_at: created,
+      updated_at: finished,
+      spec: { agent: "dispatch@1", adapter: "pi", model: "openai/gpt-test" },
+    },
+    lifecycle: lifecycle(id, created, finished),
+    result: { terminalState: "completed", artifact },
+    usage:
+      cost == null
+        ? { totals: { attempts: 0, totalTokens: 0, costUSD: 0 }, attempts: [] }
+        : { totals: { attempts: 1, totalTokens: 1200, costUSD: cost }, attempts: [{}] },
+  };
+}
+
+function fixture(): TicketJourneySource {
+  return {
+    ticket: {
+      id: "WM-542",
+      title: "Keep main focused",
+      state: "Done",
+      createdAt: "2026-01-01T09:00:00.000Z",
+      url: "https://linear.app/watt-mind/issue/WM-542",
+    },
+    activity: true,
+    events: [
+      {
+        source: "operator",
+        eventId: "dispatch-WM-542",
+        type: "factory.ticket.dispatched",
+        subject: "WM-542",
+        status: "planned",
+        occurredAt: "2026-01-01T09:10:00.000Z",
+        admittedAt: "2026-01-01T09:10:01.000Z",
+        proposalId: "prop_1",
+        runId: "run_1",
+        envelope: { payload: { ticket: "WM-542" } },
+      },
+    ],
+    proposals: [
+      {
+        id: "prop_1",
+        decision: "run",
+        status: "approved",
+        reason: null,
+        created_at: "2026-01-01T09:10:02.000Z",
+        decided_at: "2026-01-01T09:11:00.000Z",
+        runId: "run_1",
+        eventId: "dispatch-WM-542",
+        eventSource: "operator",
+        agent: "dispatch@1",
+        spec: null,
+      },
+    ],
+    runs: [
+      run(
+        "run_1",
+        "2026-01-01T09:11:00.000Z",
+        "2026-01-01T09:23:00.000Z",
+        0.77,
+        { outcome: "PR_OPEN", prUrl: "https://github.com/watt-mind/factory/pull/499" },
+      ),
+      run(
+        "run_2",
+        "2026-01-01T10:00:00.000Z",
+        "2026-01-01T10:07:00.000Z",
+        0.23,
+        { pr: 499, action: "merge_pr", checksGreen: true, outcome: "MERGED" },
+      ),
+    ],
+  };
+}
+
+describe("buildTicketJourney", () => {
+  test("orders milestones, groups lifecycle rows under runs, and computes header aggregates", () => {
+    const journey = buildTicketJourney(fixture());
+    expect(journey.timeline[0].label).toBe("filed");
+    expect(journey.timeline.map((item) => item.label)).toContain("dispatch requested");
+    const firstRun = journey.timeline.find((item) => item.id === "run:run_1");
+    expect(firstRun?.children?.map((item) => item.label)).toEqual(["QUEUED", "COMPLETED"]);
+    expect(firstRun?.children?.[1].durationMs).toBe(12 * 60 * 1000);
+    expect(journey.timeline.map((item) => item.label)).toContain("PR #499 opened");
+    expect(journey.timeline.map((item) => item.label)).toContain("CI checks green");
+    expect(journey.timeline.map((item) => item.label)).toContain("merged");
+    expect(journey.timeline.at(-1)?.label).toBe("Done");
+    expect(journey.totalCost).toBeCloseTo(1);
+    expect(journey.totalTokens).toBe(2400);
+    expect(journey.leadTimeMs).toBe(67 * 60 * 1000);
+    expect(journey.runCount).toBe(2);
+    expect(journey.prUrls).toEqual(["https://github.com/watt-mind/factory/pull/499"]);
+  });
+
+  test("derives PR, CI, merge, and approval-next-action milestones from an open merge plan", () => {
+    const source = fixture();
+    source.runs = [
+      {
+        ...source.runs[0],
+        run: { ...source.runs[0].run, runId: "run_merge", state: "PROPOSED", spec: { agent: "merge-apply@2", adapter: "fake" } },
+        lifecycle: [],
+        result: null,
+        usage: { totals: { attempts: 0, totalTokens: 0, costUSD: 0 }, attempts: [] },
+      },
+    ];
+    source.events[0] = {
+      ...source.events[0],
+      type: "factory.merge-apply.requested",
+      envelope: {
+        payload: {
+          github: "watt-mind/factory",
+          ticket: "WM-542",
+          plan: [{ action: "merge_pr", pr: 42, checksGreen: true, reason: "reviewed" }],
+        },
+      },
+    };
+    source.proposals[0] = { ...source.proposals[0], id: "prop_merge", status: "open", runId: "run_merge" };
+    const journey = buildTicketJourney(source);
+    expect(journey.prUrls).toEqual(["https://github.com/watt-mind/factory/pull/42"]);
+    expect(journey.timeline.map((item) => item.label)).toContain("PR #42 referenced");
+    expect(journey.timeline.map((item) => item.label)).toContain("CI checks green");
+    expect(journey.timeline.map((item) => item.label)).toContain("merge requested");
+    expect(journey.currentRun).toMatchObject({ runId: "run_merge", state: "PROPOSED" });
+    expect(journey.nextAction).toBe("Awaiting approval for prop_merge");
+  });
+
+  test("shows unknown aggregates as null and surfaces the latest noop", () => {
+    const source = fixture();
+    source.ticket.state = "Todo";
+    source.ticket.createdAt = null;
+    source.runs = [];
+    source.events[0].status = "noop";
+    source.proposals[0] = {
+      ...source.proposals[0],
+      decision: "noop",
+      status: "resolved",
+      reason: "owned_paths_overlap:WM-544:run_held",
+      runId: null,
+    };
+    const journey = buildTicketJourney(source);
+    expect(journey.totalCost).toBeNull();
+    expect(journey.leadTimeMs).toBeNull();
+    expect(journey.blockingReason).toBe("Owned paths overlap — WM-544 · run_held");
+    expect(journey.nextAction).toContain("Owned paths overlap");
+  });
+});
+
+describe("ticket journey helpers", () => {
+  test("formats durations and ticket ids without guessing from prose", () => {
+    expect(formatDuration(3_720_000)).toBe("1h 2m");
+    expect(formatDuration(null)).toBe("—");
+    expect(ticketIdsIn({ subject: "wm-542", payload: { ticket: "WM-544" } })).toEqual([
+      "WM-542",
+      "WM-544",
+    ]);
+    expect(ticketIdsIn({ note: "mentions WM-999 in prose" })).toEqual([]);
+  });
+
+  test("humanizes known and unknown reason codes", () => {
+    expect(humanizeReason("ticket_assigned")).toBe("Ticket is already assigned");
+    expect(humanizeReason("foreign_reason:WM-1")).toBe("Foreign reason — WM-1");
+  });
+});

--- a/event-runtime/web/src/ticketJourney.ts
+++ b/event-runtime/web/src/ticketJourney.ts
@@ -1,0 +1,562 @@
+export const TICKET_ID_PATTERN = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
+
+/** Decorate exact ticket string tokens produced by JSON/detail renderers. */
+export function installTicketJourneyLinks(root: HTMLElement, open: (ticket: string) => void): () => void {
+  const decorate = () => {
+    for (const span of root.querySelectorAll<HTMLSpanElement>("span")) {
+      if (span.childElementCount > 0 || span.dataset.ticketJourneyId) continue;
+      const ticket = (span.textContent ?? "").trim().replace(/^([\"'])|([\"'])$/g, "").toUpperCase();
+      if (!TICKET_ID_PATTERN.test(ticket)) continue;
+      span.dataset.ticketJourneyId = ticket;
+      span.setAttribute("role", "link");
+      span.tabIndex = 0;
+      span.setAttribute("aria-label", `Open ticket ${ticket}`);
+      span.title = `Open ticket journey for ${ticket}`;
+      span.classList.add("cursor-pointer", "hover:text-(--accent)", "hover:underline");
+    }
+  };
+  const ticketTarget = (target: EventTarget | null): { element: HTMLElement; ticket: string } | null => {
+    const element = target instanceof Element
+      ? target.closest<HTMLElement>("[data-ticket-journey-id], button")
+      : null;
+    if (!element) return null;
+    const dataTicket = element.dataset.ticketJourneyId;
+    const ticket = (dataTicket ?? element.textContent ?? "").trim().toUpperCase();
+    const exactCopyButton = element.tagName === "BUTTON" && element.title.trim().toUpperCase() === ticket;
+    return (dataTicket || exactCopyButton) && TICKET_ID_PATTERN.test(ticket) ? { element, ticket } : null;
+  };
+  const onClick = (event: MouseEvent) => {
+    const target = ticketTarget(event.target);
+    if (!target) return;
+    event.preventDefault();
+    event.stopPropagation();
+    open(target.ticket);
+  };
+  const onKey = (event: KeyboardEvent) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const element = event.target instanceof HTMLElement ? event.target : null;
+    const ticket = element?.dataset.ticketJourneyId;
+    if (!ticket) return;
+    event.preventDefault();
+    event.stopPropagation();
+    open(ticket);
+  };
+  decorate();
+  const observer = new MutationObserver(decorate);
+  observer.observe(root, { childList: true, subtree: true });
+  root.addEventListener("click", onClick, true);
+  root.addEventListener("keydown", onKey, true);
+  return () => {
+    observer.disconnect();
+    root.removeEventListener("click", onClick, true);
+    root.removeEventListener("keydown", onKey, true);
+  };
+}
+
+export interface TicketJourneySource {
+  ticket: {
+    id: string;
+    title: string | null;
+    state: string | null;
+    createdAt: string | null;
+    url: string;
+  };
+  activity: boolean;
+  events: JourneyEvent[];
+  proposals: JourneyProposal[];
+  runs: JourneyRun[];
+}
+
+export interface JourneyEvent {
+  source: string;
+  eventId: string;
+  type: string;
+  subject: string | null;
+  status: string;
+  occurredAt: string;
+  admittedAt: string;
+  proposalId: string | null;
+  runId: string | null;
+  envelope: Record<string, unknown>;
+}
+
+export interface JourneyProposal {
+  id: string;
+  decision: string;
+  status: string;
+  reason: string | null;
+  created_at: string;
+  decided_at: string | null;
+  runId: string | null;
+  eventId: string | null;
+  eventSource: string | null;
+  agent: string | null;
+  spec: Record<string, any> | null;
+}
+
+export interface JourneyLifecycle {
+  seq: number;
+  from_state: string | null;
+  to_state: string;
+  actor: string;
+  reason: string | null;
+  attempt: number | null;
+  at: string;
+}
+
+export interface JourneyRun {
+  run: {
+    runId: string;
+    state: string;
+    attempts: number;
+    created_at: string;
+    updated_at: string;
+    spec: {
+      agent: string;
+      adapter: string;
+      input?: unknown;
+      model?: string | null;
+      modelTier?: string | null;
+    };
+  };
+  lifecycle: JourneyLifecycle[];
+  result: Record<string, any> | null;
+  usage?: {
+    totals?: { attempts?: number; totalTokens?: number; costUSD?: number };
+    attempts?: unknown[];
+  };
+}
+
+export type TimelineKind = "linear" | "event" | "decision" | "run" | "pr" | "ci" | "merge";
+
+export interface TimelineItem {
+  id: string;
+  kind: TimelineKind;
+  at: string;
+  label: string;
+  detail: string | null;
+  href: string;
+  external?: boolean;
+  durationMs: number | null;
+  children?: TimelineItem[];
+}
+
+export interface TicketJourney {
+  ticket: TicketJourneySource["ticket"];
+  activity: boolean;
+  timeline: TimelineItem[];
+  totalCost: number | null;
+  totalTokens: number | null;
+  leadTimeMs: number | null;
+  runCount: number;
+  prUrls: string[];
+  currentRun: { runId: string; state: string; actor: string | null } | null;
+  blockingReason: string | null;
+  nextAction: string;
+}
+
+const KNOWN_REASONS: Record<string, string> = {
+  owned_paths_overlap: "Owned paths overlap",
+  ticket_assigned: "Ticket is already assigned",
+  ticket_dispatch_already_live: "A dispatch is already live",
+  same_ticket_worktree_held: "The ticket worktree is still held",
+  proposal_expired: "The proposal expired",
+  needs_human: "Human input is required",
+  attempts_exhausted: "Attempts are exhausted",
+};
+
+/** Human-readable planner reason while preserving identifiers in the suffix. */
+export function humanizeReason(reason: string | null | undefined): string | null {
+  if (!reason) return null;
+  const [code, ...suffix] = reason.split(":");
+  const words = KNOWN_REASONS[code] ?? code.replaceAll("_", " ").replace(/^./, (c) => c.toUpperCase());
+  return suffix.length ? `${words} — ${suffix.join(" · ")}` : words;
+}
+
+function validDate(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function timeOf(value: string | null | undefined, fallback = "1970-01-01T00:00:00.000Z"): string {
+  return validDate(value) == null ? fallback : value!;
+}
+
+function eventHref(event: Pick<JourneyEvent, "source" | "eventId">): string {
+  return `#/events/${encodeURIComponent(event.source)}/${encodeURIComponent(event.eventId)}`;
+}
+
+function runHref(runId: string): string {
+  return `#/run/${encodeURIComponent(runId)}`;
+}
+
+function walk(value: unknown, visit: (key: string, value: unknown) => void): void {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const entry of value) walk(entry, visit);
+    return;
+  }
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    visit(key, entry);
+    walk(entry, visit);
+  }
+}
+
+export function ticketIdsIn(value: unknown): string[] {
+  const ids = new Set<string>();
+  const add = (candidate: unknown) => {
+    if (typeof candidate !== "string") return;
+    const normalized = candidate.trim().toUpperCase();
+    if (TICKET_ID_PATTERN.test(normalized)) ids.add(normalized);
+  };
+  if (typeof value === "string") add(value);
+  walk(value, (key, entry) => {
+    if (/^(ticket|ticketId|issue|issueId|linearId|subject)$/i.test(key)) add(entry);
+  });
+  return [...ids];
+}
+
+function prUrlsIn(value: unknown): string[] {
+  const urls = new Set<string>();
+  const inspect = (entry: unknown) => {
+    if (typeof entry !== "string") return;
+    if (/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:$|[/?#])/.test(entry)) urls.add(entry);
+  };
+  inspect(value);
+  walk(value, (_key, entry) => inspect(entry));
+  return [...urls];
+}
+
+function prNumber(url: string): string {
+  return url.match(/\/pull\/(\d+)/)?.[1] ?? url;
+}
+
+function nestedValue(value: unknown, keyPattern: RegExp): unknown {
+  let found: unknown;
+  walk(value, (key, entry) => {
+    if (found === undefined && keyPattern.test(key)) found = entry;
+  });
+  return found;
+}
+
+function eventPr(event: JourneyEvent): { number: number; url: string } | null {
+  const number = Number(nestedValue(event.envelope, /^(pr|prNumber|pullRequestNumber)$/i));
+  if (!Number.isInteger(number) || number <= 0) return null;
+  const github = nestedValue(event.envelope, /^github$/i);
+  if (typeof github !== "string" || !/^[^/]+\/[^/]+$/.test(github)) return null;
+  return { number, url: `https://github.com/${github}/pull/${number}` };
+}
+
+function resultAt(run: JourneyRun): string {
+  return (
+    [...run.lifecycle].sort((a, b) => a.at.localeCompare(b.at)).at(-1)?.at ??
+    run.run.updated_at ??
+    run.run.created_at
+  );
+}
+
+function runDuration(run: JourneyRun): number | null {
+  const lifecycle = [...run.lifecycle].sort((a, b) => a.at.localeCompare(b.at));
+  const start = validDate(lifecycle[0]?.at ?? run.run.created_at);
+  const end = validDate(lifecycle.at(-1)?.at ?? run.run.updated_at);
+  return start != null && end != null && end >= start ? end - start : null;
+}
+
+export function formatDuration(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return `${hours}h${rest ? ` ${rest}m` : ""}`;
+}
+
+function lifecycleChildren(run: JourneyRun): TimelineItem[] {
+  return [...run.lifecycle]
+    .sort((a, b) => a.at.localeCompare(b.at) || a.seq - b.seq)
+    .map((entry, index, all) => {
+      const previous = index ? validDate(all[index - 1].at) : null;
+      const current = validDate(entry.at);
+      return {
+        id: `${run.run.runId}:lifecycle:${entry.seq}`,
+        kind: "run" as const,
+        at: entry.at,
+        label: entry.to_state,
+        detail: `${entry.actor}${entry.reason ? ` · ${entry.reason}` : ""}`,
+        href: runHref(run.run.runId),
+        durationMs: previous != null && current != null ? Math.max(0, current - previous) : null,
+      };
+    });
+}
+
+function proposalFor(event: JourneyEvent, proposals: JourneyProposal[]): JourneyProposal | undefined {
+  return proposals.find(
+    (proposal) =>
+      proposal.id === event.proposalId ||
+      (proposal.eventId === event.eventId && proposal.eventSource === event.source),
+  );
+}
+
+function mergeLabel(run: JourneyRun): string | null {
+  const artifact = run.result?.artifact ?? run.result ?? {};
+  const text = JSON.stringify(artifact);
+  const agent = run.run.spec.agent ?? "";
+  if (!/merge/i.test(agent) && !/merge|escalate/i.test(text)) return null;
+  if (/escalate/i.test(text)) return "merge-scan: ESCALATE";
+  if (/merged/i.test(text)) return "merged";
+  if (/merge/i.test(text)) return "merge-scan: MERGE";
+  return null;
+}
+
+function checkLabel(run: JourneyRun): { label: string; detail: string | null } | null {
+  const artifact = run.result?.artifact ?? {};
+  let checksGreen: boolean | null = null;
+  walk(artifact, (key, value) => {
+    if (/^(checksGreen|ciGreen)$/i.test(key) && typeof value === "boolean") checksGreen = value;
+  });
+  if (checksGreen == null) return null;
+  return {
+    label: checksGreen ? "CI checks green" : "CI checks red",
+    detail: checksGreen ? "All recorded checks passed" : "One or more recorded checks failed",
+  };
+}
+
+/** Pure chronological join used by the view and fixture tests. */
+export function buildTicketJourney(source: TicketJourneySource): TicketJourney {
+  const timeline: TimelineItem[] = [];
+  const resultPrUrls = new Set(source.runs.flatMap((run) => prUrlsIn(run.result)));
+  const prUrls = new Set(resultPrUrls);
+  const renderedPrUrls = new Set<string>();
+  const allActivityTimes = [
+    ...source.events.flatMap((event) => [event.occurredAt, event.admittedAt]),
+    ...source.proposals.flatMap((proposal) => [proposal.created_at, proposal.decided_at ?? ""]),
+    ...source.runs.flatMap((run) => [run.run.created_at, run.run.updated_at]),
+  ].filter((value) => validDate(value) != null);
+  const earliest = [...allActivityTimes].sort()[0] ?? null;
+
+  if (source.ticket.createdAt) {
+    timeline.push({
+      id: `${source.ticket.id}:filed`,
+      kind: "linear",
+      at: source.ticket.createdAt,
+      label: "filed",
+      detail: source.ticket.title,
+      href: source.ticket.url,
+      external: true,
+      durationMs: null,
+    });
+  }
+
+  for (const event of source.events) {
+    const proposal = proposalFor(event, source.proposals);
+    const decision = proposal?.decision ?? (event.status === "planned" ? "planned" : event.status);
+    const reason = humanizeReason(proposal?.reason);
+    const dispatch = /dispatch/i.test(event.type);
+    const agentReady = /agent[-_. ]?ready/i.test(event.type) || /agent[-_. ]?ready/i.test(JSON.stringify(event.envelope));
+    const at = timeOf(event.occurredAt, event.admittedAt);
+    timeline.push({
+      id: `event:${event.source}:${event.eventId}`,
+      kind: proposal ? "decision" : "event",
+      at,
+      label: agentReady ? "agent-ready" : dispatch ? "dispatch requested" : event.type,
+      detail: proposal ? `${decision}${reason ? ` · ${reason}` : ""}` : event.status,
+      href: eventHref(event),
+      durationMs: null,
+    });
+
+    const eventPrRef = eventPr(event);
+    if (eventPrRef) {
+      const knownUrl = [...resultPrUrls].find((url) => prNumber(url) === String(eventPrRef.number));
+      const url = knownUrl ?? eventPrRef.url;
+      prUrls.add(url);
+      if (!knownUrl && !renderedPrUrls.has(url)) {
+        renderedPrUrls.add(url);
+        timeline.push({
+          id: `pr:${url}`,
+          kind: "pr",
+          at,
+          label: `PR #${eventPrRef.number} referenced`,
+          detail: null,
+          href: url,
+          external: true,
+          durationMs: null,
+        });
+      }
+    }
+    const checksGreen = nestedValue(event.envelope, /^(checksGreen|ciGreen)$/i);
+    if (typeof checksGreen === "boolean") {
+      timeline.push({
+        id: `ci:event:${event.source}:${event.eventId}`,
+        kind: "ci",
+        at,
+        label: checksGreen ? "CI checks green" : "CI checks red",
+        detail: "Recorded by the merge plan",
+        href: eventHref(event),
+        durationMs: null,
+      });
+    }
+    const action = nestedValue(event.envelope, /^action$/i);
+    if (/merge/i.test(event.type) || (typeof action === "string" && /merge/i.test(action))) {
+      timeline.push({
+        id: `merge:event:${event.source}:${event.eventId}`,
+        kind: "merge",
+        at,
+        label: action === "merge_pr" ? "merge requested" : "merge decision",
+        detail: (nestedValue(event.envelope, /^reason$/i) as string | undefined) ?? null,
+        href: eventHref(event),
+        durationMs: null,
+      });
+    }
+  }
+
+  let totalCost = 0;
+  let totalTokens = 0;
+  let usageKnown = false;
+  const activeStates = new Set(["QUEUED", "LEASED", "RUNNING", "VERIFYING"]);
+  let currentRun: TicketJourney["currentRun"] = null;
+
+  for (const run of source.runs) {
+    const totals = run.usage?.totals;
+    const attempts = totals?.attempts ?? run.usage?.attempts?.length ?? 0;
+    if (attempts > 0 || (totals?.costUSD ?? 0) > 0 || (totals?.totalTokens ?? 0) > 0) {
+      usageKnown = true;
+      totalCost += Number(totals?.costUSD ?? 0);
+      totalTokens += Number(totals?.totalTokens ?? 0);
+    }
+    const duration = runDuration(run);
+    const model = run.run.spec.model ?? run.run.spec.modelTier ?? null;
+    const detail = [
+      run.run.spec.agent,
+      run.run.spec.adapter,
+      model,
+      formatDuration(duration),
+      attempts > 0 ? `$${Number(totals?.costUSD ?? 0).toFixed(2)}` : "—",
+    ].filter(Boolean).join(" · ");
+    timeline.push({
+      id: `run:${run.run.runId}`,
+      kind: "run",
+      at: timeOf(run.run.created_at),
+      label: `${run.run.runId} · ${run.run.state}`,
+      detail,
+      href: runHref(run.run.runId),
+      durationMs: null,
+      children: lifecycleChildren(run),
+    });
+
+    for (const url of prUrlsIn(run.result)) {
+      prUrls.add(url);
+      if (renderedPrUrls.has(url)) continue;
+      renderedPrUrls.add(url);
+      timeline.push({
+        id: `pr:${url}`,
+        kind: "pr",
+        at: resultAt(run),
+        label: `PR #${prNumber(url)} opened`,
+        detail: null,
+        href: url,
+        external: true,
+        durationMs: null,
+      });
+    }
+    const ci = checkLabel(run);
+    if (ci) {
+      timeline.push({
+        id: `ci:${run.run.runId}`,
+        kind: "ci",
+        at: resultAt(run),
+        label: ci.label,
+        detail: ci.detail,
+        href: runHref(run.run.runId),
+        durationMs: null,
+      });
+    }
+    const merge = mergeLabel(run);
+    if (merge) {
+      timeline.push({
+        id: `merge:${run.run.runId}`,
+        kind: "merge",
+        at: resultAt(run),
+        label: merge,
+        detail: run.result?.reasonCode ?? null,
+        href: runHref(run.run.runId),
+        durationMs: null,
+      });
+    }
+    if (activeStates.has(run.run.state)) {
+      const last = [...run.lifecycle].sort((a, b) => a.at.localeCompare(b.at)).at(-1);
+      currentRun = { runId: run.run.runId, state: run.run.state, actor: last?.actor ?? null };
+    }
+  }
+
+  if (/^done$/i.test(source.ticket.state ?? "")) {
+    const at = timeline.map((item) => item.at).filter((value) => validDate(value) != null).sort().at(-1) ?? earliest;
+    if (at) {
+      timeline.push({
+        id: `${source.ticket.id}:done`,
+        kind: "linear",
+        at,
+        label: "Done",
+        detail: null,
+        href: source.ticket.url,
+        external: true,
+        durationMs: null,
+      });
+    }
+  }
+
+  timeline.sort((a, b) => {
+    const diff = (validDate(a.at) ?? 0) - (validDate(b.at) ?? 0);
+    return diff || a.id.localeCompare(b.id);
+  });
+  for (let index = 0; index < timeline.length; index += 1) {
+    const previous = index ? validDate(timeline[index - 1].at) : null;
+    const current = validDate(timeline[index].at);
+    timeline[index].durationMs = previous != null && current != null ? Math.max(0, current - previous) : null;
+  }
+
+  const first = validDate(source.ticket.createdAt ?? timeline[0]?.at);
+  const last = validDate(timeline.at(-1)?.at);
+  const leadTimeMs = first != null && last != null && last > first ? last - first : null;
+  const latestNoop = [...source.proposals]
+    .filter((proposal) => proposal.decision === "noop")
+    .sort((a, b) => a.created_at.localeCompare(b.created_at))
+    .at(-1);
+  const blockingReason = humanizeReason(latestNoop?.reason);
+  const awaitingApproval = [...source.proposals]
+    .filter((proposal) => proposal.status === "open" && proposal.decision === "run")
+    .sort((a, b) => a.created_at.localeCompare(b.created_at))
+    .at(-1);
+  if (!currentRun && awaitingApproval?.runId) {
+    currentRun = { runId: awaitingApproval.runId, state: "PROPOSED", actor: null };
+  }
+  const nextAction = currentRun && currentRun.state !== "PROPOSED"
+    ? `${currentRun.runId} is ${currentRun.state.toLowerCase()}${currentRun.actor ? ` on ${currentRun.actor}` : ""}`
+    : awaitingApproval
+      ? `Awaiting approval for ${awaitingApproval.id}`
+      : blockingReason
+        ? `Waiting: ${blockingReason}`
+        : /^done$/i.test(source.ticket.state ?? "")
+          ? "No further action"
+          : prUrls.size
+            ? "Waiting for review or merge"
+            : source.activity
+              ? "Waiting for the next dispatch decision"
+              : `No runtime activity for ${source.ticket.id}`;
+
+  return {
+    ticket: source.ticket,
+    activity: source.activity,
+    timeline,
+    totalCost: usageKnown ? totalCost : null,
+    totalTokens: usageKnown ? totalTokens : null,
+    leadTimeMs,
+    runCount: source.runs.length,
+    prUrls: [...prUrls],
+    currentRun,
+    blockingReason,
+    nextAction,
+  };
+}

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -1,0 +1,104 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor, within } from "@testing-library/react";
+import { Ticket } from "./Ticket";
+import type { JourneyRun, TicketJourneySource } from "../ticketJourney";
+
+const realFetch = globalThis.fetch;
+
+function run(id: string, at: string, artifact: Record<string, unknown> = {}): JourneyRun {
+  return {
+    run: {
+      runId: id,
+      state: "COMPLETED",
+      attempts: 1,
+      created_at: at,
+      updated_at: new Date(Date.parse(at) + 60_000).toISOString(),
+      spec: { agent: id === "run_merge" ? "merge-apply@1" : "dispatch@1", adapter: "pi" },
+    },
+    lifecycle: [
+      { seq: 1, from_state: null, to_state: "QUEUED", actor: "planner", reason: null, attempt: null, at },
+      { seq: 2, from_state: "QUEUED", to_state: "COMPLETED", actor: "worker_demo", reason: "ok", attempt: 1, at: new Date(Date.parse(at) + 60_000).toISOString() },
+    ],
+    result: { terminalState: "completed", artifact },
+    usage: { totals: { attempts: 1, totalTokens: 100, costUSD: 0.5 }, attempts: [{}] },
+  };
+}
+
+function source(): TicketJourneySource {
+  return {
+    ticket: { id: "WM-542", title: "Ticket journey fixture", state: "In Review", createdAt: "2026-01-01T09:00:00.000Z", url: "https://linear.app/watt-mind/issue/WM-542" },
+    activity: true,
+    events: [{
+      source: "operator", eventId: "dispatch-542", type: "factory.ticket.dispatched", subject: "WM-542", status: "planned",
+      occurredAt: "2026-01-01T09:01:00.000Z", admittedAt: "2026-01-01T09:01:01.000Z", proposalId: "prop_1", runId: "run_dispatch",
+      envelope: { payload: { ticket: "WM-542" } },
+    }],
+    proposals: [{ id: "prop_1", decision: "run", status: "approved", reason: null, created_at: "2026-01-01T09:01:02.000Z", decided_at: null, runId: "run_dispatch", eventId: "dispatch-542", eventSource: "operator", agent: "dispatch@1", spec: null }],
+    runs: [
+      run("run_dispatch", "2026-01-01T09:02:00.000Z", { outcome: "PR_OPEN", prUrl: "https://github.com/watt-mind/factory/pull/499" }),
+      run("run_merge", "2026-01-01T10:00:00.000Z", { pr: 499, checksGreen: true, outcome: "MERGED" }),
+    ],
+  };
+}
+
+function renderTicket(data: TicketJourneySource) {
+  globalThis.fetch = (async () => new Response(JSON.stringify(data), { status: 200 })) as unknown as typeof fetch;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
+  return render(<QueryClientProvider client={queryClient}><Ticket ticketId="WM-542" onNavigate={() => {}} /></QueryClientProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+describe("Ticket journey view", () => {
+  test("renders a two-run journey, PR, aggregates, timeline sources, and current-state block", async () => {
+    const view = renderTicket(source());
+    await view.findByRole("heading", { name: "WM-542" });
+    expect(view.getAllByText("Ticket journey fixture").length).toBeGreaterThan(0);
+    expect(view.getByText("$1.00")).toBeTruthy();
+    expect(view.getByText("2", { selector: "div" })).toBeTruthy();
+    expect(view.getByText("PR #499 opened")).toBeTruthy();
+    expect(view.getByText("CI checks green")).toBeTruthy();
+    expect(view.getByText("merged")).toBeTruthy();
+    expect(view.getByRole("link", { name: "run_dispatch · COMPLETED" }).getAttribute("href")).toBe("#/run/run_dispatch");
+    const timeline = view.getByRole("region", { name: /timeline/i });
+    expect(within(timeline).getAllByText("QUEUED").length).toBeGreaterThan(0);
+    expect(view.getByRole("heading", { name: "Where it is now" })).toBeTruthy();
+  });
+
+  test("renders a noop-only ticket with an actionable blocking reason and unknown aggregates", async () => {
+    const data = source();
+    data.runs = [];
+    data.ticket.state = "Todo";
+    data.ticket.createdAt = null;
+    data.events[0].status = "noop";
+    data.proposals[0] = { ...data.proposals[0], decision: "noop", reason: "owned_paths_overlap:WM-544", runId: null };
+    const view = renderTicket(data);
+    await view.findByRole("heading", { name: "WM-542" });
+    expect(view.getAllByText("—").length).toBeGreaterThan(0);
+    expect(view.getByText("Owned paths overlap — WM-544")).toBeTruthy();
+    expect(view.getByText(/Waiting: Owned paths overlap/)).toBeTruthy();
+    expect(view.container.textContent).not.toContain("$0.00");
+  });
+
+  test("unknown ids render an inline no-activity notice instead of a blank page", async () => {
+    const data = source();
+    data.ticket.id = "WM-999";
+    data.ticket.title = null;
+    data.ticket.state = null;
+    data.ticket.createdAt = null;
+    data.ticket.url = "https://linear.app/watt-mind/issue/WM-999";
+    data.activity = false;
+    data.events = [];
+    data.proposals = [];
+    data.runs = [];
+    globalThis.fetch = (async () => new Response(JSON.stringify(data), { status: 200 })) as unknown as typeof fetch;
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, refetchInterval: false } } });
+    const view = render(<QueryClientProvider client={client}><Ticket ticketId="WM-999" onNavigate={() => {}} /></QueryClientProvider>);
+    await waitFor(() => expect(view.getByRole("status").textContent).toContain("no runtime activity for WM-999"));
+  });
+});

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1,0 +1,248 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import {
+  buildTicketJourney,
+  formatDuration,
+  TICKET_ID_PATTERN,
+  type TicketJourneySource,
+  type TimelineItem,
+} from "../ticketJourney";
+import { StateBadge, STATE_HUES } from "../components/ui";
+
+async function fetchTicketJourney(ticketId: string): Promise<TicketJourneySource> {
+  const response = await fetch(`/api/runs?ticket=${encodeURIComponent(ticketId)}`);
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      message = (await response.json()).error ?? message;
+    } catch {
+      // Keep the HTTP status when the control API did not return JSON.
+    }
+    throw new Error(message);
+  }
+  return response.json();
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-24 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2">
+      <div className="text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">{label}</div>
+      <div className="mt-0.5 tabular-nums text-[13px] font-medium text-(--text)">{value}</div>
+    </div>
+  );
+}
+
+function SourceLink({ item, children }: { item: TimelineItem; children: ReactNode }) {
+  return (
+    <a
+      href={item.href}
+      target={item.external ? "_blank" : undefined}
+      rel={item.external ? "noreferrer" : undefined}
+      className="min-w-0 hover:text-(--accent) hover:underline"
+      title={`Open source: ${item.href}`}
+    >
+      {children}
+    </a>
+  );
+}
+
+function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
+  const hue =
+    item.kind === "ci"
+      ? item.label.includes("green")
+        ? "var(--hue-ok)"
+        : "var(--hue-err)"
+      : item.kind === "merge" || item.kind === "pr"
+        ? "var(--hue-ok)"
+        : item.kind === "decision"
+          ? "var(--hue-info)"
+          : "var(--accent)";
+  const body = (
+    <div className="flex min-w-0 flex-1 items-start gap-3 pb-5">
+      <span className="relative flex w-3 shrink-0 justify-center" aria-hidden="true">
+        {!last && <span className="absolute top-2 bottom-[-22px] w-px bg-(--border)" />}
+        <span
+          className="relative mt-1.5 size-2 rounded-full ring-4 ring-(--surface-1)"
+          style={{ background: hue }}
+        />
+      </span>
+      <div className="min-w-0 flex-1">
+        <SourceLink item={item}>
+          <div className="mono break-words text-[12px] font-medium text-(--text)">{item.label}</div>
+        </SourceLink>
+        {item.detail && <div className="mt-0.5 break-words text-[11.5px] text-(--text-faint)">{item.detail}</div>}
+      </div>
+      <time className="mono shrink-0 text-[10px] text-(--text-faint)" dateTime={item.at} title={item.at}>
+        {new Date(item.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })}
+      </time>
+    </div>
+  );
+
+  return (
+    <li className="flex items-start gap-3">
+      <div className="mono w-16 shrink-0 pt-0.5 text-right text-[10px] tabular-nums text-(--text-faint)">
+        {item.durationMs == null ? "" : `+${formatDuration(item.durationMs)}`}
+      </div>
+      {item.children?.length ? (
+        <details className="min-w-0 flex-1" open>
+          <summary className="list-none cursor-pointer [&::-webkit-details-marker]:hidden">{body}</summary>
+          <ol className="mb-4 ml-[5.25rem] border-l border-(--border) pl-4">
+            {item.children.map((child) => (
+              <li key={child.id} className="grid grid-cols-[4rem_minmax(0,1fr)] gap-3 py-1 text-[11px]">
+                <span className="mono text-right tabular-nums text-(--text-faint)">
+                  {child.durationMs == null ? "" : `+${formatDuration(child.durationMs)}`}
+                </span>
+                <SourceLink item={child}>
+                  <span className="inline-flex flex-wrap items-baseline gap-x-2">
+                    <StateBadge state={child.label} hues={STATE_HUES} />
+                    {child.detail && <span className="text-(--text-faint)">{child.detail}</span>}
+                  </span>
+                </SourceLink>
+              </li>
+            ))}
+          </ol>
+        </details>
+      ) : (
+        body
+      )}
+    </li>
+  );
+}
+
+function TicketPicker({ onNavigate }: { onNavigate: (ticketId: string) => void }) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, []);
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const ticket = value.trim().toUpperCase();
+    if (!TICKET_ID_PATTERN.test(ticket)) {
+      setError(true);
+      return;
+    }
+    setError(false);
+    onNavigate(ticket);
+  };
+  return (
+    <div className="mx-auto max-w-lg p-8">
+      <h1 className="display text-xl font-semibold">Ticket journey</h1>
+      <p className="mt-2 text-[13px] text-(--text-dim)">
+        Enter a Linear ticket id to see its decisions, attempts, PR, CI, and merge history on one timeline.
+      </p>
+      <form onSubmit={submit} className="mt-5 flex gap-2">
+        <input
+          ref={inputRef}
+          autoFocus
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="WM-542"
+          aria-label="Ticket id"
+          aria-invalid={error}
+          className="mono min-w-0 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-2 text-[13px] outline-none focus:border-(--accent)"
+        />
+        <button type="submit" className="rounded-md bg-(--accent) px-4 py-2 text-[12px] font-medium text-(--on-accent)">
+          Open
+        </button>
+      </form>
+      {error && <div role="alert" className="mt-2 text-[11px] text-(--hue-err)">Use an id like WM-542.</div>}
+      <div className="mt-3 text-[11px] text-(--text-faint)">Shortcut: <span className="mono">g k</span></div>
+    </div>
+  );
+}
+
+export function Ticket({ ticketId, onNavigate }: { ticketId: string | null; onNavigate: (ticketId: string) => void }) {
+  const normalized = ticketId?.trim().toUpperCase() ?? null;
+  const valid = normalized != null && TICKET_ID_PATTERN.test(normalized);
+  const query = useQuery({
+    queryKey: ["ticket-journey", normalized],
+    queryFn: () => fetchTicketJourney(normalized!),
+    enabled: valid,
+    refetchInterval: 5000,
+  });
+
+  if (!ticketId) return <TicketPicker onNavigate={onNavigate} />;
+  if (!valid) {
+    return (
+      <div className="p-8">
+        <div role="alert" className="rounded-md border border-(--hue-warn) bg-(--surface-1) p-4 text-(--hue-warn)">
+          Invalid ticket id <span className="mono">{ticketId}</span>. Use an id like WM-542.
+        </div>
+        <button type="button" onClick={() => onNavigate("")} className="mt-3 text-[12px] text-(--accent) hover:underline">Choose another ticket</button>
+      </div>
+    );
+  }
+  if (query.isPending) return <div className="p-8 text-[13px] text-(--text-faint)">Loading {normalized} journey…</div>;
+  if (query.isError || !query.data) {
+    return (
+      <div className="p-8">
+        <div role="alert" className="rounded-md border border-(--hue-err) bg-(--surface-1) p-4 text-(--hue-err)">
+          Cannot load {normalized}: {(query.error as Error)?.message ?? "control API unavailable"}
+        </div>
+      </div>
+    );
+  }
+
+  const journey = buildTicketJourney(query.data);
+  const cost = journey.totalCost == null ? "—" : `$${journey.totalCost.toFixed(2)}`;
+  const tokens = journey.totalTokens == null ? "—" : journey.totalTokens.toLocaleString();
+  const title = journey.ticket.title ?? "title not recorded";
+  const state = journey.ticket.state ?? "unknown";
+
+  return (
+    <div className="h-full overflow-auto bg-(--surface-0) p-5 lg:p-7">
+      <div className="mx-auto max-w-6xl">
+        <header className="rounded-lg border border-(--border) bg-(--surface-1) p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="display mono text-lg font-semibold text-(--text)">{journey.ticket.id}</h1>
+                <StateBadge state={state} />
+              </div>
+              <div className="mt-1 break-words text-[14px] text-(--text-dim)">{title}</div>
+            </div>
+            <div className="flex flex-wrap gap-3 text-[12px]">
+              <a href={journey.ticket.url} target="_blank" rel="noreferrer" className="text-(--accent) hover:underline">Open in Linear ↗</a>
+              {journey.prUrls[0] && <a href={journey.prUrls[0]} target="_blank" rel="noreferrer" className="text-(--accent) hover:underline">Open PR ↗</a>}
+            </div>
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Metric label="total cost" value={cost} />
+            <Metric label="lead time" value={formatDuration(journey.leadTimeMs)} />
+            <Metric label="runs" value={String(journey.runCount)} />
+            <Metric label="PRs" value={String(journey.prUrls.length)} />
+            <Metric label="tokens" value={tokens} />
+          </div>
+        </header>
+
+        {!journey.activity ? (
+          <div role="status" className="mt-5 rounded-lg border border-dashed border-(--border-strong) bg-(--surface-1) p-8 text-center">
+            <div className="mono text-[13px] text-(--text-dim)">no runtime activity for {journey.ticket.id}</div>
+            <a href={journey.ticket.url} target="_blank" rel="noreferrer" className="mt-2 inline-block text-[12px] text-(--accent) hover:underline">Open in Linear ↗</a>
+          </div>
+        ) : (
+          <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
+            <section aria-labelledby="ticket-timeline" className="rounded-lg border border-(--border) bg-(--surface-1) p-5">
+              <h2 id="ticket-timeline" className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Timeline · oldest to newest</h2>
+              <ol className="mt-5">
+                {journey.timeline.map((item, index) => <TimelineRow key={item.id} item={item} last={index === journey.timeline.length - 1} />)}
+              </ol>
+            </section>
+            <aside className="self-start rounded-lg border border-(--border) bg-(--surface-1) p-4 lg:sticky lg:top-5">
+              <h2 className="text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">Where it is now</h2>
+              <dl className="mt-3 space-y-3 text-[12px]">
+                <div><dt className="text-(--text-faint)">Linear state</dt><dd className="mt-1"><StateBadge state={state} /></dd></div>
+                <div><dt className="text-(--text-faint)">Current run / worker</dt><dd className="mono mt-1 break-words text-(--text-dim)">{journey.currentRun ? `${journey.currentRun.runId}${journey.currentRun.actor ? ` · ${journey.currentRun.actor}` : ""}` : "—"}</dd></div>
+                <div><dt className="text-(--text-faint)">Blocking reason</dt><dd className="mt-1 break-words text-(--text-dim)">{journey.blockingReason ?? "—"}</dd></div>
+                <div className="border-t border-(--border) pt-3"><dt className="text-(--text-faint)">Next action</dt><dd className="mt-1 break-words font-medium text-(--text)">{journey.nextAction}</dd></div>
+              </dl>
+            </aside>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `#/tickets/:id` with a client-side ticket timeline builder, aggregates, lifecycle groups, and current-state guidance
- join ticket events, proposals, runs, usage, dispatch results, and PR-linked merge activity through the control API
- wire Tickets navigation, `g k`, command-palette ticket lookup, and ticket-value links from detail panes

## Verification
- `bun test event-runtime/lib && cd event-runtime/web && bun run build && bun test`
- pass: 864 lib tests, TypeScript/Vite production build, 704 web tests

UX critique: required — SHIP (round 2 after resolving round-1 findings)
Evidence: http://127.0.0.1:7501/#/tickets/WM-100 and /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-3f33221b-9680-4318-9c3f-7aa66d5271c1.png

Fixes WM-595
