### PR TITLE
feat(web): align Inbox list chrome (WM-616)

### DIFF
--- a/event-runtime/web/src/filterQuery.test.ts
+++ b/event-runtime/web/src/filterQuery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   EVENT_FACETS,
+  INBOX_FACETS,
   PROPOSAL_FACETS,
   RUN_FACETS,
   chipHelp,
@@ -13,7 +14,7 @@ import {
   proposalRunState,
   removeFilterToken,
 } from "./filterQuery";
-import type { AdmittedEvent, Proposal, RunListItem } from "./types";
+import type { AdmittedEvent, InboxItem, Proposal, RunListItem } from "./types";
 
 const run = (over: Partial<RunListItem> = {}): RunListItem => ({
   runId: "run_48ac91",
@@ -50,6 +51,22 @@ const event = (over: Partial<AdmittedEvent> = {}): AdmittedEvent => ({
   ...over,
 });
 
+const inboxItem = (over: Partial<InboxItem> = {}): InboxItem => ({
+  id: "inbox_1",
+  kind: "BLOCKED",
+  severity: "normal",
+  title: "BLOCKED WM-616: choose the list layout",
+  body: "Inbox chrome needs parity with Runs",
+  refs: { repo: "factory", issue: "WM-616" },
+  source: "agent:run_1",
+  createdAt: "2026-08-14T09:00:00.000Z",
+  ackedAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  delivery: {},
+  ...over,
+});
+
 const proposal = (over: Partial<Proposal> = {}): Proposal => ({
   id: "prop_8f12",
   decision: "run",
@@ -76,6 +93,8 @@ const matchEvent = (input: string, row = event()) =>
   matchesFilterQuery(row, parseFilterQuery(input, EVENT_FACETS), EVENT_FACETS, undefined);
 const matchProposal = (input: string, row = proposal(), runStates = new Map<string, string>()) =>
   matchesFilterQuery(row, parseFilterQuery(input, PROPOSAL_FACETS), PROPOSAL_FACETS, { runStates });
+const matchInbox = (input: string, row = inboxItem()) =>
+  matchesFilterQuery(row, parseFilterQuery(input, INBOX_FACETS), INBOX_FACETS, undefined);
 
 describe("parseFilterQuery", () => {
   test("keyed tokens, flags and leftover words, each keeping its offsets", () => {
@@ -233,6 +252,16 @@ describe("matchesFilterQuery", () => {
     expect(matchProposal("is:stale", proposal({ status: "approved" }), new Map([["run_48ac91", "COMPLETED"]]))).toBe(false);
     expect(matchProposal("is:stale", proposal({ status: "rejected" }), new Map([["run_48ac91", "FAILED"]]))).toBe(false);
     expect(matchProposal("is:stale", proposal({ status: "expired" }), new Map([["run_48ac91", "CANCELLED"]]))).toBe(false);
+  });
+
+  test("Inbox facets cover kind, status, references, and title/body text", () => {
+    expect(matchInbox("kind:blocked repo:factory issue:WM-616 is:open")).toBe(true);
+    expect(matchInbox("chrome parity")).toBe(true);
+    expect(matchInbox("repo:bj29")).toBe(false);
+    expect(matchInbox("is:acked")).toBe(false);
+    expect(matchInbox("is:acked", inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" }))).toBe(true);
+    expect(matchInbox("is:resolved", inboxItem({ resolvedAt: "2026-08-14T11:00:00.000Z" }))).toBe(true);
+    expect(matchInbox("is:open", inboxItem({ ackedAt: "2026-08-14T10:00:00.000Z" }))).toBe(false);
   });
 
   test("Proposals keyed fields cover the columns the list shows", () => {

--- a/event-runtime/web/src/filterQuery.ts
+++ b/event-runtime/web/src/filterQuery.ts
@@ -11,7 +11,7 @@
  * view already searched — because that is what pasting an id expects to do.
  */
 
-import type { AdmittedEvent, Proposal, RunListItem } from "./types";
+import type { AdmittedEvent, InboxItem, Proposal, RunListItem } from "./types";
 
 /** What a field accessor may return: one value, several, or nothing. */
 export type FieldValue = string | null | undefined | readonly (string | null | undefined)[];
@@ -330,6 +330,35 @@ export const RUN_FACETS: FilterFacets<RunListItem, RunFilterContext> = {
   values: {
     state: RUN_STATES,
     adapter: ADAPTERS,
+  },
+};
+
+export const INBOX_FACETS: FilterFacets<InboxItem, undefined> = {
+  fields: {
+    kind: (item) => item.kind,
+    repo: (item) => item.refs.repo,
+    issue: (item) => item.refs.issue,
+  },
+  flags: {
+    open: {
+      help: "Not acknowledged or resolved.",
+      test: (item) => !item.ackedAt && !item.resolvedAt,
+    },
+    acked: {
+      help: "Acknowledged but not resolved.",
+      test: (item) => !!item.ackedAt && !item.resolvedAt,
+    },
+    resolved: {
+      help: "Resolved inbox item.",
+      test: (item) => !!item.resolvedAt,
+    },
+  },
+  text: (item) => [item.title, item.body],
+  values: {
+    kind: [
+      "decision_needed", "proposal_expired", "BLOCKED", "ESCALATED", "human_needed",
+      "CI RED", "SMOKE RED", "CIRCUIT BREAKER", "RC READY",
+    ],
   },
 };
 

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -1,6 +1,6 @@
 import "../test-dom";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Inbox,
@@ -14,9 +14,11 @@ import {
 } from "./Inbox";
 import { api } from "../api";
 import type { InboxItem } from "../types";
+import { changeInput } from "../test-render";
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 function item(overrides: Partial<InboxItem> & Pick<InboxItem, "id" | "kind">): InboxItem {
@@ -96,7 +98,7 @@ let ledger: InboxItem[] = [];
 
 beforeEach(() => {
   ledger = [
-    item({ id: "inbox_open_1", kind: "BLOCKED", title: "BLOCKED WM-1: decide X", createdAt: T0, refs: { runId: "run_a", issue: "WM-1" } }),
+    item({ id: "inbox_open_1", kind: "BLOCKED", title: "BLOCKED WM-1: decide X", body: "Choose a safe recovery", createdAt: T0, refs: { runId: "run_a", issue: "WM-1", repo: "factory" } }),
     item({ id: "inbox_open_2", kind: "CI RED", title: "CI RED WM-2/PR #9", createdAt: T1, refs: { pr: "https://github.com/watt-mind/factory/pull/9" } }),
     item({ id: "inbox_acked_1", kind: "ESCALATED", title: "ESCALATED merge", createdAt: T0, ackedAt: T1 }),
     item({ id: "inbox_resolved_1", kind: "RC READY", title: "RC READY factory", createdAt: T0, ackedAt: T1, resolvedAt: T2, resolvedBy: "operator" }),
@@ -156,6 +158,72 @@ describe("Inbox view", () => {
     // Group headers in triage order.
     expect(view.getByText("Decide")).toBeTruthy();
     expect(view.getByText("Red")).toBeTruthy();
+  });
+
+  test("filters with inbox facets and free text, with an Esc-hinted empty state", async () => {
+    const { view } = renderInbox();
+    const input = await waitFor(() => view.getByLabelText("Filter inbox")) as HTMLInputElement;
+
+    act(() => changeInput(input, "kind:blocked repo:factory issue:WM-1 is:open"));
+    expect(view.getByText("BLOCKED WM-1: decide X")).toBeTruthy();
+    expect(view.queryByText("CI RED WM-2/PR #9")).toBeNull();
+
+    act(() => changeInput(input, "safe recovery"));
+    expect(view.getByText("BLOCKED WM-1: decide X")).toBeTruthy();
+
+    act(() => changeInput(input, "kind:no-such-kind"));
+    expect(view.getByText("No inbox items match this filter.")).toBeTruthy();
+    expect(view.getByText("Esc clears the filter")).toBeTruthy();
+  });
+
+  test("Display groups by kind or none and shared group headers collapse rows", async () => {
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("BLOCKED WM-1: decide X"));
+
+    const decide = view.getByRole("button", { name: /Decide 1/ });
+    expect(decide.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(decide);
+    expect(decide.getAttribute("aria-expanded")).toBe("false");
+    expect(view.queryByText("BLOCKED WM-1: decide X")).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: /Display/ }));
+    const chooseGroup = (name: string) => {
+      fireEvent.click(view.getByRole("combobox", { name: "Group by" }));
+      fireEvent.mouseDown(within(view.getByRole("listbox", { name: "Group by options" })).getByRole("option", { name }));
+    };
+    chooseGroup("Kind");
+    expect(view.getByRole("button", { name: /BLOCKED 1/ })).toBeTruthy();
+    expect(view.getByRole("button", { name: /CI RED 1/ })).toBeTruthy();
+
+    chooseGroup("No grouping");
+    expect(view.queryByRole("button", { name: /BLOCKED 1/ })).toBeNull();
+    expect(view.getByText("BLOCKED WM-1: decide X")).toBeTruthy();
+    expect(view.getByText("CI RED WM-2/PR #9")).toBeTruthy();
+  });
+
+  test("Kind and Age headers are sortable and persist ordering through display state", async () => {
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("BLOCKED WM-1: decide X"));
+    const age = view.getByRole("button", { name: "Age" }).closest("th")!;
+    expect(age.getAttribute("aria-sort")).toBe("ascending");
+    fireEvent.click(view.getByRole("button", { name: "Kind" }));
+    expect(view.getByRole("button", { name: "Kind" }).closest("th")?.getAttribute("aria-sort")).toBe("ascending");
+    const persisted = JSON.parse(localStorage.getItem("evrt-display-inbox") ?? "{}");
+    expect(persisted.sortBy).toBe("kind");
+  });
+
+  test("keeps Title visible when every display property is toggled off", async () => {
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("BLOCKED WM-1: decide X"));
+    fireEvent.click(view.getByRole("button", { name: /Display/ }));
+    const dialog = view.getByRole("dialog", { name: "Display options" });
+    for (const label of ["Kind", "Title", "Age", "Refs", "Sent"]) {
+      fireEvent.click(within(dialog).getByRole("button", { name: label }));
+    }
+    expect(view.getByRole("columnheader", { name: "Title" })).toBeTruthy();
+    expect(view.getByText("BLOCKED WM-1: decide X")).toBeTruthy();
+    const persisted = JSON.parse(localStorage.getItem("evrt-display-inbox") ?? "{}");
+    expect(persisted.hiddenColumns).not.toContain("title");
   });
 
   test("empty Open tab is a sentence, not a table", async () => {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -1,8 +1,23 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { api } from "../api";
-import { keyGuard, useListKeys, useNow, useTabKeys } from "../hooks";
+import { keyGuard, useDisplayOptions, useListKeys, useNow, useTabKeys } from "../hooks";
 import { goPrefixActive } from "../goSequence";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  removeCustomColumn,
+  sortRows,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+  type DisplayState,
+} from "../displayOptions";
+import { DisplayOptions, exportJson } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
+import { INBOX_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import type { InboxItem } from "../types";
 import {
   Ago,
@@ -10,8 +25,11 @@ import {
   CopyActions,
   DetailPane,
   Dialog,
+  FilterInput,
+  GroupHeaderRow,
   JumpLink,
   KV,
+  ListEmpty,
   ListPane,
   Section,
   StateBadge,
@@ -65,6 +83,48 @@ export function groupOf(kind: string): InboxGroup {
 export const INBOX_KIND_HUES: Record<string, string> = Object.fromEntries(
   INBOX_GROUPS.flatMap((g) => g.kinds.map((k) => [k, g.hue])),
 );
+
+const INBOX_GROUP_HUES = Object.fromEntries(
+  [...INBOX_GROUPS, OTHER_GROUP].map((group) => [group.label, group.hue]),
+);
+
+/** Shared display grammar for Inbox: triage grouping and oldest-first age are the operator defaults. */
+export const INBOX_DISPLAY: DisplayConfig<InboxItem> = {
+  view: "inbox",
+  groups: [
+    {
+      key: "attention",
+      label: "Group (Decide/Red/Ready)",
+      get: (item) => groupOf(item.kind).label,
+      order: [...INBOX_GROUPS.map((group) => group.label), OTHER_GROUP.label],
+      hue: INBOX_GROUP_HUES,
+    },
+    { key: "kind", label: "Kind", get: (item) => item.kind, hue: INBOX_KIND_HUES },
+    { key: "repo", label: "Repo", get: (item) => item.refs.repo ?? "—" },
+  ],
+  sorts: [
+    { key: "age", label: "Age", get: (item) => item.createdAt, column: "age" },
+    { key: "kind", label: "Kind", get: (item) => item.kind, column: "kind" },
+  ],
+  columns: [
+    { key: "kind", label: "Kind" },
+    { key: "title", label: "Title" },
+    { key: "age", label: "Age" },
+    { key: "refs", label: "Refs" },
+    { key: "sent", label: "Sent" },
+  ],
+  defaults: { groupBy: "attention", sortBy: "age", sortDir: "asc" },
+};
+
+/** Keep one identity column visible while allowing every Inbox property to be toggled. */
+export function ensureInboxColumn(state: DisplayState): DisplayState {
+  const visibleBuiltIn = INBOX_DISPLAY.columns.some((column) => !state.hiddenColumns.includes(column.key));
+  const visibleCustom = state.customColumns.some(
+    (path) => !state.hiddenColumns.includes(`custom:${path}`),
+  );
+  if (visibleBuiltIn || visibleCustom) return state;
+  return { ...state, hiddenColumns: state.hiddenColumns.filter((key) => key !== "title") };
+}
 
 export type InboxItemStatus = Exclude<InboxTab, "all">;
 
@@ -154,14 +214,33 @@ export function Inbox({
   const items = query.data?.items ?? [];
 
   const [tab, setTab] = useState<InboxTab>("open");
+  const [filter, setFilter] = useState("");
   const counts = useMemo(() => {
     const c: Record<InboxTab, number> = { open: 0, acked: 0, resolved: 0, all: items.length };
     for (const it of items) c[itemStatus(it)] += 1;
     return c;
   }, [items]);
 
-  const visibleGroups = useMemo(() => groupItems(items.filter((it) => matchesTab(it, tab))), [items, tab]);
-  const visible = useMemo(() => visibleGroups.flatMap((g) => g.items), [visibleGroups]);
+  const byTab = useMemo(() => items.filter((item) => matchesTab(item, tab)), [items, tab]);
+  const parsed = useMemo(() => parseFilterQuery(filter, INBOX_FACETS), [filter]);
+  const filtered = useMemo(
+    () => byTab.filter((item) => matchesFilterQuery(item, parsed, INBOX_FACETS, undefined)),
+    [byTab, parsed],
+  );
+  const [display, updateDisplay] = useDisplayOptions(INBOX_DISPLAY);
+  const setDisplay = (next: DisplayState | ((state: DisplayState) => DisplayState)) => {
+    updateDisplay((state) => ensureInboxColumn(typeof next === "function" ? next(state) : next));
+  };
+  const sections = useMemo(
+    () => buildSections(filtered, INBOX_DISPLAY, display),
+    [filtered, display],
+  );
+  const visible = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
+  const cols = visibleColumns(INBOX_DISPLAY, display);
+  const show = useMemo(() => new Set(cols.map((column) => column.key)), [cols]);
 
   const sel = focusItemId ? (items.find((it) => it.id === focusItemId) ?? null) : null;
   const selectedIndex = sel ? visible.findIndex((it) => it.id === sel.id) : -1;
@@ -257,7 +336,13 @@ export function Inbox({
   });
 
   const tdCls = "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
-  const openEmpty = tab === "open" && visible.length === 0 && query.isSuccess;
+  const openEmpty = tab === "open" && byTab.length === 0 && !filter.trim() && query.isSuccess;
+  const handleExport = () => {
+    const sorted = sortRows(filtered, INBOX_DISPLAY, display);
+    const dateStr = new Date().toISOString().slice(0, 10);
+    exportJson(`inbox-export-${dateStr}.json`, sorted);
+    notify(`Exported ${sorted.length} inbox item${sorted.length === 1 ? "" : "s"} to JSON`, "info");
+  };
 
   return (
     <div className="flex h-full min-w-0">
@@ -267,7 +352,7 @@ export function Inbox({
             <>
               <h1 className="display mb-4 text-lg font-semibold">Inbox</h1>
               <div className="mb-3 flex flex-wrap items-center gap-2">
-                <div className="flex gap-1" role="tablist" aria-label="Inbox status">
+                <div className="flex min-w-0 flex-1 flex-wrap gap-1" role="tablist" aria-label="Inbox status">
                   {INBOX_TABS.map((t, idx) => (
                     <button
                       key={t}
@@ -290,6 +375,23 @@ export function Inbox({
                     </button>
                   ))}
                 </div>
+                <span className="ml-auto">
+                  <DisplayOptions
+                    config={INBOX_DISPLAY}
+                    state={display}
+                    onChange={setDisplay}
+                    onExport={filtered.length > 0 ? handleExport : undefined}
+                    rows={byTab}
+                  />
+                </span>
+                <FilterInput
+                  value={filter}
+                  onChange={setFilter}
+                  placeholder="kind:… is:open repo:… issue:…"
+                  label="Filter inbox"
+                  query={parsed}
+                  facets={INBOX_FACETS}
+                />
               </div>
             </>
           }
@@ -319,47 +421,119 @@ export function Inbox({
             <table className="w-full border-separate border-spacing-0">
               <thead>
                 <tr className="text-left text-[11px] text-(--text-faint)">
-                  <Th label="Kind" />
-                  <Th label="Title" />
-                  <Th label="Age" />
-                  <Th label="Refs" />
-                  <Th label="Sent" title="Telegram delivery: sent, failed, or not attempted" />
+                  {cols.map((column) => {
+                    const sort = INBOX_DISPLAY.sorts.find((field) => field.column === column.key);
+                    const isCustom = column.isCustom || column.key.startsWith("custom:");
+                    const customPath = column.key.replace(/^custom:/, "");
+                    const isCurrentSort = isCustom
+                      ? display.sortBy === column.key
+                      : sort && display.sortBy === sort.key;
+                    return (
+                      <Th
+                        key={column.key}
+                        label={column.label}
+                        title={column.key === "sent" ? "Telegram delivery: sent, failed, or not attempted" : undefined}
+                        dir={isCurrentSort ? display.sortDir : null}
+                        naturalDir={sort?.defaultDir ?? "asc"}
+                        onSort={sort || isCustom
+                          ? () => setDisplay((state) => cycleColumnSort(INBOX_DISPLAY, state, column.key))
+                          : undefined}
+                        onRemove={isCustom
+                          ? () => setDisplay((state) => removeCustomColumn(state, customPath))
+                          : undefined}
+                      />
+                    );
+                  })}
                 </tr>
               </thead>
               <tbody>
-                {query.isPending && !query.data && (
-                  <tr>
-                    <td colSpan={5} className="px-3 py-8 text-center text-(--text-faint)">Loading inbox…</td>
-                  </tr>
-                )}
-                {query.isError && !query.data && (
-                  <tr>
-                    <td colSpan={5} className="px-3 py-8 text-center text-(--text-faint)">
-                      Cannot reach the control API — the inbox will appear when it is up.
-                    </td>
-                  </tr>
-                )}
-                {query.isSuccess && visible.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="px-3 py-8 text-center text-(--text-faint)">
-                      {tab === "acked" ? "No acked items." : tab === "resolved" ? "No resolved items yet." : "The ledger is empty."}
-                    </td>
-                  </tr>
-                )}
-                {visibleGroups.map(({ group, items: rows }) => (
-                  <GroupRows
-                    key={group.id}
-                    group={group}
-                    rows={rows}
-                    now={now}
-                    selectedId={sel?.id ?? null}
-                    onSelect={onSelectItem}
-                    onJumpRun={onJumpRun}
-                    onJumpProposal={onJumpProposal}
-                    onJumpEvent={onJumpEvent}
-                    tdCls={tdCls}
+                {(() => {
+                  const renderRow = (item: InboxItem) => {
+                    const delivery = deliveryState(item);
+                    return (
+                      <tr
+                        key={item.id}
+                        onClick={() => onSelectItem(item.id)}
+                        aria-selected={item.id === sel?.id}
+                        className={`cursor-pointer hover:bg-(--surface-1) ${item.id === sel?.id ? "row-selected" : ""}`}
+                      >
+                        {show.has("kind") && (
+                          <td className={`${tdCls} w-32`}>
+                            <StateBadge state={item.kind} hues={INBOX_KIND_HUES} dot={false} />
+                          </td>
+                        )}
+                        {show.has("title") && (
+                          <td className={`${tdCls} min-w-40 max-w-0`}>
+                            <div className="truncate text-(--text)" title={item.title}>{item.title}</div>
+                          </td>
+                        )}
+                        {show.has("age") && (
+                          <td className={`${tdCls} w-16 text-(--text-faint)`}>
+                            <Ago iso={item.createdAt} now={now} />
+                          </td>
+                        )}
+                        {show.has("refs") && (
+                          <td className={`${tdCls} w-40 max-w-40`}>
+                            <RefChips
+                              item={item}
+                              onJumpRun={onJumpRun}
+                              onJumpProposal={onJumpProposal}
+                              onJumpEvent={onJumpEvent}
+                            />
+                          </td>
+                        )}
+                        {show.has("sent") && (
+                          <td className={`${tdCls} w-12`}>
+                            <span
+                              role="img"
+                              aria-label={deliveryText(item)}
+                              title={deliveryText(item)}
+                              className="inline-block size-2 rounded-full"
+                              style={{ background: DELIVERY_HUES[delivery] }}
+                            />
+                          </td>
+                        )}
+                        {cols.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
+                          <CustomCell key={column.key} row={item} path={column.key.replace(/^custom:/, "")} />
+                        ))}
+                      </tr>
+                    );
+                  };
+                  if (!grouped(display)) return sections[0]?.rows.map(renderRow);
+                  return sections.map((section) => {
+                    const collapsed = display.collapsed.includes(section.key);
+                    return (
+                      <Fragment key={section.key}>
+                        <GroupHeaderRow
+                          colSpan={Math.max(cols.length, 1)}
+                          section={section}
+                          collapsed={collapsed}
+                          onToggle={() => setDisplay((state) => toggleCollapsed(state, section.key))}
+                        />
+                        {!collapsed && section.rows.map(renderRow)}
+                      </Fragment>
+                    );
+                  });
+                })()}
+                {filtered.length === 0 && (
+                  <ListEmpty
+                    colSpan={Math.max(cols.length, 1)}
+                    query={query}
+                    filtered={byTab.length > 0}
+                    onClear={filter.trim() ? () => setFilter("") : undefined}
+                    noun="inbox items"
+                    empty={
+                      tab === "acked"
+                        ? "No acked items."
+                        : tab === "resolved"
+                          ? "No resolved items yet."
+                          : tab === "open"
+                            ? "Nothing waiting on you."
+                            : "The ledger is empty."
+                    }
+                    escHint={Boolean(filter.trim())}
                   />
-                ))}
+                )}
               </tbody>
             </table>
           )}
@@ -496,80 +670,6 @@ export function Inbox({
         </Dialog>
       )}
     </div>
-  );
-}
-
-function GroupRows({
-  group,
-  rows,
-  now,
-  selectedId,
-  onSelect,
-  onJumpRun,
-  onJumpProposal,
-  onJumpEvent,
-  tdCls,
-}: {
-  group: InboxGroup;
-  rows: InboxItem[];
-  now: number;
-  selectedId: string | null;
-  onSelect: (id: string) => void;
-  onJumpRun: (runId: string) => void;
-  onJumpProposal: (id: string) => void;
-  onJumpEvent: (source: string, eventId: string) => void;
-  tdCls: string;
-}) {
-  return (
-    <>
-      <tr>
-        <td
-          colSpan={5}
-          className="sticky top-7 z-10 border-b border-(--border) bg-(--surface-0) px-3 py-1 text-[11px] font-medium"
-          style={{ color: group.hue }}
-        >
-          <span aria-hidden="true" className="mr-1.5 inline-block size-1.5 rounded-full align-middle" style={{ background: group.hue }} />
-          {group.label}
-          <span className="ml-1.5 tabular-nums text-(--text-faint)">{rows.length}</span>
-        </td>
-      </tr>
-      {rows.map((item) => {
-        const d = deliveryState(item);
-        return (
-          <tr
-            key={item.id}
-            onClick={() => onSelect(item.id)}
-            aria-selected={item.id === selectedId}
-            className={`cursor-pointer hover:bg-(--surface-1) ${item.id === selectedId ? "row-selected" : ""}`}
-          >
-            <td className={`${tdCls} w-32`}>
-              <StateBadge state={item.kind} hues={INBOX_KIND_HUES} dot={false} />
-            </td>
-            {/* Title is the decision text: it truncates last. `max-w-0` lets it
-                shrink-to-fit, `min-w-40` stops it collapsing to a glyph when
-                the pane opens at ~1100px — Refs gives up width first. */}
-            <td className={`${tdCls} min-w-40 max-w-0`}>
-              <div className="truncate text-(--text)" title={item.title}>{item.title}</div>
-            </td>
-            <td className={`${tdCls} w-16 text-(--text-faint)`}>
-              <Ago iso={item.createdAt} now={now} />
-            </td>
-            <td className={`${tdCls} w-40 max-w-40`}>
-              <RefChips item={item} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpEvent={onJumpEvent} />
-            </td>
-            <td className={`${tdCls} w-12`}>
-              <span
-                role="img"
-                aria-label={deliveryText(item)}
-                title={deliveryText(item)}
-                className="inline-block size-2 rounded-full"
-                style={{ background: DELIVERY_HUES[d] }}
-              />
-            </td>
-          </tr>
-        );
-      })}
-    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add persisted Inbox display options for grouping, ordering, properties, custom columns, and export
- use shared collapsible group headers plus facet/free-text filtering and recoverable empty states
- add sortable Kind/Age headers and regression coverage for grouping, collapse, facets, sorting, and column visibility

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (715 tests)
- `factory security` — pass

UX critique: required — SHIP (2 rounds); evidence: http://127.0.0.1:7543/#/inbox and /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-66db878a-d40c-4475-b258-a6e2fa525796.png

Fixes WM-616