### PR TITLE
fix(worktree): preserve abandoned dirty checkouts (WM-627)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -411,6 +411,8 @@ exec "${realGit}" "$@"
         FACTORY_WT_ROOT: tempWtRoot,
         FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
         FACTORY_WORKTREE_PRESERVATION_REPORT: reportPath,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
         PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
       },
     });
@@ -434,7 +436,7 @@ exec "${realGit}" "$@"
     rmSync(mockBin, { recursive: true, force: true });
     Bun.spawnSync({ cmd: ["git", "branch", "-D", branch, ...(wipBranch ? [wipBranch] : [])], cwd: path.resolve(import.meta.dir, "..") });
   }
-});
+}, 20_000);
 
 test("re-dispatch refuses a dirty worktree with typed worktree_in_use when a live owner exists", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-live-dirty-"));

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -375,6 +375,109 @@ test("re-dispatch fast-forwards a deliberately stale branch to the current base"
   }
 });
 
+test("re-dispatch preserves an abandoned dirty zero-ahead worktree on a conventional wip branch", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-abandoned-dirty-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-abandoned-dirty-bin-"));
+  const ticketId = `WM-${Date.now()}${process.pid}${Math.floor(Math.random() * 10000)}`;
+  const branch = `feat/${ticketId}`;
+  const expectedPath = path.join(tempWtRoot, ticketId);
+  const reportPath = path.join(tempWtRoot, "preservation.json");
+  let wipBranch = null;
+
+  try {
+    expect(Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    }).exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "abandoned.txt"), "preserve this work\n");
+
+    const realGit = Bun.which("git");
+    writeFileSync(path.join(mockBin, "git"), `#!/usr/bin/env bash
+if [[ "$*" == *" push -u origin wip/${ticketId}-"* ]]; then
+  echo "simulated push failure" >&2
+  exit 1
+fi
+exec "${realGit}" "$@"
+`, { mode: 0o755 });
+
+    const recovered = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
+        FACTORY_WORKTREE_PRESERVATION_REPORT: reportPath,
+        PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    expect(recovered.exitCode).toBe(0);
+    expect(recovered.stdout.toString()).toContain("preserved abandoned worktree changes on wip/");
+    expect(recovered.stderr.toString()).toContain("keeping it locally");
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    wipBranch = report.ref;
+    expect(wipBranch).toMatch(new RegExp(`^wip/${ticketId}-\\d{8}T\\d{6}Z(?:-\\d+)?$`));
+    expect(report.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(report.push).toBe("local_only");
+    expect(Bun.spawnSync({ cmd: ["git", "branch", "--show-current"], cwd: expectedPath }).stdout.toString().trim()).toBe(branch);
+    expect(Bun.spawnSync({ cmd: ["git", "status", "--porcelain"], cwd: expectedPath }).stdout.toString()).toBe("");
+    expect(Bun.spawnSync({ cmd: ["git", "show", `${wipBranch}:abandoned.txt`], cwd: expectedPath }).stdout.toString()).toBe("preserve this work\n");
+    expect(Bun.spawnSync({ cmd: ["git", "log", "-1", "--format=%s", wipBranch], cwd: expectedPath }).stdout.toString().trim())
+      .toBe(`chore(wip): preserve ${ticketId} worktree changes (${ticketId})`);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch, ...(wipBranch ? [wipBranch] : [])], cwd: path.resolve(import.meta.dir, "..") });
+  }
+});
+
+test("re-dispatch refuses a dirty worktree with typed worktree_in_use when a live owner exists", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-live-dirty-"));
+  const ticketId = makeTestTicket("LIVEOWNER");
+  const branch = `feat/${ticketId}`;
+  const expectedPath = path.join(tempWtRoot, ticketId);
+  const reportPath = path.join(tempWtRoot, "must-not-exist.json");
+  const leasePath = path.join(tempWtRoot, "live-owner-lease.json");
+
+  try {
+    expect(Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    }).exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "live-owner.txt"), "still in use\n");
+    writeFileSync(leasePath, JSON.stringify({ owner: "new-live-owner", pid: 42 }));
+
+    const refused = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
+        FACTORY_WORKTREE_PRESERVATION_REPORT: reportPath,
+        FACTORY_WORKTREE_EXPECTED_LEASE_FILE: leasePath,
+        FACTORY_WORKTREE_EXPECTED_LEASE_PID: String(process.pid),
+      },
+    });
+    expect(refused.exitCode).not.toBe(0);
+    expect(refused.stderr.toString()).toContain("worktree_in_use");
+    expect(readFileSync(path.join(expectedPath, "live-owner.txt"), "utf8")).toBe("still in use\n");
+    expect(existsSync(reportPath)).toBe(false);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
+  }
+});
+
 test("merge-fix re-dispatch resumes a committed PR branch as-is", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-merge-fix-"));
   const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-open-pr-bin-"));
@@ -394,7 +497,7 @@ test("merge-fix re-dispatch resumes a committed PR branch as-is", () => {
     writeFileSync(path.join(expectedPath, "merge-fix.txt"), "resolved conflict\n");
     expect(Bun.spawnSync({ cmd: ["git", "add", "merge-fix.txt"], cwd: expectedPath }).exitCode).toBe(0);
     expect(Bun.spawnSync({
-      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "merge fix"],
+      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "test(worktree): preserve merge fix branch (WM-1)"],
       cwd: expectedPath,
       stdout: "pipe",
       stderr: "pipe",
@@ -451,7 +554,7 @@ test("explicit resume flag and environment preserve committed branches without q
       writeFileSync(path.join(expectedPath, "resume.txt"), `${mode}\n`);
       expect(Bun.spawnSync({ cmd: ["git", "add", "resume.txt"], cwd: expectedPath }).exitCode).toBe(0);
       expect(Bun.spawnSync({
-        cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", `explicit ${mode} resume`],
+        cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", `test(worktree): exercise explicit ${mode} resume (WM-1)`],
         cwd: expectedPath,
         stdout: "pipe",
         stderr: "pipe",
@@ -491,9 +594,9 @@ exit 99
       Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: path.resolve(import.meta.dir, "..") });
     }
   }
-});
+}, 15_000);
 
