### PR TITLE
fix(event-runtime-web): organize Projects list

### DIFF
--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -351,6 +351,66 @@ describe("Projects quick dispatch and GitHub chords (WM-294)", () => {
   });
 });
 
+describe("Projects toolbar counts and ordering (WM-560)", () => {
+  test("tab counts partition All and the default order is dispatchable first, then name", async () => {
+    await withApi(
+      {
+        repos: async () => ({
+          repos: [
+            repo({ name: "z-report", reportOnly: true }),
+            repo({ name: "z-dispatch", reportOnly: false }),
+            repo({ name: "a-report", reportOnly: true }),
+            repo({ name: "a-dispatch", reportOnly: false }),
+          ],
+        }),
+      },
+      async () => {
+        const r = renderProjects();
+        await r.findByText("a-dispatch");
+
+        const tabs = r.getAllByRole("tab");
+        const counts = tabs.map((tab) => Number(tab.querySelector(".tabular-nums")?.textContent));
+        expect(counts).toEqual([4, 2, 2]);
+        expect(counts[1] + counts[2]).toBe(counts[0]);
+
+        const rowNames = () =>
+          Array.from(r.container.querySelectorAll("tbody tr td:first-child")).map((cell) => cell.textContent);
+        expect(rowNames()).toEqual(["a-dispatch", "z-dispatch", "a-report", "z-report"]);
+
+        fireEvent.click(r.getByRole("button", { name: "Name" }));
+        expect(rowNames()).toEqual(["a-dispatch", "a-report", "z-dispatch", "z-report"]);
+        fireEvent.click(r.getByRole("button", { name: "Name" }));
+        expect(rowNames()).toEqual(["z-report", "z-dispatch", "a-report", "a-dispatch"]);
+        fireEvent.click(r.getByRole("button", { name: "Name" }));
+        expect(rowNames()).toEqual(["a-dispatch", "z-dispatch", "a-report", "z-report"]);
+      },
+    );
+  });
+
+  test("Worktree Scripts uses the shared faint placeholder when no scripts exist", async () => {
+    await withApi(
+      {
+        repos: async () => ({
+          repos: [
+            repo({
+              hasWorktreeUp: false,
+              hasWorktreeDown: false,
+              hasWorktreeWarm: false,
+            }),
+          ],
+        }),
+      },
+      async () => {
+        const r = renderProjects();
+        await r.findByText("factory");
+        const scriptsCell = r.container.querySelector("tbody tr td:last-child");
+        const placeholder = scriptsCell?.querySelector("span.text-\\(--text-faint\\)");
+        expect(placeholder?.textContent).toBe("—");
+      },
+    );
+  });
+});
+
 describe("Projects mode tabs and hotkeys (WM-234)", () => {
   test("renders mode tabs with role=tab, aria-selected, and numeric hints", async () => {
     await withApi({ repos: async () => ({ repos: [repo()] }) }, async () => {

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -42,7 +42,11 @@ const projectTarget = (repo: RepoItem) => repo.project || repo.github || repo.pa
 const worktreeScripts = (repo: RepoItem) =>
   [repo.hasWorktreeUp && "up", repo.hasWorktreeDown && "down", repo.hasWorktreeWarm && "warm"]
     .filter(Boolean)
-    .join(" · ") || "—";
+    .join(" · ");
+
+const defaultProjectOrder = (a: RepoItem, b: RepoItem) =>
+  Number(a.reportOnly) - Number(b.reportOnly) ||
+  a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" });
 
 const PROJECTS_SORT: DisplayConfig<RepoItem> = {
   view: "projects-table-sort",
@@ -131,10 +135,19 @@ export function Projects({
   });
 
   const repos = query.data?.repos ?? [];
+  const modeCounts = useMemo(
+    () => ({
+      ALL: repos.length,
+      DISPATCHABLE: repos.filter((repo) => !repo.reportOnly).length,
+      REPORT_ONLY: repos.filter((repo) => repo.reportOnly).length,
+    }),
+    [repos],
+  );
+  const defaultOrdered = useMemo(() => repos.slice().sort(defaultProjectOrder), [repos]);
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    return repos.filter((r) => {
+    return defaultOrdered.filter((r) => {
       if (filterMode === "DISPATCHABLE" && r.reportOnly) return false;
       if (filterMode === "REPORT_ONLY" && !r.reportOnly) return false;
       if (!q) return true;
@@ -145,7 +158,7 @@ export function Projects({
         (r.github && r.github.toLowerCase().includes(q))
       );
     });
-  }, [repos, filter, filterMode]);
+  }, [defaultOrdered, filter, filterMode]);
   const [sort, setSort] = useState(() => defaultDisplayState(PROJECTS_SORT));
   const visible = useMemo(() => sortRows(filtered, PROJECTS_SORT, sort), [filtered, sort]);
 
@@ -384,34 +397,35 @@ export function Projects({
               surface="registry"
               subject={{ label: "Projects", plural: true }}
             />
-            <div className="mb-3">
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <div className="flex min-w-0 flex-1 flex-wrap gap-1 text-[12px]" role="tablist" aria-label="Project mode">
+                {PROJECT_MODES.map((mode, idx) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    role="tab"
+                    aria-selected={filterMode === mode}
+                    onClick={() => setFilterMode(mode)}
+                    className={`shrink-0 rounded-md px-2.5 py-1 font-medium transition-colors ${
+                      filterMode === mode
+                        ? "bg-(--surface-3) text-(--text)"
+                        : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+                    }`}
+                  >
+                    {mode === "ALL" ? "All" : mode === "DISPATCHABLE" ? "Dispatchable" : "Report-Only"}
+                    <span className="ml-1.5 tabular-nums text-(--text-faint)">{modeCounts[mode]}</span>
+                    <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
+                      {idx + 1}
+                    </span>
+                  </button>
+                ))}
+              </div>
               <FilterInput
                 value={filter}
                 onChange={setFilter}
                 placeholder="Filter repo, project, team, github… (/)"
                 label="Filter repositories"
               />
-            </div>
-            <div className="mb-3 flex gap-1 text-[12px]" role="tablist" aria-label="Project mode">
-              {PROJECT_MODES.map((mode, idx) => (
-                <button
-                  key={mode}
-                  type="button"
-                  role="tab"
-                  aria-selected={filterMode === mode}
-                  onClick={() => setFilterMode(mode)}
-                  className={`rounded px-2 py-0.5 font-medium transition-colors ${
-                    filterMode === mode
-                      ? "bg-(--surface-3) text-(--text)"
-                      : "text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
-                  }`}
-                >
-                  {mode === "ALL" ? "All" : mode === "DISPATCHABLE" ? "Dispatchable" : "Report-Only"}
-                  <span aria-hidden="true" className="mono ml-1 text-(--text-faint) text-[10px] opacity-70">
-                    {idx + 1}
-                  </span>
-                </button>
-              ))}
             </div>
           </>
         }
@@ -477,7 +491,7 @@ export function Projects({
                     {r.deployBranch ? ` → ${r.deployBranch}` : ""}
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-faint)">
-                    {worktreeScripts(r)}
+                    {worktreeScripts(r) || <span className="text-(--text-faint)">—</span>}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
## Summary
- align Projects tabs and filter in a single responsive toolbar
- add per-mode counts and dispatchable-first/name-ascending default ordering
- keep all table headers sortable and render missing worktree scripts with the shared faint placeholder
- add coverage for count partitioning, default ordering, sort cycling, and the placeholder

## Verification
- `cd event-runtime/web && bun run build && bun test`

UX critique: required — SHIP

Evidence: `http://127.0.0.1:7583/#/projects`; `/var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-ebcd4448-56d7-4ba5-8fac-0ecba1a6926e.png`

Follow-up filed: WM-628

Fixes WM-560