### PR TITLE
feat(event-runtime-web): ArtifactView — schema-derived rendering of run artifacts with a Raw toggle; inspect prints the view summary (WM-455)

### DIFF
--- a/event-runtime/cli/inspect.mjs
+++ b/event-runtime/cli/inspect.mjs
@@ -1,5 +1,23 @@
+import { inspectHeader } from "../lib/artifact-view.mjs";
 import { fail, pad, withClient } from "./shared.mjs";
 import { spendLine } from "./status.mjs";
+
+/**
+ * The view sidecar for this run's agent, from `GET /agents` (WM-454), or
+ * null when the agent ships none — or when the registry cannot be read:
+ * `inspect` is a read of one run and must not fail because the header
+ * garnish did.
+ */
+async function viewFor(client, agentRef) {
+  if (typeof client.agents !== "function") return null;
+  try {
+    const { agents = [] } = await client.agents();
+    const def = agents.find((a) => a.ref === agentRef || a.id === agentRef);
+    return def?.outputView ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export async function inspect(client, runId) {
   const view = await client.run(runId);
@@ -30,6 +48,12 @@ export async function inspect(client, runId) {
   }
   if (view.result) {
     console.log("\nresult");
+    // The view's summary and status first (WM-455): what the artifact says,
+    // before the JSON that says it.
+    if (view.result.artifact !== undefined) {
+      const artifactView = await viewFor(client, run.spec.agent);
+      for (const line of inspectHeader(artifactView, view.result.artifact)) console.log(`  ${line}`);
+    }
     console.log(
       `  terminalState ${view.result.terminalState}   reason ${view.result.reasonCode ?? "-"}`,
     );

--- a/event-runtime/lib/artifact-view.mjs
+++ b/event-runtime/lib/artifact-view.mjs
@@ -194,3 +194,29 @@ export function validateArtifactView(view, outputSchema) {
 
   return { valid: errors.length === 0, errors };
 }
+
+/**
+ * The lines `cli.mjs inspect` prints first in its result section when the
+ * run's agent ships a view (design §2.4): the `summary` prose, then the
+ * status as `<label>: <value>` where the label is the last token of
+ * `status.path` (`recommendation: ESCALATE`). Pure; a pointer that does not
+ * resolve in this artifact contributes nothing, and no view means no lines.
+ * @returns {string[]}
+ */
+export function inspectHeader(view, artifact) {
+  if (!isObject(view)) return [];
+  const lines = [];
+  if (typeof view.summary === "string") {
+    const summary = resolvePointer(artifact, view.summary);
+    if (typeof summary === "string" && summary.trim()) lines.push(summary.trim());
+  }
+  if (isObject(view.status) && typeof view.status.path === "string") {
+    const value = resolvePointer(artifact, view.status.path);
+    if (value !== undefined && value !== null && (typeof value !== "object")) {
+      const tokens = parsePointer(view.status.path) ?? [];
+      const label = tokens.length ? tokens[tokens.length - 1] : "status";
+      lines.push(`${label}: ${String(value)}`);
+    }
+  }
+  return lines;
+}

--- a/event-runtime/lib/artifact-view.test.mjs
+++ b/event-runtime/lib/artifact-view.test.mjs
@@ -8,6 +8,7 @@ import {
   FORMATS,
   SECTION_KINDS,
   TONES,
+  inspectHeader,
   parsePointer,
   resolvePointer,
   resolveSchemaPointer,
@@ -280,5 +281,26 @@ describe("committed views fit their agents' output schemas (drift gate, design Â
     expect(merge.sections.find((s) => s.path === "/escalate").columns).toContain("reason");
     expect(merge.sections.find((s) => s.path === "/plan").columns).toContain("reason");
     expect(merge.sections.find((s) => s.path === "/fix").columns).toContain("finding");
+  });
+});
+
+describe("inspectHeader â€” the first lines of `inspect`'s result section (WM-455)", () => {
+  const view = JSON.parse(readFileSync(path.join(RUNTIME_ROOT, "agents", "merge-scan.view.json"), "utf8"));
+
+  test("summary prose, then status as `<label>: <value>` with the pointer's last token as label", () => {
+    expect(inspectHeader(view, { summary: "  Two PRs held. ", recommendation: "ESCALATE", escalate: [] })).toEqual([
+      "Two PRs held.",
+      "recommendation: ESCALATE",
+    ]);
+  });
+
+  test("a pointer that does not resolve contributes nothing; no view means no lines", () => {
+    expect(inspectHeader(view, { recommendation: "NOOP" })).toEqual(["recommendation: NOOP"]);
+    expect(inspectHeader(view, { summary: "only prose" })).toEqual(["only prose"]);
+    expect(inspectHeader(view, { summary: "", recommendation: { nested: true } })).toEqual([]);
+    expect(inspectHeader(view, "not an object")).toEqual([]);
+    expect(inspectHeader(null, { summary: "x" })).toEqual([]);
+    expect(inspectHeader(undefined, { summary: "x" })).toEqual([]);
+    expect(inspectHeader({ schemaVersion: ARTIFACT_VIEW_SCHEMA_VERSION, sections: [] }, { summary: "x" })).toEqual([]);
   });
 });

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -1,0 +1,198 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { ArtifactView as ArtifactViewDoc } from "../types";
+import { ARTIFACT_RAW_KEY, ArtifactPanel, ArtifactView } from "./ArtifactView";
+
+const AGENTS = path.resolve(import.meta.dir, "../../../agents");
+const readView = (name: string): ArtifactViewDoc =>
+  JSON.parse(readFileSync(path.join(AGENTS, `${name}.view.json`), "utf8"));
+const triageView = readView("triage-scan");
+const mergeView = readView("merge-scan");
+
+const triageArtifact = {
+  recommendation: "TRIAGE",
+  repo: "factory",
+  summary: "Three issues moved; one needs a human.",
+  plan: [
+    { issueId: "WM-1", action: "label-agent-ready", reason: "Complete spec." },
+    {
+      issueId: "WM-2",
+      action: "needs-human",
+      reason: "Scope unclear.",
+      detail: "## Acceptance Criteria\n- decide the scope",
+      ownedPaths: ["src/a.ts", "src/b.ts"],
+    },
+    { issueId: "WM-3", action: "label-agent-ready", reason: "Ready." },
+  ],
+};
+
+/** Real shape (GET /api/runs/run_44fa5716-… on the live instance): escalations only, empty plan/fix. */
+const mergeArtifact = {
+  base: "develop",
+  deployBranch: "main",
+  escalate: [
+    { headSha: "c3d50c8d494caeca7de97b5a7dd598463098a6d0", pr: 471, reason: "Existing draft hold.", ticket: "WM-210" },
+    { headSha: "e1b1942fb255dc588d35fde9c8b03419ec81527e", pr: 474, reason: "CI in progress.", ticket: "WM-193" },
+  ],
+  fix: [],
+  github: "watt-mind/factory",
+  plan: [],
+  recommendation: "ESCALATE",
+  repo: "factory",
+  summary: "Thirteen open PRs; no PR met the MERGE bar.",
+};
+
+beforeEach(() => localStorage.removeItem(ARTIFACT_RAW_KEY));
+afterEach(() => {
+  cleanup();
+  localStorage.removeItem(ARTIFACT_RAW_KEY);
+});
+
+describe("ArtifactView with the shipped triage-scan view (WM-455)", () => {
+  test("summary first, status badge in the header, grouped plan rows with issue chips, expand behind a disclosure", () => {
+    const r = render(<ArtifactView artifact={triageArtifact} view={triageView} />);
+    expect(r.getByText("Triage plan")).toBeTruthy();
+    expect(r.getByText("TRIAGE")).toBeTruthy();
+    expect(r.getByText("Three issues moved; one needs a human.")).toBeTruthy();
+
+    // Grouped by action, first-seen order, with counts.
+    const groups = r.getAllByRole("button", { name: /label-agent-ready|needs-human/ });
+    expect(groups.map((g) => g.textContent?.replace(/\s+/g, "").trim())).toEqual([
+      "label-agent-ready2",
+      "needs-human1",
+    ]);
+
+    // Issue chips link to Linear.
+    const chip = r.getByRole("link", { name: "WM-2" }) as HTMLAnchorElement;
+    expect(chip.getAttribute("href")).toBe("https://linear.app/watt-mind/issue/WM-2");
+    expect(chip.getAttribute("target")).toBe("_blank");
+
+    // Expand columns hide until the row's disclosure opens.
+    expect(r.queryByText("detail")).toBeNull();
+    const expanders = r.getAllByRole("button", { name: "Expand row" });
+    expect(expanders).toHaveLength(1);
+    fireEvent.click(expanders[0]);
+    expect(r.getByText("detail")).toBeTruthy();
+    expect(r.getByText(/decide the scope/)).toBeTruthy();
+    expect(r.getByText("src/a.ts")).toBeTruthy();
+    fireEvent.click(r.getByRole("button", { name: "Collapse row" }));
+    expect(r.queryByText("detail")).toBeNull();
+
+    // Collapsing a group hides its rows.
+    fireEvent.click(groups[0]);
+    expect(r.queryByRole("link", { name: "WM-1" })).toBeNull();
+    expect(r.getByRole("link", { name: "WM-2" })).toBeTruthy();
+
+    // Repo keyvalue.
+    expect(r.getByText("Repo")).toBeTruthy();
+    expect(r.getByText("factory")).toBeTruthy();
+  });
+
+  test("a missing optional path renders without that section", () => {
+    const r = render(
+      <ArtifactView artifact={{ recommendation: "NOOP", summary: "Nothing to do.", repo: "factory" }} view={triageView} />,
+    );
+    expect(r.getByText("Nothing to do.")).toBeTruthy();
+    expect(r.getByText("NOOP")).toBeTruthy();
+    expect(r.queryByText("Plan")).toBeNull();
+    expect(r.queryByRole("table")).toBeNull();
+    expect(r.getByText("Repo")).toBeTruthy();
+  });
+});
+
+describe("ArtifactPanel — Raw toggle and fallback", () => {
+  test("no view → JsonBlock only, no toggle", () => {
+    const r = render(<ArtifactPanel artifact={triageArtifact} view={null} />);
+    expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
+    expect(r.queryByRole("table")).toBeNull();
+    expect(r.container.querySelector("pre")?.textContent).toContain('"recommendation": "TRIAGE"');
+  });
+
+  test("Raw toggle round-trips between the view and JsonBlock and persists", () => {
+    const r = render(<ArtifactPanel artifact={triageArtifact} view={triageView} />);
+    expect(r.getByRole("table")).toBeTruthy();
+    expect(r.container.querySelector("pre")).toBeNull();
+
+    const group = r.getByRole("group", { name: "Artifact rendering" });
+    const raw = within(group).getByRole("button", { name: "Raw" });
+    const view = within(group).getByRole("button", { name: "View" });
+    expect(view.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(raw);
+    expect(r.queryByRole("table")).toBeNull();
+    expect(r.container.querySelector("pre")?.textContent).toContain('"issueId": "WM-1"');
+    expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
+    expect(within(r.getByRole("group", { name: "Artifact rendering" })).getByRole("button", { name: "Raw" }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(within(r.getByRole("group", { name: "Artifact rendering" })).getByRole("button", { name: "View" }));
+    expect(r.getByRole("table")).toBeTruthy();
+    expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("0");
+  });
+
+  test("a persisted Raw preference opens on JSON", () => {
+    localStorage.setItem(ARTIFACT_RAW_KEY, "1");
+    const r = render(<ArtifactPanel artifact={triageArtifact} view={triageView} />);
+    expect(r.queryByRole("table")).toBeNull();
+    expect(r.container.querySelector("pre")).toBeTruthy();
+    expect(r.getByRole("group", { name: "Artifact rendering" })).toBeTruthy();
+  });
+
+  test("a view that says nothing about this artifact falls back to JSON without a toggle", () => {
+    const r = render(<ArtifactPanel artifact={{ type: "assistant", message: "hi" }} view={triageView} />);
+    expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
+    expect(r.container.querySelector("pre")).toBeTruthy();
+  });
+});
+
+describe("ArtifactView with the shipped merge-scan view", () => {
+  test("renders the real merge-plan shape: status, escalate table with pr and ticket chips, whole-artifact keyvalue", () => {
+    const r = render(<ArtifactView artifact={mergeArtifact} view={mergeView} />);
+    expect(r.getByText("Merge plan")).toBeTruthy();
+    expect(r.getByText("ESCALATE")).toBeTruthy();
+    expect(r.getByText("Thirteen open PRs; no PR met the MERGE bar.")).toBeTruthy();
+
+    // Empty tables are labelled and honest, not dropped (the pointer resolves).
+    expect(r.getByText("Merge")).toBeTruthy();
+    expect(r.getByText("Fix")).toBeTruthy();
+    expect(r.getAllByText("None.")).toHaveLength(2);
+
+    const pr = r.getByRole("link", { name: "#471" }) as HTMLAnchorElement;
+    expect(pr.getAttribute("href")).toBe("https://github.com/watt-mind/factory/pull/471");
+    expect((r.getByRole("link", { name: "WM-210" }) as HTMLAnchorElement).getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-210",
+    );
+    expect(r.getByText("Existing draft hold.")).toBeTruthy();
+
+    // headSha is expand-only, shortened to 12 with the full sha in the title.
+    expect(r.queryByText("c3d50c8d494c")).toBeNull();
+    fireEvent.click(r.getAllByRole("button", { name: "Expand row" })[0]);
+    expect(r.getByText("c3d50c8d494c").getAttribute("title")).toBe("c3d50c8d494caeca7de97b5a7dd598463098a6d0");
+
+    // `path: ""` keyvalue over the whole artifact, `keys` subset, absent noopReason dropped.
+    expect(r.getByText("github")).toBeTruthy();
+    expect(r.getByText("watt-mind/factory")).toBeTruthy();
+    expect(r.getByText("deployBranch")).toBeTruthy();
+    expect(r.getByText("main")).toBeTruthy();
+    expect(r.queryByText("noopReason")).toBeNull();
+  });
+
+  test("run chips call onJumpRun when the host provides it, else link to #/runs/<id>", () => {
+    const view: ArtifactViewDoc = {
+      schemaVersion: "factory.artifact-view/v1",
+      sections: [{ path: "/runs", as: "list", label: "Runs", formats: { "": "run" } }],
+    };
+    const artifact = { runs: ["run_44fa5716-0304-49b1-8b65-a45500d0d784"] };
+    const jumped: string[] = [];
+    const r = render(<ArtifactView artifact={artifact} view={view} onJumpRun={(id) => jumped.push(id)} />);
+    fireEvent.click(r.getByRole("button", { name: "run_44fa5716" }));
+    expect(jumped).toEqual(["run_44fa5716-0304-49b1-8b65-a45500d0d784"]);
+    cleanup();
+    const r2 = render(<ArtifactView artifact={artifact} view={view} />);
+    expect((r2.getByRole("link", { name: "run_44fa5716" }) as HTMLAnchorElement).getAttribute("href")).toBe(
+      "#/runs/run_44fa5716-0304-49b1-8b65-a45500d0d784",
+    );
+  });
+});

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -1,0 +1,578 @@
+/**
+ * ArtifactView — schema-derived rendering of a run artifact
+ * (docs/event-runtime-artifact-views.md §2.4, WM-455).
+ *
+ * One generic component for every agent that ships a `.view.json`: it draws
+ * whatever `lib/artifactView.ts` derived from the view + artifact and never
+ * looks at the agent's name. `ArtifactPanel` is what the two artifact
+ * positions mount — it owns the View / Raw toggle (persisted like the other
+ * display options) and falls back to `JsonBlock` when no view applies.
+ */
+import { Fragment, useMemo, useState, type ReactNode } from "react";
+import { hashPath, hashProject, withProject } from "../hash";
+import {
+  headerFor,
+  sectionsFor,
+  TONE_HUES,
+  viewApplies,
+  type Cell,
+  type Formatted,
+  type RowGroup,
+  type SectionModel,
+  type TableRow,
+} from "../lib/artifactView";
+import type { ArtifactTone, ArtifactView as ArtifactViewDoc } from "../types";
+import { DisclosureChevron, JsonBlock, JumpLink, StateBadge, Th } from "./ui";
+
+// ---------------------------------------------------------------------------
+// Raw toggle persistence
+// ---------------------------------------------------------------------------
+
+/** One key for both artifact positions: an operator who wants JSON wants it everywhere. */
+export const ARTIFACT_RAW_KEY = "evrt-artifact-raw";
+
+export function loadArtifactRaw(): boolean {
+  try {
+    return localStorage.getItem(ARTIFACT_RAW_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveArtifactRaw(raw: boolean): void {
+  try {
+    localStorage.setItem(ARTIFACT_RAW_KEY, raw ? "1" : "0");
+  } catch {
+    // Private mode / quota: the toggle still works for this page.
+  }
+}
+
+/** Two-state segmented control, `aria-pressed` on the active half. */
+export function RawToggle({ raw, onChange }: { raw: boolean; onChange: (raw: boolean) => void }) {
+  const opt = (value: boolean, label: string) => (
+    <button
+      type="button"
+      aria-pressed={raw === value}
+      onClick={() => onChange(value)}
+      className={`cursor-pointer rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+        raw === value ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:text-(--text-dim)"
+      }`}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <span
+      role="group"
+      aria-label="Artifact rendering"
+      className="inline-flex shrink-0 items-center gap-0.5 rounded-md border border-(--border) bg-(--surface-1) p-0.5"
+    >
+      {opt(false, "View")}
+      {opt(true, "Raw")}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+const toneStyle = (tone: ArtifactTone | undefined) =>
+  tone && tone !== "neutral" ? { color: TONE_HUES[tone] } : undefined;
+
+/** A tone-bearing value wears the same pill as a state badge — one shape for "this is a verdict". */
+function TonePill({ text, tone }: { text: string; tone: ArtifactTone }) {
+  const hue = TONE_HUES[tone];
+  return (
+    <span
+      className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium"
+      style={{ color: hue, background: `color-mix(in oklch, ${hue} 12%, transparent)` }}
+    >
+      {text}
+    </span>
+  );
+}
+
+const compactJson = (v: unknown): string => {
+  const s = JSON.stringify(v);
+  return s.length > 120 ? `${s.slice(0, 117)}…` : s;
+};
+
+function runHref(runId: string): string {
+  return `#/${withProject(hashPath("runs", runId), hashProject(window.location.hash))}`;
+}
+
+/** Draw one formatted value. `block` is the expanded/keyvalue rendering, where nested JSON gets room. */
+function Value({
+  f,
+  tone,
+  block = false,
+  onJumpRun,
+}: {
+  f: Formatted;
+  tone?: ArtifactTone;
+  block?: boolean;
+  onJumpRun?: (runId: string) => void;
+}) {
+  switch (f.kind) {
+    case "empty":
+      return <span className="text-(--text-faint)">—</span>;
+    case "chip": {
+      const title =
+        f.chip === "issue" ? `Open ${f.id} in Linear` : f.chip === "pr" ? (f.href ? `Open pull request ${f.text}` : `Pull request ${f.text}`) : f.id;
+      if (f.chip === "run") {
+        return (
+          <JumpLink
+            href={onJumpRun ? undefined : runHref(f.id)}
+            onClick={onJumpRun ? () => onJumpRun(f.id) : undefined}
+            title={title}
+            className="text-(--accent)"
+          >
+            {f.text}
+          </JumpLink>
+        );
+      }
+      if (!f.href) return <span className="mono">{f.text}</span>;
+      return (
+        <a
+          href={f.href}
+          target="_blank"
+          rel="noreferrer"
+          title={title}
+          onClick={(e) => e.stopPropagation()}
+          className="mono text-(--accent) hover:underline"
+        >
+          {f.text}
+        </a>
+      );
+    }
+    case "state":
+      return <StateBadge state={f.state} />;
+    case "link":
+      return (
+        <a href={f.href} target="_blank" rel="noreferrer" className="break-all text-(--accent) hover:underline">
+          {f.text}
+        </a>
+      );
+    case "json":
+      if (block) {
+        if (Array.isArray(f.value) && f.value.every((v) => v === null || typeof v !== "object")) {
+          return (
+            <ul className="m-0 list-none p-0">
+              {f.value.map((v, i) => (
+                <li key={i} className="mono break-all py-px text-[11.5px] text-(--text-dim)">
+                  {String(v)}
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        return <JsonBlock value={f.value} />;
+      }
+      return (
+        <span className="mono text-(--text-faint)" title={JSON.stringify(f.value)}>
+          {compactJson(f.value)}
+        </span>
+      );
+    case "text":
+      if (tone && tone !== "muted") return <TonePill text={f.text} tone={tone} />;
+      return (
+        <span
+          className={`${f.mono ? "mono" : ""} ${block ? "break-words whitespace-pre-wrap" : ""} ${
+            tone === "muted" ? "text-(--text-faint)" : ""
+          }`}
+          style={toneStyle(tone)}
+          title={f.title}
+        >
+          {f.text}
+        </span>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+function SectionHeading({ label, count }: { label: string | undefined; count?: number }) {
+  if (!label) return null;
+  return (
+    <div className="mb-1 flex items-baseline gap-2 text-[11px] font-medium tracking-wide text-(--text-faint) uppercase">
+      <span>{label}</span>
+      {count !== undefined && <span className="tabular-nums normal-case">{count}</span>}
+    </div>
+  );
+}
+
+const CELL = "border-b border-(--border) px-3 py-1.5 align-top";
+
+function ExpandedRow({ row, colSpan, onJumpRun }: { row: TableRow; colSpan: number; onJumpRun?: (id: string) => void }) {
+  return (
+    <tr>
+      <td colSpan={colSpan} className="border-b border-(--border) bg-(--surface-1) px-3 py-2">
+        <div className="grid grid-cols-[minmax(0,10rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 text-[11.5px]">
+          {row.expand.map((cell) => (
+            <Fragment key={cell.key}>
+              <span className="truncate text-(--text-faint)" title={cell.key}>
+                {cell.key}
+              </span>
+              <div className="min-w-0 text-(--text-dim)">
+                <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+              </div>
+            </Fragment>
+          ))}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function Rows({
+  rows,
+  columns,
+  hasExpand,
+  open,
+  onToggle,
+  onJumpRun,
+}: {
+  rows: TableRow[];
+  columns: string[];
+  hasExpand: boolean;
+  open: Set<number>;
+  onToggle: (index: number) => void;
+  onJumpRun?: (id: string) => void;
+}) {
+  const colSpan = columns.length + (hasExpand ? 1 : 0);
+  return (
+    <>
+      {rows.map((row) => {
+        const expandable = row.expand.length > 0;
+        const isOpen = open.has(row.index);
+        return (
+          <Fragment key={row.index}>
+            <tr
+              className={expandable ? "cursor-pointer hover:bg-(--surface-1)" : undefined}
+              onClick={expandable ? () => onToggle(row.index) : undefined}
+            >
+              {hasExpand && (
+                <td className={`${CELL} w-6 pr-0`}>
+                  {expandable && (
+                    <button
+                      type="button"
+                      aria-expanded={isOpen}
+                      aria-label={isOpen ? "Collapse row" : "Expand row"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggle(row.index);
+                      }}
+                      className="inline-flex cursor-pointer items-center"
+                    >
+                      <DisclosureChevron open={isOpen} />
+                    </button>
+                  )}
+                </td>
+              )}
+              {row.cells.map((cell) => (
+                <td key={cell.key} className={`${CELL} ${wideColumn(cell) ? "" : "whitespace-nowrap"}`}>
+                  <Value f={cell.value} tone={cell.tone} onJumpRun={onJumpRun} />
+                </td>
+              ))}
+            </tr>
+            {expandable && isOpen && <ExpandedRow row={row} colSpan={colSpan} onJumpRun={onJumpRun} />}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+/** Prose cells (a `reason`) wrap; identifiers, chips and badges stay on one line. */
+const wideColumn = (cell: Cell): boolean => cell.value.kind === "text" && !cell.value.mono && !cell.tone;
+
+function GroupRow({
+  group,
+  colSpan,
+  collapsed,
+  onToggle,
+}: {
+  group: RowGroup;
+  colSpan: number;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  const hue = group.tone ? TONE_HUES[group.tone] : "var(--text-faint)";
+  return (
+    <tr>
+      <td colSpan={colSpan} className="p-0">
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          onClick={onToggle}
+          className="flex h-7 w-full cursor-pointer items-center gap-2 border-b border-(--border) bg-(--surface-1) px-3 text-left transition-colors hover:bg-(--surface-2)"
+        >
+          <DisclosureChevron open={!collapsed} />
+          <span
+            aria-hidden
+            className="size-2 rounded-full"
+            style={{ background: hue, boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)` }}
+          />
+          <span className="text-[11.5px] font-medium text-(--text)">{group.label}</span>
+          <span className="tabular-nums text-[11px] text-(--text-faint)">{group.rows.length}</span>
+          {collapsed && <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">collapsed</span>}
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function TableSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "table" }>; onJumpRun?: (id: string) => void }) {
+  const [open, setOpen] = useState<Set<number>>(() => new Set());
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set());
+  const toggleRow = (index: number) =>
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  const toggleGroup = (key: string) =>
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  const colSpan = s.columns.length + (s.hasExpand ? 1 : 0);
+  return (
+    <section aria-label={s.label ?? "table"} className="mb-4 last:mb-0">
+      <SectionHeading label={s.label} count={s.rows.length} />
+      {s.rows.length === 0 ? (
+        <div className="text-[12px] text-(--text-faint)">None.</div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-(--border)">
+          <table className="w-full border-separate border-spacing-0 text-[12px]">
+            <thead>
+              <tr className="text-left text-[11px] text-(--text-faint)">
+                {s.hasExpand && <Th label="" />}
+                {s.columns.map((c) => (
+                  <Th key={c} label={c} />
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {s.groups
+                ? s.groups.map((g) => (
+                    <Fragment key={g.key}>
+                      <GroupRow
+                        group={g}
+                        colSpan={colSpan}
+                        collapsed={collapsedGroups.has(g.key)}
+                        onToggle={() => toggleGroup(g.key)}
+                      />
+                      {!collapsedGroups.has(g.key) && (
+                        <Rows
+                          rows={g.rows}
+                          columns={s.columns}
+                          hasExpand={s.hasExpand}
+                          open={open}
+                          onToggle={toggleRow}
+                          onJumpRun={onJumpRun}
+                        />
+                      )}
+                    </Fragment>
+                  ))
+                : (
+                    <Rows
+                      rows={s.rows}
+                      columns={s.columns}
+                      hasExpand={s.hasExpand}
+                      open={open}
+                      onToggle={toggleRow}
+                      onJumpRun={onJumpRun}
+                    />
+                  )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function KeyValueSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "keyvalue" }>; onJumpRun?: (id: string) => void }) {
+  return (
+    <section aria-label={s.label ?? "details"} className="mb-4 last:mb-0">
+      <SectionHeading label={s.label} />
+      <div className="text-[12px]">
+        {s.entries.map((cell) => (
+          <div key={cell.key} className="grid grid-cols-[minmax(0,8rem)_minmax(0,1fr)] items-baseline gap-3 py-[3px]">
+            <div className="truncate text-(--text-faint)" title={cell.key}>
+              {cell.key}
+            </div>
+            <div className="min-w-0 text-(--text-dim)">
+              <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ListSection({ s, onJumpRun }: { s: Extract<SectionModel, { as: "list" }>; onJumpRun?: (id: string) => void }) {
+  return (
+    <section aria-label={s.label ?? "list"} className="mb-4 last:mb-0">
+      <SectionHeading label={s.label} count={s.items.length} />
+      {s.items.length === 0 ? (
+        <div className="text-[12px] text-(--text-faint)">None.</div>
+      ) : (
+        <ul className="m-0 list-none p-0 text-[12px]">
+          {s.items.map((cell) => (
+            <li key={cell.key} className="flex items-baseline gap-2 py-[3px] text-(--text-dim)">
+              <span aria-hidden className="text-(--text-faint)">·</span>
+              <Value f={cell.value} tone={cell.tone} block onJumpRun={onJumpRun} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SectionBlock({ s, onJumpRun }: { s: SectionModel; onJumpRun?: (id: string) => void }) {
+  switch (s.as) {
+    case "table":
+      return <TableSection s={s} onJumpRun={onJumpRun} />;
+    case "keyvalue":
+      return <KeyValueSection s={s} onJumpRun={onJumpRun} />;
+    case "list":
+      return <ListSection s={s} onJumpRun={onJumpRun} />;
+    case "badge":
+      return (
+        <section aria-label={s.label ?? "badge"} className="mb-4 last:mb-0">
+          <SectionHeading label={s.label} />
+          <TonePill text={s.value} tone={s.tone ?? "neutral"} />
+        </section>
+      );
+    case "code":
+      return (
+        <section aria-label={s.label ?? "code"} className="mb-4 last:mb-0">
+          <SectionHeading label={s.label} />
+          <pre
+            data-language={s.language}
+            className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap"
+          >
+            {s.text}
+          </pre>
+        </section>
+      );
+    case "prose":
+      return (
+        <section aria-label={s.label ?? "prose"} className="mb-4 last:mb-0">
+          <SectionHeading label={s.label} />
+          <p className="m-0 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text-dim)">{s.text}</p>
+        </section>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The view
+// ---------------------------------------------------------------------------
+
+export function ArtifactView({
+  artifact,
+  schema,
+  view,
+  onJumpRun,
+  actions,
+}: {
+  artifact: unknown;
+  schema?: unknown;
+  view: ArtifactViewDoc;
+  /** Run chips jump here when the host has a selection callback; else they link to `#/runs/<id>`. */
+  onJumpRun?: (runId: string) => void;
+  /** Right-aligned header slot — the host's Raw toggle. */
+  actions?: ReactNode;
+}) {
+  const header = useMemo(() => headerFor(view, artifact, schema), [view, artifact, schema]);
+  const sections = useMemo(() => sectionsFor(view, artifact), [view, artifact]);
+  const statusHues = header.status?.tone ? { [header.status.value]: TONE_HUES[header.status.tone] } : {};
+  return (
+    <div data-artifact-view className="text-[12px]">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {header.title && <span className="font-medium text-(--text)">{header.title}</span>}
+        {header.status && (
+          <span title={`${header.status.label}: ${header.status.value}`}>
+            <StateBadge state={header.status.value} hues={statusHues} dot={false} />
+          </span>
+        )}
+        {actions && <span className="ml-auto">{actions}</span>}
+      </div>
+      {header.summary && (
+        <p className="mb-3 mt-0 text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-(--text-dim)">
+          {header.summary}
+        </p>
+      )}
+      {sections.map((s, i) => (
+        <SectionBlock key={`${s.as}:${s.label ?? i}`} s={s} onJumpRun={onJumpRun} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The artifact position: the view when one applies, `JsonBlock` otherwise,
+ * and a View / Raw toggle whenever there is a choice. `view` is whatever the
+ * `/agents` item for the run's agent carries — null/undefined keeps today's
+ * JSON exactly.
+ */
+export function ArtifactPanel({
+  artifact,
+  schema,
+  view,
+  onJumpRun,
+  raw: rawProp,
+  onRawChange,
+  rawFallback,
+}: {
+  artifact: unknown;
+  schema?: unknown;
+  view: ArtifactViewDoc | null | undefined;
+  onJumpRun?: (runId: string) => void;
+  /** Controlled Raw state (the Artifacts inspector keeps its own); uncontrolled + persisted when absent. */
+  raw?: boolean;
+  onRawChange?: (raw: boolean) => void;
+  /** What Raw shows; defaults to `JsonBlock` over the artifact. */
+  rawFallback?: ReactNode;
+}) {
+  const [rawState, setRawState] = useState(loadArtifactRaw);
+  const raw = rawProp ?? rawState;
+  const setRaw = (next: boolean) => {
+    saveArtifactRaw(next);
+    setRawState(next);
+    onRawChange?.(next);
+  };
+  const applies = viewApplies(view, artifact);
+  const fallback = rawFallback ?? <JsonBlock value={artifact} />;
+  if (!applies) return <>{fallback}</>;
+  if (raw) {
+    return (
+      <div>
+        <div className="mb-2 flex justify-end">
+          <RawToggle raw onChange={setRaw} />
+        </div>
+        {fallback}
+      </div>
+    );
+  }
+  return (
+    <ArtifactView
+      artifact={artifact}
+      schema={schema}
+      view={view}
+      onJumpRun={onJumpRun}
+      actions={<RawToggle raw={false} onChange={setRaw} />}
+    />
+  );
+}

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -209,7 +209,8 @@ const CELL = "border-b border-(--border) px-3 py-1.5 align-top";
 function ExpandedRow({ row, colSpan, onJumpRun }: { row: TableRow; colSpan: number; onJumpRun?: (id: string) => void }) {
   return (
     <tr>
-      <td colSpan={colSpan} className="border-b border-(--border) bg-(--surface-1) px-3 py-2">
+      {/* theme.css pins `table td` to nowrap for list tables; expanded detail is prose. */}
+      <td colSpan={colSpan} className="border-b border-(--border) bg-(--surface-1) px-3 py-2 whitespace-normal">
         <div className="grid grid-cols-[minmax(0,10rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 text-[11.5px]">
           {row.expand.map((cell) => (
             <Fragment key={cell.key}>
@@ -273,7 +274,10 @@ function Rows({
                 </td>
               )}
               {row.cells.map((cell) => (
-                <td key={cell.key} className={`${CELL} ${wideColumn(cell) ? "" : "whitespace-nowrap"}`}>
+                <td
+                  key={cell.key}
+                  className={`${CELL} ${wideColumn(cell) ? "min-w-[10rem] whitespace-normal [overflow-wrap:anywhere]" : "whitespace-nowrap"}`}
+                >
                   <Value f={cell.value} tone={cell.tone} onJumpRun={onJumpRun} />
                 </td>
               ))}

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -1,12 +1,18 @@
 import "../test-dom";
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { api } from "../api";
+import { ARTIFACT_RAW_KEY } from "./ArtifactView";
 import { RunDetailBlocks, isCancellable, modelTierText, pinnedModelText } from "./RunDetailBlocks";
 import {
+  createAgentsFixture,
   createLifecycleEventFixture,
   createRunDetailFixture,
   renderWithClient,
   restoreApi,
+  stubApi,
 } from "../test-render";
 import type { RunDetail, RunState } from "../types";
 
@@ -278,5 +284,53 @@ describe("pinnedModelText / modelTierText (WM-221)", () => {
     expect(modelTierText({ adapter: "fake", modelTier: null, model: null })).toBe("n/a");
     // A declared tier survives even where the adapter cannot use it.
     expect(modelTierText({ adapter: "command", modelTier: "light", model: null })).toBe("light");
+  });
+});
+
+describe("artifact position renders the agent's view (WM-455)", () => {
+  const TRIAGE_VIEW = JSON.parse(readFileSync(path.resolve(import.meta.dir, "../../../agents/triage-scan.view.json"), "utf8"));
+  const triageAgent = {
+    ref: "triage-scan@1",
+    id: "triage-scan",
+    outputSchema: { title: "triage plan" },
+    outputView: TRIAGE_VIEW,
+  };
+  const artifact = {
+    recommendation: "TRIAGE",
+    repo: "factory",
+    summary: "One issue is ready.",
+    plan: [{ issueId: "WM-7", action: "label-agent-ready", reason: "Complete." }],
+  };
+  const withArtifact = () =>
+    createRunDetailFixture({
+      run: { state: "COMPLETED", spec: { agent: "triage-scan@1" } } as RunDetail["run"],
+      result: { terminalState: "COMPLETED", reasonCode: null, artifact },
+    });
+
+  afterEach(() => localStorage.removeItem(ARTIFACT_RAW_KEY));
+
+  test("with a view from /agents: summary, status, plan table with an issue chip, and a Raw toggle back to JSON", async () => {
+    stubApi({ agents: mock(async () => createAgentsFixture({ agents: [triageAgent] as never })) });
+    const r2 = renderBlocks(withArtifact());
+    expect(await r2.findByText("One issue is ready.")).toBeTruthy();
+    expect(r2.getByText("TRIAGE")).toBeTruthy();
+    expect((r2.getByRole("link", { name: "WM-7" }) as HTMLAnchorElement).getAttribute("href")).toBe(
+      "https://linear.app/watt-mind/issue/WM-7",
+    );
+    fireEvent.click(r2.getByRole("button", { name: "Raw" }));
+    expect(r2.queryByRole("table")).toBeNull();
+    const pre = Array.from(r2.container.querySelectorAll("pre")).find((el) => el.textContent?.includes('"issueId": "WM-7"'));
+    expect(pre).toBeTruthy();
+    expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
+  });
+
+  test("no view for the agent → the JSON block, unchanged, and no toggle", async () => {
+    stubApi({ agents: mock(async () => createAgentsFixture({ agents: [{ ...triageAgent, outputView: null }] as never })) });
+    const r = renderBlocks(withArtifact());
+    await waitFor(() => expect(api.agents).toHaveBeenCalled());
+    expect(r.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
+    expect(r.queryByRole("table")).toBeNull();
+    const pre = Array.from(r.container.querySelectorAll("pre")).find((el) => el.textContent?.includes('"issueId": "WM-7"'));
+    expect(pre).toBeTruthy();
   });
 });

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { Suspense, lazy, useState, type ReactNode } from "react";
 import { api, artifactUrl } from "../api";
 import { hashPath, hashProject, withProject } from "../hash";
 import { dur } from "../heartbeat";
@@ -20,8 +20,15 @@ import {
   shortId,
 } from "./ui";
 import { AgentHoverCard } from "./AgentHoverCard";
-import { ArtifactPanel } from "./ArtifactView";
 import { attrIcon } from "./attrIcons";
+
+/**
+ * The artifact view renderer (WM-455) is fetched on demand: RunDetailBlocks
+ * is on the eager Runs path and the entry chunk is budgeted
+ * (vite.config.ts); until the chunk lands the JSON block below stands in,
+ * which is also exactly what an agent without a view gets.
+ */
+const ArtifactPanel = lazy(() => import("./ArtifactView").then((m) => ({ default: m.ArtifactPanel })));
 
 export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
 export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && state !== "VERIFYING";
@@ -717,11 +724,17 @@ export function RunDetailBlocks({
         >
           {d.result.artifact !== undefined ? (
             <Disclosure label="artifact" defaultOpen>
-              <ArtifactPanel
-                artifact={d.result.artifact}
-                schema={agentDef?.outputSchema}
-                view={agentDef?.outputView}
-              />
+              {agentDef?.outputView ? (
+                <Suspense fallback={<JsonBlock value={d.result.artifact} />}>
+                  <ArtifactPanel
+                    artifact={d.result.artifact}
+                    schema={agentDef.outputSchema}
+                    view={agentDef.outputView}
+                  />
+                </Suspense>
+              ) : (
+                <JsonBlock value={d.result.artifact} />
+              )}
             </Disclosure>
           ) : (
             <Disclosure label="result" defaultOpen>

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -1,5 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-import { artifactUrl } from "../api";
+import { api, artifactUrl } from "../api";
 import { hashPath, hashProject, withProject } from "../hash";
 import { dur } from "../heartbeat";
 import type { ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunSpec, RunState } from "../types";
@@ -19,6 +20,7 @@ import {
   shortId,
 } from "./ui";
 import { AgentHoverCard } from "./AgentHoverCard";
+import { ArtifactPanel } from "./ArtifactView";
 import { attrIcon } from "./attrIcons";
 
 export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
@@ -493,6 +495,14 @@ export function RunDetailBlocks({
     : null;
   const clocks = current ? deadlinesOf(current, d.run.spec.timeoutSeconds, now) : null;
 
+  // The artifact's view sidecar rides the `/agents` item for this run's agent
+  // (WM-454); the same query AgentHoverCard already keeps warm, so no new
+  // request per run. No agent, no view → the JSON block, unchanged.
+  const agentsQ = useQuery({ queryKey: ["agents"], queryFn: () => api.agents(), staleTime: 30_000 });
+  const agentDef = (agentsQ.data?.agents ?? []).find(
+    (a) => a.ref === d.run.spec.agent || a.id === d.run.spec.agent,
+  );
+
   return (
     <>
       <Section title="Run" icons>
@@ -707,7 +717,11 @@ export function RunDetailBlocks({
         >
           {d.result.artifact !== undefined ? (
             <Disclosure label="artifact" defaultOpen>
-              <JsonBlock value={d.result.artifact} />
+              <ArtifactPanel
+                artifact={d.result.artifact}
+                schema={agentDef?.outputSchema}
+                view={agentDef?.outputView}
+              />
             </Disclosure>
           ) : (
             <Disclosure label="result" defaultOpen>

--- a/event-runtime/web/src/lib/artifactView.test.ts
+++ b/event-runtime/web/src/lib/artifactView.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { ArtifactView } from "../types";
+import {
+  formatBytes,
+  formatValue,
+  githubOf,
+  groupRows,
+  headerFor,
+  parsePointer,
+  resolvePointer,
+  resolveRelative,
+  sectionsFor,
+  toneFor,
+  viewApplies,
+} from "./artifactView";
+
+const AGENTS = path.resolve(import.meta.dir, "../../../agents");
+const readView = (name: string): ArtifactView =>
+  JSON.parse(readFileSync(path.join(AGENTS, `${name}.view.json`), "utf8"));
+
+const triageView = readView("triage-scan");
+const mergeView = readView("merge-scan");
+
+const triageArtifact = {
+  recommendation: "TRIAGE",
+  repo: "factory",
+  summary: "Three issues moved; one needs a human.",
+  plan: [
+    { issueId: "WM-1", action: "label-agent-ready", reason: "Complete spec." },
+    { issueId: "WM-2", action: "needs-human", reason: "Scope unclear.", detail: "## Acceptance Criteria\n- x" },
+    { issueId: "WM-3", action: "label-agent-ready", reason: "Ready.", ownedPaths: ["a.ts", "b.ts"] },
+  ],
+};
+
+const mergeArtifact = {
+  recommendation: "ESCALATE",
+  repo: "factory",
+  github: "watt-mind/factory",
+  base: "develop",
+  deployBranch: "main",
+  plan: [],
+  fix: [
+    {
+      pr: 12,
+      headSha: "a".repeat(40),
+      baseSha: "b".repeat(40),
+      headRef: "feat/x",
+      ticket: "WM-12",
+      finding: "lint",
+      findingHash: "h1",
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: false,
+      ownedPaths: ["src/a.ts"],
+    },
+  ],
+  escalate: [{ pr: 471, ticket: "WM-210", headSha: "c".repeat(40), reason: "Draft hold." }],
+  summary: "One escalation.",
+};
+
+describe("resolvePointer (RFC 6901, mirrors lib/artifact-view.mjs)", () => {
+  test("walks objects and arrays, unescapes ~0/~1, and returns undefined for anything absent", () => {
+    const doc = { a: { "b/c": [10, { "~": 1 }] }, "": "empty" };
+    expect(resolvePointer(doc, "")).toBe(doc);
+    expect(resolvePointer(doc, "/a/b~1c/0")).toBe(10);
+    expect(resolvePointer(doc, "/a/b~1c/1/~0")).toBe(1);
+    expect(resolvePointer(doc, "/")).toBe("empty");
+    expect(resolvePointer(doc, "/a/b~1c/2")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b~1c/01")).toBeUndefined();
+    expect(resolvePointer(doc, "/a/b~1c/-")).toBeUndefined();
+    expect(resolvePointer(doc, "/nope")).toBeUndefined();
+    expect(resolvePointer(doc, "a")).toBeUndefined();
+    expect(resolvePointer(doc, 42)).toBeUndefined();
+    expect(resolvePointer("scalar", "/x")).toBeUndefined();
+    expect(parsePointer("/x/y")).toEqual(["x", "y"]);
+    expect(parsePointer("x")).toBeNull();
+  });
+
+  test("resolveRelative takes plain names and slash paths, like the runtime's relativeNode", () => {
+    const item = { a: { b: [1, 2] }, "": "blank" };
+    expect(resolveRelative(item, "a/b/1")).toBe(2);
+    expect(resolveRelative(item, "/a/b/0")).toBe(1);
+    expect(resolveRelative(item, "a")).toEqual({ b: [1, 2] });
+    expect(resolveRelative(item, "")).toBe(item);
+    expect(resolveRelative(item, "zzz")).toBeUndefined();
+  });
+});
+
+describe("formatValue", () => {
+  test("issue / pr / run become chips; pr links only when the artifact names its repo", () => {
+    expect(formatValue("WM-455", "issue")).toEqual({
+      kind: "chip",
+      chip: "issue",
+      id: "WM-455",
+      text: "WM-455",
+      href: "https://linear.app/watt-mind/issue/WM-455",
+    });
+    expect(formatValue(471, "pr", { github: "watt-mind/factory" })).toEqual({
+      kind: "chip",
+      chip: "pr",
+      id: "471",
+      text: "#471",
+      href: "https://github.com/watt-mind/factory/pull/471",
+    });
+    expect(formatValue("#9", "pr")).toMatchObject({ kind: "chip", text: "#9", href: null });
+    expect(formatValue("run_44fa5716-0304-49b1-8b65-a45500d0d784", "run")).toMatchObject({
+      kind: "chip",
+      chip: "run",
+      id: "run_44fa5716-0304-49b1-8b65-a45500d0d784",
+      text: "run_44fa5716",
+    });
+  });
+
+  test("state / sha / url / duration / datetime / bytes / count use the app's formatters", () => {
+    expect(formatValue("COMPLETED", "state")).toEqual({ kind: "state", state: "COMPLETED" });
+    expect(formatValue("c".repeat(40), "sha")).toEqual({ kind: "text", text: "c".repeat(12), mono: true, title: "c".repeat(40) });
+    expect(formatValue("https://x.test/a", "url")).toEqual({ kind: "link", href: "https://x.test/a", text: "https://x.test/a" });
+    expect(formatValue(90, "duration")).toMatchObject({ kind: "text", text: "1:30", title: "90s" });
+    expect(formatValue(1536, "bytes")).toMatchObject({ kind: "text", text: "1.5 KB" });
+    expect(formatValue(1234567, "count")).toMatchObject({ kind: "text", text: (1234567).toLocaleString(), mono: true });
+    const dt = formatValue("2026-08-17T10:00:00.000Z", "datetime");
+    expect(dt.kind).toBe("text");
+    if (dt.kind === "text") expect(dt.title).toBe("2026-08-17T10:00:00.000Z");
+    expect(formatValue("not a date", "datetime")).toEqual({ kind: "text", text: "not a date", mono: false });
+  });
+
+  test("no format: prose is proportional, identifiers and numbers are mono, nested values are json, absent is empty", () => {
+    expect(formatValue("Scope unclear.")).toEqual({ kind: "text", text: "Scope unclear.", mono: false });
+    expect(formatValue("feat/x")).toEqual({ kind: "text", text: "feat/x", mono: true });
+    expect(formatValue(true)).toEqual({ kind: "text", text: "true", mono: true });
+    expect(formatValue({ a: 1 })).toEqual({ kind: "json", value: { a: 1 } });
+    expect(formatValue(undefined)).toEqual({ kind: "empty" });
+    expect(formatValue(null, "issue")).toEqual({ kind: "empty" });
+    expect(formatValue("")).toEqual({ kind: "empty" });
+  });
+
+  test("formatBytes keeps the Artifacts view's units", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(3 * 1024 ** 2)).toBe("3.0 MB");
+    expect(formatBytes(1024 ** 3)).toBe("1.0 GB");
+  });
+});
+
+describe("toneFor / githubOf", () => {
+  test("matches by string form, ignores unknown tones and non-maps", () => {
+    const map = { "true": "ok", "false": "warn", weird: "purple" };
+    expect(toneFor(true, map)).toBe("ok");
+    expect(toneFor("false", map)).toBe("warn");
+    expect(toneFor("weird", map)).toBeUndefined();
+    expect(toneFor("x", map)).toBeUndefined();
+    expect(toneFor("x", "ok")).toBeUndefined();
+    expect(toneFor(null, map)).toBeUndefined();
+  });
+  test("githubOf accepts only owner/repo at the root", () => {
+    expect(githubOf(mergeArtifact)).toBe("watt-mind/factory");
+    expect(githubOf({ github: "not a repo" })).toBeNull();
+    expect(githubOf(triageArtifact)).toBeNull();
+    expect(githubOf("nope")).toBeNull();
+  });
+});
+
+describe("headerFor", () => {
+  test("summary prose, status with the last pointer token as label, title from the view then the schema", () => {
+    const h = headerFor(triageView, triageArtifact, { title: "schema title" });
+    expect(h.title).toBe("Triage plan");
+    expect(h.summary).toBe("Three issues moved; one needs a human.");
+    expect(h.status).toEqual({ label: "recommendation", value: "TRIAGE", tone: "ok" });
+    const bare = headerFor({ schemaVersion: "factory.artifact-view/v1", sections: [] }, {}, { title: "schema title" });
+    expect(bare).toEqual({ title: "schema title", summary: null, status: null });
+    const noStatus = headerFor(mergeView, { summary: "s" });
+    expect(noStatus.status).toBeNull();
+    expect(noStatus.summary).toBe("s");
+  });
+});
+
+describe("sectionsFor with the shipped triage-scan view", () => {
+  test("renders the plan as a table grouped by action with issue chips, tones, and expand cells", () => {
+    const sections = sectionsFor(triageView, triageArtifact);
+    expect(sections.map((s) => s.as)).toEqual(["table", "keyvalue"]);
+    const table = sections[0];
+    if (table.as !== "table") throw new Error("expected table");
+    expect(table.label).toBe("Plan");
+    expect(table.columns).toEqual(["issueId", "action", "reason"]);
+    expect(table.rows).toHaveLength(3);
+    expect(table.rows[0].cells[0].value).toMatchObject({ kind: "chip", chip: "issue", id: "WM-1" });
+    expect(table.rows[0].cells[1].tone).toBe("ok");
+    expect(table.rows[1].cells[1].tone).toBe("warn");
+    expect(table.rows[0].expand).toEqual([]);
+    expect(table.rows[1].expand.map((c) => c.key)).toEqual(["detail"]);
+    expect(table.rows[2].expand[0]).toMatchObject({ key: "ownedPaths", value: { kind: "json", value: ["a.ts", "b.ts"] } });
+    expect(table.hasExpand).toBe(true);
+    // Grouped in first-seen order, group tone from the column's tone map.
+    expect(table.groups?.map((g) => [g.label, g.rows.length, g.tone])).toEqual([
+      ["label-agent-ready", 2, "ok"],
+      ["needs-human", 1, "warn"],
+    ]);
+    // Rows keep their source index across grouping so React keys stay stable.
+    expect(table.groups?.[0].rows.map((r) => r.index)).toEqual([0, 2]);
+
+    const repo = sections[1];
+    if (repo.as !== "keyvalue") throw new Error("expected keyvalue");
+    expect(repo.entries).toEqual([{ key: "Repo", value: { kind: "text", text: "factory", mono: true }, tone: undefined }]);
+  });
+
+  test("a section whose pointer is absent in this artifact is dropped, not invented", () => {
+    const sections = sectionsFor(triageView, { recommendation: "NOOP", summary: "Nothing to do.", repo: "factory" });
+    expect(sections.map((s) => s.as)).toEqual(["keyvalue"]);
+    expect(sectionsFor(triageView, { plan: "not-an-array" })).toEqual([]);
+    expect(sectionsFor(triageView, null)).toEqual([]);
+  });
+
+  test("groupRows parks rows without the property under — at the end", () => {
+    const sections = sectionsFor(triageView, {
+      plan: [{ issueId: "WM-9", reason: "r" }, { issueId: "WM-8", action: "move-to-todo", reason: "r" }],
+    });
+    const table = sections[0];
+    if (table.as !== "table") throw new Error("expected table");
+    expect(table.groups?.map((g) => g.label)).toEqual(["move-to-todo", "—"]);
+    expect(groupRows(table.rows, "action").map((g) => g.rows.length)).toEqual([1, 1]);
+  });
+});
+
+describe("sectionsFor with the shipped merge-scan view", () => {
+  test("empty tables stay (as empty), pr chips link to the artifact's github, keyvalue over the whole artifact keeps only present keys", () => {
+    const sections = sectionsFor(mergeView, mergeArtifact);
+    expect(sections.map((s) => s.label)).toEqual(["Merge", "Fix", "Escalate", "Repo"]);
+    const [plan, fix, escalate, repo] = sections;
+    if (plan.as !== "table" || fix.as !== "table" || escalate.as !== "table" || repo.as !== "keyvalue") throw new Error("shape");
+    expect(plan.rows).toEqual([]);
+    expect(plan.groups).toBeNull();
+    expect(fix.rows[0].cells.map((c) => c.key)).toEqual(["pr", "ticket", "round", "mechanical", "finding"]);
+    expect(fix.rows[0].cells[0].value).toMatchObject({ kind: "chip", chip: "pr", href: "https://github.com/watt-mind/factory/pull/12" });
+    expect(fix.rows[0].cells[3]).toMatchObject({ tone: "ok", value: { kind: "text", text: "true" } });
+    expect(fix.rows[0].expand.find((c) => c.key === "withinOwnedPaths")?.tone).toBe("error");
+    expect(fix.rows[0].expand.find((c) => c.key === "headSha")?.value).toMatchObject({ kind: "text", text: "a".repeat(12) });
+    expect(escalate.rows[0].cells[1].value).toMatchObject({ kind: "chip", chip: "issue", id: "WM-210" });
+    expect(repo.entries.map((e) => e.key)).toEqual(["repo", "github", "base", "deployBranch"]);
+  });
+
+  test("viewApplies gates the Artifacts inspector: a merge plan yes, a transcript-shaped object no", () => {
+    expect(viewApplies(mergeView, mergeArtifact)).toBe(true);
+    expect(viewApplies(mergeView, { type: "assistant", message: "hi" })).toBe(false);
+    expect(viewApplies(mergeView, "string")).toBe(false);
+    expect(viewApplies(null, mergeArtifact)).toBe(false);
+    expect(viewApplies(undefined, mergeArtifact)).toBe(false);
+  });
+});
+
+describe("the other section kinds", () => {
+  const view: ArtifactView = {
+    schemaVersion: "factory.artifact-view/v1",
+    sections: [
+      { path: "/verdict", as: "badge", label: "Verdict", tone: { PASS: "ok", FAIL: "error" } },
+      { path: "/log", as: "code", label: "Log", language: "text" },
+      { path: "/notes", as: "prose" },
+      { path: "/files", as: "list", label: "Files" },
+      { path: "/checks", as: "list", label: "Checks", itemLabel: "name", tone: { name: { lint: "ok" } } },
+      { path: "/count", as: "keyvalue", label: "Count", formats: { "": "count" } },
+      { path: "/blob", as: "code" },
+    ],
+  };
+  test("badge, code, prose, list (scalars and itemLabel), scalar keyvalue, object code", () => {
+    const sections = sectionsFor(view, {
+      verdict: "FAIL",
+      log: "line 1\nline 2",
+      notes: "All good.",
+      files: ["a.ts", "b.ts"],
+      checks: [{ name: "lint" }, { name: "typecheck" }],
+      count: 4200,
+      blob: { k: 1 },
+    });
+    expect(sections).toEqual([
+      { as: "badge", label: "Verdict", value: "FAIL", tone: "error" },
+      { as: "code", label: "Log", text: "line 1\nline 2", language: "text" },
+      { as: "prose", label: undefined, text: "All good." },
+      {
+        as: "list",
+        label: "Files",
+        items: [
+          { key: "0", value: { kind: "text", text: "a.ts", mono: true }, tone: undefined },
+          { key: "1", value: { kind: "text", text: "b.ts", mono: true }, tone: undefined },
+        ],
+      },
+      {
+        as: "list",
+        label: "Checks",
+        items: [
+          { key: "0", value: { kind: "text", text: "lint", mono: true }, tone: "ok" },
+          { key: "1", value: { kind: "text", text: "typecheck", mono: true }, tone: undefined },
+        ],
+      },
+      { as: "keyvalue", label: undefined, entries: [{ key: "Count", value: { kind: "text", text: (4200).toLocaleString(), mono: true }, tone: undefined }] },
+      { as: "code", label: undefined, text: JSON.stringify({ k: 1 }, null, 2), language: "json" },
+    ]);
+  });
+});

--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -1,0 +1,441 @@
+/**
+ * Artifact views — pure half of the `factory.artifact-view/v1` renderer
+ * (docs/event-runtime-artifact-views.md §2.4, WM-455). No DOM, no React:
+ * this module turns a view sidecar plus a concrete artifact into renderable
+ * section models, and `components/ArtifactView.tsx` only draws them.
+ *
+ * `resolvePointer` mirrors `event-runtime/lib/artifact-view.mjs` line for
+ * line — the runtime already proved every pointer resolves in the output
+ * *schema*; here a pointer that resolves to `undefined` in a given artifact
+ * simply drops its section (optional fields are optional, §2.2).
+ */
+import { dur } from "../heartbeat";
+import type { ArtifactFormat, ArtifactTone, ArtifactView, ArtifactViewSection } from "../types";
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+const hasOwn = (obj: unknown, key: string): boolean =>
+  isObject(obj) && Object.prototype.hasOwnProperty.call(obj, key);
+
+/** RFC 6901: split a pointer into unescaped reference tokens; null when malformed. */
+export function parsePointer(pointer: unknown): string[] | null {
+  if (typeof pointer !== "string") return null;
+  if (pointer === "") return [];
+  if (!pointer.startsWith("/")) return null;
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+/**
+ * Resolve an RFC 6901 pointer against a document. Returns `undefined` when
+ * the pointer is malformed or any step is absent — never throws, never
+ * invents a value.
+ */
+export function resolvePointer(doc: unknown, pointer: unknown): unknown {
+  const tokens = parsePointer(pointer);
+  if (tokens === null) return undefined;
+  let node: unknown = doc;
+  for (const token of tokens) {
+    if (Array.isArray(node)) {
+      if (!/^(0|[1-9][0-9]*)$/.test(token)) return undefined;
+      const index = Number(token);
+      if (index >= node.length) return undefined;
+      node = node[index];
+    } else if (isObject(node)) {
+      if (!hasOwn(node, token)) return undefined;
+      node = node[token];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+/**
+ * A section-relative key is a plain property name or a pointer-ish path
+ * (`a/b`, `/a/b`) — the same rule `relativeNode` applies in the runtime
+ * validator, so what validated there resolves here.
+ */
+export function resolveRelative(base: unknown, key: string): unknown {
+  if (key === "") return base;
+  const tokens = key.startsWith("/") ? parsePointer(key) : key.split("/");
+  if (!tokens || tokens.length === 0) return undefined;
+  let node: unknown = base;
+  for (const token of tokens) {
+    if (Array.isArray(node)) {
+      if (!/^(0|[1-9][0-9]*)$/.test(token)) return undefined;
+      node = node[Number(token)];
+    } else if (isObject(node)) {
+      if (!hasOwn(node, token)) return undefined;
+      node = node[token];
+    } else {
+      return undefined;
+    }
+    if (node === undefined) return undefined;
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Tones
+// ---------------------------------------------------------------------------
+
+/** Tones map onto the theme's four semantic hues; `neutral` and `muted` share idle. */
+export const TONE_HUES: Record<ArtifactTone, string> = {
+  ok: "var(--hue-ok)",
+  warn: "var(--hue-warn)",
+  error: "var(--hue-err)",
+  muted: "var(--hue-idle)",
+  neutral: "var(--hue-idle)",
+};
+
+/**
+ * The tone a value earns from a (value → tone) map, or `undefined` when the
+ * map names no such value. Values are matched by their string form so a
+ * boolean `true` finds the `"true"` key merge-scan's view uses.
+ */
+export function toneFor(value: unknown, toneMap: unknown): ArtifactTone | undefined {
+  if (!isObject(toneMap) || value === undefined || value === null) return undefined;
+  const key = typeof value === "string" ? value : String(value);
+  const tone = toneMap[key];
+  return typeof tone === "string" && tone in TONE_HUES ? (tone as ArtifactTone) : undefined;
+}
+
+/** A section's tone map for one column/key — table/keyvalue/list nest one map per key. */
+function columnToneMap(section: ArtifactViewSection, key: string): unknown {
+  const t = section.tone?.[key];
+  return isObject(t) ? t : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Formats
+// ---------------------------------------------------------------------------
+
+/**
+ * Where the closed formats link to. Issues jump to Linear (the same base the
+ * Inbox uses); PRs need the repo, which the artifact itself names at `/github`
+ * when the agent reports one (merge-scan does) — no repo, no link, chip only.
+ */
+export const LINEAR_ISSUE_URL = "https://linear.app/watt-mind/issue/";
+export const issueHref = (id: string): string => `${LINEAR_ISSUE_URL}${encodeURIComponent(id)}`;
+export const prHref = (n: string | number, github: string | null | undefined): string | null =>
+  github ? `https://github.com/${github}/pull/${n}` : null;
+
+export interface FormatContext {
+  /** `owner/repo`, from the artifact's own `/github` when present. */
+  github?: string | null;
+}
+
+/**
+ * What a formatted value renders as. Chips are jump targets (`issue`, `pr`,
+ * `run`), `state` wears the run-state hue, `link` opens in a new tab, `json`
+ * is a nested value the caller draws compactly, everything else is text.
+ */
+export type Formatted =
+  | { kind: "empty" }
+  | { kind: "text"; text: string; mono: boolean; title?: string }
+  | { kind: "chip"; chip: "issue" | "pr" | "run"; id: string; text: string; href: string | null }
+  | { kind: "state"; state: string }
+  | { kind: "link"; href: string; text: string }
+  | { kind: "json"; value: unknown };
+
+const asText = (v: unknown): string => (typeof v === "string" ? v : String(v));
+
+/** Whether a string reads as prose (spaces) rather than an identifier. */
+const looksLikeIdentifier = (s: string): boolean => !/\s/.test(s);
+
+const isScalar = (v: unknown): boolean =>
+  v === null || ["string", "number", "boolean"].includes(typeof v);
+
+/**
+ * `formatValue(value, format)` for the closed §2.2 format set. Unknown or
+ * absent format falls through to the plain rendering, so a view can only
+ * *add* meaning to a value, never hide one.
+ */
+export function formatValue(value: unknown, format?: ArtifactFormat, ctx: FormatContext = {}): Formatted {
+  if (value === undefined || value === null || value === "") return { kind: "empty" };
+  if (!isScalar(value)) return { kind: "json", value };
+  const text = asText(value);
+  switch (format) {
+    case "issue":
+      return { kind: "chip", chip: "issue", id: text, text, href: issueHref(text) };
+    case "pr": {
+      const n = text.replace(/^#/, "");
+      return { kind: "chip", chip: "pr", id: n, text: `#${n}`, href: prHref(n, ctx.github) };
+    }
+    case "run":
+      return { kind: "chip", chip: "run", id: text, text: shortRunId(text), href: null };
+    case "state":
+      return { kind: "state", state: text };
+    case "url":
+      return { kind: "link", href: text, text };
+    case "sha":
+      return { kind: "text", text: text.slice(0, 12), mono: true, title: text };
+    case "repo":
+      return { kind: "text", text, mono: true };
+    case "duration":
+      // Seconds — the runtime's own duration fields are `*Seconds`; `dur` takes ms.
+      return typeof value === "number"
+        ? { kind: "text", text: dur(value * 1000), mono: true, title: `${value}s` }
+        : { kind: "text", text, mono: looksLikeIdentifier(text) };
+    case "datetime": {
+      const ms = typeof value === "number" ? value : Date.parse(text);
+      return Number.isNaN(ms)
+        ? { kind: "text", text, mono: false }
+        : { kind: "text", text: new Date(ms).toLocaleString(), mono: false, title: new Date(ms).toISOString() };
+    }
+    case "bytes":
+      return typeof value === "number"
+        ? { kind: "text", text: formatBytes(value), mono: true, title: `${value} B` }
+        : { kind: "text", text, mono: true };
+    case "count":
+      return typeof value === "number"
+        ? { kind: "text", text: value.toLocaleString(), mono: true }
+        : { kind: "text", text, mono: true };
+    default:
+      return typeof value === "string"
+        ? { kind: "text", text, mono: looksLikeIdentifier(text) }
+        : { kind: "text", text, mono: true };
+  }
+}
+
+/** `run_ec9c87f9-…` → `run_ec9c87f9`, the app-wide short form (`shortId` in ui.tsx). */
+function shortRunId(id: string): string {
+  const sep = id.indexOf("_");
+  if (sep === -1) return id;
+  const body = id.slice(sep + 1);
+  return body.length <= 8 ? id : id.slice(0, sep + 1) + body.slice(0, 8);
+}
+
+/** Byte counts as the Artifacts view has always shown them (moved here so both stay pure). */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+// ---------------------------------------------------------------------------
+// Section models
+// ---------------------------------------------------------------------------
+
+export interface Cell {
+  key: string;
+  value: Formatted;
+  tone?: ArtifactTone;
+}
+
+export interface TableRow {
+  /** Index in the source array — stable across grouping, used as the React key. */
+  index: number;
+  cells: Cell[];
+  /** `expand` keys that are present on this row, in view order. */
+  expand: Cell[];
+  raw: unknown;
+}
+
+export interface RowGroup {
+  key: string;
+  label: string;
+  tone?: ArtifactTone;
+  rows: TableRow[];
+}
+
+export type SectionModel =
+  | {
+      as: "table";
+      label: string | undefined;
+      columns: string[];
+      rows: TableRow[];
+      /** Present only when the view names `groupBy`; rows are then also inside groups. */
+      groups: RowGroup[] | null;
+      hasExpand: boolean;
+    }
+  | { as: "keyvalue"; label: string | undefined; entries: Cell[] }
+  | { as: "list"; label: string | undefined; items: Cell[] }
+  | { as: "badge"; label: string | undefined; value: string; tone?: ArtifactTone }
+  | { as: "code"; label: string | undefined; text: string; language?: string }
+  | { as: "prose"; label: string | undefined; text: string };
+
+const groupLabel = (v: unknown): string => (v === undefined || v === null || v === "" ? "—" : asText(v));
+
+/**
+ * Group table rows by one item property, first-seen order, so the artifact's
+ * own ordering (which the agent chose) survives. Rows without the property
+ * gather under `—` at the end.
+ */
+export function groupRows(rows: TableRow[], groupBy: string, toneMap?: unknown): RowGroup[] {
+  const groups = new Map<string, RowGroup>();
+  let missing: RowGroup | null = null;
+  for (const row of rows) {
+    const value = resolveRelative(row.raw, groupBy);
+    if (value === undefined || value === null || value === "") {
+      missing ??= { key: " missing", label: "—", rows: [] };
+      missing.rows.push(row);
+      continue;
+    }
+    const key = asText(value);
+    let group = groups.get(key);
+    if (!group) {
+      group = { key, label: groupLabel(value), tone: toneFor(value, toneMap), rows: [] };
+      groups.set(key, group);
+    }
+    group.rows.push(row);
+  }
+  const out = [...groups.values()];
+  if (missing) out.push(missing);
+  return out;
+}
+
+function cellFor(section: ArtifactViewSection, item: unknown, key: string, ctx: FormatContext): Cell {
+  const raw = resolveRelative(item, key);
+  return {
+    key,
+    value: formatValue(raw, section.formats?.[key], ctx),
+    tone: toneFor(raw, columnToneMap(section, key)),
+  };
+}
+
+function tableSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+  if (!Array.isArray(node)) return null;
+  const columns = section.columns ?? [];
+  const expandKeys = section.expand ?? [];
+  const rows: TableRow[] = node.map((item, index) => ({
+    index,
+    cells: columns.map((c) => cellFor(section, item, c, ctx)),
+    expand: expandKeys
+      .map((k) => cellFor(section, item, k, ctx))
+      .filter((cell) => cell.value.kind !== "empty"),
+    raw: item,
+  }));
+  const groups = section.groupBy ? groupRows(rows, section.groupBy, columnToneMap(section, section.groupBy)) : null;
+  return {
+    as: "table",
+    label: section.label,
+    columns,
+    rows,
+    groups,
+    hasExpand: rows.some((r) => r.expand.length > 0),
+  };
+}
+
+function keyvalueSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+  if (!isObject(node)) {
+    // A scalar keyvalue: one row whose label is the section's — a heading
+    // over a single row would just say the same word twice.
+    if (!isScalar(node)) return null;
+    const value = formatValue(node, section.formats?.[""], ctx);
+    if (value.kind === "empty") return null;
+    return {
+      as: "keyvalue",
+      label: undefined,
+      entries: [{ key: section.label ?? lastToken(section.path), value, tone: toneFor(node, section.tone?.[""]) }],
+    };
+  }
+  const keys = section.keys ?? Object.keys(node);
+  const entries = keys
+    .map((k) => cellFor(section, node, k, ctx))
+    .filter((cell) => cell.value.kind !== "empty");
+  if (entries.length === 0) return null;
+  return { as: "keyvalue", label: section.label, entries };
+}
+
+function listSection(section: ArtifactViewSection, node: unknown, ctx: FormatContext): SectionModel | null {
+  if (!Array.isArray(node)) return null;
+  const items: Cell[] = node.map((item, index) => {
+    const raw = section.itemLabel ? resolveRelative(item, section.itemLabel) : item;
+    return {
+      key: String(index),
+      value: formatValue(raw, section.formats?.[section.itemLabel ?? ""], ctx),
+      tone: toneFor(raw, section.tone?.[section.itemLabel ?? ""]),
+    };
+  });
+  return { as: "list", label: section.label, items };
+}
+
+const lastToken = (pointer: string): string => {
+  const tokens = parsePointer(pointer) ?? [];
+  return tokens.length ? tokens[tokens.length - 1] : "value";
+};
+
+/**
+ * `sectionsFor(view, artifact)` → renderable section models, in view order.
+ * A section whose pointer does not resolve in this artifact is dropped, as
+ * is one whose value has the wrong shape for its `as` (a table over a
+ * non-array) — the JSON stays one Raw toggle away, so dropping is honest,
+ * inventing a rendering is not.
+ */
+export function sectionsFor(view: ArtifactView, artifact: unknown): SectionModel[] {
+  const ctx: FormatContext = { github: githubOf(artifact) };
+  const out: SectionModel[] = [];
+  for (const section of view.sections ?? []) {
+    const node = resolvePointer(artifact, section.path);
+    if (node === undefined || node === null) continue;
+    let model: SectionModel | null = null;
+    switch (section.as) {
+      case "table":
+        model = tableSection(section, node, ctx);
+        break;
+      case "keyvalue":
+        model = keyvalueSection(section, node, ctx);
+        break;
+      case "list":
+        model = listSection(section, node, ctx);
+        break;
+      case "badge":
+        if (isScalar(node)) {
+          model = { as: "badge", label: section.label, value: asText(node), tone: toneFor(node, section.tone) };
+        }
+        break;
+      case "code":
+        if (typeof node === "string") model = { as: "code", label: section.label, text: node, language: section.language };
+        else if (!isScalar(node)) model = { as: "code", label: section.label, text: JSON.stringify(node, null, 2), language: "json" };
+        break;
+      case "prose":
+        if (isScalar(node)) model = { as: "prose", label: section.label, text: asText(node) };
+        break;
+    }
+    if (model) out.push(model);
+  }
+  return out;
+}
+
+/** The artifact's own `owner/repo` when it reports one — the only place a PR link can come from. */
+export function githubOf(artifact: unknown): string | null {
+  const g = isObject(artifact) ? artifact.github : undefined;
+  return typeof g === "string" && /^[^/\s]+\/[^/\s]+$/.test(g) ? g : null;
+}
+
+/** The header: prose summary and status badge (§2.2 `summary`, `status`). */
+export interface ViewHeader {
+  title: string | null;
+  summary: string | null;
+  status: { label: string; value: string; tone?: ArtifactTone } | null;
+}
+
+export function headerFor(view: ArtifactView, artifact: unknown, schema?: unknown): ViewHeader {
+  const schemaTitle = isObject(schema) && typeof schema.title === "string" ? schema.title : null;
+  const summary = view.summary !== undefined ? resolvePointer(artifact, view.summary) : undefined;
+  const statusValue = view.status ? resolvePointer(artifact, view.status.path) : undefined;
+  return {
+    title: view.title ?? schemaTitle,
+    summary: typeof summary === "string" && summary.trim() ? summary : null,
+    status:
+      view.status && isScalar(statusValue) && statusValue !== null && statusValue !== ""
+        ? { label: lastToken(view.status.path), value: asText(statusValue), tone: toneFor(statusValue, view.status.tone) }
+        : null,
+  };
+}
+
+/**
+ * Whether this view says anything at all about this artifact — the gate the
+ * Artifacts inspector uses before swapping its text preview for the view
+ * (a transcript that happens to parse as JSON must not wear a merge-plan).
+ */
+export function viewApplies(view: ArtifactView | null | undefined, artifact: unknown): view is ArtifactView {
+  if (!view || !isObject(artifact)) return false;
+  const h = headerFor(view, artifact);
+  return h.summary !== null || h.status !== null || sectionsFor(view, artifact).length > 0;
+}

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -316,6 +316,55 @@ export interface AgentEventRoute {
   resolvedModel: string | null;
 }
 
+/**
+ * `factory.artifact-view/v1` — the sidecar rendering hints an agent may ship
+ * beside its output schema (docs/event-runtime-artifact-views.md §2.2). The
+ * closed vocabularies mirror `SECTION_KINDS` / `FORMATS` / `TONES` in
+ * `event-runtime/lib/artifact-view.mjs`; per-`as` key applicability is
+ * enforced there at registry load, so the web renderer trusts the shape.
+ */
+export type ArtifactTone = "ok" | "warn" | "error" | "muted" | "neutral";
+export type ArtifactFormat =
+  | "issue"
+  | "pr"
+  | "url"
+  | "sha"
+  | "repo"
+  | "run"
+  | "duration"
+  | "datetime"
+  | "state"
+  | "bytes"
+  | "count";
+export type ArtifactSectionKind = "table" | "keyvalue" | "list" | "badge" | "code" | "prose";
+export interface ArtifactViewSection {
+  /** RFC 6901 pointer into the artifact; `""` is the whole document. */
+  path: string;
+  as: ArtifactSectionKind;
+  label?: string;
+  /** table */
+  columns?: string[];
+  groupBy?: string;
+  expand?: string[];
+  /** keyvalue */
+  keys?: string[];
+  /** list */
+  itemLabel?: string;
+  /** code */
+  language?: string;
+  /** column/key (or `""` for the section value itself) → format */
+  formats?: Record<string, ArtifactFormat>;
+  /** table/keyvalue/list: column/key → (value → tone); badge: value → tone */
+  tone?: Record<string, ArtifactTone | Record<string, ArtifactTone>>;
+}
+export interface ArtifactView {
+  schemaVersion: "factory.artifact-view/v1";
+  title?: string;
+  summary?: string;
+  status?: { path: string; tone: Record<string, ArtifactTone> };
+  sections: ArtifactViewSection[];
+}
+
 /** One registered agent, fully readable: definition, prompt, schemas, pins. */
 export interface AgentDef {
   ref: string;
@@ -334,7 +383,7 @@ export interface AgentDef {
   outputSchema: unknown;
   /** Artifact-view sidecar (WM-454), null when the agent ships none. */
   outputViewFile?: string | null;
-  outputView?: unknown;
+  outputView?: ArtifactView | null;
   pins: Record<string, string>;
   /** Closed-execution shape: fixed argv (command adapter) or action registry. */
   command: string[] | null;

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -2,9 +2,12 @@ import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { useState } from "react";
 import type { ArtifactInventoryItem } from "../types";
 import { Artifacts, formatBytes, type ArtifactFilters } from "./Artifacts";
+import { ARTIFACT_RAW_KEY } from "../components/ArtifactView";
 import { handleRunArtifactClick } from "./Runs";
 
 const originalFetch = globalThis.fetch;
@@ -57,16 +60,19 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   Object.defineProperty(navigator, "clipboard", { configurable: true, value: originalClipboard });
   localStorage.removeItem("evrt-display-artifacts");
+  localStorage.removeItem(ARTIFACT_RAW_KEY);
 });
 
 function renderArtifacts(
   onJumpRun = mock(() => {}),
   initialFilters: ArtifactFilters = { kind: null, orphan: null, search: "" },
+  seed: { items?: ArtifactInventoryItem[]; agents?: unknown[] } = {},
 ) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchInterval: false, staleTime: Infinity } },
   });
-  client.setQueryData(["artifacts"], { artifacts: ITEMS });
+  client.setQueryData(["artifacts"], { artifacts: seed.items ?? ITEMS });
+  if (seed.agents) client.setQueryData(["agents"], { agents: seed.agents, edges: {}, eventTypes: [], contracts: {} });
   client.setQueryData(["events", "all-for-artifacts"], {
     events: [
       {
@@ -231,5 +237,64 @@ describe("Artifacts inventory (WM-207)", () => {
     );
     fireEvent.click(runLink.getByRole("link", { name: "Open" }));
     expect(window.location.hash).toBe(`#/${`artifacts/${"b".repeat(64)}`}`);
+  });
+});
+
+describe("Artifacts inspector renders a view for the producing agent's artifact (WM-455)", () => {
+  const MERGE_VIEW = JSON.parse(readFileSync(path.resolve(import.meta.dir, "../../../agents/merge-scan.view.json"), "utf8"));
+  const MERGE_AGENT = { ref: "merge-scan@2", id: "merge-scan", outputSchema: { title: "merge plan" }, outputView: MERGE_VIEW };
+  const MERGE_ITEM: ArtifactInventoryItem = {
+    sha256: "d".repeat(64),
+    sizeBytes: 900,
+    mtime: "2026-01-05T03:04:05.000Z",
+    referenced: true,
+    references: [
+      { runId: "run_merge", kind: "report", agent: "merge-scan@2", state: "COMPLETED", createdAt: "2026-01-05T03:04:05.000Z" },
+    ],
+  };
+  const MERGE_PLAN = {
+    recommendation: "ESCALATE",
+    repo: "factory",
+    github: "watt-mind/factory",
+    base: "develop",
+    deployBranch: "main",
+    plan: [],
+    fix: [],
+    escalate: [{ pr: 471, ticket: "WM-210", headSha: "c".repeat(40), reason: "Draft hold." }],
+    summary: "One PR held.",
+  };
+
+  test("a stored merge-plan JSON draws through the merge-scan view, Raw swaps back to the line preview", async () => {
+    globalThis.fetch = mock(async () => new Response(JSON.stringify(MERGE_PLAN), { status: 200 })) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${"d".repeat(64)}`;
+    const view = renderArtifacts(undefined, undefined, { items: [MERGE_ITEM, ...ITEMS], agents: [MERGE_AGENT] });
+
+    expect(await view.findByText("One PR held.")).toBeTruthy();
+    expect(view.getByText("ESCALATE")).toBeTruthy();
+    expect((view.getByRole("link", { name: "#471" }) as HTMLAnchorElement).getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/pull/471",
+    );
+    expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
+    expect(view.queryByRole("combobox", { name: "Search artifact content" })).toBeNull();
+    expect(view.getByText(/Merge plan · merge-scan@2/)).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: "Raw" }));
+    const preview = view.getByRole("region", { name: "Artifact content" });
+    expect(preview.textContent).toContain('"recommendation": "ESCALATE"');
+    expect(view.getByRole("combobox", { name: "Search artifact content" })).toBeTruthy();
+    expect(localStorage.getItem(ARTIFACT_RAW_KEY)).toBe("1");
+
+    fireEvent.click(view.getByRole("button", { name: "View" }));
+    expect(view.queryByRole("region", { name: "Artifact content" })).toBeNull();
+    expect(view.getByText("One PR held.")).toBeTruthy();
+  });
+
+  test("a transcript from an agent with a view keeps the plain preview — the view says nothing about it", async () => {
+    globalThis.fetch = mock(async () => new Response(JSON.stringify({ type: "assistant", text: "hi" }), { status: 200 })) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${"d".repeat(64)}`;
+    const view = renderArtifacts(undefined, undefined, { items: [MERGE_ITEM, ...ITEMS], agents: [MERGE_AGENT] });
+    const preview = await view.findByRole("region", { name: "Artifact content" });
+    expect(preview.textContent).toContain('"type": "assistant"');
+    expect(view.queryByRole("group", { name: "Artifact rendering" })).toBeNull();
   });
 });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { api, artifactUrl, fetchArtifacts } from "../api";
+import { ArtifactPanel, loadArtifactRaw } from "../components/ArtifactView";
 import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import {
@@ -23,7 +24,10 @@ import {
   type DisplayConfig,
 } from "../displayOptions";
 import { useDisplayOptions, useNow } from "../hooks";
-import type { AdmittedEvent, ArtifactInventoryItem, StatusView } from "../types";
+import { formatBytes, viewApplies } from "../lib/artifactView";
+import type { AdmittedEvent, AgentDef, ArtifactInventoryItem, StatusView } from "../types";
+
+export { formatBytes };
 
 export type ArtifactFilters = {
   kind: string | null;
@@ -35,13 +39,6 @@ const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
 
 function kindsOf(artifact: ArtifactInventoryItem): string[] {
   return [...new Set(artifact.references.flatMap((reference) => reference.kind ?? []))];
-}
-
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
-  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
 }
 
 const ARTIFACTS_DISPLAY: DisplayConfig<ArtifactInventoryItem> = {
@@ -111,6 +108,17 @@ function containsArtifactHash(value: unknown, sha256: string, seen = new Set<obj
   return Array.isArray(value)
     ? value.some((entry) => containsArtifactHash(entry, sha256, seen))
     : Object.values(value).some((entry) => containsArtifactHash(entry, sha256, seen));
+}
+
+/** The stored bytes as one JSON object, or null — the only shape a view can describe. */
+function parsedObject(raw: string): Record<string, unknown> | null {
+  if (!/^\s*\{/.test(raw)) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
 }
 
 function formattedContent(raw: string, kinds: string[]): string {
@@ -228,6 +236,15 @@ export function Artifacts({
     enabled: selectedSha !== null,
     refetchInterval: 10_000,
   });
+  // The producing run's agent may ship a view sidecar (WM-454); when the
+  // stored bytes are that agent's artifact, the inspector draws it (WM-455).
+  const agentsQ = useQuery({
+    queryKey: ["agents"],
+    queryFn: () => api.agents(),
+    enabled: selectedSha !== null,
+    staleTime: 30_000,
+  });
+  const [artifactRaw, setArtifactRaw] = useState(loadArtifactRaw);
 
   const kinds = useMemo(
     () =>
@@ -276,6 +293,21 @@ export function Artifacts({
   );
   const selectedKinds = selected ? kindsOf(selected) : [];
   const preview = contentQ.data === undefined ? null : formattedContent(contentQ.data, selectedKinds);
+  const parsedArtifact = useMemo(
+    () => (contentQ.data === undefined ? null : parsedObject(contentQ.data)),
+    [contentQ.data],
+  );
+  const producerAgent: AgentDef | undefined = useMemo(() => {
+    const refs = selected?.references.map((reference) => reference.agent).filter(Boolean) ?? [];
+    const defs = agentsQ.data?.agents ?? [];
+    for (const ref of refs) {
+      const def = defs.find((a) => a.ref === ref || a.id === ref);
+      if (def?.outputView) return def;
+    }
+    return undefined;
+  }, [selected, agentsQ.data]);
+  const viewShown =
+    parsedArtifact !== null && viewApplies(producerAgent?.outputView, parsedArtifact) && !artifactRaw;
   const previewLines = preview?.split("\n") ?? [];
   const matchCount = contentSearch.trim()
     ? previewLines.filter((line) => line.toLowerCase().includes(contentSearch.trim().toLowerCase())).length
@@ -606,21 +638,39 @@ export function Artifacts({
             <div>
               <h2 className="display text-[12px] font-semibold">Preview</h2>
               <p className="mt-0.5 text-[11px] text-(--text-faint)">
-                {matchCount === null ? `${previewLines.length.toLocaleString()} lines` : `${matchCount.toLocaleString()} matching lines`}
+                {viewShown
+                  ? `${producerAgent?.outputView?.title ?? "view"} · ${producerAgent?.ref}`
+                  : matchCount === null
+                    ? `${previewLines.length.toLocaleString()} lines`
+                    : `${matchCount.toLocaleString()} matching lines`}
               </p>
             </div>
-            <FilterInput value={contentSearch} onChange={setContentSearch} placeholder="Find in content…" label="Search artifact content" />
+            {!viewShown && (
+              <FilterInput value={contentSearch} onChange={setContentSearch} placeholder="Find in content…" label="Search artifact content" />
+            )}
           </div>
           {contentQ.isPending && <div className="mt-3 text-[12px] text-(--text-faint)">Loading artifact preview…</div>}
           {contentQ.isError && <div className="mt-3 text-[12px] text-(--hue-err)">Could not load artifact content: {(contentQ.error as Error).message}</div>}
           {preview !== null && (
-            <div role="region" aria-label="Artifact content" className="mono mt-3 max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed">
-              {previewLines.map((line, index) => (
-                <div key={index} className={`grid grid-cols-[4rem_minmax(0,1fr)] px-2 ${contentSearch.trim() && line.toLowerCase().includes(contentSearch.trim().toLowerCase()) ? "bg-(--surface-2)" : ""}`}>
-                  <span aria-hidden="true" className="select-none border-r border-(--border) pr-2 text-right text-(--text-faint)">{index + 1}</span>
-                  <span className="min-w-0 whitespace-pre-wrap break-words pl-3">{highlightedLine(line, contentSearch)}</span>
-                </div>
-              ))}
+            <div className="mt-3">
+              <ArtifactPanel
+                artifact={parsedArtifact ?? preview}
+                schema={producerAgent?.outputSchema}
+                view={parsedArtifact ? producerAgent?.outputView : null}
+                onJumpRun={onJumpRun}
+                raw={artifactRaw}
+                onRawChange={setArtifactRaw}
+                rawFallback={
+                  <div role="region" aria-label="Artifact content" className="mono max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed">
+                    {previewLines.map((line, index) => (
+                      <div key={index} className={`grid grid-cols-[4rem_minmax(0,1fr)] px-2 ${contentSearch.trim() && line.toLowerCase().includes(contentSearch.trim().toLowerCase()) ? "bg-(--surface-2)" : ""}`}>
+                        <span aria-hidden="true" className="select-none border-r border-(--border) pr-2 text-right text-(--text-faint)">{index + 1}</span>
+                        <span className="min-w-0 whitespace-pre-wrap break-words pl-3">{highlightedLine(line, contentSearch)}</span>
+                      </div>
+                    ))}
+                  </div>
+                }
+              />
             </div>
           )}
         </section>


### PR DESCRIPTION
Fixes WM-455

## What

Schema-derived rendering of run artifacts (docs/event-runtime-artifact-views.md §2.4) on top of the WM-454 sidecar contract.

- `web/src/lib/artifactView.ts` (pure, no DOM): `resolvePointer` (RFC 6901, mirrors `lib/artifact-view.mjs`), `resolveRelative`, `sectionsFor(view, artifact)` → section models (absent pointers dropped), `groupRows`, `formatValue(value, format)` for the closed format set (`issue`/`pr`/`run` → chips, `state` → run-state hue, `duration`/`datetime`/`bytes`/`count` formatters), `toneFor`, `headerFor`, `viewApplies`. `formatBytes` moved here from `views/Artifacts.tsx` (re-exported). Unit-tested in `artifactView.test.ts`.
- `web/src/components/ArtifactView.tsx`: `ArtifactView({ artifact, schema, view })` renders summary prose, status badge, sections in order — `table` (grouped when `groupBy`, `expand` behind a per-row disclosure, chips/tone pills per column), `keyvalue` (incl. `path: ""` + `keys`), `list`, `badge`, `code`, `prose`. Never branches on the agent name. `ArtifactPanel` owns the **View / Raw** toggle (persisted in `localStorage` `evrt-artifact-raw`, like the collapsed-sections key) and falls back to `JsonBlock` when no view applies. Reuses `StateBadge`, `JumpLink`, `DisclosureChevron`, `Th`, `JsonBlock`.
- `RunDetailBlocks.tsx`: looks the run's agent up in the `/agents` query (same one `AgentHoverCard` keeps warm) and mounts `ArtifactPanel` at the artifact position; lazy-loaded (`React.lazy` + `Suspense`, `JsonBlock` fallback) so the entry chunk stays at 551.66 kB (budget 575). No view → unchanged `JsonBlock`.
- `views/Artifacts.tsx`: when the stored bytes parse as one JSON object and the producing reference's agent ships a view that says something about it (`viewApplies` — a transcript never wears a merge plan), the inspector draws the view; Raw swaps back to the existing line-numbered preview + search.
- `types.ts`: `ArtifactView`, `ArtifactViewSection`, `ArtifactFormat`, `ArtifactTone`, `ArtifactSectionKind`; `AgentDef.outputView` narrowed to `ArtifactView | null`. `api.ts` unchanged; parity test in `lib/api.test.mjs` passes.
- CLI: `inspectHeader(view, artifact)` in `lib/artifact-view.mjs` (tested in `lib/artifact-view.test.mjs`); `cli/inspect.mjs` (where `inspect` lives after the WM-290 split — the ticket names `cli.mjs`) prints the view's summary and `<label>: <value>` status as the first lines of the result section, best-effort (a failed `/agents` read never fails `inspect`).

## Tests

`ArtifactView.test.tsx`: triage-scan fixture through the shipped view (grouped rows, issue chips, expand disclosure, Raw round-trip + persistence), missing optional path, no view → JsonBlock, merge-scan fixture in the real live shape through `agents/merge-scan.view.json`, run chips via `onJumpRun` / `#/runs/<id>`. `RunDetailBlocks.test.tsx` and `Artifacts.test.tsx` cover the two mount points.

## Verification

```
bun test event-runtime/web event-runtime/lib/artifact-view.test.mjs && bun run --cwd event-runtime/web build && bun build/emit.mjs --check && bun run format:check
```
754 pass / 0 fail; entry chunk 551.66 kB (ArtifactView is its own 15.8 kB chunk); emit check ok (pre-existing "floor delivery" notice about other repos, exit 0); prettier clean.

## UX critique

One round against the worktree build served on :7455 over the live read-only API (:7381), Chrome DevTools screenshots of `#/run/<merge-scan>` (view + Raw), `#/run/<triage-scan>` (grouped plan) and the Runs side panel. Finding fixed in-branch: `theme.css` pins `table td` to `nowrap`, so `reason` cells overflowed the 400 px pane — prose columns now `whitespace-normal` + `overflow-wrap: anywhere` (40-char SHAs in reasons no longer force a horizontal scroll). Verdict: SHIP.

## Owned Paths

All edits inside Owned Paths; no `RunFull.tsx`/`Runs.tsx` plumbing was needed (run chips fall back to `#/runs/<id>` hrefs). Substitution: `event-runtime/cli/inspect.mjs` edited instead of `event-runtime/cli.mjs`.
