### PR TITLE
fix(web): survive API restart outages (WM-625)

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -218,6 +218,18 @@ case "$ACTION" in
       fi
     fi
 
+    # Keep the web endpoint available if serve.mjs exits on an unexpected
+    # process-level failure. The supervisor only runs while the API daemon is
+    # alive, so `factory down` cannot turn into a restart race.
+    if pid_alive "$RUN_DIR/web-supervisor.pid"; then
+      info "web supervisor already running (pid $(cat "$RUN_DIR/web-supervisor.pid"))"
+    else
+      info "starting web supervisor"
+      spawn_daemon "$RUN_DIR/web-supervisor.pid" "$RUN_DIR/web.log" "$REPO" \
+        env FACTORY_RUN_DIR="$RUN_DIR" FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+        bash "$REPO/bin/live-stack.sh" __supervise-web "$DEV"
+    fi
+
     # 5. Wait for web server (vite has to boot a dep-optimize pass on a cold cache)
     WEB_TRIES=30
     if [[ "$DEV" -eq 1 ]]; then WEB_TRIES=150; fi
@@ -250,6 +262,41 @@ case "$ACTION" in
     printf '  status:  factory events status\n'
     printf '  tail:    factory tail\n'
     printf '  down:    factory down\n\n'
+    ;;
+
+  __supervise-web)
+    # The static server normally survives API restarts. If an unrelated
+    # uncaught process error does terminate it, keep the UI reachable while the
+    # API daemon is still alive. A bounded one-second check avoids crash-looping
+    # while still recovering before the next operator pulse.
+    WEB_DEV="${1:-0}"
+    WEB_CHILD_PID=""
+    # A replacement stays in this supervisor's process group rather than being
+    # detached. `factory down` can therefore stop the whole group atomically,
+    # including a child spawned just before SIGTERM reaches this shell.
+    trap 'if [[ -n "$WEB_CHILD_PID" ]]; then kill -TERM "$WEB_CHILD_PID" 2>/dev/null || true; fi; exit 0' TERM INT
+    while pid_alive "$RUN_DIR/serve.pid"; do
+      if ! pid_alive "$RUN_DIR/web.pid"; then
+        printf '%s [web-supervisor] web server down; restarting\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        if [[ "$WEB_DEV" -eq 1 ]]; then
+          (
+            cd "$REPO/event-runtime/web"
+            exec env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+              bunx vite --host 127.0.0.1 --port "$WEB_PORT" --strictPort
+          ) >>"$RUN_DIR/web.log" 2>&1 &
+        else
+          (
+            cd "$REPO/event-runtime/web"
+            exec env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+              bun "$REPO/event-runtime/web/serve.mjs"
+          ) >>"$RUN_DIR/web.log" 2>&1 &
+        fi
+        WEB_CHILD_PID=$!
+        printf '%s\n' "$WEB_CHILD_PID" >"$RUN_DIR/web.pid"
+      fi
+      sleep "${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
+    done
+    printf '%s [web-supervisor] event runtime stopped; supervisor exiting\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     ;;
 
   __supervise-worker)
@@ -310,6 +357,12 @@ case "$ACTION" in
       if pid_alive "$RUN_DIR/worker.pid"; then
         warn "worker pool still draining after ${POOL_WAIT}s — stopping it anyway; the reaper requeues any lease left behind"
       fi
+    fi
+    # Stop and reap the web supervisor before terminating the web process, or
+    # it could observe the planned shutdown as a crash and replace the daemon.
+    if [[ -f "$RUN_DIR/web-supervisor.pid" ]]; then
+      term_daemon "$RUN_DIR/web-supervisor.pid" "web supervisor"
+      await_daemon "$RUN_DIR/web-supervisor.pid" "web supervisor"
     fi
     term_daemon "$RUN_DIR/web.pid" "web server"
     term_daemon "$RUN_DIR/worker.pid" "worker"

--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -24,6 +24,16 @@ if (!existsSync(path.join(DIST, "index.html"))) {
   process.exit(1);
 }
 
