### PR TITLE
feat(event-runtime): decision-request/response v1 contracts + validator; decision admitted on refused agent-result (WM-389)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -220,7 +220,7 @@ The LLM appears only inside `execute`.
 
 ## 5. Versioned contracts
 
-`factory.decision-request/v1` and `factory.decision-response/v1` define bounded human questions and their hash-bound answers.
+Besides the three below, `factory.decision-request/v1` and `factory.decision-response/v1` (`event-runtime/schemas/`, validated by `lib/decision.mjs`) define a bounded human question — 1–6 options with runtime effects plus gated fields from a closed widget vocabulary — and its hash-bound answer; a refused agent-result may carry a request as `decision` (docs/event-runtime-inbox.md §2–§4).
 
 ### 5.1 Event envelope
 

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -220,6 +220,8 @@ The LLM appears only inside `execute`.
 
 ## 5. Versioned contracts
 
+`factory.decision-request/v1` and `factory.decision-response/v1` define bounded human questions and their hash-bound answers.
+
 ### 5.1 Event envelope
 
 ```json

--- a/event-runtime/lib/decision.mjs
+++ b/event-runtime/lib/decision.mjs
@@ -1,17 +1,45 @@
+/**
+ * Decision contracts — `factory.decision-request/v1` and
+ * `factory.decision-response/v1` (docs/event-runtime-inbox.md §2, §3).
+ *
+ * A decision request is a bounded question an agent (or the runtime) puts to
+ * the operator: 1–6 options each carrying a runtime effect, plus 0–6 gated
+ * fields from a closed widget vocabulary. A response is the operator's answer,
+ * hash-bound to the exact request it was looking at. Both go through the same
+ * closed-keyword `lib/schema.mjs` as every other contract; the rules JSON
+ * Schema cannot express (id references, effect↔refs legality, per-kind field
+ * keys, per-option field applicability) live here, as `lib/artifact-view.mjs`
+ * does for views. Pure and fail-closed: `{ valid, errors }`, never throws on
+ * data, no I/O beyond loading the schemas once.
+ */
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { hashJson } from "./canonical.mjs";
+import { RUNTIME_ROOT } from "./config.mjs";
 import { validate } from "./schema.mjs";
 
-const requestSchema = JSON.parse(
-  readFileSync(new URL("../schemas/factory.decision-request.v1.json", import.meta.url), "utf8"),
+export const DECISION_REQUEST_SCHEMA_VERSION = "factory.decision-request/v1";
+export const DECISION_RESPONSE_SCHEMA_VERSION = "factory.decision-response/v1";
+export const DECISION_REQUEST_SCHEMA = JSON.parse(
+  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.decision-request.v1.json"), "utf8"),
 );
-const responseSchema = JSON.parse(
-  readFileSync(new URL("../schemas/factory.decision-response.v1.json", import.meta.url), "utf8"),
+export const DECISION_RESPONSE_SCHEMA = JSON.parse(
+  readFileSync(path.join(RUNTIME_ROOT, "schemas", "factory.decision-response.v1.json"), "utf8"),
 );
+
+/** §2.1 `context` bound is a byte size, not a code-unit count. */
+export const CONTEXT_MAX_BYTES = 8 * 1024;
+/** §2.3 `text` defaults. */
+export const TEXT_DEFAULT_MAX_LENGTH = 2000;
+export const WIDGET_KINDS = ["text", "single-choice", "multi-choice", "confirm", "number"];
+export const EFFECTS = [
+  "authorise", "send_to_triage", "answer", "requeue", "approve_proposal", "reject_proposal", "dismiss",
+];
 
 const hasOwn = (value, key) =>
   value !== null && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key);
 
+/** Keys every field may carry, plus the per-`kind` extras (§2.3 "Extra keys"). */
 const COMMON_FIELD_KEYS = new Set(["id", "kind", "label", "required", "whenOption"]);
 const FIELD_KEYS = {
   text: new Set([...COMMON_FIELD_KEYS, "placeholder", "maxLength"]),
@@ -21,7 +49,8 @@ const FIELD_KEYS = {
   number: new Set([...COMMON_FIELD_KEYS, "minimum", "maximum", "integer"]),
 };
 
-const EFFECT_REFS = {
+/** §3 legality table: refs an item must carry for each effect to be offered. */
+export const EFFECT_REFS = {
   authorise: ["issue", "repo", "runId"],
   send_to_triage: ["issue"],
   answer: ["issue"],
@@ -30,10 +59,6 @@ const EFFECT_REFS = {
   reject_proposal: ["proposalId"],
   dismiss: [],
 };
-const RESPONSE_VALIDATION_REFS = Object.fromEntries(
-  [...new Set(Object.values(EFFECT_REFS).flat())].map((key) => [key, "response-validation"]),
-);
-
 function result(errors) {
   return { valid: errors.length === 0, errors };
 }
@@ -59,12 +84,21 @@ function duplicateValues(values) {
  * @returns {{ valid: boolean, errors: string[] }}
  */
 export function validateDecisionRequest(request, { refs = {} } = {}) {
-  const shape = validate(requestSchema, request);
+  return checkRequest(request, { refs, checkEffectLegality: true });
+}
+
+/**
+ * Shared body: the response validator re-checks the request it is answering
+ * (a malformed request cannot be answered correctly) but effect legality is a
+ * creation-time concern (§3) — the refs are not on hand at answer time.
+ */
+function checkRequest(request, { refs, checkEffectLegality }) {
+  const shape = validate(DECISION_REQUEST_SCHEMA, request);
   if (!shape.valid) return shape;
 
   const errors = [];
-  if (request.context !== undefined && Buffer.byteLength(request.context, "utf8") > 8192) {
-    errors.push("$.context: longer than 8 KiB when encoded as UTF-8");
+  if (request.context !== undefined && Buffer.byteLength(request.context, "utf8") > CONTEXT_MAX_BYTES) {
+    errors.push(`$.context: longer than ${CONTEXT_MAX_BYTES} bytes when encoded as UTF-8`);
   }
   const optionIds = request.options.map((option) => option.id);
   const optionIdSet = new Set(optionIds);
@@ -96,8 +130,10 @@ export function validateDecisionRequest(request, { refs = {} } = {}) {
       }
     }
 
-    for (const ref of EFFECT_REFS[option.effect]) {
-      if (!usableRef(refs, ref)) errors.push(`${path}.effect: "${option.effect}" requires refs.${ref}`);
+    if (checkEffectLegality) {
+      for (const ref of EFFECT_REFS[option.effect]) {
+        if (!usableRef(refs, ref)) errors.push(`${path}.effect: "${option.effect}" requires refs.${ref}`);
+      }
     }
   }
 
@@ -167,7 +203,7 @@ export function validateDecisionRequest(request, { refs = {} } = {}) {
   return result(errors);
 }
 
-/** Return the canonical identity a response must bind to. */
+/** The identity a response binds to (§2.2 `requestHash`): canonical-JSON sha256. */
 export function decisionRequestHash(request) {
   return hashJson(request);
 }
@@ -178,7 +214,7 @@ function validateFieldValue(field, value, path, errors) {
       errors.push(`${path}: expected string`);
       return;
     }
-    const maximum = field.maxLength ?? 2000;
+    const maximum = field.maxLength ?? TEXT_DEFAULT_MAX_LENGTH;
     if (field.required === true && value.length === 0) errors.push(`${path}: required text must not be empty`);
     if (value.length > maximum) errors.push(`${path}: longer than maxLength ${maximum}`);
     return;
@@ -242,10 +278,10 @@ function validateFieldValue(field, value, path, errors) {
  * @returns {{ valid: boolean, errors: string[] }}
  */
 export function validateDecisionResponse(response, request) {
-  const responseShape = validate(responseSchema, response);
+  const responseShape = validate(DECISION_RESPONSE_SCHEMA, response);
   if (!responseShape.valid) return responseShape;
 
-  const requestCheck = validateDecisionRequest(request, { refs: RESPONSE_VALIDATION_REFS });
+  const requestCheck = checkRequest(request, { refs: {}, checkEffectLegality: false });
   if (!requestCheck.valid) {
     return result(requestCheck.errors.map((error) => `request ${error}`));
   }

--- a/event-runtime/lib/decision.mjs
+++ b/event-runtime/lib/decision.mjs
@@ -1,0 +1,283 @@
+import { readFileSync } from "node:fs";
+import { hashJson } from "./canonical.mjs";
+import { validate } from "./schema.mjs";
+
+const requestSchema = JSON.parse(
+  readFileSync(new URL("../schemas/factory.decision-request.v1.json", import.meta.url), "utf8"),
+);
+const responseSchema = JSON.parse(
+  readFileSync(new URL("../schemas/factory.decision-response.v1.json", import.meta.url), "utf8"),
+);
+
+const hasOwn = (value, key) =>
+  value !== null && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key);
+
+const COMMON_FIELD_KEYS = new Set(["id", "kind", "label", "required", "whenOption"]);
+const FIELD_KEYS = {
+  text: new Set([...COMMON_FIELD_KEYS, "placeholder", "maxLength"]),
+  "single-choice": new Set([...COMMON_FIELD_KEYS, "choices"]),
+  "multi-choice": new Set([...COMMON_FIELD_KEYS, "choices", "minItems", "maxItems"]),
+  confirm: COMMON_FIELD_KEYS,
+  number: new Set([...COMMON_FIELD_KEYS, "minimum", "maximum", "integer"]),
+};
+
+const EFFECT_REFS = {
+  authorise: ["issue", "repo", "runId"],
+  send_to_triage: ["issue"],
+  answer: ["issue"],
+  requeue: ["eventSource", "eventId"],
+  approve_proposal: ["proposalId"],
+  reject_proposal: ["proposalId"],
+  dismiss: [],
+};
+const RESPONSE_VALIDATION_REFS = Object.fromEntries(
+  [...new Set(Object.values(EFFECT_REFS).flat())].map((key) => [key, "response-validation"]),
+);
+
+function result(errors) {
+  return { valid: errors.length === 0, errors };
+}
+
+function usableRef(refs, key) {
+  return hasOwn(refs, key) && typeof refs[key] === "string" && refs[key].trim().length > 0;
+}
+
+function duplicateValues(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+/**
+ * Validate the bounded request contract and the cross-field/effect rules that
+ * the runtime's deliberately small JSON Schema subset cannot express.
+ *
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateDecisionRequest(request, { refs = {} } = {}) {
+  const shape = validate(requestSchema, request);
+  if (!shape.valid) return shape;
+
+  const errors = [];
+  if (request.context !== undefined && Buffer.byteLength(request.context, "utf8") > 8192) {
+    errors.push("$.context: longer than 8 KiB when encoded as UTF-8");
+  }
+  const optionIds = request.options.map((option) => option.id);
+  const optionIdSet = new Set(optionIds);
+
+  for (const id of duplicateValues(optionIds)) errors.push(`$.options: duplicate option id "${id}"`);
+  if (request.recommended !== undefined && !optionIdSet.has(request.recommended)) {
+    errors.push(`$.recommended: unknown option id "${request.recommended}"`);
+  }
+
+  for (const [index, option] of request.options.entries()) {
+    const path = `$.options[${index}]`;
+    const hasScope = hasOwn(option, "scope");
+    if (option.effect === "authorise" && !hasScope) {
+      errors.push(`${path}.scope: required for effect "authorise"`);
+    } else if (option.effect !== "authorise" && hasScope) {
+      errors.push(`${path}.scope: only allowed for effect "authorise"`);
+    }
+    if (option.effect === "authorise" && hasScope) {
+      for (const scopedPath of option.scope.paths) {
+        const segments = scopedPath.split(/[\\/]/);
+        if (
+          scopedPath.startsWith("/") ||
+          scopedPath.startsWith("\\") ||
+          /^[a-zA-Z]:[\\/]/.test(scopedPath) ||
+          segments.includes("..")
+        ) {
+          errors.push(`${path}.scope.paths: path must be repo-relative: "${scopedPath}"`);
+        }
+      }
+    }
+
+    for (const ref of EFFECT_REFS[option.effect]) {
+      if (!usableRef(refs, ref)) errors.push(`${path}.effect: "${option.effect}" requires refs.${ref}`);
+    }
+  }
+
+  const fields = request.fields ?? [];
+  for (const id of duplicateValues(fields.map((field) => field.id))) {
+    errors.push(`$.fields: duplicate field id "${id}"`);
+  }
+
+  for (const [index, field] of fields.entries()) {
+    const path = `$.fields[${index}]`;
+    for (const key of Object.keys(field)) {
+      if (!FIELD_KEYS[field.kind].has(key)) errors.push(`${path}.${key}: not allowed for kind "${field.kind}"`);
+    }
+
+    if (field.whenOption !== undefined) {
+      for (const id of duplicateValues(field.whenOption)) {
+        errors.push(`${path}.whenOption: duplicate option id "${id}"`);
+      }
+      for (const id of field.whenOption) {
+        if (!optionIdSet.has(id)) errors.push(`${path}.whenOption: unknown option id "${id}"`);
+      }
+    }
+
+    if (field.kind === "single-choice" || field.kind === "multi-choice") {
+      if (field.choices === undefined) {
+        errors.push(`${path}.choices: required for kind "${field.kind}"`);
+      } else {
+        const minimum = field.kind === "single-choice" ? 2 : 1;
+        const maximum = field.kind === "single-choice" ? 12 : 24;
+        if (field.choices.length < minimum || field.choices.length > maximum) {
+          errors.push(`${path}.choices: ${field.kind} requires ${minimum}–${maximum} choices`);
+        }
+        for (const id of duplicateValues(field.choices.map((choice) => choice.id))) {
+          errors.push(`${path}.choices: duplicate choice id "${id}"`);
+        }
+      }
+    }
+
+    if (field.kind === "multi-choice" && field.choices !== undefined) {
+      const minimum = field.minItems ?? 0;
+      const maximum = field.maxItems ?? field.choices.length;
+      if (minimum > maximum) errors.push(`${path}: minItems cannot exceed maxItems`);
+      if (minimum > field.choices.length) errors.push(`${path}.minItems: cannot exceed the number of choices`);
+      if (maximum > field.choices.length) errors.push(`${path}.maxItems: cannot exceed the number of choices`);
+    }
+
+    if (field.kind === "number" && field.minimum !== undefined && field.maximum !== undefined) {
+      if (field.minimum > field.maximum) errors.push(`${path}: minimum cannot exceed maximum`);
+    }
+  }
+
+  for (const [index, option] of request.options.entries()) {
+    if (option.effect !== "reject_proposal") continue;
+    const reasonField = fields.some(
+      (field) =>
+        field.kind === "text" &&
+        field.required === true &&
+        (field.whenOption === undefined || field.whenOption.includes(option.id)),
+    );
+    if (!reasonField) {
+      errors.push(
+        `$.options[${index}].effect: "reject_proposal" requires an applicable required text field`,
+      );
+    }
+  }
+
+  return result(errors);
+}
+
+/** Return the canonical identity a response must bind to. */
+export function decisionRequestHash(request) {
+  return hashJson(request);
+}
+
+function validateFieldValue(field, value, path, errors) {
+  if (field.kind === "text") {
+    if (typeof value !== "string") {
+      errors.push(`${path}: expected string`);
+      return;
+    }
+    const maximum = field.maxLength ?? 2000;
+    if (field.required === true && value.length === 0) errors.push(`${path}: required text must not be empty`);
+    if (value.length > maximum) errors.push(`${path}: longer than maxLength ${maximum}`);
+    return;
+  }
+
+  if (field.kind === "single-choice") {
+    if (typeof value !== "string") {
+      errors.push(`${path}: expected a choice id string`);
+      return;
+    }
+    if (!field.choices.some((choice) => choice.id === value)) {
+      errors.push(`${path}: unknown choice id "${value}"`);
+    }
+    return;
+  }
+
+  if (field.kind === "multi-choice") {
+    if (!Array.isArray(value)) {
+      errors.push(`${path}: expected an array of choice ids`);
+      return;
+    }
+    if (!value.every((entry) => typeof entry === "string")) {
+      errors.push(`${path}: every choice id must be a string`);
+      return;
+    }
+    const duplicates = duplicateValues(value);
+    for (const id of duplicates) errors.push(`${path}: duplicate choice id "${id}"`);
+    const choices = new Set(field.choices.map((choice) => choice.id));
+    for (const id of value) {
+      if (!choices.has(id)) errors.push(`${path}: unknown choice id "${id}"`);
+    }
+    const minimum = field.minItems ?? (field.required === true ? 1 : 0);
+    const maximum = field.maxItems ?? field.choices.length;
+    if (value.length < minimum) errors.push(`${path}: fewer than minItems ${minimum}`);
+    if (value.length > maximum) errors.push(`${path}: more than maxItems ${maximum}`);
+    return;
+  }
+
+  if (field.kind === "confirm") {
+    if (typeof value !== "boolean") errors.push(`${path}: expected boolean`);
+    else if (field.required === true && value !== true) errors.push(`${path}: required confirmation must be true`);
+    return;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    errors.push(`${path}: expected a finite number`);
+    return;
+  }
+  if (field.minimum !== undefined && value < field.minimum) {
+    errors.push(`${path}: below minimum ${field.minimum}`);
+  }
+  if (field.maximum !== undefined && value > field.maximum) {
+    errors.push(`${path}: above maximum ${field.maximum}`);
+  }
+  if (field.integer === true && !Number.isInteger(value)) errors.push(`${path}: expected an integer`);
+}
+
+/**
+ * Validate one operator response against the exact request it answers.
+ *
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateDecisionResponse(response, request) {
+  const responseShape = validate(responseSchema, response);
+  if (!responseShape.valid) return responseShape;
+
+  const requestCheck = validateDecisionRequest(request, { refs: RESPONSE_VALIDATION_REFS });
+  if (!requestCheck.valid) {
+    return result(requestCheck.errors.map((error) => `request ${error}`));
+  }
+
+  const errors = [];
+  if (response.requestHash !== decisionRequestHash(request)) errors.push("$.requestHash: does not match request");
+
+  const option = request.options.find((candidate) => candidate.id === response.optionId);
+  if (option === undefined) {
+    errors.push(`$.optionId: unknown option id "${response.optionId}"`);
+    return result(errors);
+  }
+
+  const declaredFields = new Map((request.fields ?? []).map((field) => [field.id, field]));
+  const applicableFields = (request.fields ?? []).filter(
+    (field) => field.whenOption === undefined || field.whenOption.includes(option.id),
+  );
+  const applicableIds = new Set(applicableFields.map((field) => field.id));
+
+  for (const key of Object.keys(response.fields)) {
+    if (!declaredFields.has(key)) errors.push(`$.fields.${key}: undeclared field`);
+    else if (!applicableIds.has(key)) errors.push(`$.fields.${key}: field does not apply to option "${option.id}"`);
+  }
+
+  for (const field of applicableFields) {
+    const present = hasOwn(response.fields, field.id);
+    if (!present) {
+      if (field.required === true) errors.push(`$.fields.${field.id}: required field is missing`);
+      continue;
+    }
+    validateFieldValue(field, response.fields[field.id], `$.fields.${field.id}`, errors);
+  }
+
+  return result(errors);
+}

--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -1,0 +1,518 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decisionRequestHash,
+  validateDecisionRequest,
+  validateDecisionResponse,
+} from "./decision.mjs";
+
+const EXAMPLE_REQUEST = {
+  schemaVersion: "factory.decision-request/v1",
+  question: "WM-313 changes how the pi adapter reads FACTORY_EVENT_SECRET. May I proceed?",
+  context:
+    "The ticket moves secret handling from env to a file the worker mounts…\n\nRisk: a wrong path leaks the secret into the run journal.",
+  recommended: "authorise",
+  options: [
+    {
+      id: "authorise",
+      label: "Authorise within these paths",
+      description: "Re-dispatch me with your approval bound to WM-313 as written now.",
+      effect: "authorise",
+      tone: "primary",
+      scope: {
+        paths: [
+          "event-runtime/lib/adapters/pi.mjs",
+          "event-runtime/lib/security-env.mjs",
+        ],
+        summary:
+          "Read the event secret from FACTORY_EVENT_SECRET_FILE when set; never log its value.",
+      },
+    },
+    {
+      id: "triage",
+      label: "Send back to Triage",
+      description: "The ticket should be re-scoped before anyone touches this.",
+      effect: "send_to_triage",
+      tone: "neutral",
+    },
+    {
+      id: "dismiss",
+      label: "Not now",
+      effect: "dismiss",
+      tone: "neutral",
+    },
+  ],
+  fields: [
+    {
+      id: "insight",
+      kind: "text",
+      label: "Anything I should know before I start",
+      placeholder: "e.g. the file path convention, or a test to add",
+      required: false,
+      maxLength: 2000,
+    },
+    {
+      id: "paths",
+      kind: "multi-choice",
+      label: "Restrict me to",
+      choices: [
+        { id: "pi", label: "event-runtime/lib/adapters/pi.mjs" },
+        { id: "env", label: "event-runtime/lib/security-env.mjs" },
+      ],
+      required: true,
+      whenOption: ["authorise"],
+    },
+    {
+      id: "confirm",
+      kind: "confirm",
+      label: "I understand this changes secret handling on every worker",
+      required: true,
+      whenOption: ["authorise"],
+    },
+  ],
+};
+
+const ALL_REFS = {
+  issue: "WM-313",
+  repo: "factory",
+  runId: "run_313",
+  eventSource: "linear",
+  eventId: "delivery-313",
+  proposalId: "prop_313",
+};
+
+const clone = (value) => structuredClone(value);
+
+function dismissRequest(overrides = {}) {
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: "What should happen?",
+    options: [{ id: "dismiss", label: "Dismiss", effect: "dismiss" }],
+    ...overrides,
+  };
+}
+
+function requestForEffect(effect) {
+  const option = { id: "choice", label: "Choose", effect };
+  if (effect === "authorise") {
+    option.scope = { paths: ["event-runtime/lib/decision.mjs"], summary: "Validate decisions." };
+  }
+  const request = dismissRequest({ options: [option] });
+  if (effect === "reject_proposal") {
+    request.fields = [
+      { id: "reason", kind: "text", label: "Reason", required: true, whenOption: ["choice"] },
+    ];
+  }
+  return request;
+}
+
+function expectInvalid(request, refs = ALL_REFS) {
+  const checked = validateDecisionRequest(request, { refs });
+  expect(checked.valid).toBe(false);
+  expect(checked.errors.length).toBeGreaterThan(0);
+}
+
+describe("validateDecisionRequest", () => {
+  test("accepts the §2.1 example verbatim", () => {
+    expect(validateDecisionRequest(EXAMPLE_REQUEST, { refs: ALL_REFS })).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  test("enforces the top-level bounds and rejects unknown properties", () => {
+    expect(validateDecisionRequest(dismissRequest(), { refs: {} }).valid).toBe(true);
+
+    for (const request of [
+      dismissRequest({ question: "" }),
+      dismissRequest({ question: "x".repeat(281) }),
+      dismissRequest({ context: "x".repeat(8193) }),
+      dismissRequest({ context: "🙂".repeat(4096) }),
+      dismissRequest({ options: [] }),
+      dismissRequest({ options: Array.from({ length: 7 }, (_, id) => ({ id: `o${id}`, label: "x", effect: "dismiss" })) }),
+      { ...dismissRequest(), unexpected: true },
+    ]) {
+      expectInvalid(request, {});
+    }
+  });
+
+  test("enforces option shape, bounds, ids, and uniqueness", () => {
+    for (const option of [
+      { id: "Bad", label: "x", effect: "dismiss" },
+      { id: "ok", label: "", effect: "dismiss" },
+      { id: "ok", label: "x".repeat(61), effect: "dismiss" },
+      { id: "ok", label: "x", description: "x".repeat(281), effect: "dismiss" },
+      { id: "ok", label: "x", effect: "invented" },
+      { id: "ok", label: "x", effect: "dismiss", tone: "loud" },
+      { id: "ok", label: "x", effect: "dismiss", extra: true },
+    ]) {
+      expectInvalid(dismissRequest({ options: [option] }), {});
+    }
+    expectInvalid(
+      dismissRequest({
+        options: [
+          { id: "same", label: "One", effect: "dismiss" },
+          { id: "same", label: "Two", effect: "dismiss" },
+        ],
+      }),
+      {},
+    );
+  });
+
+  test("recommended and whenOption name existing unique options", () => {
+    expect(validateDecisionRequest(dismissRequest({ recommended: "dismiss" }), { refs: {} }).valid).toBe(true);
+    expectInvalid(dismissRequest({ recommended: "missing" }), {});
+    expect(
+      validateDecisionRequest(
+        dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["dismiss"] }] }),
+        { refs: {} },
+      ).valid,
+    ).toBe(true);
+    expectInvalid(
+      dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["missing"] }] }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["dismiss", "dismiss"] }] }),
+      {},
+    );
+  });
+
+  test("scope is present exactly for authorise and observes its bounds", () => {
+    expect(validateDecisionRequest(requestForEffect("authorise"), { refs: ALL_REFS }).valid).toBe(true);
+
+    const missing = requestForEffect("authorise");
+    delete missing.options[0].scope;
+    expectInvalid(missing);
+
+    expectInvalid(
+      dismissRequest({
+        options: [
+          {
+            id: "dismiss",
+            label: "Dismiss",
+            effect: "dismiss",
+            scope: { paths: ["x"], summary: "not allowed" },
+          },
+        ],
+      }),
+      {},
+    );
+
+    const noPaths = requestForEffect("authorise");
+    noPaths.options[0].scope.paths = [];
+    expectInvalid(noPaths);
+    const tooManyPaths = requestForEffect("authorise");
+    tooManyPaths.options[0].scope.paths = Array.from({ length: 33 }, (_, index) => `p${index}`);
+    expectInvalid(tooManyPaths);
+    const longSummary = requestForEffect("authorise");
+    longSummary.options[0].scope.summary = "x".repeat(501);
+    expectInvalid(longSummary);
+    const absolutePath = requestForEffect("authorise");
+    absolutePath.options[0].scope.paths = ["/etc/passwd"];
+    expectInvalid(absolutePath);
+    const traversalPath = requestForEffect("authorise");
+    traversalPath.options[0].scope.paths = ["event-runtime/../outside"];
+    expectInvalid(traversalPath);
+  });
+
+  test("every effect requires the refs declared in §3", () => {
+    const requirements = {
+      authorise: ["issue", "repo", "runId"],
+      send_to_triage: ["issue"],
+      answer: ["issue"],
+      requeue: ["eventSource", "eventId"],
+      approve_proposal: ["proposalId"],
+      reject_proposal: ["proposalId"],
+      dismiss: [],
+    };
+
+    for (const [effect, requiredRefs] of Object.entries(requirements)) {
+      const request = requestForEffect(effect);
+      expect(validateDecisionRequest(request, { refs: ALL_REFS }).valid).toBe(true);
+      for (const ref of requiredRefs) {
+        const refs = { ...ALL_REFS };
+        delete refs[ref];
+        expectInvalid(request, refs);
+      }
+    }
+  });
+
+  test("reject_proposal requires an applicable required text field", () => {
+    expect(validateDecisionRequest(requestForEffect("reject_proposal"), { refs: ALL_REFS }).valid).toBe(true);
+
+    const absent = requestForEffect("reject_proposal");
+    absent.fields = [];
+    expectInvalid(absent);
+
+    const optional = requestForEffect("reject_proposal");
+    optional.fields[0].required = false;
+    expectInvalid(optional);
+
+    const wrongKind = requestForEffect("reject_proposal");
+    wrongKind.fields[0] = { id: "reason", kind: "confirm", label: "Reason", required: true };
+    expectInvalid(wrongKind);
+
+    const gatedElsewhere = requestForEffect("reject_proposal");
+    gatedElsewhere.options.push({ id: "other", label: "Other", effect: "dismiss" });
+    gatedElsewhere.fields[0].whenOption = ["other"];
+    expectInvalid(gatedElsewhere);
+  });
+
+  test("enforces field count, ids, kind-specific keys, choices, and numeric relations", () => {
+    const sixFields = Array.from({ length: 6 }, (_, index) => ({
+      id: `f${index}`,
+      kind: "text",
+      label: `Field ${index}`,
+    }));
+    expect(validateDecisionRequest(dismissRequest({ fields: sixFields }), { refs: {} }).valid).toBe(true);
+    expectInvalid(dismissRequest({ fields: [...sixFields, { id: "f6", kind: "text", label: "Seven" }] }), {});
+    expectInvalid(dismissRequest({ fields: [sixFields[0], { ...sixFields[0] }] }), {});
+    expectInvalid(dismissRequest({ fields: [{ id: "Bad", kind: "text", label: "Bad" }] }), {});
+    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "unknown", label: "Bad" }] }), {});
+    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "confirm", label: "Bad", maxLength: 2 }] }), {});
+    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "text", label: "Bad", maxLength: 8193 }] }), {});
+
+    expect(
+      validateDecisionRequest(
+        dismissRequest({
+          fields: [
+            {
+              id: "pick",
+              kind: "single-choice",
+              label: "Pick",
+              choices: [
+                { id: "a", label: "A" },
+                { id: "b", label: "B" },
+              ],
+            },
+          ],
+        }),
+        { refs: {} },
+      ).valid,
+    ).toBe(true);
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "pick", kind: "single-choice", label: "Pick", choices: [{ id: "a", label: "A" }] }],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [
+          {
+            id: "pick",
+            kind: "multi-choice",
+            label: "Pick",
+            choices: [
+              { id: "a", label: "A" },
+              { id: "a", label: "Again" },
+            ],
+          },
+        ],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [
+          {
+            id: "pick",
+            kind: "multi-choice",
+            label: "Pick",
+            choices: [
+              { id: "a", label: "A" },
+              { id: "b", label: "B" },
+            ],
+            minItems: 2,
+            maxItems: 1,
+          },
+        ],
+      }),
+      {},
+    );
+    expectInvalid(
+      dismissRequest({
+        fields: [{ id: "count", kind: "number", label: "Count", minimum: 2, maximum: 1 }],
+      }),
+      {},
+    );
+  });
+});
+
+const RESPONSE_REQUEST = dismissRequest({
+  options: [
+    { id: "save", label: "Save", effect: "dismiss" },
+    { id: "other", label: "Other", effect: "dismiss" },
+  ],
+  fields: [
+    { id: "note", kind: "text", label: "Note", required: true, maxLength: 3 },
+    {
+      id: "single",
+      kind: "single-choice",
+      label: "Single",
+      required: true,
+      choices: [
+        { id: "a", label: "A" },
+        { id: "b", label: "B" },
+      ],
+    },
+    {
+      id: "multi",
+      kind: "multi-choice",
+      label: "Multi",
+      required: true,
+      choices: [
+        { id: "a", label: "A" },
+        { id: "b", label: "B" },
+        { id: "c", label: "C" },
+      ],
+      minItems: 1,
+      maxItems: 2,
+    },
+    { id: "confirm", kind: "confirm", label: "Confirm", required: true },
+    {
+      id: "count",
+      kind: "number",
+      label: "Count",
+      required: true,
+      minimum: 1,
+      maximum: 3,
+      integer: true,
+    },
+    { id: "other_note", kind: "text", label: "Other note", whenOption: ["other"] },
+  ],
+});
+
+function validResponse() {
+  return {
+    schemaVersion: "factory.decision-response/v1",
+    requestHash: decisionRequestHash(RESPONSE_REQUEST),
+    optionId: "save",
+    fields: { note: "yes", single: "a", multi: ["a", "b"], confirm: true, count: 2 },
+    decidedBy: "operator",
+    decidedAt: "2026-08-16T12:41:07.000Z",
+  };
+}
+
+function expectInvalidResponse(mutator) {
+  const response = validResponse();
+  mutator(response);
+  const checked = validateDecisionResponse(response, RESPONSE_REQUEST);
+  expect(checked.valid).toBe(false);
+  expect(checked.errors.length).toBeGreaterThan(0);
+}
+
+describe("decisionRequestHash", () => {
+  test("uses canonical JSON key ordering", () => {
+    const reordered = { options: RESPONSE_REQUEST.options, question: RESPONSE_REQUEST.question, fields: RESPONSE_REQUEST.fields, schemaVersion: RESPONSE_REQUEST.schemaVersion };
+    expect(decisionRequestHash(reordered)).toBe(decisionRequestHash(RESPONSE_REQUEST));
+    expect(decisionRequestHash(RESPONSE_REQUEST)).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+});
+
+describe("validateDecisionResponse", () => {
+  test("accepts every widget kind when applicable values satisfy the request", () => {
+    expect(validateDecisionResponse(validResponse(), RESPONSE_REQUEST)).toEqual({ valid: true, errors: [] });
+  });
+
+  test("requires the exact request hash and a declared option", () => {
+    expectInvalidResponse((response) => {
+      response.requestHash = `sha256:${"0".repeat(64)}`;
+    });
+    expectInvalidResponse((response) => {
+      response.optionId = "missing";
+    });
+  });
+
+  test("requires applicable required fields and non-empty required values", () => {
+    expectInvalidResponse((response) => {
+      delete response.fields.note;
+    });
+    expectInvalidResponse((response) => {
+      response.fields.note = "";
+    });
+    const defaultRequiredMulti = clone(RESPONSE_REQUEST);
+    delete defaultRequiredMulti.fields[2].minItems;
+    const emptyMulti = validResponse();
+    emptyMulti.requestHash = decisionRequestHash(defaultRequiredMulti);
+    emptyMulti.fields.multi = [];
+    expect(validateDecisionResponse(emptyMulti, defaultRequiredMulti).valid).toBe(false);
+    expectInvalidResponse((response) => {
+      response.fields.confirm = false;
+    });
+  });
+
+  test("validates text type and maxLength", () => {
+    expectInvalidResponse((response) => {
+      response.fields.note = 3;
+    });
+    expectInvalidResponse((response) => {
+      response.fields.note = "long";
+    });
+  });
+
+  test("validates single-choice type and membership", () => {
+    expectInvalidResponse((response) => {
+      response.fields.single = ["a"];
+    });
+    expectInvalidResponse((response) => {
+      response.fields.single = "missing";
+    });
+  });
+
+  test("validates multi-choice type, membership, uniqueness, minItems, and maxItems", () => {
+    expectInvalidResponse((response) => {
+      response.fields.multi = "a";
+    });
+    expectInvalidResponse((response) => {
+      response.fields.multi = ["missing"];
+    });
+    expectInvalidResponse((response) => {
+      response.fields.multi = ["a", "a"];
+    });
+    expectInvalidResponse((response) => {
+      response.fields.multi = [];
+    });
+    expectInvalidResponse((response) => {
+      response.fields.multi = ["a", "b", "c"];
+    });
+  });
+
+  test("validates number type, minimum, maximum, and integer", () => {
+    expectInvalidResponse((response) => {
+      response.fields.count = "2";
+    });
+    expectInvalidResponse((response) => {
+      response.fields.count = 0;
+    });
+    expectInvalidResponse((response) => {
+      response.fields.count = 4;
+    });
+    expectInvalidResponse((response) => {
+      response.fields.count = 1.5;
+    });
+  });
+
+  test("rejects undeclared and option-inapplicable field keys", () => {
+    expectInvalidResponse((response) => {
+      response.fields.unknown = "x";
+    });
+    expectInvalidResponse((response) => {
+      response.fields.other_note = "hidden";
+    });
+  });
+
+  test("rejects unknown response properties and malformed requests", () => {
+    expectInvalidResponse((response) => {
+      response.extra = true;
+    });
+    const invalidRequest = clone(RESPONSE_REQUEST);
+    invalidRequest.options = [];
+    expect(validateDecisionResponse(validResponse(), invalidRequest).valid).toBe(false);
+
+    const semanticallyInvalidRequest = clone(RESPONSE_REQUEST);
+    delete semanticallyInvalidRequest.fields[1].choices;
+    expect(() => validateDecisionResponse(validResponse(), semanticallyInvalidRequest)).not.toThrow();
+    expect(validateDecisionResponse(validResponse(), semanticallyInvalidRequest).valid).toBe(false);
+  });
+});

--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DECISION_REQUEST_SCHEMA,
+  DECISION_RESPONSE_SCHEMA,
+  EFFECT_REFS,
+  EFFECTS,
+  WIDGET_KINDS,
   decisionRequestHash,
   validateDecisionRequest,
   validateDecisionResponse,
 } from "./decision.mjs";
+import { validate } from "./schema.mjs";
 
 const EXAMPLE_REQUEST = {
   schemaVersion: "factory.decision-request/v1",
@@ -111,6 +117,36 @@ function expectInvalid(request, refs = ALL_REFS) {
   expect(checked.errors.length).toBeGreaterThan(0);
 }
 
+describe("contract schemas", () => {
+  test("use only the closed keyword subset and close every object", () => {
+    // An unsupported keyword is reported as an error by lib/schema.mjs, so a
+    // clean run against any value proves the schema stays inside the subset.
+    for (const schema of [DECISION_REQUEST_SCHEMA, DECISION_RESPONSE_SCHEMA]) {
+      const errors = validate(schema, {}).errors;
+      expect(errors.some((e) => e.includes("unsupported schema keyword"))).toBe(false);
+    }
+    const walk = (node, at) => {
+      if (node === null || typeof node !== "object") return;
+      if (Array.isArray(node)) return node.forEach((n, i) => walk(n, `${at}[${i}]`));
+      if (node.type === "object" && at !== "response.properties.fields") {
+        expect(node.additionalProperties, `${at} must be closed`).toBe(false);
+      }
+      for (const [k, v] of Object.entries(node)) walk(v, `${at}.${k}`);
+    };
+    walk(DECISION_REQUEST_SCHEMA, "request");
+    walk(DECISION_RESPONSE_SCHEMA, "response");
+    // The response's `fields` map is keyed by request-declared ids — closed by
+    // the validator, not the schema.
+    expect(DECISION_RESPONSE_SCHEMA.properties.fields.additionalProperties).toEqual({});
+  });
+
+  test("encode the closed effect and widget enums", () => {
+    expect(DECISION_REQUEST_SCHEMA.properties.options.items.properties.effect.enum).toEqual(EFFECTS);
+    expect(DECISION_REQUEST_SCHEMA.properties.fields.items.properties.kind.enum).toEqual(WIDGET_KINDS);
+    expect(Object.keys(EFFECT_REFS)).toEqual(EFFECTS);
+  });
+});
+
 describe("validateDecisionRequest", () => {
   test("accepts the §2.1 example verbatim", () => {
     expect(validateDecisionRequest(EXAMPLE_REQUEST, { refs: ALL_REFS })).toEqual({
@@ -175,6 +211,7 @@ describe("validateDecisionRequest", () => {
       dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: ["dismiss", "dismiss"] }] }),
       {},
     );
+    expectInvalid(dismissRequest({ fields: [{ id: "note", kind: "text", label: "Note", whenOption: [] }] }), {});
   });
 
   test("scope is present exactly for authorise and observes its bounds", () => {
@@ -271,6 +308,12 @@ describe("validateDecisionRequest", () => {
     expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "unknown", label: "Bad" }] }), {});
     expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "confirm", label: "Bad", maxLength: 2 }] }), {});
     expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "text", label: "Bad", maxLength: 8193 }] }), {});
+    expectInvalid(
+      dismissRequest({ fields: [{ id: "x", kind: "text", label: "Bad", placeholder: "p".repeat(281) }] }),
+      {},
+    );
+    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "number", label: "Bad", choices: [] }] }), {});
+    expectInvalid(dismissRequest({ fields: [{ id: "x", kind: "single-choice", label: "No choices" }] }), {});
 
     expect(
       validateDecisionRequest(
@@ -415,6 +458,34 @@ describe("validateDecisionResponse", () => {
     expect(validateDecisionResponse(validResponse(), RESPONSE_REQUEST)).toEqual({ valid: true, errors: [] });
   });
 
+  test("a field gated on the chosen option applies; the same field is rejected for another option", () => {
+    const other = validResponse();
+    other.optionId = "other";
+    other.fields.other_note = "shown for other";
+    expect(validateDecisionResponse(other, RESPONSE_REQUEST)).toEqual({ valid: true, errors: [] });
+
+    const otherMissingOptional = validResponse();
+    otherMissingOptional.optionId = "other";
+    expect(validateDecisionResponse(otherMissingOptional, RESPONSE_REQUEST).valid).toBe(true);
+  });
+
+  test("optional applicable fields may be omitted but must be well-typed when present", () => {
+    const optionalRequest = dismissRequest({
+      fields: [{ id: "n", kind: "number", label: "N", minimum: 0 }],
+    });
+    const omitted = {
+      ...validResponse(),
+      requestHash: decisionRequestHash(optionalRequest),
+      optionId: "dismiss",
+      fields: {},
+    };
+    expect(validateDecisionResponse(omitted, optionalRequest)).toEqual({ valid: true, errors: [] });
+    const badType = { ...omitted, fields: { n: "1" } };
+    expect(validateDecisionResponse(badType, optionalRequest).valid).toBe(false);
+    const belowMin = { ...omitted, fields: { n: -1 } };
+    expect(validateDecisionResponse(belowMin, optionalRequest).valid).toBe(false);
+  });
+
   test("requires the exact request hash and a declared option", () => {
     expectInvalidResponse((response) => {
       response.requestHash = `sha256:${"0".repeat(64)}`;
@@ -502,9 +573,18 @@ describe("validateDecisionResponse", () => {
     });
   });
 
-  test("rejects unknown response properties and malformed requests", () => {
+  test("rejects unknown response properties, bad timestamps, and malformed requests", () => {
     expectInvalidResponse((response) => {
       response.extra = true;
+    });
+    expectInvalidResponse((response) => {
+      response.decidedAt = "yesterday";
+    });
+    expectInvalidResponse((response) => {
+      response.requestHash = "not-a-hash";
+    });
+    expectInvalidResponse((response) => {
+      response.decidedBy = "";
     });
     const invalidRequest = clone(RESPONSE_REQUEST);
     invalidRequest.options = [];

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -14,6 +14,7 @@ import { spawnSync } from "node:child_process";
 import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes, hashJson, sha256Hex } from "./canonical.mjs";
+import { validateDecisionRequest } from "./decision.mjs";
 import { validate } from "./schema.mjs";
 import { PathViolation, safeJoin } from "./workspace.mjs";
 
@@ -194,6 +195,9 @@ export function verifyResult({
   if (!shape.valid) throw new ContractViolation(shape.errors);
 
   if (candidate.terminalState === "refused") return verifyRefused({ spec, def, candidate, attempt });
+  if (candidate.decision !== undefined) {
+    throw new ContractViolation(["decision_not_allowed_on_completed_result"]);
+  }
   return verifyCompleted({
     spec, def, candidate, workspaceDir, attempt, journalHead, extraArtifacts, worktreeRecord, verifyTimeoutMs,
   });
@@ -214,6 +218,18 @@ function verifyRefused({ spec, def, candidate, attempt }) {
 
   const context = {};
   const checks = ["schema_valid"];
+  if (candidate.decision !== undefined) {
+    const decisionCheck = validateDecisionRequest(candidate.decision, {
+      refs: {
+        issue: spec.input?.ticket,
+        repo: spec.input?.repo,
+        runId: spec.runId,
+      },
+    });
+    if (decisionCheck.valid) context.decision = candidate.decision;
+    else context.decisionErrors = decisionCheck.errors;
+    checks.push("decision_validated");
+  }
   if (candidate.artifact !== undefined) {
     const artifactCheck = validate(def.outputSchema, candidate.artifact);
     if (!artifactCheck.valid) throw new ContractViolation(artifactCheck.errors);

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -43,6 +43,21 @@ const VALID_ARTIFACT = {
   recommendedAction: "dispatch",
 };
 
+const VALID_DECISION = {
+  schemaVersion: "factory.decision-request/v1",
+  question: "May I proceed within the ticket's owned paths?",
+  recommended: "authorise",
+  options: [
+    {
+      id: "authorise",
+      label: "Authorise",
+      effect: "authorise",
+      scope: { paths: ["event-runtime/lib/verify.mjs"], summary: "Apply the scoped change." },
+    },
+    { id: "dismiss", label: "Dismiss", effect: "dismiss" },
+  ],
+};
+
 describe("verifyResult", () => {
   test("valid completed result → result + receipt with recomputed hashes", () => {
     const evidence = { queries: ["q1"] };
@@ -305,6 +320,52 @@ describe("verifyResult", () => {
     expect(out.result.attempt).toBe(2);
     expect(out.result.artifact).toBeUndefined();
     expect(out.result.artifactHash).toBeUndefined();
+  });
+
+  test("refused with a valid decision → decision retained", () => {
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "refused",
+      reasonCode: "needs_human",
+      decision: VALID_DECISION,
+    });
+    const spec = makeSpec({ repo: "factory", ticket: "WM-389" });
+    const out = verifyResult({ spec, def, registry, workspaceDir: dir, attempt: 1 });
+    expect(out.kind).toBe("refused");
+    expect(out.result.decision).toEqual(VALID_DECISION);
+    expect(out.result.decisionErrors).toBeUndefined();
+  });
+
+  test("refused with an invalid decision → refusal retained with decision errors", () => {
+    const decision = { ...VALID_DECISION, recommended: "missing" };
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "refused",
+      reasonCode: "needs_human",
+      decision,
+    });
+    const spec = makeSpec({ repo: "factory", ticket: "WM-389" });
+    const out = verifyResult({ spec, def, registry, workspaceDir: dir, attempt: 1 });
+    expect(out.kind).toBe("refused");
+    expect(out.result.decision).toBeUndefined();
+    expect(out.result.decisionErrors).toBeArray();
+    expect(out.result.decisionErrors[0]).toContain("recommended");
+  });
+
+  test("completed with a decision → ContractViolation", () => {
+    const dir = makeWorkspace({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+      decision: VALID_DECISION,
+    });
+    try {
+      verifyResult({ spec: makeSpec(), def, registry, workspaceDir: dir, attempt: 1 });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toEqual(["decision_not_allowed_on_completed_result"]);
+    }
   });
 
   test("refused with an unknown reasonCode → ContractViolation", () => {

--- a/event-runtime/schemas/factory.agent-result.v1.json
+++ b/event-runtime/schemas/factory.agent-result.v1.json
@@ -7,6 +7,7 @@
     "schemaVersion": { "const": "factory.agent-result/v1" },
     "terminalState": { "enum": ["completed", "refused"] },
     "reasonCode": { "type": "string", "minLength": 1 },
+    "decision": {},
     "artifact": {},
     "evidence": {},
     "artifacts": {

--- a/event-runtime/schemas/factory.decision-request.v1.json
+++ b/event-runtime/schemas/factory.decision-request.v1.json
@@ -1,0 +1,96 @@
+{
+  "title": "factory.decision-request/v1 — a bounded human decision authored by an agent or the runtime",
+  "type": "object",
+  "required": ["schemaVersion", "question", "options"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.decision-request/v1" },
+    "question": { "type": "string", "minLength": 1, "maxLength": 280 },
+    "context": { "type": "string", "maxLength": 8192 },
+    "recommended": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+    "options": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": ["id", "label", "effect"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+          "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "description": { "type": "string", "maxLength": 280 },
+          "effect": {
+            "enum": [
+              "authorise",
+              "send_to_triage",
+              "answer",
+              "requeue",
+              "approve_proposal",
+              "reject_proposal",
+              "dismiss"
+            ]
+          },
+          "tone": { "enum": ["primary", "danger", "neutral"] },
+          "scope": {
+            "type": "object",
+            "required": ["paths", "summary"],
+            "additionalProperties": false,
+            "properties": {
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 32,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "summary": { "type": "string", "maxLength": 500 }
+            }
+          }
+        }
+      }
+    },
+    "fields": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": ["id", "kind", "label"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+          "kind": { "enum": ["text", "single-choice", "multi-choice", "confirm", "number"] },
+          "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "required": { "type": "boolean" },
+          "whenOption": {
+            "type": "array",
+            "maxItems": 6,
+            "items": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" }
+          },
+          "placeholder": { "type": "string" },
+          "maxLength": { "type": "integer", "minimum": 1, "maximum": 8192 },
+          "choices": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 24,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+                "label": { "type": "string", "minLength": 1, "maxLength": 60 },
+                "description": { "type": "string", "maxLength": 280 }
+              }
+            }
+          },
+          "minItems": { "type": "integer", "minimum": 0, "maximum": 24 },
+          "maxItems": { "type": "integer", "minimum": 0, "maximum": 24 },
+          "minimum": { "type": "number" },
+          "maximum": { "type": "number" },
+          "integer": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/event-runtime/schemas/factory.decision-request.v1.json
+++ b/event-runtime/schemas/factory.decision-request.v1.json
@@ -43,7 +43,7 @@
                 "maxItems": 32,
                 "items": { "type": "string", "minLength": 1 }
               },
-              "summary": { "type": "string", "maxLength": 500 }
+              "summary": { "type": "string", "minLength": 1, "maxLength": 500 }
             }
           }
         }
@@ -64,10 +64,11 @@
           "required": { "type": "boolean" },
           "whenOption": {
             "type": "array",
+            "minItems": 1,
             "maxItems": 6,
             "items": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" }
           },
-          "placeholder": { "type": "string" },
+          "placeholder": { "type": "string", "maxLength": 280 },
           "maxLength": { "type": "integer", "minimum": 1, "maximum": 8192 },
           "choices": {
             "type": "array",

--- a/event-runtime/schemas/factory.decision-response.v1.json
+++ b/event-runtime/schemas/factory.decision-response.v1.json
@@ -8,7 +8,10 @@
     "requestHash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
     "optionId": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
     "fields": { "type": "object", "additionalProperties": {} },
-    "decidedBy": { "type": "string", "minLength": 1 },
-    "decidedAt": { "type": "string", "minLength": 1 }
+    "decidedBy": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "decidedAt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    }
   }
 }

--- a/event-runtime/schemas/factory.decision-response.v1.json
+++ b/event-runtime/schemas/factory.decision-response.v1.json
@@ -1,0 +1,14 @@
+{
+  "title": "factory.decision-response/v1 — an operator answer bound to a decision request",
+  "type": "object",
+  "required": ["schemaVersion", "requestHash", "optionId", "fields", "decidedBy", "decidedAt"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.decision-response/v1" },
+    "requestHash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "optionId": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,31}$" },
+    "fields": { "type": "object", "additionalProperties": {} },
+    "decidedBy": { "type": "string", "minLength": 1 },
+    "decidedAt": { "type": "string", "minLength": 1 }
+  }
+}


### PR DESCRIPTION
Fixes WM-389

Epic WM-383. Adds the two contracts the inbox epic builds on and lets a refusing agent attach a question to its `result.json`. Nothing touches ledger, API, or web (WM-390/391/392).

## What
- `event-runtime/schemas/factory.decision-request.v1.json`, `factory.decision-response.v1.json` — closed keyword subset only, `additionalProperties: false` throughout, all §2.1/§2.2/§2.3 bounds (question 1–280, context ≤ 8 KiB, options 1–6, fields 0–6, five widget kinds, tone enum, effect enum, scope shape 1–32 paths + ≤ 500 summary).
- `event-runtime/lib/decision.mjs` — `validateDecisionRequest(request, { refs })`, `validateDecisionResponse(response, request)`, `decisionRequestHash(request)` (= `hashJson`). Semantic rules in code, same shape as `lib/artifact-view.mjs`: `recommended`/`whenOption` name existing options, `scope` iff `authorise`, `reject_proposal` needs an applicable required `text` field, effect ↔ refs legality per §3, per-kind field keys, choice bounds/uniqueness, min/max coherence, repo-relative scope paths; response: option exists, only applicable fields, type/required/`minItems`/`maxItems`/`minimum`/`maximum`/`integer`, `confirm` required ⇒ `true`, no undeclared keys, `requestHash` match.
- `schemas/factory.agent-result.v1.json` gains optional `decision`; `verifyRefused` validates it with refs `{ issue: input.ticket, repo: input.repo, runId }` → `result.decision` or `result.decisionErrors` (refusal still succeeds); `decision` on `completed` → `ContractViolation("decision_not_allowed_on_completed_result")`.
- `docs/event-runtime.md` §5 mentions the two contracts.

## Draft salvage
The abandoned-attempt draft was largely right and was kept: schemas, validator logic, most tests, verify wiring. Changed: rebased onto current develop (conflict in `verifyResult` resolved, keeps `worktreeRecord`/`verifyTimeoutMs`); removed the fake-refs hack used to re-check the request during response validation (now an internal `checkRequest` with `checkEffectLegality: false`); exported schema/enum constants + module docstring; schemas tightened (`whenOption` minItems 1, `placeholder` ≤ 280, `scope.summary` non-empty, `decidedAt` ISO pattern, `decidedBy` bound); tests extended (gated-field-applies passing case, optional-field omission, keyword-subset/closed-object schema check, timestamp/hash shape).

## Verification
`bun test event-runtime/lib/decision.test.mjs event-runtime/lib/verify.test.mjs && bun test && bun build/emit.mjs --check && bun run format:check`
- decision + verify tests: 53 pass, 0 fail.
- full `bun test`: 1779 tests; only `bin/worktree-checkout.test.mjs` (3) fails — the fixture's `git commit -m "merge fix"` is rejected by the WM-609 commit-msg hook (known, WM-619). Web tests needed a `bun install` in the worktree (stale node_modules), then 737/737 green. Load flakes seen once in `adapters/command.test.mjs` / `merge.test.mjs` pass in isolation.
- `bun build/emit.mjs --check` exit 0 (pre-existing "floor delivery stale" warning about other repos' checkouts); `format:check` clean.