-test("re-dispatch refuses a branch carrying unique commits and names the escape", () => {
+test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservation", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-unique-"));
   const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-no-pr-bin-"));
   const ticketId = makeTestTicket("UNIQUE");
@@ -511,17 +614,12 @@ test("re-dispatch refuses a branch carrying unique commits and names the escape"
     writeFileSync(path.join(expectedPath, "unique.txt"), "ticket work\n");
     expect(Bun.spawnSync({ cmd: ["git", "add", "unique.txt"], cwd: expectedPath }).exitCode).toBe(0);
     expect(Bun.spawnSync({
-      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "unique ticket commit"],
+      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "test(worktree): create unique ticket commit (WM-1)"],
       cwd: expectedPath,
       stdout: "pipe",
       stderr: "pipe",
     }).exitCode).toBe(0);
-    expect(Bun.spawnSync({
-      cmd: ["bash", DOWN, ticketId],
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-      stdout: "pipe",
-      stderr: "pipe",
-    }).exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "still-dirty.txt"), "uncommitted after unique commit\n");
 
     writeFileSync(path.join(mockBin, "gh"), "#!/usr/bin/env bash\nprintf '0\\n'\n", { mode: 0o755 });
     const secondUp = Bun.spawnSync({
@@ -531,6 +629,8 @@ test("re-dispatch refuses a branch carrying unique commits and names the escape"
       env: {
         ...process.env,
         FACTORY_WT_ROOT: tempWtRoot,
+        FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
+        FACTORY_WORKTREE_PRESERVATION_REPORT: path.join(tempWtRoot, "must-not-preserve.json"),
         PATH: `${mockBin}${path.delimiter}${process.env.PATH}`,
       },
     });
@@ -538,7 +638,9 @@ test("re-dispatch refuses a branch carrying unique commits and names the escape"
     expect(secondUp.stderr.toString()).toContain("worktree_branch_has_commits");
     expect(secondUp.stderr.toString()).toContain(branch);
     expect(secondUp.stderr.toString()).toContain("re-run with --resume");
-    expect(existsSync(expectedPath)).toBe(false);
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(readFileSync(path.join(expectedPath, "still-dirty.txt"), "utf8")).toBe("uncommitted after unique commit\n");
+    expect(existsSync(path.join(tempWtRoot, "must-not-preserve.json"))).toBe(false);
   } finally {
     Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
     rmSync(tempWtRoot, { recursive: true, force: true });

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -76,6 +76,65 @@ worktree_add() { # <worktree> <branch> <base-ref> [repo]
   done
 }
 
+# Preserve a dirty, abandoned zero-ahead ticket branch before re-dispatch.
+# The caller has already proved no other live run owns the tree and holds the
+# per-ticket lifecycle lock. The report is consumed by event-runtime so the
+# durable workspace marker and Linear both name the recovery ref.
+preserve_abandoned_worktree() { # <worktree> <ticket> <ticket-branch> <report-path>
+  local wt="$1" ticket="$2" ticket_branch="$3" report="$4"
+  local timestamp wip_branch suffix=1 commit_sha push_status push_error_file push_error=""
+  timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+  wip_branch="wip/$ticket-$timestamp"
+  while git -C "$wt" show-ref --verify --quiet "refs/heads/$wip_branch"; do
+    suffix=$((suffix + 1))
+    wip_branch="wip/$ticket-$timestamp-$suffix"
+  done
+
+  git -C "$wt" switch -c "$wip_branch" >/dev/null \
+    || die "worktree_wip_preserve_failed: could not create '$wip_branch'"
+  if ! git -C "$wt" add -A; then
+    git -C "$wt" switch "$ticket_branch" >/dev/null 2>&1 || true
+    git -C "$wt" branch -D "$wip_branch" >/dev/null 2>&1 || true
+    die "worktree_wip_preserve_failed: could not stage dirty worktree on '$wip_branch'"
+  fi
+  if ! git -C "$wt" commit -m "chore(wip): preserve $ticket worktree changes ($ticket)" >/dev/null; then
+    # Both refs still point at the same commit, so switching back carries the
+    # staged/unstaged files with it and restores the exact dirty ticket tree.
+    git -C "$wt" switch "$ticket_branch" >/dev/null 2>&1 || true
+    git -C "$wt" branch -D "$wip_branch" >/dev/null 2>&1 || true
+    die "worktree_wip_preserve_failed: could not commit dirty worktree on '$wip_branch'"
+  fi
+  commit_sha=$(git -C "$wt" rev-parse HEAD)
+
+  push_error_file="${report}.push-error.$$"
+  if git -C "$wt" push -u origin "$wip_branch" > /dev/null 2>"$push_error_file"; then
+    push_status="pushed"
+  else
+    push_status="local_only"
+    push_error=$(tail -c 4096 "$push_error_file" 2>/dev/null || true)
+    warn "could not push preserved branch '$wip_branch'; keeping it locally${push_error:+: $push_error}"
+  fi
+  rm -f "$push_error_file"
+
+  git -C "$wt" switch "$ticket_branch" >/dev/null \
+    || die "worktree_wip_preserve_failed: preserved changes on '$wip_branch' but could not return to '$ticket_branch'"
+  [[ -z "$(git -C "$wt" status --porcelain)" ]] \
+    || die "worktree_wip_preserve_failed: '$ticket_branch' remained dirty after preserving changes on '$wip_branch'"
+
+  PRESERVATION_REPORT="$report" PRESERVATION_REF="$wip_branch" \
+    PRESERVATION_COMMIT="$commit_sha" PRESERVATION_PUSH="$push_status" \
+    PRESERVATION_PUSH_ERROR="$push_error" bun --eval '
+      import { writeFileSync } from "node:fs";
+      writeFileSync(process.env.PRESERVATION_REPORT, JSON.stringify({
+        ref: process.env.PRESERVATION_REF,
+        commit: process.env.PRESERVATION_COMMIT,
+        push: process.env.PRESERVATION_PUSH,
+        ...(process.env.PRESERVATION_PUSH_ERROR ? { pushError: process.env.PRESERVATION_PUSH_ERROR } : {}),
+      }) + "\n");
+    '
+  info "preserved abandoned worktree changes on $wip_branch ($push_status)"
+}
+
 
 WT_ROOT="${FACTORY_WT_ROOT:-$HOME/Develop/.worktrees/factory}"
 BASE_BRANCH="${FACTORY_BASE_BRANCH:-develop}"

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -97,7 +97,10 @@ preserve_abandoned_worktree() { # <worktree> <ticket> <ticket-branch> <report-pa
     git -C "$wt" branch -D "$wip_branch" >/dev/null 2>&1 || true
     die "worktree_wip_preserve_failed: could not stage dirty worktree on '$wip_branch'"
   fi
-  if ! git -C "$wt" commit -m "chore(wip): preserve $ticket worktree changes ($ticket)" >/dev/null; then
+  if ! git -C "$wt" \
+    -c user.name="Factory Worktree Recovery" \
+    -c user.email="factory@users.noreply.github.com" \
+    commit -m "chore(wip): preserve $ticket worktree changes ($ticket)" >/dev/null; then
     # Both refs still point at the same commit, so switching back carries the
     # staged/unstaged files with it and restores the exact dirty ticket tree.
     git -C "$wt" switch "$ticket_branch" >/dev/null 2>&1 || true

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -34,6 +34,11 @@ LIVE=0
 CHECKOUT_ONLY=0
 NO_FETCH=0
 RESUME="${FACTORY_WORKTREE_RESUME:-0}"
+PRESERVE_ABANDONED="${FACTORY_WORKTREE_PRESERVE_ABANDONED:-0}"
+WORKTREE_IN_USE="${FACTORY_WORKTREE_IN_USE:-0}"
+PRESERVATION_REPORT="${FACTORY_WORKTREE_PRESERVATION_REPORT:-}"
+EXPECTED_LEASE_FILE="${FACTORY_WORKTREE_EXPECTED_LEASE_FILE:-}"
+EXPECTED_LEASE_PID="${FACTORY_WORKTREE_EXPECTED_LEASE_PID:-}"
 POS=0
 
 while [[ $# -gt 0 ]]; do
@@ -65,6 +70,16 @@ done
 
 [[ "$RESUME" == "0" || "$RESUME" == "1" ]] \
   || die "FACTORY_WORKTREE_RESUME must be 0 or 1 (got '$RESUME')"
+[[ "$PRESERVE_ABANDONED" == "0" || "$PRESERVE_ABANDONED" == "1" ]] \
+  || die "FACTORY_WORKTREE_PRESERVE_ABANDONED must be 0 or 1 (got '$PRESERVE_ABANDONED')"
+[[ "$WORKTREE_IN_USE" == "0" || "$WORKTREE_IN_USE" == "1" ]] \
+  || die "FACTORY_WORKTREE_IN_USE must be 0 or 1 (got '$WORKTREE_IN_USE')"
+[[ "$PRESERVE_ABANDONED" -eq 0 || -n "$PRESERVATION_REPORT" ]] \
+  || die "FACTORY_WORKTREE_PRESERVATION_REPORT is required when preserving an abandoned worktree"
+[[ -z "$EXPECTED_LEASE_PID" || "$EXPECTED_LEASE_PID" =~ ^[0-9]+$ ]] \
+  || die "FACTORY_WORKTREE_EXPECTED_LEASE_PID must be numeric (got '$EXPECTED_LEASE_PID')"
+[[ -z "$EXPECTED_LEASE_PID" || -n "$EXPECTED_LEASE_FILE" ]] \
+  || die "FACTORY_WORKTREE_EXPECTED_LEASE_FILE is required with FACTORY_WORKTREE_EXPECTED_LEASE_PID"
 
 REPO="$(repo_root)"
 WORKTREE_LIFECYCLE_LOCK=""
@@ -165,8 +180,30 @@ else
         CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
         [[ "$CURRENT_BRANCH" == "$BRANCH" ]] \
           || die "worktree_branch_mismatch: $WT is on '${CURRENT_BRANCH:-detached HEAD}', expected '$BRANCH'"
-        [[ -z "$(git -C "$WT" status --porcelain)" ]] \
-          || die "worktree_branch_dirty: $WT has uncommitted work — re-run with --resume or clean it explicitly before re-dispatch"
+        if [[ -n "$(git -C "$WT" status --porcelain)" ]]; then
+          if [[ "$WORKTREE_IN_USE" -eq 1 ]]; then
+            die "worktree_in_use: $WT has uncommitted work owned by a live run or lease"
+          fi
+          if [[ "$PRESERVE_ABANDONED" -eq 1 ]]; then
+            if [[ -n "$EXPECTED_LEASE_PID" ]]; then
+              OBSERVED_LEASE_PID=$(LEASE_FILE="$EXPECTED_LEASE_FILE" bun --eval '
+                import { readFileSync } from "node:fs";
+                try {
+                  const lease = JSON.parse(readFileSync(process.env.LEASE_FILE, "utf8"));
+                  if (Number.isInteger(lease.pid)) process.stdout.write(String(lease.pid));
+                } catch {}
+              ')
+              [[ "$OBSERVED_LEASE_PID" == "$EXPECTED_LEASE_PID" ]] \
+                && kill -0 "$EXPECTED_LEASE_PID" 2>/dev/null \
+                || die "worktree_in_use: the worker lease changed before abandoned worktree preservation"
+            fi
+            mkdir -p "$(dirname "$PRESERVATION_REPORT")"
+            rm -f "$PRESERVATION_REPORT"
+            preserve_abandoned_worktree "$WT" "$TICKET" "$BRANCH" "$PRESERVATION_REPORT"
+          else
+            die "worktree_branch_dirty: $WT has uncommitted work — re-run with --resume or clean it explicitly before re-dispatch"
+          fi
+        fi
         # `merge --ff-only` is non-destructive if another process commits after
         # inspection; unlike reset --hard, it can never discard that commit.
         git -C "$WT" merge --ff-only "$BASE_REF" >/dev/null \

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -11,9 +11,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { Database } from "bun:sqlite";
+import { leaseDir, liveWorkerLeases } from "../../lib/worker-leases.mjs";
 import { canonicalJson } from "./canonical.mjs";
 import { materializeArtifact } from "./artifacts.mjs";
-import { artifactsRoot } from "./config.mjs";
+import { artifactsRoot, dbPath, FACTORY_ROOT } from "./config.mjs";
 import { getRepo, loadRepos } from "./repos.mjs";
 import { materializeCheckout, releaseCheckout } from "./repository.mjs";
 import { findPriorResumeContext } from "./transcripts.mjs";
@@ -121,6 +123,78 @@ export function resolveInputRef(input, expr) {
  * worker that dies and restarts must still know what to tear down.
  */
 const WORKTREE_MARKER = ".worktree.json";
+const ACTIVE_RUN_STATES = new Set(["PROPOSED", "APPROVED", "QUEUED", "LEASED", "RUNNING", "VERIFYING"]);
+
+/**
+ * Return competing runtime ownership for a ticket, excluding the run currently
+ * provisioning its own workspace. The shared worker lease is the fast local
+ * liveness signal; the run ledger closes the gap where a worker is non-terminal
+ * but its lease heartbeat has not yet appeared (WM-627).
+ */
+export function detectWorktreeOwnershipConflict({
+  repo,
+  ticket,
+  runId,
+  attempt,
+  databasePath = dbPath(),
+  leases = liveWorkerLeases(repo),
+} = {}) {
+  let currentLeaseOwner = null;
+  const runs = [];
+  if (existsSync(databasePath)) {
+    let db;
+    try {
+      db = new Database(databasePath, { readonly: true });
+      currentLeaseOwner = db
+        .query(`SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`)
+        .get(runId, attempt)?.lease_owner ?? null;
+      for (const row of db.query(`SELECT run_id, state, spec_json FROM runs`).all()) {
+        if (row.run_id === runId || !ACTIVE_RUN_STATES.has(row.state)) continue;
+        let input;
+        try { input = JSON.parse(row.spec_json)?.input; } catch { continue; }
+        if (input?.repo === repo && input?.ticket === ticket) {
+          runs.push({ runId: row.run_id, state: row.state });
+        }
+      }
+    } catch (err) {
+      return { reason: `runtime ownership ledger unreadable: ${err.message}`, runs: [], leases: [] };
+    } finally {
+      db?.close();
+    }
+  }
+
+  const competingLeases = leases
+    .filter((lease) => lease?.repo === repo && lease?.ticket === ticket)
+    .filter((lease) => currentLeaseOwner ? lease.owner !== currentLeaseOwner : lease.pid !== process.pid)
+    .map((lease) => ({ owner: lease.owner, pid: lease.pid }));
+  if (runs.length === 0 && competingLeases.length === 0) return null;
+  return { reason: "ticket has a non-terminal run or live worker lease", runs, leases: competingLeases };
+}
+
+function commentOnPreservedWorktree({ ticket, preservation }) {
+  const text = `Recovered an abandoned dirty worktree before re-dispatch: preserved its uncommitted changes at \`${preservation.ref}\` (commit ${preservation.commit}, ${preservation.push === "pushed" ? "pushed to origin" : "kept locally because push failed"}).`;
+  const result = spawnSync("bun", [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text], {
+    cwd: FACTORY_ROOT,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(String(result.stderr || result.stdout || `Linear comment exited ${result.status}`).trim());
+  }
+  return { status: "posted" };
+}
+
+function readPreservationReport(reportPath) {
+  if (!existsSync(reportPath)) return null;
+  const report = JSON.parse(readFileSync(reportPath, "utf8"));
+  if (
+    typeof report?.ref !== "string" || !report.ref.startsWith("wip/")
+    || !/^[0-9a-f]{40}$/.test(report.commit)
+    || !["pushed", "local_only"].includes(report.push)
+  ) {
+    throw new Error("expected ref, 40-character commit, and pushed|local_only push status");
+  }
+  return report;
+}
 
 /**
  * Tier-2 mutating workspace (docs/event-runtime-dispatch.md §5, WM-108):
@@ -137,7 +211,16 @@ const WORKTREE_MARKER = ".worktree.json";
  * repo's declared `verify` command rides along in the returned record — the
  * §9 verifier runs it as ordinary code, never trusting the agent's report.
  */
-function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
+function materializeWorktree({
+  workspaceDir,
+  input,
+  checkoutDir,
+  timeoutMs,
+  runId,
+  attempt,
+  ownershipConflict,
+  preservationComment,
+}) {
   const repoName = input?.repo;
   const ticket = input?.ticket;
   if (!repoName || !ticket) {
@@ -150,6 +233,15 @@ function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
     );
   }
   const worktreePath = path.join(repo.worktreeRoot, ticket);
+  if (existsSync(worktreePath)) {
+    const conflict = ownershipConflict({ repo: repoName, ticket, runId, attempt });
+    if (conflict) {
+      throw new WorktreeError(
+        `worktree_in_use: ${repoName}/${ticket} at ${worktreePath} is owned by a live run or lease`,
+        conflict,
+      );
+    }
+  }
   const record = {
     repo: repoName,
     ticket,
@@ -167,10 +259,21 @@ function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
   // worktree already exists. It reports that condition out-of-band and still
   // exits zero; a non-zero exit remains a provisioning failure.
   const reportPath = path.join(workspaceDir, ".worktree-up.json");
+  const preservationPath = path.join(workspaceDir, ".worktree-preservation.json");
+  rmSync(preservationPath, { force: true });
   const up = spawnSync("/bin/bash", [repo.worktreeUp, ticket], {
     cwd: repo.path,
     encoding: "utf8",
-    env: { ...process.env, FACTORY_WORKTREE_REPORT: reportPath },
+    env: {
+      ...process.env,
+      FACTORY_WORKTREE_REPORT: reportPath,
+      FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
+      FACTORY_WORKTREE_PRESERVATION_REPORT: preservationPath,
+      // Revalidated by factory's worktree-up while it holds the per-ticket
+      // lifecycle lock, narrowing the ownership-check/preservation race.
+      FACTORY_WORKTREE_EXPECTED_LEASE_FILE: path.join(leaseDir(), `${repoName}-${ticket}.json`),
+      FACTORY_WORKTREE_EXPECTED_LEASE_PID: String(process.pid),
+    },
     timeout: timeoutMs,
   });
   // A timeout surfaces as up.error, not a non-zero status, so both are failures
@@ -195,6 +298,24 @@ function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
     throw new WorktreeError(`worktree_up reported success for ${repoName}/${ticket} but did not create ${worktreePath}`);
   }
 
+  let preservation = null;
+  try {
+    preservation = readPreservationReport(preservationPath);
+  } catch (err) {
+    throw new WorktreeError(`worktree_up wrote an invalid preservation report for ${repoName}/${ticket}: ${err.message}`);
+  }
+  if (preservation) {
+    record.preservedWip = preservation;
+    writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+    try {
+      record.preservedWip.comment = preservationComment({ ticket, repo: repoName, preservation });
+    } catch (err) {
+      record.preservedWip.comment = { status: "failed", error: err.message };
+      writeFileSync(path.join(workspaceDir, WORKTREE_MARKER), `${canonicalJson(record)}\n`, "utf8");
+      throw new WorktreeError(`preserved ${repoName}/${ticket} at ${preservation.ref} but could not post the Linear comment: ${err.message}`);
+    }
+  }
+
   let baseline = null;
   if (existsSync(reportPath)) {
     try {
@@ -215,14 +336,20 @@ function materializeWorktree({ workspaceDir, input, checkoutDir, timeoutMs }) {
   // The agent contract points it at input.json, so runtime-discovered context
   // must be present there rather than hidden in an implementation marker.
   // Keep the run spec immutable; this is workspace-local execution context.
-  if (baseline) {
-    const enrichedInput = {
-      ...input,
-      baseline: {
+  if (baseline || preservation) {
+    const enrichedInput = { ...input };
+    if (baseline) {
+      enrichedInput.baseline = {
         ...baseline,
         guidance: `The ${baseline.check} check already fails at this commit. If your ticket is unrelated, do not fix it; if it is related, use this as the starting point.`,
-      },
-    };
+      };
+    }
+    if (preservation) {
+      enrichedInput.worktreeRecovery = {
+        ...record.preservedWip,
+        guidance: `An abandoned prior attempt was preserved at ${preservation.ref} before this clean re-dispatch.`,
+      };
+    }
     writeFileSync(path.join(workspaceDir, "input.json"), `${canonicalJson(enrichedInput)}\n`, "utf8");
   }
   return record;
@@ -237,6 +364,8 @@ export function createWorkspace({
   artifactStore = artifactsRoot(),
   worktreeTimeoutMs = worktreeScriptTimeoutMs(),
   adapter = null,
+  worktreeOwnershipConflict = detectWorktreeOwnershipConflict,
+  worktreePreservationComment = commentOnPreservedWorktree,
 }) {
   // Lease loss can leave the prior attempt's scratch directory behind. Read
   // recognized harness session metadata before creating the new attempt;
@@ -284,6 +413,10 @@ export function createWorkspace({
         input,
         checkoutDir: workspace.checkoutDir ?? "repo",
         timeoutMs: worktreeTimeoutMs,
+        runId,
+        attempt,
+        ownershipConflict: worktreeOwnershipConflict,
+        preservationComment: worktreePreservationComment,
       });
     } catch (err) {
       if (err instanceof WorktreeError) throw err;

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -2,7 +2,11 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { PathViolation, WorktreeError, createWorkspace, destroyWorkspace, safeJoin } from "./workspace.mjs";
+import { Database } from "bun:sqlite";
+import {
+  PathViolation, WorktreeError, createWorkspace, destroyWorkspace,
+  detectWorktreeOwnershipConflict, safeJoin,
+} from "./workspace.mjs";
 
 function tmpRoot() {
   return mkdtempSync(path.join(os.tmpdir(), "evrt-ws-"));
@@ -30,6 +34,46 @@ describe("safeJoin", () => {
     expect(() => safeJoin(ws, undefined)).toThrow(PathViolation);
     expect(() => safeJoin(ws, ".")).toThrow(PathViolation);
   });
+});
+
+test("detectWorktreeOwnershipConflict excludes self but reports competing runs and leases", () => {
+  const root = tmpRoot();
+  const databasePath = path.join(root, "runtime.db");
+  const db = new Database(databasePath);
+  db.exec(`
+    CREATE TABLE runs (run_id TEXT, state TEXT, spec_json TEXT);
+    CREATE TABLE attempts (run_id TEXT, attempt INTEGER, lease_owner TEXT);
+  `);
+  const spec = JSON.stringify({ input: { repo: "factory", ticket: "WM-627" } });
+  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_self", "RUNNING", spec);
+  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_other", "VERIFYING", spec);
+  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run("run_done", "FAILED", spec);
+  db.query(`INSERT INTO attempts VALUES (?, ?, ?)`).run("run_self", 1, "worker_self");
+  db.close();
+
+  const conflict = detectWorktreeOwnershipConflict({
+    repo: "factory",
+    ticket: "WM-627",
+    runId: "run_self",
+    attempt: 1,
+    databasePath,
+    leases: [
+      { repo: "factory", ticket: "WM-627", owner: "worker_self", pid: process.pid },
+      { repo: "factory", ticket: "WM-627", owner: "worker_other", pid: 42 },
+    ],
+  });
+  expect(conflict).toMatchObject({
+    runs: [{ runId: "run_other", state: "VERIFYING" }],
+    leases: [{ owner: "worker_other", pid: 42 }],
+  });
+  expect(detectWorktreeOwnershipConflict({
+    repo: "factory",
+    ticket: "WM-627",
+    runId: "run_self",
+    attempt: 1,
+    databasePath,
+    leases: [{ repo: "factory", ticket: "WM-627", owner: "worker_self", pid: process.pid }],
+  })?.runs).toEqual([{ runId: "run_other", state: "VERIFYING" }]);
 });
 
 describe("createWorkspace / destroyWorkspace", () => {
@@ -103,6 +147,10 @@ describe("worktree workspaces (WM-108)", () => {
       `#!/bin/bash\nset -e\nmkdir -p "${wtRoot}/$1"\nprintf '%s\\n' '{"status":"red","check":"web_build","command":"bun run build:fast","exitCode":1,"output":"entry chunk exceeds budget"}' > "$FACTORY_WORKTREE_REPORT"\n`,
     );
     writeFileSync(
+      path.join(repoDir, "bin", "worktree-up-recovered.sh"),
+      `#!/bin/bash\nset -e\necho "up-recovered $1" >> "${callsLog}"\nmkdir -p "${wtRoot}/$1"\nprintf '%s\\n' '{"ref":"wip/WM-13-20260817T183000Z","commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","push":"local_only","pushError":"offline"}' > "$FACTORY_WORKTREE_PRESERVATION_REPORT"\n`,
+    );
+    writeFileSync(
       path.join(repoDir, "bin", "worktree-down-refuse.sh"),
       `#!/bin/bash\necho "warn: cleanup probe used fallback" >&2\necho "fatal: refusing dirty tree" >&2\nexit 1\n`,
     );
@@ -131,6 +179,9 @@ describe("worktree workspaces (WM-108)", () => {
         `    worktree_root: ${wtRoot}\n` +
         `  - name: red-baseline\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up-red-baseline.sh\n    worktree_down: bin/worktree-down.sh\n` +
+        `    worktree_root: ${wtRoot}\n    verify: bun test\n` +
+        `  - name: recovered-up\n    path: ${repoDir}\n    base: develop\n` +
+        `    worktree_up: bin/worktree-up-recovered.sh\n    worktree_down: bin/worktree-down.sh\n` +
         `    worktree_root: ${wtRoot}\n    verify: bun test\n` +
         `  - name: refusing-down\n    path: ${repoDir}\n    base: develop\n` +
         `    worktree_up: bin/worktree-up.sh\n    worktree_down: bin/worktree-down-refuse.sh\n` +
@@ -231,6 +282,52 @@ describe("worktree workspaces (WM-108)", () => {
     expect(Date.now() - started).toBeLessThan(1_000);
     expect(existsSync(dir)).toBe(true);
     expect(existsSync(path.join(wtRoot, "WM-10"))).toBe(true);
+  });
+
+  test("a live competing run or lease refuses an existing tree before worktree_up", () => {
+    const tree = path.join(wtRoot, "WM-13");
+    mkdirSync(tree, { recursive: true });
+    const before = calls().filter((call) => call.startsWith("up WM-13 ")).length;
+
+    expect(() => make("wtrepo", "WM-13", "run_wt13", {
+      worktreeOwnershipConflict: () => ({
+        reason: "ticket has a non-terminal run or live worker lease",
+        runs: [{ runId: "run_other", state: "RUNNING" }],
+        leases: [{ owner: "worker_other", pid: 42 }],
+      }),
+    })).toThrow(/worktree_in_use/);
+    expect(calls().filter((call) => call.startsWith("up WM-13 "))).toHaveLength(before);
+    expect(existsSync(tree)).toBe(true);
+  });
+
+  test("a recovered wip ref is journaled in the workspace marker/input and commented once", () => {
+    const comments = [];
+    const { dir, worktree } = make("recovered-up", "WM-13", "run_wt13_recovered", {
+      worktreeOwnershipConflict: () => null,
+      worktreePreservationComment: (entry) => {
+        comments.push(entry);
+        return { status: "posted" };
+      },
+    });
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toMatchObject({
+      repo: "recovered-up",
+      ticket: "WM-13",
+      preservation: { ref: "wip/WM-13-20260817T183000Z", push: "local_only" },
+    });
+    expect(worktree.preservedWip).toMatchObject({
+      ref: "wip/WM-13-20260817T183000Z",
+      commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      push: "local_only",
+      comment: { status: "posted" },
+    });
+    expect(JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).preservedWip).toEqual(worktree.preservedWip);
+    expect(JSON.parse(readFileSync(path.join(dir, "input.json"), "utf8")).worktreeRecovery).toMatchObject({
+      ref: "wip/WM-13-20260817T183000Z",
+      guidance: expect.stringContaining("abandoned prior attempt"),
+    });
+    expect(destroyWorkspace(dir)).toBe(true);
   });
 
   test("a red baseline is recorded in the marker and agent input without aborting workspace creation", () => {


### PR DESCRIPTION
## Summary
- preserve abandoned dirty zero-ahead worktrees on timestamped `wip/` branches before clean re-dispatch
- refuse live runtime ownership with typed `worktree_in_use` and revalidate the worker lease under the lifecycle lock
- record the recovery ref in workspace lifecycle context and post one Linear comment
- retain unique-commit/open-PR behavior and cover all three cases

## Verification
- `bun test bin/worktree-checkout.test.mjs event-runtime/lib/workspace.test.mjs` — 48 pass, 0 fail

UX critique: skipped — backend/internal worktree provisioning with no user-facing surface

Follow-ups:
- WM-632 tracks the out-of-scope shared lease overwrite race in `lib/worker-leases.mjs`.
- WM-633 tracks the 18:32Z unclaim-path amendment, which requires files outside WM-627 Owned Paths.

Fixes WM-627