+function fatalProcessError(kind, error) {
+  console.error(`[web] ${kind}:`, error);
+  // A process-level failure may leave Bun.serve in an unknown state. Exit
+  // non-zero so live-stack's supervisor replaces this process cleanly.
+  process.exit(1);
+}
+
+process.on("uncaughtException", (error, origin) => fatalProcessError(`uncaughtException (${origin})`, error));
+process.on("unhandledRejection", (reason) => fatalProcessError("unhandledRejection", reason));
+
 Bun.serve({
   hostname: HOST,
   port: WEB_PORT,
@@ -38,17 +48,31 @@ Bun.serve({
       const bodyless = req.method === "GET" || req.method === "HEAD";
       const headers = bodyless ? new Headers(req.headers) : req.headers;
       const init = { method: req.method, headers };
-      if (bodyless) {
-        // Drain any non-standard incoming payload so a keep-alive connection
-        // remains aligned for the client's next request. Its framing headers
-        // must not describe a body that the upstream request intentionally omits.
-        await req.arrayBuffer();
-        headers.delete("content-length");
-        headers.delete("transfer-encoding");
-      } else {
-        init.body = req.body;
+      try {
+        if (bodyless) {
+          // Drain any non-standard incoming payload so a keep-alive connection
+          // remains aligned for the client's next request. Its framing headers
+          // must not describe a body that the upstream request intentionally omits.
+          await req.arrayBuffer();
+          headers.delete("content-length");
+          headers.delete("transfer-encoding");
+        } else {
+          init.body = req.body;
+        }
+        return await fetch(target, init);
+      } catch (error) {
+        // Backend restarts are expected during deploys and watch-mode reloads.
+        // Keep the static server alive and give clients an explicit retryable
+        // response instead of allowing Bun's rejected fetch to escape.
+        console.error(`[web] ${req.method} ${url.pathname} upstream unavailable:`, error);
+        return new Response(JSON.stringify({ error: "event runtime temporarily unavailable" }), {
+          status: 503,
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            "retry-after": "1",
+          },
+        });
       }
-      return fetch(target, init);
     }
 
     // Static, confined to dist/ — reject traversal rather than resolving it.

--- a/event-runtime/web/serve.test.mjs
+++ b/event-runtime/web/serve.test.mjs
@@ -8,6 +8,7 @@ const WEB_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DIST_INDEX = path.join(WEB_DIR, "dist", "index.html");
 
 let api;
+let apiPort;
 let proxy;
 let webPort;
 let createdDistIndex = false;
@@ -52,30 +53,16 @@ beforeAll(async () => {
     createdDistIndex = true;
   }
 
-  api = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    async fetch(req) {
-      const url = new URL(req.url);
-      received.push({
-        method: req.method,
-        pathname: url.pathname,
-        body: await req.text(),
-        marker: req.headers.get("x-proxy-test"),
-      });
-      return new Response("forwarded", {
-        status: 201,
-        headers: { "x-upstream-method": req.method },
-      });
-    },
-  });
-
+  // Start the proxy while its upstream port is deliberately closed. The
+  // recovery test opens an API on this same port after proving a failed fetch
+  // neither escapes nor kills the static server.
+  apiPort = reservePort();
   webPort = reservePort();
   proxy = Bun.spawn(["bun", path.join(WEB_DIR, "serve.mjs")], {
     cwd: WEB_DIR,
     env: {
       ...process.env,
-      FACTORY_EVENT_PORT: String(api.port),
+      FACTORY_EVENT_PORT: String(apiPort),
       FACTORY_EVENT_WEB_PORT: String(webPort),
     },
     stdout: "pipe",
@@ -106,6 +93,40 @@ afterAll(async () => {
 });
 
 describe("event-runtime web API proxy", () => {
+  test("returns 503 while the API is down, stays alive, then recovers", async () => {
+    const unavailable = await requestProxy("GET", "/health");
+
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(unavailable.body)).toEqual({
+      error: "event runtime temporarily unavailable",
+    });
+    expect(proxy.exitCode).toBe(null);
+
+    api = Bun.serve({
+      hostname: "127.0.0.1",
+      port: apiPort,
+      async fetch(req) {
+        const url = new URL(req.url);
+        received.push({
+          method: req.method,
+          pathname: url.pathname,
+          body: await req.text(),
+          marker: req.headers.get("x-proxy-test"),
+        });
+        return new Response("forwarded", {
+          status: url.pathname === "/health" ? 200 : 201,
+          headers: { "x-upstream-method": req.method },
+        });
+      },
+    });
+
+    const recovered = await requestProxy("GET", "/health");
+    expect(recovered.status).toBe(200);
+    expect(recovered.body).toBe("forwarded");
+    expect(proxy.exitCode).toBe(null);
+  });
+
   test.each([
     ["GET", undefined],
     ["GET", "ignored get payload"],

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -52,6 +52,7 @@ function hasLinearKey() {
 
 export async function gatherPulse({
   port = 7381,
+  webPort = 7382,
   host = "127.0.0.1",
   repoName = "factory",
   fetchLinear = true,
@@ -59,7 +60,7 @@ export async function gatherPulse({
 } = {}) {
   const pulse = {
     timestamp: new Date().toISOString(),
-    stack: { api: { ok: false }, web: { ok: false }, workers: { total: 0, busy: 0, idle: 0, list: [] } },
+    stack: { api: { ok: false }, web: { ok: false, port: webPort }, workers: { total: 0, busy: 0, idle: 0, list: [] } },
     runs: { active: [], proposed: 0, byState: {} },
     supply: { repo: repoName, team: "WM", dispatchable: 0, triage: 0, tickets: [] },
     prs: { total: 0, candidates: [] },
@@ -79,10 +80,17 @@ export async function gatherPulse({
 
   // 2. Web UI Health
   try {
-    const webRes = await fetch(`http://${host}:7382/`, { signal: AbortSignal.timeout(2000) });
-    pulse.stack.web = { ok: webRes.ok || webRes.status === 404 }; // serving HTTP
-  } catch {
-    pulse.stack.web = { ok: false };
+    const webRes = await fetch(`http://${host}:${webPort}/`, { signal: AbortSignal.timeout(2000) });
+    const ok = webRes.ok || webRes.status === 404; // serving HTTP
+    pulse.stack.web = ok
+      ? { ok: true, port: webPort }
+      : { ok: false, port: webPort, error: `WEB_DOWN: Web UI returned HTTP ${webRes.status}` };
+  } catch (err) {
+    pulse.stack.web = {
+      ok: false,
+      port: webPort,
+      error: `WEB_DOWN: Web UI on :${webPort} unreachable (${err.message})`,
+    };
   }
 
   // 3. Status & Workers & Runs from API (if alive)
@@ -233,8 +241,11 @@ export function formatPulse(pulse) {
     : c.red("✗ down");
   lines.push(`  API (:7381):     ${apiStatus}`);
 
-  const webStatus = pulse.stack.web.ok ? c.green("✓ up") : c.yellow("! down or unreachable");
-  lines.push(`  Web (:7382):     ${webStatus}`);
+  const webPort = pulse.stack.web.port ?? 7382;
+  const webStatus = pulse.stack.web.ok
+    ? c.green("✓ up")
+    : c.red(`✗ ${pulse.stack.web.error || "WEB_DOWN: down or unreachable"}`);
+  lines.push(`  Web (:${webPort}):     ${webStatus}`);
 
   const workers = pulse.stack.workers;
   const workerDetail = workers.total > 0


### PR DESCRIPTION
## Summary
- return a retryable JSON 503 when the web proxy cannot reach the event-runtime API
- add fatal process guards plus a live-stack supervisor that restarts a dead web server while serve is alive
- make `factory pulse` report `WEB_DOWN` explicitly and cover closed-port recovery

## Verification
- `bun test event-runtime/web/serve.test.mjs && bash -n bin/live-stack.sh`
- `bun test bin/live-stack.test.mjs`
- `bun test orchestrator/pulse.test.mjs`
- manual supervisor check: killed worktree web pid; supervisor assigned a new pid and :7603 recovered

UX critique: skipped — backend/runtime reliability change with no user-completable flow.

Fixes WM-625