### PR TITLE
fix(worker): resume own claim after lease loss (WM-621)

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -149,6 +149,18 @@ function fetchTicketDefault(ticketId) {
   }
 }
 
+function fetchViewerDefault() {
+  try {
+    const out = execFileSync("bun", [linearCli(), "raw", "query{ viewer{ id name } }"], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    });
+    return JSON.parse(out)?.viewer ?? null;
+  } catch (err) {
+    const stderr = String(err?.stderr ?? "");
+    throw new Error(`linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`);
+  }
+}
+
 const IN_FLIGHT_QUERY =
   `query($t:String!,$p:String!){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, state:{name:{eq:"In Progress"}} }){ nodes{ identifier description } } }`;
 
@@ -323,10 +335,12 @@ function refusal(reason, evidence, decision = "noop", detail = null) {
  */
 export function worktreeDispatchAutoEligibility(payload, {
   fetchTicket = fetchTicketDefault,
+  fetchViewer = fetchViewerDefault,
   fetchInFlight = fetchInFlightDefault,
   countLeases = (repoName) => liveWorkerLeases(repoName).length,
   maxInFlightFallback,
   budgetRefusal = defaultBudgetRefusal,
+  claimedRetry = null,
   now = Date.now(),
 } = {}) {
   const evidence = {
@@ -376,12 +390,53 @@ export function worktreeDispatchAutoEligibility(payload, {
   evidence.ticket = evidenceTicket(ticket, payload?.ticket);
   if (!ticket) return refusal("ticket_not_found", evidence, "human_needed");
   evidence.checks.ticket_found = true;
-  if (ticket.assignee) return refusal("ticket_assigned", evidence);
-  evidence.checks.ticket_unassigned = true;
-  if (ticket.state?.name !== "Todo") return refusal("ticket_not_todo", evidence);
-  evidence.checks.ticket_todo = true;
-  if (!evidence.ticket.labels.includes("ai:agent-ready")) return refusal("ticket_not_agent_ready", evidence);
-  evidence.checks.ticket_agent_ready = true;
+
+  // A lease-loss retry is the one exception to the ordinary Todo/unassigned
+  // admission rule. The prior attempt already performed the Linear claim, so
+  // its durable state is expected to be In Progress and assigned. Accept that
+  // state only when the worker proves this is the same run's lease-expired
+  // attempt and Linear still names the factory's own viewer identity.
+  const canResumeClaim = Boolean(
+    claimedRetry?.runId &&
+    Number.isInteger(claimedRetry?.priorAttempt) &&
+    claimedRetry.priorAttempt > 0 &&
+    claimedRetry?.reasonCode === "lease_expired"
+  );
+  let retryClaimedByFactory = false;
+  let resumingOwnClaim = false;
+  if (ticket.assignee) {
+    if (!canResumeClaim) return refusal("ticket_assigned", evidence);
+    const viewer = fetchViewer();
+    if (!viewer?.id || ticket.assignee.id !== viewer.id) return refusal("ticket_assigned", evidence);
+    retryClaimedByFactory = true;
+  } else {
+    evidence.checks.ticket_unassigned = true;
+  }
+
+  if (ticket.state?.name !== "Todo") {
+    if (!(retryClaimedByFactory && ticket.state?.name === "In Progress")) {
+      return refusal("ticket_not_todo", evidence);
+    }
+    resumingOwnClaim = true;
+    evidence.checks.ticket_claim_retry = true;
+    evidence.checks.ticket_in_progress_retry = true;
+    evidence.ticket.claimedRetryRunId = claimedRetry.runId;
+  } else {
+    // Assignment alone is not a surviving factory claim. Requiring the state
+    // transition as well prevents an own-assigned Todo ticket from bypassing
+    // the normal claim mutation and its read-back concurrency control.
+    if (retryClaimedByFactory) return refusal("ticket_assigned", evidence);
+    evidence.checks.ticket_todo = true;
+  }
+
+  if (!evidence.ticket.labels.includes("ai:agent-ready")) {
+    if (!(resumingOwnClaim && evidence.ticket.labels.includes("ai:in-progress"))) {
+      return refusal("ticket_not_agent_ready", evidence);
+    }
+    evidence.checks.ticket_in_progress_label_retry = true;
+  } else {
+    evidence.checks.ticket_agent_ready = true;
+  }
   if (evidence.ticket.labels.includes("ai:escalated")) {
     return refusal("ticket_escalated", evidence);
   }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -607,6 +607,60 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
+  test("lease-loss retry accepts only the factory viewer's surviving In Progress claim (WM-621)", () => {
+    withReposRoot(
+      `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
+      () => {
+        const claimedTicket = (assignee) => ({
+          identifier: "WM-621",
+          state: { name: "In Progress" },
+          assignee,
+          labels: { nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }] },
+          description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
+        });
+        const baseDispatch = {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchViewer: () => ({ id: "factory-user", name: "Factory" }),
+          fetchInFlight: () => [],
+          claimedRetry: { runId: "run_same", priorAttempt: 1, reasonCode: "lease_expired" },
+        };
+
+        const resumed = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-621" },
+          { ...baseDispatch, fetchTicket: () => claimedTicket({ id: "factory-user" }) },
+        );
+        expect(resumed.ok).toBe(true);
+        expect(resumed.evidence.checks).toMatchObject({
+          ticket_claim_retry: true,
+          ticket_in_progress_retry: true,
+          ticket_in_progress_label_retry: true,
+        });
+
+        const foreign = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-621" },
+          { ...baseDispatch, fetchTicket: () => claimedTicket({ id: "someone-else" }) },
+        );
+        expect(foreign.refusal).toMatchObject({ decision: "noop", reason: "ticket_assigned" });
+
+        const ownAssignedTodo = worktreeDispatchAutoEligibility(
+          { repo: "gated", ticket: "WM-621" },
+          {
+            ...baseDispatch,
+            fetchTicket: () => ({
+              ...claimedTicket({ id: "factory-user" }),
+              state: { name: "Todo" },
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+            }),
+          },
+        );
+        expect(ownAssignedTodo.refusal).toMatchObject({ decision: "noop", reason: "ticket_assigned" });
+      },
+    );
+  });
+
   test("a genuine sensitive-path refusal names the intersecting configured globs", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -375,6 +375,27 @@ function hasPlanTimeDispatchEvidence(spec) {
   return Boolean(spec?.approvalPolicy?.dispatchEvidence?.ticket?.descriptionHash);
 }
 
+/**
+ * A reaped lease leaves the Linear claim in place. Prove from the attempt
+ * ledger that this new attempt belongs to the same run and immediately follows
+ * a lease-expired claim before relaxing the Todo/unassigned dispatch gate.
+ */
+function claimedRetryFor(db, runId, attempt) {
+  if (!Number.isInteger(attempt) || attempt <= 1) return null;
+  const priorAttempt = attempt - 1;
+  const prior = db.query(
+    `SELECT terminal_state, reason_code FROM attempts WHERE run_id = ? AND attempt = ?`,
+  ).get(runId, priorAttempt);
+  if (prior?.terminal_state !== "FAILED" || prior?.reason_code !== "lease_expired") return null;
+  const requeue = db.query(
+    `SELECT reason FROM lifecycle_events
+     WHERE run_id = ? AND to_state = 'QUEUED' AND attempt = ?
+     ORDER BY seq DESC LIMIT 1`,
+  ).get(runId, priorAttempt);
+  if (requeue?.reason !== "retry:environment") return null;
+  return { runId, priorAttempt, reasonCode: "lease_expired" };
+}
+
 function contradictsPlanTimeOwnedPaths(spec, gateResult) {
   const planned = spec?.approvalPolicy?.dispatchEvidence?.ticket;
   const current = gateResult?.evidence?.ticket;
@@ -659,12 +680,29 @@ export async function executeClaimed(db, registry, adapters, claim, {
   let checkoutPath = null;
   let checkoutBaseline = null;
   let worktreeRecord = null;
+  const cleanupWorkspace = ({ retainWorkspace = false } = {}) => {
+    if (!workspaceDir) return;
+    const fenced = !assertCurrentToken(db, runId, fencingToken);
+    if (fenced && spec.workspace?.type === "worktree") {
+      // A newer attempt for this run uses the same delegated worktree. Remove
+      // only the stale attempt's teardown marker so destroyWorkspace cleans its
+      // wrapper directory without invoking worktree_down under the live retry.
+      try { unlinkSync(path.join(workspaceDir, ".worktree.json")); } catch {}
+    }
+    destroyWorkspace(workspaceDir, {
+      retain: retainWorkspace,
+      checkout: fenced ? null : checkoutPath,
+      repoName,
+    });
+  };
   const repoName = spec.input?.repoPin?.repo ?? spec.input?.repo ?? null;
   const ticketId = spec.input?.ticket ?? null;
   const isWorktree = spec.workspace?.type === "worktree";
 
   let leaseHeartbeat = null;
   let ticketClaimed = false;
+  const ticketLeaseOwner = `${owner}:${runId}:${fencingToken}`;
+  const mayMutateClaimedTicket = () => ticketClaimed && assertCurrentToken(db, runId, fencingToken);
   let attemptUsage = { adapter: adapterOverride ?? spec.adapter };
 
   let dispatchOpts = dispatch;
@@ -886,7 +924,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
       let gateResult;
       try {
-        gateResult = worktreeDispatchAutoEligibility(spec.input, dispatchOpts);
+        gateResult = worktreeDispatchAutoEligibility(spec.input, {
+          ...(dispatchOpts ?? {}),
+          claimedRetry: claimedRetryFor(db, runId, attempt),
+        });
       } catch (err) {
         if (hasPlanTimeDispatchEvidence(spec) && String(err?.message ?? err).startsWith("linear_read_failed:")) {
           return deferTransientGate("linear_read_failed");
@@ -909,25 +950,34 @@ export async function executeClaimed(db, registry, adapters, claim, {
         return { runId, attempt, terminalState: "REFUSED", reasonCode: gateRefusal.reason, receipt: res?.receipt };
       }
 
-      let claimRes;
-      try {
-        claimRes = await claimTicketFn({ repo: repoName, ticket: ticketId, harness: spec.adapter ?? "claude" });
-      } finally {
+      // The retry gate has already re-read and authenticated the surviving
+      // claim. Do not run the mutating claim command again: besides being
+      // redundant, that could steal the ticket if ownership changed in the
+      // narrow interval after the gate read.
+      const resumedClaim = gateResult.evidence?.checks?.ticket_claim_retry === true;
+      if (!resumedClaim) {
+        let claimRes;
+        try {
+          claimRes = await claimTicketFn({ repo: repoName, ticket: ticketId, harness: spec.adapter ?? "claude" });
+        } finally {
+          releaseClaimLock(lockFile);
+        }
+
+        if (!claimRes?.ok) {
+          const reasonCode = claimRes?.reasonCode || "ticket_claim_lost";
+          const res = refuseTerminal(reasonCode, ["dispatch_claim"]);
+          if (res?.fenced) return { fenced: true };
+          return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
+        }
+      } else {
         releaseClaimLock(lockFile);
       }
 
-      if (!claimRes?.ok) {
-        const reasonCode = claimRes?.reasonCode || "ticket_claim_lost";
-        const res = refuseTerminal(reasonCode, ["dispatch_claim"]);
-        if (res?.fenced) return { fenced: true };
-        return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
-      }
-
       ticketClaimed = true;
-      writeWorkerLease({ repo: repoName, ticket: ticketId, owner, pid: process.pid, dir: leasesDir, now: nowFn() });
+      writeWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, pid: process.pid, dir: leasesDir, now: nowFn() });
       leaseHeartbeat = setInterval(() => {
         try {
-          renewWorkerLease({ repo: repoName, ticket: ticketId, owner, dir: leasesDir, now: Date.now() });
+          renewWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, dir: leasesDir, now: Date.now() });
         } catch {}
       }, LEASE_HEARTBEAT_MS);
       leaseHeartbeat?.unref?.();
@@ -948,7 +998,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     const adapter = adapters[adapterKey];
     if (!adapter) {
       const res = failTerminal("FAILED", "unknown_adapter", "unknown_adapter");
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+      cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode: "unknown_adapter" };
     }
@@ -956,7 +1006,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
 
     if (!verifyDefHash(spec, def)) {
       const refusedRes = refuseTerminal("agent_definition_mismatch", ["def_hash_mismatch"], { causeTyped: true });
-      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       if (refusedRes?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "REFUSED", reasonCode: "agent_definition_mismatch", receipt: refusedRes.receipt };
     }
@@ -993,10 +1043,10 @@ export async function executeClaimed(db, registry, adapters, claim, {
     if (outcome?.usage) attemptUsage = { adapter: adapterKey, ...outcome.usage };
 
     if (abortController.signal.aborted) {
-      if (ticketClaimed) {
+      if (mayMutateClaimedTicket()) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "cancelled", log: null }); } catch {}
       }
-      if (workspaceDir) destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       const res = txImmediate(db, () => {
         const currentNow = nowFn();
         if (!assertCurrentToken(db, runId, fencingToken)) {
@@ -1033,33 +1083,33 @@ export async function executeClaimed(db, registry, adapters, claim, {
       }
 
       if (!lateCompletion) {
-        if (ticketClaimed) {
+        if (mayMutateClaimedTicket()) {
           try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "timeout", log: null }); } catch {}
         }
         const res = failTerminal("TIMED_OUT", "timeout", "timeout");
-        destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+        cleanupWorkspace({ retainWorkspace: retain });
         if (res?.fenced) return { fenced: true };
         return { runId, attempt, terminalState: "TIMED_OUT", reasonCode: "timeout" };
       }
     }
     const denial = policyDenials[0];
     if (!lateCompletion && denial) {
-      if (ticketClaimed) {
+      if (mayMutateClaimedTicket()) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `policy_denied:${denial.tool}`, log: null }); } catch {}
       }
       const reasonCode = `policy_denied:${denial.tool}`;
       const res = failTerminal("FAILED", reasonCode, reasonCode);
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+      cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
     if (!lateCompletion && exitCode !== 0) {
-      if (ticketClaimed) {
+      if (mayMutateClaimedTicket()) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `agent_exit_${exitCode}`, log: null }); } catch {}
       }
       const reasonCode = `agent_exit_${exitCode}`;
       const res = failTerminal("FAILED", reasonCode, reasonCode);
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+      cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
@@ -1070,7 +1120,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
     if (!isWorktree && !def.mutating && checkoutPath && (checkoutBaseline === null || repositoryStatus(checkoutPath) !== checkoutBaseline)) {
       const reasonCode = "workspace_integrity_violation";
       const res = failTerminal("FAILED", reasonCode, reasonCode);
-      destroyWorkspace(workspaceDir, { retain: true, checkout: checkoutPath, repoName });
+      cleanupWorkspace({ retainWorkspace: true });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
@@ -1089,7 +1139,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
       return { ok: true };
     });
     if (toVerifying?.fenced) {
-      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       return { fenced: true };
     }
 
@@ -1102,7 +1152,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
       if (!(err instanceof ContractViolation)) throw err;
       const reasonCode = err.reasonCode === "baseline_red" ? "baseline_red" : "contract_violation";
       const failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
-      if (ticketClaimed) {
+      if (mayMutateClaimedTicket()) {
         if (reasonCode === "baseline_red") {
           try {
             blockTicketFn({
@@ -1142,13 +1192,13 @@ export async function executeClaimed(db, registry, adapters, claim, {
         }
         return { ok: true };
       });
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
+      cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }
 
     if (verified.kind === "refused") {
-      if (ticketClaimed) {
+      if (mayMutateClaimedTicket()) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: `refused: ${verified.reasonCode}`, log: null }); } catch {}
       }
       const collected = [];
@@ -1201,7 +1251,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow, attemptUsage);
         return { ok: true, receipt };
       });
-      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "REFUSED", reasonCode: verified.reasonCode, receipt: res.receipt };
     }
@@ -1263,18 +1313,18 @@ export async function executeClaimed(db, registry, adapters, claim, {
     });
 
     if (published.fenced) {
-      destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       return { fenced: true };
     }
-    destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+    cleanupWorkspace();
     return { runId, attempt, terminalState: "COMPLETED", reasonCode: "ok", receipt: published.receipt };
   } catch (err) {
-    if (ticketClaimed) {
+    if (mayMutateClaimedTicket()) {
       try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: err?.message ?? String(err), log: null }); } catch {}
     }
     if (err instanceof IllegalTransition) {
       // Operator moved the run under us (cancel) — stop quietly, publish nothing.
-      if (workspaceDir) destroyWorkspace(workspaceDir, { checkout: checkoutPath, repoName });
+      cleanupWorkspace();
       const state = db.query(`SELECT state FROM runs WHERE run_id = ?`).get(runId)?.state;
       if (state === "CANCELLED") {
         return { cancelled: true };
@@ -1306,16 +1356,14 @@ export async function executeClaimed(db, registry, adapters, claim, {
     } catch {
       // if failTerminal could not transition, continue
     }
-    if (workspaceDir) {
-      destroyWorkspace(workspaceDir, { retain, checkout: checkoutPath, repoName });
-    }
+    cleanupWorkspace({ retainWorkspace: retain });
     if (res?.fenced) return { fenced: true };
     return { runId, attempt, terminalState: "FAILED", reasonCode, error: err?.message };
   } finally {
     stopCancellationMonitor();
     if (leaseHeartbeat) clearInterval(leaseHeartbeat);
     if (ticketClaimed) {
-      try { releaseWorkerLease({ repo: repoName, ticket: ticketId, owner, dir: leasesDir }); } catch {}
+      try { releaseWorkerLease({ repo: repoName, ticket: ticketId, owner: ticketLeaseOwner, dir: leasesDir }); } catch {}
     }
   }
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1790,6 +1790,101 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     expect(sum5.reasonCode).toBe("ticket_claim_lost");
   });
 
+  test("lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-claim-retry-locks-"));
+    const leaseDir = mkdtempSync(path.join(os.tmpdir(), "evrt-claim-retry-leases-"));
+    const spec = queueRun(db, makeDispatchSpec({
+      input: { repo: "wt-worker", ticket: "WM-621" },
+    }));
+    let now = T0;
+    let ticket = readyDispatchTicket("WM-621");
+    let claimCalls = 0;
+    let unclaimCalls = 0;
+    let adapterCalls = 0;
+    let releaseFirst;
+    let releaseSecond;
+    let markFirstStarted;
+    let markSecondStarted;
+    const firstStarted = new Promise((resolve) => { markFirstStarted = resolve; });
+    const secondStarted = new Promise((resolve) => { markSecondStarted = resolve; });
+    const firstRelease = new Promise((resolve) => { releaseFirst = resolve; });
+    const secondRelease = new Promise((resolve) => { releaseSecond = resolve; });
+    const retryAdapter = {
+      async execute(args) {
+        adapterCalls += 1;
+        if (adapterCalls === 1) {
+          markFirstStarted();
+          await firstRelease;
+          return { exitCode: 1, timedOut: false };
+        }
+        markSecondStarted();
+        await secondRelease;
+        return dispatchFakeAdapter.execute(args);
+      },
+    };
+    const o = opts({
+      now: () => now,
+      workspacesRoot: freshRoot(),
+      dispatch: {
+        locksDir: lockDir,
+        leasesDir: leaseDir,
+        fetchTicket: () => ticket,
+        fetchViewer: () => ({ id: "factory-user", name: "Factory" }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => {
+          claimCalls += 1;
+          ticket = readyDispatchTicket("WM-621", {
+            state: { name: "In Progress" },
+            assignee: { id: "factory-user", name: "Factory" },
+            labels: { nodes: [{ name: "ai:in-progress" }, { name: "agent:claude-code" }] },
+          });
+          return { ok: true };
+        },
+        unclaimTicket: () => {
+          unclaimCalls += 1;
+          ticket = readyDispatchTicket("WM-621");
+          return true;
+        },
+      },
+    });
+
+    const firstClaim = claimNext(db, o);
+    const firstExecution = executeClaimed(db, registry, { fake: retryAdapter }, firstClaim, o);
+    let retryExecution;
+    try {
+      await firstStarted;
+      expect(claimCalls).toBe(1);
+      expect(ticket.state.name).toBe("In Progress");
+
+      now = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+      expect(reapExpiredLeases(db, { now, policyVersion: "test" })).toBe(1);
+      expect(runState(db, spec.runId)).toBe("QUEUED");
+
+      retryExecution = runOnce(db, registry, { fake: retryAdapter }, o);
+      await secondStarted;
+      expect(claimCalls).toBe(1);
+      expect(lifecycleOf(db, spec.runId)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),
+      ]));
+
+      releaseFirst();
+      expect(await firstExecution).toEqual({ fenced: true });
+      expect(unclaimCalls).toBe(0);
+      expect(ticket.state.name).toBe("In Progress");
+      expect(liveWorkerLeases("wt-worker", { dir: leaseDir, now })).toHaveLength(1);
+
+      releaseSecond();
+      const retried = await retryExecution;
+      expect(retried).toMatchObject({ attempt: 2, terminalState: "COMPLETED" });
+    } finally {
+      releaseFirst();
+      releaseSecond();
+      await Promise.allSettled([firstExecution, retryExecution].filter(Boolean));
+    }
+  });
+
   test("claim-time Linear read failure contradicting plan evidence requeues with backoff", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-transient-linear-"));


### PR DESCRIPTION
## Summary
- authenticate lease-loss retries against the same run ledger and the factory Linear viewer
- allow the surviving In Progress/ai:in-progress claim without re-running the mutating claim command
- fence stale attempts from unclaiming, releasing the retry lease, or tearing down its delegated worktree
- cover successful attempt-2 resume plus foreign/invalid claim refusal

## Verification
- `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs` — 125 pass, 0 fail

UX critique: skipped — backend worker/runtime behavior with no user-facing surface

Fixes WM-621