### PR TITLE
feat(event-runtime): sandbox the agent execution path — pi/claude honour def.sandbox, fail closed otherwise (WM-313)

### DIFF
--- a/event-runtime/lib/adapters/actions.mjs
+++ b/event-runtime/lib/adapters/actions.mjs
@@ -22,6 +22,17 @@ import { spawnSync } from "node:child_process";
 import { appendFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
+
+/**
+ * No guest execution path exists for this adapter (WM-313): its actions are
+ * `ssh` to registered hosts, which a deny-all guest cannot reach and which
+ * would need the SSH agent — the one thing the sandbox exists to withhold.
+ * A sandboxed definition is refused, not run on the host.
+ */
+export const SANDBOX_SUPPORT = "unsupported";
+const SANDBOX_REFUSAL_REASON =
+  "the actions adapter runs registered ssh templates against remote hosts; there is no guest execution path and the SSH agent must not enter the microVM";
 
 const OUTPUT_TAIL_CHARS = 2_000;
 
@@ -220,6 +231,7 @@ async function executeItemList({ spec, def, workspaceDir, timeoutMs }) {
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({ spec, def, workspaceDir, timeoutMs }) {
+  refuseSandbox("actions", def, SANDBOX_REFUSAL_REASON);
   // Two closed-registry shapes: a per-item local argv list (OPS-229) and the
   // remote probe → act → probe flow (OPS-208). The definition picks.
   if (def.itemsField) return executeItemList({ spec, def, workspaceDir, timeoutMs });

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -16,8 +16,17 @@ import { createWriteStream, readFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
 
 export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
+
+/**
+ * No guest execution path exists for this adapter (WM-313): a sandboxed
+ * definition is refused, not run on the host. See lib/adapters/sandboxed.mjs.
+ */
+export const SANDBOX_SUPPORT = "unsupported";
+const SANDBOX_REFUSAL_REASON =
+  "the agy CLI has no guest execution path yet — its binary, Google Cloud/Antigravity auth, and prompt transport have not been translated to the microVM";
 
 export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
@@ -309,6 +318,7 @@ export async function execute({
   abortSignal,
   signal,
 }) {
+  refuseSandbox("agy", def, SANDBOX_REFUSAL_REASON);
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -15,6 +15,13 @@
  * additionally mapped to factory.trace/v1 events via the optional `onTrace`
  * callback so the operator can watch the agent live. Trace mapping is
  * best-effort — an unparseable or unrecognized line is ignored, never fatal.
+ *
+ * Sandboxing (WM-313): this adapter does NOT yet execute inside the Gondolin
+ * microVM, and it says so — a definition carrying a `sandbox` block is refused
+ * with `SandboxUnsupportedError` before anything is spawned, never run on the
+ * host as if the block were absent. The deferral is deliberate and narrow;
+ * `SANDBOX_DEFERRAL_REASON` below is the whole rationale, and it names what
+ * the pi path did not have to solve.
  */
 import { spawn } from "node:child_process";
 import { createWriteStream, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -22,6 +29,34 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { FACTORY_ROOT } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
+
+/**
+ * Deferred, not ignored. Everything this adapter passes claude on the host is
+ * a host-shaped contract that has no guest translation yet:
+ *   - `--mcp-config` names `FACTORY_ROOT/config/mcp/claude.json`, whose only
+ *     server is fetched with `npx` — a deny-all guest cannot start it, and a
+ *     translated config would need the checkout mounted read-only in the guest;
+ *   - the generated `--settings` policy for `mutating: false` carries host
+ *     absolute deny paths (`Edit(//<checkoutDir>/**)`, `filesystem.denyWrite`)
+ *     and turns on Claude Code's own OS sandbox (`sandbox.enabled`), which is
+ *     seatbelt/bubblewrap — untested inside an Alpine guest and, with
+ *     `allowUnsandboxedCommands: false`, would deny every Bash call if absent;
+ *   - the auth model is subscription OAuth held on the host (this adapter
+ *     strips ANTHROPIC_API_KEY on purpose); in-guest that becomes API-key
+ *     placeholder mode, a billing-policy change docs/eval-gondolin-guest-image.md
+ *     §4.2 says must be an explicit profile, not a transparent switch.
+ * pi shares the third point but not the first two: its extensions and tools are
+ * argv-declared and it needs no host config file, which is why it went first.
+ * Until a follow-up translates the settings/MCP contract to guest paths, the
+ * only honest behaviour is to refuse — placement then keeps such a definition
+ * from ever being claimed by a worker that would refuse it.
+ */
+export const SANDBOX_DEFERRAL_REASON =
+  "claude's --mcp-config and generated --settings policy carry host absolute paths and enable Claude Code's own OS sandbox, neither of which has a guest translation yet (WM-313 deferral; see lib/adapters/claude.mjs)";
+
+/** This adapter refuses sandboxed definitions (fail closed) until the deferral above is resolved. */
+export const SANDBOX_SUPPORT = "unsupported";
 
 export const KILL_GRACE_MS = 30_000;
 
@@ -312,6 +347,10 @@ export async function execute({
   abortSignal,
   signal,
 }) {
+  // First, before the prompt is read or the env assembled: a sandboxed
+  // definition never reaches the host spawn below (WM-313).
+  refuseSandbox("claude", def, SANDBOX_DEFERRAL_REASON);
+
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -15,8 +15,54 @@ import {
   PUSH_CREDENTIAL_ENV,
   READ_ONLY_TOOLS,
   safeChildEnvironment,
+  SANDBOX_DEFERRAL_REASON,
+  SANDBOX_SUPPORT,
   WRITE_TOOLS,
 } from "./claude.mjs";
+import { SandboxUnsupportedError } from "./sandboxed.mjs";
+
+describe("sandbox decision (WM-313): deferred, so refused — never ignored", () => {
+  const sandboxedDef = (promptPath) => ({
+    ref: "sandboxed-claude@1",
+    promptPath,
+    mutating: false,
+    sandbox: { provider: "gondolin", allowedHosts: ["api.anthropic.com"] },
+  });
+
+  test("declares itself unsupported and carries the reasoned deferral", () => {
+    expect(SANDBOX_SUPPORT).toBe("unsupported");
+    expect(SANDBOX_DEFERRAL_REASON).toContain("--mcp-config");
+    expect(SANDBOX_DEFERRAL_REASON).toContain("--settings");
+    expect(SANDBOX_DEFERRAL_REASON).toContain("WM-313");
+  });
+
+  test("a sandboxed definition is refused with a typed error naming the adapter, before any spawn or workspace write", async () => {
+    const workspaceDir = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-claude-sandbox-")));
+    const promptPath = path.join(workspaceDir, "prompt.md");
+    writeFileSync(promptPath, "hello", "utf8");
+    let caught;
+    try {
+      await execute({
+        spec: { agent: "sandboxed-claude@1", input: {}, workspace: { type: "repository", checkoutDir: "repo" } },
+        def: sandboxedDef(promptPath),
+        workspaceDir,
+        timeoutMs: 1000,
+        env: { PATH: workspaceDir },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+    expect(caught.code).toBe("sandbox_unsupported");
+    expect(caught.adapter).toBe("claude");
+    expect(caught.message).toContain('adapter "claude" cannot honour a sandbox policy');
+    expect(caught.message).toContain(SANDBOX_DEFERRAL_REASON);
+    // Nothing host-side happened: no settings policy, no transcript.
+    expect(existsSync(path.join(workspaceDir, ".claude-policy.json"))).toBe(false);
+    expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+});
 
 describe("isHarnessDenial (WM-127)", () => {
   test("matches the harness's own refusal shapes", () => {

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -18,13 +18,18 @@
  * reach the guest only as placeholders. The result contract is identical
  * either way — the same result.json, the same captured artifact, the same
  * exit-code semantics — so downstream verification cannot tell the two apart.
- * Without the block, this adapter behaves exactly as it always has.
+ * Without the block, this adapter behaves exactly as it always has. The
+ * decision itself (sandboxed, or refused) is not this adapter's own any more:
+ * it goes through lib/adapters/sandboxed.mjs like every other adapter (WM-313).
  */
 import { spawn } from "node:child_process";
 import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
-import { runInSandbox } from "../sandbox/gondolin.mjs";
+import { runSandboxed, sandboxRequested } from "./sandboxed.mjs";
+
+/** This adapter executes inside the VM when a definition asks (WM-185). */
+export const SANDBOX_SUPPORT = "gondolin";
 
 const KILL_GRACE_MS = 10_000;
 const OUTPUT_TAIL_CHARS = 2_000;
@@ -103,28 +108,22 @@ function writeResultJson({ workspaceDir, def, argv, output }) {
  *
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
-async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal }) {
-  // Array-form exec does not search $PATH inside the guest, and a host path
-  // like /opt/homebrew/bin/bun does not exist there. Failing here with the
-  // real reason beats a bare "no such file" from inside a VM.
-  if (!argv[0].startsWith("/")) {
-    throw new Error(
-      `definition ${def.ref} is sandboxed, so its command must start with an absolute guest path (got ${JSON.stringify(argv[0])})`,
-    );
-  }
-
+async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal, onTrace, runSandbox }) {
   let output = "";
   const collect = (chunk) => {
     output = (output + chunk).slice(-OUTPUT_TAIL_CHARS);
   };
   const capture = def.captureStdout ? createWriteStream(path.join(workspaceDir, def.captureStdout)) : null;
 
-  const { exitCode, timedOut } = await runInSandbox({
-    policy: def.sandbox,
-    command: argv,
+  const { exitCode, timedOut } = await runSandboxed({
+    adapter: "command",
+    def,
+    argv,
     workspaceDir,
     timeoutMs,
     abortSignal,
+    onTrace,
+    runSandbox,
     onStdout: (chunk) => {
       capture?.write(chunk);
       collect(chunk);
@@ -142,14 +141,14 @@ async function executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSigna
 /**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
-export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal, signal }) {
+export async function execute({ spec, def, workspaceDir, timeoutMs, abortSignal, signal, onTrace, runSandbox }) {
   if (!Array.isArray(def.command) || def.command.length === 0) {
     throw new Error(`definition ${def.ref} has no command template — not a command-adapter agent`);
   }
   const argv = resolveTemplate(def.command, spec.input);
 
-  if (def.sandbox) {
-    return executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal: abortSignal ?? signal });
+  if (sandboxRequested(def)) {
+    return executeSandboxed({ def, argv, workspaceDir, timeoutMs, abortSignal: abortSignal ?? signal, onTrace, runSandbox });
   }
 
   return new Promise((resolve, reject) => {

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -9,7 +9,8 @@ import { loadRegistry } from "../registry.mjs";
 import { validate } from "../schema.mjs";
 import { emitDueTicks } from "../schedules.mjs";
 import { preflight } from "../sandbox/gondolin.mjs";
-import { execute, resolveTemplate } from "./command.mjs";
+import { execute, resolveTemplate, SANDBOX_SUPPORT } from "./command.mjs";
+import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
 
 const def = (command) => ({ ref: "test-cmd@1", command });
 const spec = (input) => ({ input });
@@ -309,6 +310,53 @@ describe("sandboxed execution (WM-185)", () => {
         timeoutMs: 5000,
       }),
     ).rejects.toThrow(/unknown sandbox provider/);
+  });
+
+  test("goes through the shared sandbox seam (WM-313): the stubbed VM boundary sees the argv, and the result contract plus console artifact are written on the host", async () => {
+    expect(SANDBOX_SUPPORT).toBe("gondolin");
+    const workspaceDir = ws();
+    const trace = [];
+    let seen;
+    const outcome = await execute({
+      spec: spec({}),
+      def: sandboxDef(["/bin/echo", "hi"], { captureStdout: "out.txt" }),
+      workspaceDir,
+      timeoutMs: 5000,
+      onTrace: (kind, payload) => trace.push({ kind, payload }),
+      runSandbox: async (request) => {
+        seen = request;
+        request.onStdout("hi\n");
+        return { exitCode: 0, timedOut: false, bootMs: 9 };
+      },
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    // No stdin wrapping for the command adapter: the argv runs as declared, no shell.
+    expect(seen.command).toEqual(["/bin/echo", "hi"]);
+    expect(seen.policy).toEqual({ provider: "gondolin", allowedHosts: [] });
+    expect(seen.workspaceDir).toBe(workspaceDir);
+    const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+    expect(result.artifact.command).toEqual(["/bin/echo", "hi"]);
+    expect(result.artifact.outputTail).toContain("hi");
+    expect(readFileSync(path.join(workspaceDir, "out.txt"), "utf8")).toBe("hi\n");
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("adapter=command");
+    expect(trace.some((t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console")).toBe(true);
+  });
+
+  test("a cancelled sandboxed command resolves like a cancelled host command: null exit, not timed out", async () => {
+    const ac = new AbortController();
+    const pending = execute({
+      spec: spec({}),
+      def: sandboxDef(["/bin/sleep", "60"]),
+      workspaceDir: ws(),
+      timeoutMs: 60_000,
+      abortSignal: ac.signal,
+      runSandbox: ({ abortSignal }) =>
+        new Promise((_, reject) => {
+          abortSignal.addEventListener("abort", () => reject(Object.assign(new Error("runner exited (null)"), { code: "sandbox_runner_crashed" })));
+        }),
+    });
+    setTimeout(() => ac.abort(), 5);
+    expect(await pending).toEqual({ exitCode: null, timedOut: false });
   });
 
   const report = preflight();

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -32,8 +32,17 @@ import { createInterface } from "node:readline";
 import { FACTORY_ROOT } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
 
 export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
+
+/**
+ * No guest execution path exists for this adapter (WM-313): a sandboxed
+ * definition is refused, not run on the host. See lib/adapters/sandboxed.mjs.
+ */
+export const SANDBOX_SUPPORT = "unsupported";
+const SANDBOX_REFUSAL_REASON =
+  "the Cursor Agent CLI has no guest execution path yet — its binary and CURSOR_API_KEY transport have not been translated to the microVM";
 
 export const KILL_GRACE_MS = 30_000;
 
@@ -259,6 +268,7 @@ export async function execute({
   abortSignal,
   signal,
 }) {
+  refuseSandbox("cursor", def, SANDBOX_REFUSAL_REASON);
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -10,6 +10,14 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { TRACE_EVENTS_CAP } from "../trace.mjs";
+import { refuseSandbox } from "./sandboxed.mjs";
+
+/**
+ * The fake spawns nothing, so there is nothing to isolate — but it must still
+ * decide (WM-313): a sandboxed definition is refused, so `--adapter-override
+ * fake` cannot become the way a sandbox requirement quietly disappears.
+ */
+export const SANDBOX_SUPPORT = "unsupported";
 
 /**
  * Deterministic factory.trace/v1 sequence for the happy-path modes, so tests
@@ -99,6 +107,7 @@ export function mergeScanArtifact(repo) {
 }
 
 export async function execute({ spec, def, workspaceDir, timeoutMs, env, onTrace, abortSignal, signal }) {
+  refuseSandbox("fake", def, "the fake adapter runs no process and models no VM; a sandboxed definition cannot be exercised through it");
   // Every real adapter captures the agent's output as a runtime artifact
   // (worker.mjs RUNTIME_ARTIFACTS). The fake must too, or it models a world
   // where transcripts do not exist — which is exactly what run-postmortem

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -36,17 +36,40 @@
  * usage, so `execute()` accumulates `extractUsage()` across the run and emits
  * one combined `usage` trace event at process close — present fields when pi
  * reported them, explicit null/empty when it never got that far.
+ *
+ * A definition with a `sandbox` block (WM-313) runs pi INSIDE the Gondolin
+ * microVM instead of on the host: the workspace is the guest's cwd through the
+ * policy's mount, the prompt is redirected from a workspace file (the VM
+ * request has no stdin channel), egress is the definition's allowlist,
+ * credentials reach the guest only as placeholders that the host substitutes
+ * for allowlisted upstreams, and the guest environment is built from constants
+ * — the caller's `env` and the worker's credentials never cross. Everything
+ * downstream of stdout (transcript, trace, usage, exit/timeout/cancel
+ * semantics, result.json under the workspace) is the same code as the host
+ * path, so the two cannot drift. See lib/adapters/sandboxed.mjs.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, readFileSync } from "node:fs";
+import { createWriteStream, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { PassThrough } from "node:stream";
 import { FACTORY_ROOT } from "../config.mjs";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import { guestBinary, guestEnvironment, runSandboxed, sandboxRequested } from "./sandboxed.mjs";
 
 // PUSH_CREDENTIAL_ENV is imported, not redeclared: the WM-128 carve-out is one
 // list shared by both LLM adapters (WM-223), so it cannot drift between them.
 export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV };
+
+/** This adapter executes inside the VM when a definition asks (WM-313). */
+export const SANDBOX_SUPPORT = "gondolin";
+
+/**
+ * Workspace file the prompt is written to for a sandboxed run, then redirected
+ * onto pi's stdin inside the guest. Not an artifact: it is the same text the
+ * host path pipes, and it lives beside input.json under the workspace mount.
+ */
+export const SANDBOX_PROMPT_FILE = ".prompt.md";
 
 export const KILL_GRACE_MS = 30_000;
 
@@ -328,6 +351,189 @@ export function extractUsage(msg) {
 }
 
 /**
+ * Everything downstream of pi's stdout, shared by the host and sandboxed
+ * paths so the transcript artifact, live trace, denial detection, and usage
+ * accounting are one implementation: pipe the stream to `.transcript.json`,
+ * map each NDJSON line to trace events, accumulate usage. `finish()` emits
+ * the combined `usage` trace event, reports usage, and returns the outcome
+ * fields the worker reads.
+ *
+ * @param {import("node:stream").Readable|null} stdout
+ */
+function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
+  // Capture the CLI's structured output as a runtime artifact, same
+  // contract as the claude adapter: NDJSON, one message per line.
+  const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
+  transcript.on("error", () => {});
+  if (stdout) {
+    stdout.pipe(transcript);
+  }
+
+  // Live trace: same stdout, line by line. Observational only — a trace
+  // recorder must never race execution by terminating the child.
+  const policyDenials = [];
+  let lastTool = null;
+  const toolNames = new Map();
+  let turnCount = 0;
+  let costTotal = null;
+  const usageTotals = {};
+  let observedModel = null;
+  if (stdout) {
+    const lines = createInterface({ input: stdout });
+    lines.on("line", (line) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return; // not JSON — ignore
+      }
+      try {
+        if (parsed?.type === "message_end" && typeof parsed.message?.model === "string") {
+          observedModel = parsed.message.model;
+        } else if (typeof parsed?.model === "string") {
+          observedModel = parsed.model;
+        }
+        for (const event of mapStreamEvent(parsed)) {
+          if (event.kind === "tool_use") {
+            lastTool = event.payload?.name ?? null;
+            if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
+          }
+          onTrace?.(event.kind, event.payload);
+          const content = typeof event.payload?.content === "string" ? event.payload.content : "";
+          if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
+            const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
+            policyDenials.push(denial);
+            onTrace?.("lifecycle", { note: "policy_denial", ...denial });
+          }
+        }
+        const turnUsage = extractUsage(parsed);
+        if (turnUsage) {
+          turnCount += 1;
+          if (turnUsage.costUSD !== null) costTotal = (costTotal ?? 0) + turnUsage.costUSD;
+          for (const [key, value] of Object.entries(turnUsage.usage)) {
+            usageTotals[key] = (usageTotals[key] ?? 0) + value;
+          }
+        }
+      } catch {
+        // a recorder failure must never fail the run
+      }
+    });
+  }
+
+  const finish = ({ exitCode, timedOut }) => {
+    // pi has no single terminal summary message; report what was actually
+    // observed — explicit null/empty when the run never produced a turn,
+    // never a fabricated zero.
+    onTrace?.("usage", {
+      durationMs: null,
+      numTurns: turnCount > 0 ? turnCount : null,
+      costUSD: costTotal,
+      usage: usageTotals,
+    });
+
+    const normalized = {
+      model: observedModel ?? spec?.model ?? def?.model ?? null,
+      inputTokens: usageTotals.input ?? 0,
+      outputTokens: usageTotals.output ?? 0,
+      cacheCreationInputTokens: usageTotals.cacheWrite ?? 0,
+      cacheReadInputTokens: usageTotals.cacheRead ?? 0,
+      costUSD: typeof costTotal === "number" ? costTotal : 0,
+    };
+
+    try {
+      onUsage?.(normalized);
+    } catch {
+      // Usage is observability: a consumer failure must not change execution.
+    }
+
+    // Same WM-127 rule as claude: a denial observed mid-run is evidence,
+    // not a verdict — only surfaced to the worker when the run also failed.
+    return {
+      exitCode,
+      timedOut,
+      policyDenials: exitCode === 0 ? [] : policyDenials,
+      usage: normalized,
+    };
+  };
+
+  return { transcript, finish };
+}
+
+/**
+ * Sandboxed execution (WM-313): pi runs inside the microVM. The guest sees
+ * the workspace at the policy's mount point as its cwd, so `./input.json` and
+ * `./result.json` in PROMPT_SUFFIX resolve to the host workspace the verifier
+ * reads — on success, failure, and timeout alike, because VFS writes land on
+ * the host as the guest makes them.
+ *
+ * What is deliberately different from the host path, and why:
+ *   - no CLI resolution on the host: the binary is a guest path
+ *     (`sandbox.guestBinaries.pi`, default /usr/local/bin/pi per the image
+ *     contract). A missing guest binary is a guest exec failure, reported
+ *     through the console artifact.
+ *   - no `safeChildEnvironment`: nothing from the worker's env is forwarded.
+ *     `PI_OFFLINE=1` keeps pi's own update/telemetry traffic from tripping the
+ *     deny-all default; the model call itself needs its host in
+ *     `sandbox.allowedHosts` and its key declared in `sandbox.secrets` (the
+ *     guest holds only the placeholder).
+ *   - no `--fork <session>`: sessions live in the guest's ephemeral home, so a
+ *     prior attempt's native session cannot exist there. The worker's resume
+ *     lookup keys on the transcript's cwd matching the host workspace, which a
+ *     guest transcript never does, so this is belt-and-braces plus a note.
+ */
+async function executeSandboxed({
+  spec,
+  def,
+  workspaceDir,
+  timeoutMs,
+  onTrace,
+  onUsage,
+  resume,
+  abortSignal,
+  runSandbox,
+}) {
+  const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
+  writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
+
+  if (resume?.sessionId) {
+    onTrace?.("lifecycle", { note: "sandbox_resume_unavailable", sessionId: resume.sessionId });
+  }
+  const bin = guestBinary(def, "pi");
+  const argv = [bin, ...buildPiArgv({ def, model: spec?.model, resumeSessionId: null })];
+
+  const stdout = new PassThrough();
+  const { transcript, finish } = attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage });
+  const transcriptClosed = new Promise((done) => {
+    transcript.on("close", done);
+    transcript.on("finish", done);
+  });
+
+  let sandboxOutcome;
+  try {
+    sandboxOutcome = await runSandboxed({
+      adapter: "pi",
+      def,
+      workspaceDir,
+      argv,
+      stdinFile: SANDBOX_PROMPT_FILE,
+      env: guestEnvironment({ PI_OFFLINE: "1" }),
+      timeoutMs,
+      abortSignal,
+      onTrace,
+      runSandbox,
+      onStdout: (chunk) => stdout.write(chunk),
+    });
+  } finally {
+    stdout.end();
+  }
+  // The transcript must be flushed before the worker hashes it — the guest is
+  // gone, so nothing else is holding the run open.
+  await transcriptClosed;
+
+  return finish({ exitCode: sandboxOutcome.exitCode, timedOut: sandboxOutcome.timedOut });
+}
+
+/**
  * @returns {Promise<{ exitCode: number | null, timedOut: boolean }>}
  */
 export async function execute({
@@ -342,7 +548,18 @@ export async function execute({
   resume = null,
   abortSignal,
   signal,
+  runSandbox,
 }) {
+  // The sandbox decision comes first, before the host env is assembled or a
+  // host CLI is looked for: a sandboxed definition must never reach the host
+  // spawn below, whatever else happens.
+  if (sandboxRequested(def)) {
+    return executeSandboxed({
+      spec, def, workspaceDir, timeoutMs, onTrace, onUsage, resume,
+      abortSignal: abortSignal ?? signal, runSandbox,
+    });
+  }
+
   const prompt = readFileSync(def.promptPath, "utf8") + PROMPT_SUFFIX;
   const childEnv = safeChildEnvironment(env, def);
 
@@ -372,64 +589,7 @@ export async function execute({
     child.stdin.write(prompt);
     child.stdin.end();
 
-    // Capture the CLI's structured output as a runtime artifact, same
-    // contract as the claude adapter: NDJSON, one message per line.
-    const transcript = createWriteStream(path.join(workspaceDir, ".transcript.json"));
-    transcript.on("error", () => {});
-    if (child.stdout) {
-      child.stdout.pipe(transcript);
-    }
-
-    // Live trace: same stdout, line by line. Observational only — a trace
-    // recorder must never race execution by terminating the child.
-    const policyDenials = [];
-    let lastTool = null;
-    const toolNames = new Map();
-    let turnCount = 0;
-    let costTotal = null;
-    const usageTotals = {};
-    let observedModel = null;
-    if (child.stdout) {
-      const lines = createInterface({ input: child.stdout });
-      lines.on("line", (line) => {
-        let parsed;
-        try {
-          parsed = JSON.parse(line);
-        } catch {
-          return; // not JSON — ignore
-        }
-        try {
-          if (parsed?.type === "message_end" && typeof parsed.message?.model === "string") {
-            observedModel = parsed.message.model;
-          } else if (typeof parsed?.model === "string") {
-            observedModel = parsed.model;
-          }
-          for (const event of mapStreamEvent(parsed)) {
-            if (event.kind === "tool_use") {
-              lastTool = event.payload?.name ?? null;
-              if (event.payload?.id) toolNames.set(event.payload.id, lastTool);
-            }
-            onTrace?.(event.kind, event.payload);
-            const content = typeof event.payload?.content === "string" ? event.payload.content : "";
-            if (event.kind === "tool_result" && event.payload?.isError && isHarnessDenial(content)) {
-              const denial = { tool: toolNames.get(event.payload?.toolUseId) ?? lastTool ?? "unknown", rule: clip(content) };
-              policyDenials.push(denial);
-              onTrace?.("lifecycle", { note: "policy_denial", ...denial });
-            }
-          }
-          const turnUsage = extractUsage(parsed);
-          if (turnUsage) {
-            turnCount += 1;
-            if (turnUsage.costUSD !== null) costTotal = (costTotal ?? 0) + turnUsage.costUSD;
-            for (const [key, value] of Object.entries(turnUsage.usage)) {
-              usageTotals[key] = (usageTotals[key] ?? 0) + value;
-            }
-          }
-        } catch {
-          // a recorder failure must never fail the run
-        }
-      });
-    }
+    const { transcript, finish } = attachOutput({ stdout: child.stdout, workspaceDir, spec, def, onTrace, onUsage });
 
     let timedOut = false;
     let killTimer = null;
@@ -467,39 +627,7 @@ export async function execute({
       clearTimeout(termTimer);
       if (killTimer) clearTimeout(killTimer);
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
-      // pi has no single terminal summary message; report what was actually
-      // observed — explicit null/empty when the run never produced a turn,
-      // never a fabricated zero.
-      onTrace?.("usage", {
-        durationMs: null,
-        numTurns: turnCount > 0 ? turnCount : null,
-        costUSD: costTotal,
-        usage: usageTotals,
-      });
-
-      const normalized = {
-        model: observedModel ?? spec?.model ?? def?.model ?? null,
-        inputTokens: usageTotals.input ?? 0,
-        outputTokens: usageTotals.output ?? 0,
-        cacheCreationInputTokens: usageTotals.cacheWrite ?? 0,
-        cacheReadInputTokens: usageTotals.cacheRead ?? 0,
-        costUSD: typeof costTotal === "number" ? costTotal : 0,
-      };
-
-      try {
-        onUsage?.(normalized);
-      } catch {
-        // Usage is observability: a consumer failure must not change execution.
-      }
-
-      // Same WM-127 rule as claude: a denial observed mid-run is evidence,
-      // not a verdict — only surfaced to the worker when the run also failed.
-      resolve({
-        exitCode,
-        timedOut,
-        policyDenials: exitCode === 0 ? [] : policyDenials,
-        usage: normalized,
-      });
+      resolve(finish({ exitCode, timedOut }));
     });
   });
 }

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -19,7 +19,10 @@ import {
   READ_ONLY_TOOLS,
   resolvePiCommand,
   safeChildEnvironment,
+  SANDBOX_PROMPT_FILE,
 } from "./pi.mjs";
+import { preflight, SandboxUnavailableError } from "../sandbox/gondolin.mjs";
+import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {
@@ -776,4 +779,314 @@ process.stdin.on("end", () => {
       }),
     ).rejects.toMatchObject({ code: "cli_not_found" });
   });
+});
+
+/**
+ * Sandboxed execution (WM-313). The VM boundary is stubbed at `runSandbox`
+ * for the contract tests — the same seam lib/adapters/sandboxed.test.mjs
+ * exercises — and a gated real-VM block at the end proves the mechanism with
+ * an actual guest, skipping (not failing) where `preflight()` says no.
+ */
+describe("sandboxed execution (WM-313)", () => {
+  const tmpBase = realpathSync(mkdtempSync(path.join(tmpdir(), "evrt-pi-sandbox-")));
+  afterAll(() => rmSync(tmpBase, { recursive: true, force: true }));
+  const ws = () => realpathSync(mkdtempSync(path.join(tmpBase, "ws-")));
+  const promptFile = path.join(tmpBase, "prompt.md");
+  writeFileSync(promptFile, "You are a sandboxed test agent.", "utf8");
+
+  const sandboxDef = (extra = {}) => ({
+    ref: "sandboxed-pi@1",
+    promptPath: promptFile,
+    mutating: false,
+    sandbox: {
+      provider: "gondolin",
+      allowedHosts: ["api.openai.com"],
+      secrets: { OPENAI_API_KEY: { hosts: ["api.openai.com"], env: "FACTORY_TEST_FAKE_OPENAI_KEY" } },
+    },
+    ...extra,
+  });
+  const spec = { agent: "sandboxed-pi@1", input: { repos: ["bj29"] }, model: "openai/gpt-5.6-terra" };
+
+  /** A stand-in for the VM: records the request, "runs" a scripted guest. */
+  function fakeVm({ stdoutLines = [], exitCode = 0, timedOut = false, writeResult = true, bootMs = 42 } = {}) {
+    const calls = [];
+    const runSandbox = async (request) => {
+      calls.push(request);
+      for (const line of stdoutLines) request.onStdout(`${JSON.stringify(line)}\n`);
+      request.onStderr?.("guest stderr line\n");
+      if (writeResult) {
+        // The guest writes ./result.json under its cwd, which is the host
+        // workspace through the mount — the stub writes to the same place.
+        writeFileSync(
+          path.join(request.workspaceDir, "result.json"),
+          JSON.stringify({ schemaVersion: "factory.agent-result/v1", terminalState: "completed", reasonCode: "ok", artifact: {}, evidence: {} }),
+        );
+      }
+      return { exitCode, timedOut, bootMs };
+    };
+    return { calls, runSandbox };
+  }
+
+  test("runs pi inside the VM: guest binary, prompt via workspace file, built guest env, no host CLI needed", async () => {
+    const workspaceDir = ws();
+    const vm = fakeVm({
+      stdoutLines: [
+        { type: "session", id: "sess-1", cwd: "/workspace" },
+        { type: "message_end", message: { role: "assistant", model: "gpt-5.6-terra", content: [{ type: "text", text: "Working in the VM..." }], usage: { input: 15, output: 25, cost: { total: 0.001 } } } },
+      ],
+    });
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec,
+      def: sandboxDef(),
+      workspaceDir,
+      timeoutMs: 5000,
+      // Everything a served worker would hand over — none of it may reach the guest.
+      env: { PATH: "/nonexistent", OPENAI_API_KEY: "sk-fake-host-key-must-not-cross", GITHUB_TOKEN: "ghp-fake", CUSTOM_VAR: "host-only" },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+      runSandbox: vm.runSandbox,
+    });
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+      usage: { model: "gpt-5.6-terra", inputTokens: 15, outputTokens: 25, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, costUSD: 0.001 },
+    });
+
+    expect(vm.calls).toHaveLength(1);
+    const req = vm.calls[0];
+    // 1. The policy is the definition's, verbatim — placeholders are the runner's job.
+    expect(req.policy).toEqual(sandboxDef().sandbox);
+    expect(req.workspaceDir).toBe(workspaceDir);
+    expect(req.timeoutMs).toBe(5000);
+
+    // 2. argv: guest binary (not a host lookup), stdin redirected from the workspace prompt file.
+    expect(req.command.slice(0, 3)).toEqual(["/bin/sh", "-c", `exec "$0" "$@" < ./${SANDBOX_PROMPT_FILE}`]);
+    expect(req.command[3]).toBe("/usr/local/bin/pi");
+    const piArgs = req.command.slice(4);
+    expect(piArgs.slice(0, 3)).toEqual(["-p", "--mode", "json"]);
+    expect(piArgs[piArgs.indexOf("--model") + 1]).toBe("openai/gpt-5.6-terra");
+    expect(piArgs[piArgs.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash");
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), "utf8")).toBe(`You are a sandboxed test agent.${PROMPT_SUFFIX}`);
+
+    // 3. Guest env is built, not inherited: no host key, no push token, no
+    //    caller var, no host HOME/PATH; PI_OFFLINE keeps update traffic off
+    //    the deny-all proxy.
+    expect(req.env.OPENAI_API_KEY).toBeUndefined();
+    expect(req.env.GITHUB_TOKEN).toBeUndefined();
+    expect(req.env.CUSTOM_VAR).toBeUndefined();
+    expect(req.env.HOME).toBe("/root");
+    expect(req.env.PATH).toContain("/usr/local/bin");
+    expect(req.env.PI_OFFLINE).toBe("1");
+    expect(JSON.stringify(req)).not.toContain("sk-fake-host-key-must-not-cross");
+
+    // 4. Same downstream contract as the host path: transcript, trace, usage, result.json where the verifier looks.
+    expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain('"type":"message_end"');
+    expect(traceEvents.some((e) => e.kind === "assistant_text" && e.payload.text === "Working in the VM...")).toBe(true);
+    expect(traceEvents.find((e) => e.kind === "usage").payload.numTurns).toBe(1);
+    expect(JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8")).terminalState).toBe("completed");
+
+    // 5. Guest console is an artifact and a trace event.
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("guest stderr line");
+    expect(traceEvents.find((e) => e.kind === "lifecycle" && e.payload.note === "sandbox_console").payload).toMatchObject({ adapter: "pi", exitCode: 0, bootMs: 42 });
+  });
+
+  test("a per-definition guest binary override is honoured; a relative one is refused before the VM", async () => {
+    const vm = fakeVm();
+    await execute({ spec, def: sandboxDef({ sandbox: { ...sandboxDef().sandbox, guestBinaries: { pi: "/opt/tools/pi" } } }), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm.runSandbox });
+    expect(vm.calls[0].command[3]).toBe("/opt/tools/pi");
+
+    const vm2 = fakeVm();
+    await expect(
+      execute({ spec, def: sandboxDef({ sandbox: { ...sandboxDef().sandbox, guestBinaries: { pi: "pi" } } }), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm2.runSandbox }),
+    ).rejects.toThrow(/absolute guest path/);
+    expect(vm2.calls).toHaveLength(0);
+  });
+
+  test("a sandboxed definition never resolves or spawns a host pi, even when none is on PATH", async () => {
+    // Host path with this env throws CliNotFoundError; the sandboxed path must not even look.
+    const vm = fakeVm();
+    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, env: { PATH: tmpBase }, runSandbox: vm.runSandbox });
+    expect(outcome.exitCode).toBe(0);
+    expect(vm.calls).toHaveLength(1);
+  });
+
+  test("a prior native session is not forked into the guest (sessions are per-VM); the run notes it", async () => {
+    const vm = fakeVm();
+    const trace = [];
+    await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, resume: { sessionId: "sess-prior" }, runSandbox: vm.runSandbox, onTrace: (k, p) => trace.push({ k, p }) });
+    expect(vm.calls[0].command).not.toContain("--fork");
+    expect(trace.some((t) => t.k === "lifecycle" && t.p.note === "sandbox_resume_unavailable")).toBe(true);
+  });
+
+  test("nonzero guest exit propagates like a host exit; denials are surfaced only then", async () => {
+    const vm = fakeVm({ exitCode: 3, writeResult: false });
+    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, runSandbox: vm.runSandbox });
+    expect(outcome.exitCode).toBe(3);
+    expect(outcome.timedOut).toBe(false);
+  });
+
+  test("timeout: identical outcome shape to the host path, and a result.json the guest managed to write survives", async () => {
+    // Host reference: the stub ignores SIGTERM and gets killed → { exitCode: null, timedOut: true }.
+    const vm = fakeVm({ exitCode: null, timedOut: true, writeResult: true });
+    const workspaceDir = ws();
+    const outcome = await execute({ spec, def: sandboxDef(), workspaceDir, timeoutMs: 100, runSandbox: vm.runSandbox });
+    expect(outcome.exitCode).toBeNull();
+    expect(outcome.timedOut).toBe(true);
+    // The worker's late-completion preflight (verifyResult on TIMED_OUT) reads
+    // this file from the same workspace — the file the guest wrote.
+    expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(true);
+    expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(true);
+  });
+
+  test("cancel: identical outcome shape to the host path — null exit, timedOut false", async () => {
+    const ac = new AbortController();
+    const runSandbox = ({ abortSignal }) =>
+      new Promise((_, reject) => {
+        // What the real runner does on SIGTERM: dies without an exit event,
+        // which gondolin.mjs reports as sandbox_runner_crashed.
+        abortSignal.addEventListener("abort", () => reject(Object.assign(new Error("runner exited (null) without reporting a guest exit code"), { code: "sandbox_runner_crashed" })));
+      });
+    const pending = execute({ spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 60_000, abortSignal: ac.signal, runSandbox });
+    setTimeout(() => ac.abort(), 10);
+    const outcome = await pending;
+    expect(outcome.exitCode).toBeNull();
+    expect(outcome.timedOut).toBe(false);
+  });
+
+  test("a host that cannot honour the policy fails typed — never falls back to a host pi", async () => {
+    // Real runInSandbox with a preflight-failing host env: no qemu → SandboxUnavailableError.
+    // Injecting nothing here would hit this machine's real preflight, which may pass; force the failure instead.
+    const outcome = execute({
+      spec, def: sandboxDef(), workspaceDir: ws(), timeoutMs: 1000, env: { PATH: `${tmpBase}` },
+      runSandbox: async () => { throw new SandboxUnavailableError("qemu-system-aarch64 is not on PATH"); },
+    });
+    await expect(outcome).rejects.toBeInstanceOf(SandboxUnavailableError);
+  });
+
+  test("an invalid policy is refused before any VM: unknown provider", async () => {
+    // Goes through the real runInSandbox, whose first step is normalizePolicy — host-independent.
+    await expect(
+      execute({ spec, def: sandboxDef({ sandbox: { provider: "firecracker" } }), workspaceDir: ws(), timeoutMs: 1000 }),
+    ).rejects.toThrow(/unknown sandbox provider/);
+  });
+
+  // ---- real VM, gated on preflight() -------------------------------------
+  const report = preflight();
+  const itVM = report.available ? test : test.skip;
+  if (!report.available) console.warn(`[WM-313] skipping real-VM pi sandbox tests — ${report.reason}`);
+  const VM_TIMEOUT = 180_000;
+
+  /**
+   * A guest-side stand-in for pi: POSIX sh (the Alpine guest has no pi yet —
+   * docs/eval-gondolin-guest-image.md), mounted read-only at /opt/tools and
+   * selected via sandbox.guestBinaries. It reads its prompt from stdin, prints
+   * one pi-shaped message_end line, and writes ./result.json into its cwd —
+   * i.e. through the workspace mount, onto the host.
+   */
+  const guestToolsDir = path.join(tmpBase, "guest-tools");
+  mkdirSync(guestToolsDir, { recursive: true });
+  writeFileSync(
+    path.join(guestToolsDir, "pi"),
+    `#!/bin/sh
+prompt=$(cat)
+if [ -f ./.behaviour ]; then behaviour=$(cat ./.behaviour); else behaviour=normal; fi
+echo "guest pi: cwd=$(pwd) key=\${OPENAI_API_KEY:-unset} home=$HOME" >&2
+if [ "$behaviour" = "sleep" ]; then
+  echo '{"type":"session","id":"guest-sess","cwd":"/workspace"}'
+  echo '{"schemaVersion":"factory.agent-result/v1","terminalState":"completed","reasonCode":"ok","artifact":{"partial":true},"evidence":{}}' > ./result.json
+  sleep 600
+  exit 0
+fi
+printf '%s\\n' "$prompt" > ./.prompt-as-seen
+echo '{"type":"session","id":"guest-sess","cwd":"/workspace"}'
+echo '{"type":"message_end","message":{"role":"assistant","model":"guest-model","content":[{"type":"text","text":"hello from the guest"}],"usage":{"input":3,"output":4,"cost":{"total":0.0001}}}}'
+echo "{\\"schemaVersion\\":\\"factory.agent-result/v1\\",\\"terminalState\\":\\"completed\\",\\"reasonCode\\":\\"ok\\",\\"artifact\\":{\\"argv\\":\\"$*\\",\\"keyLooksLikePlaceholder\\":\\"$(case "\${OPENAI_API_KEY:-}" in GONDOLIN_SECRET_*) echo yes;; *) echo no;; esac)\\"},\\"evidence\\":{}}" > ./result.json
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  const vmDef = (extra = {}) =>
+    sandboxDef({
+      sandbox: {
+        ...sandboxDef().sandbox,
+        mounts: { "/opt/tools": { path: guestToolsDir, readonly: true } },
+        guestBinaries: { pi: "/opt/tools/pi" },
+      },
+      ...extra,
+    });
+  // The declared secret resolves from the HOST env at run time. This is a
+  // fake, test-only value; the assertion is that the guest never sees it.
+  const FAKE_KEY = "sk-test-fake-not-a-real-key-000";
+  const withFakeKey = async (fn) => {
+    const prev = process.env.FACTORY_TEST_FAKE_OPENAI_KEY;
+    process.env.FACTORY_TEST_FAKE_OPENAI_KEY = FAKE_KEY;
+    try {
+      return await fn();
+    } finally {
+      if (prev === undefined) delete process.env.FACTORY_TEST_FAKE_OPENAI_KEY;
+      else process.env.FACTORY_TEST_FAKE_OPENAI_KEY = prev;
+    }
+  };
+
+  itVM("real VM: pi runs in the guest, prompt arrives on stdin, result.json lands on the host, the key is a placeholder", async () => {
+    await withFakeKey(async () => {
+      const workspaceDir = ws();
+      const trace = [];
+      const outcome = await execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 120_000, env: { OPENAI_API_KEY: "sk-host-side-fake" }, onTrace: (k, p) => trace.push({ k, p }) });
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.timedOut).toBe(false);
+      expect(outcome.usage.model).toBe("guest-model");
+      expect(outcome.usage.inputTokens).toBe(3);
+
+      const result = JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8"));
+      expect(result.terminalState).toBe("completed");
+      expect(result.artifact.argv).toContain("-p --mode json");
+      expect(result.artifact.keyLooksLikePlaceholder).toBe("yes");
+      expect(readFileSync(path.join(workspaceDir, ".prompt-as-seen"), "utf8")).toContain("You are a sandboxed test agent.");
+      expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).toContain("hello from the guest");
+      const console_ = readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8");
+      expect(console_).toContain("guest pi: cwd=/workspace");
+      expect(console_).toContain("key=GONDOLIN_SECRET_");
+      expect(console_).not.toContain(FAKE_KEY);
+      expect(readFileSync(path.join(workspaceDir, ".transcript.json"), "utf8")).not.toContain(FAKE_KEY);
+      expect(trace.some((t) => t.k === "assistant_text" && t.p.text === "hello from the guest")).toBe(true);
+    });
+  }, VM_TIMEOUT);
+
+  itVM("real VM: timeout caps the guest and the partial result.json is on the host", async () => {
+    await withFakeKey(async () => {
+      const workspaceDir = ws();
+      writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
+      const started = Date.now();
+      // Generous enough that a cold guest (first exec after asset load) has
+      // written result.json before the cap lands; the assertion is on the cap.
+      const outcome = await execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 10_000 });
+      expect(outcome.timedOut).toBe(true);
+      expect(outcome.exitCode).toBeNull();
+      expect(Date.now() - started).toBeLessThan(60_000);
+      expect(JSON.parse(readFileSync(path.join(workspaceDir, "result.json"), "utf8")).artifact.partial).toBe(true);
+    });
+  }, VM_TIMEOUT);
+
+  itVM("real VM: cooperative cancel tears the guest down and reports like a host cancel", async () => {
+    await withFakeKey(async () => {
+      const workspaceDir = ws();
+      writeFileSync(path.join(workspaceDir, ".behaviour"), "sleep");
+      const ac = new AbortController();
+      const trace = [];
+      const pending = execute({ spec, def: vmDef(), workspaceDir, timeoutMs: 120_000, abortSignal: ac.signal, onTrace: (k, p) => trace.push({ k, p }) });
+      // Abort once the guest has produced its first line, i.e. it is really running.
+      for (let i = 0; i < 600 && !trace.some((t) => t.k === "lifecycle" || t.k === "assistant_text"); i += 1) {
+        if (existsSync(path.join(workspaceDir, "result.json"))) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      ac.abort();
+      const outcome = await pending;
+      expect(outcome.timedOut).toBe(false);
+      expect(outcome.exitCode).toBeNull();
+    });
+  }, VM_TIMEOUT);
 });

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -1,0 +1,260 @@
+/**
+ * The sandbox decision, shared by every adapter (WM-313).
+ *
+ * WM-185 built the Gondolin microVM harness (lib/sandbox/) and wired exactly
+ * one adapter to it: `command`. The two adapters that spawn LLM agents with a
+ * shell — `pi` and `claude` — read the same definitions and simply never
+ * looked at `def.sandbox`, so a definition asking for isolation got a host
+ * process and no error. That inverts the threat model in
+ * docs/eval-gondolin-sandbox.md §1.1: closed-argv commands could be isolated,
+ * open-ended agents could not.
+ *
+ * This module is the seam that makes ignoring the block impossible by
+ * omission. Every adapter's `execute()` starts by consulting it, and there are
+ * exactly two legal outcomes when a definition carries `sandbox`:
+ *
+ *   1. the adapter runs the agent INSIDE the VM through `runSandboxed()`, or
+ *   2. the adapter refuses with `SandboxUnsupportedError` (typed, naming the
+ *      adapter and the reason) via `refuseSandbox()`.
+ *
+ * Silently running on the host is not on that list. `sandboxed.test.mjs`
+ * enumerates every module in this directory and proves each one lands on (1)
+ * or (2), so a new adapter that forgets to decide fails the suite rather than
+ * quietly widening the fleet's host-execution surface.
+ *
+ * Fallback is deliberate, never accidental: a host that cannot honour the
+ * policy surfaces `SandboxUnavailableError` from lib/sandbox/gondolin.mjs and
+ * the run fails typed. Placement (`sandbox=gondolin`, lib/workers.mjs
+ * `satisfiesPlacement`) is what keeps such a run off that host in the first
+ * place; this module never re-routes to host execution.
+ *
+ * Secrets never pass through here. A policy names host env vars; resolution
+ * and placeholder substitution live in lib/sandbox/policy.mjs and runner.mjs.
+ * The guest environment this module assembles is built from constants and a
+ * short locale allowlist — the caller's `env` (which for a served worker is
+ * the whole of `process.env`) is not forwarded, because keeping the worker's
+ * credentials out of a model-controlled guest is the point of the exercise.
+ */
+import { createWriteStream } from "node:fs";
+import path from "node:path";
+import { runInSandbox } from "../sandbox/gondolin.mjs";
+
+/**
+ * Where an agent-CLI adapter expects its binary inside the guest, per the
+ * image contract in docs/eval-gondolin-guest-image.md §2.3. Array-form exec
+ * inside the VM does not search $PATH, so these are absolute by construction.
+ * A definition may override per adapter through `sandbox.guestBinaries`
+ * (e.g. to point at a read-only `sandbox.mounts` entry carrying the toolchain
+ * — the virtio-fs route the RFC prefers over rebuilding per run).
+ */
+export const GUEST_BINARIES = Object.freeze({
+  pi: "/usr/local/bin/pi",
+  claude: "/usr/local/bin/claude",
+});
+
+/** The guest's default PATH lacks /usr/local/bin, which is where the image contract puts the CLIs. */
+export const GUEST_PATH = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+export const GUEST_HOME = "/root";
+export const GUEST_SHELL = "/bin/sh";
+
+/**
+ * Guest console capture: boot timing, guest stderr, exit/timeout/failure, in
+ * one file next to result.json so a sandboxed failure is as diagnosable as a
+ * host one. Retained with the workspace on failure, and its tail also rides a
+ * `lifecycle` trace event so `inspect` shows it without the workspace.
+ */
+export const SANDBOX_CONSOLE_FILE = ".sandbox-console.log";
+const CONSOLE_TRACE_CHARS = 4000;
+
+/** Locale-only variables copied from the worker into the guest; nothing else crosses. */
+const GUEST_LOCALE_ENV = ["LANG", "LC_ALL", "LC_CTYPE"];
+
+export class SandboxUnsupportedError extends Error {
+  constructor(adapter, reason) {
+    super(
+      `adapter "${adapter}" cannot honour a sandbox policy — the definition asks for one, so the run is refused rather than executed on the host. ${reason}`,
+    );
+    this.name = "SandboxUnsupportedError";
+    this.code = "sandbox_unsupported";
+    this.adapter = adapter;
+  }
+}
+
+/** Does this definition ask to be sandboxed? Anything but absent/null counts, so a malformed block is refused later, not ignored. */
+export function sandboxRequested(def) {
+  return def?.sandbox !== undefined && def?.sandbox !== null;
+}
+
+/**
+ * The fail-closed half of the decision. An adapter that cannot execute inside
+ * the VM calls this first thing in `execute()`; it is a no-op for ordinary
+ * definitions and a typed refusal for sandboxed ones.
+ */
+export function refuseSandbox(adapter, def, reason) {
+  if (!sandboxRequested(def)) return;
+  throw new SandboxUnsupportedError(adapter, reason);
+}
+
+/** Absolute guest path of an adapter's CLI, honouring a per-definition override. */
+export function guestBinary(def, adapter) {
+  const override = def?.sandbox?.guestBinaries?.[adapter];
+  const resolved = override ?? GUEST_BINARIES[adapter];
+  if (typeof resolved !== "string" || !resolved.startsWith("/")) {
+    throw new Error(
+      `definition ${def?.ref ?? "?"} is sandboxed, so sandbox.guestBinaries.${adapter} must be an absolute guest path (got ${JSON.stringify(override ?? null)})`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * The environment an agent CLI sees inside the guest. Built, not inherited:
+ * the worker's env carries the credentials the sandbox exists to withhold, and
+ * host paths (HOME, PATH, TMPDIR) mean nothing in an Alpine guest anyway.
+ * Placeholders for declared secrets are added AFTER this by runner.mjs, so a
+ * value here can never shadow one.
+ *
+ * @param {Record<string,string>} extra - adapter-specific, non-secret additions
+ * @param {Record<string,string|undefined>} [hostEnv]
+ */
+export function guestEnvironment(extra = {}, hostEnv = process.env) {
+  const env = { HOME: GUEST_HOME, PATH: GUEST_PATH, TERM: "dumb" };
+  for (const key of GUEST_LOCALE_ENV) {
+    if (typeof hostEnv[key] === "string" && hostEnv[key] !== "") env[key] = hostEnv[key];
+  }
+  return { ...env, ...extra };
+}
+
+/**
+ * Wrap an argv so the guest process reads its stdin from a workspace file.
+ * `runInSandbox()` has no stdin channel (its request carries secrets and is
+ * one-shot), and pi's prompt has always travelled on stdin — so the prompt is
+ * written into the workspace on the host and redirected inside the guest.
+ * The redirect target is relative to the guest cwd, which `runInSandbox`
+ * pins to the policy's workspace mount, so no host path is ever spliced in.
+ * The script string is a constant; the binary and its arguments arrive as
+ * positional parameters (`$0`, `$@`) and are never re-parsed by the shell.
+ */
+export function withStdinFile(argv, stdinFile) {
+  if (typeof stdinFile !== "string" || !/^[A-Za-z0-9._-]+$/.test(stdinFile)) {
+    throw new Error(`sandbox stdin file must be a bare workspace filename, got ${JSON.stringify(stdinFile)}`);
+  }
+  return [GUEST_SHELL, "-c", `exec "$0" "$@" < ./${stdinFile}`, ...argv];
+}
+
+function assertGuestArgv(def, argv) {
+  if (!Array.isArray(argv) || argv.length === 0 || typeof argv[0] !== "string" || !argv[0].startsWith("/")) {
+    // Array-form exec does not search $PATH inside the guest, and a host path
+    // like /opt/homebrew/bin/bun does not exist there. Failing here with the
+    // real reason beats a bare "no such file" from inside a VM.
+    throw new Error(
+      `definition ${def?.ref ?? "?"} is sandboxed, so its command must start with an absolute guest path (got ${JSON.stringify(argv?.[0] ?? null)})`,
+    );
+  }
+}
+
+/**
+ * Run one adapter's process inside the microVM, preserving the host-path
+ * contract the worker relies on:
+ *
+ *   - `{ exitCode, timedOut }` with the same meaning as a host child: a guest
+ *     timeout is `{ exitCode: null, timedOut: true }`, a cooperative cancel
+ *     (`abortSignal`) resolves `{ exitCode: null, timedOut: false }` exactly as
+ *     a SIGTERMed host child does — the worker checks the abort signal itself.
+ *   - anything the guest wrote under the workspace mount is on the host by the
+ *     time this resolves, because VFS writes are performed synchronously by
+ *     the runner and the runner has exited.
+ *   - the guest console lands in `SANDBOX_CONSOLE_FILE` and a `lifecycle`
+ *     trace event on every path (success, failure, timeout, cancel, refusal).
+ *
+ * `runSandbox` is injectable so adapter tests stub the VM boundary; the
+ * default is the real `runInSandbox`.
+ *
+ * @returns {Promise<{ exitCode: number|null, timedOut: boolean, bootMs: number|null }>}
+ */
+export async function runSandboxed({
+  adapter,
+  def,
+  workspaceDir,
+  argv,
+  stdinFile,
+  env = {},
+  timeoutMs,
+  abortSignal,
+  onStdout,
+  onStderr,
+  onTrace,
+  runSandbox = runInSandbox,
+}) {
+  assertGuestArgv(def, argv);
+  const command = stdinFile ? withStdinFile(argv, stdinFile) : argv;
+
+  const consolePath = path.join(workspaceDir, SANDBOX_CONSOLE_FILE);
+  const consoleStream = createWriteStream(consolePath);
+  consoleStream.on("error", () => {});
+  let consoleTail = "";
+  const note = (line) => {
+    const text = `${line}\n`;
+    consoleStream.write(text);
+    consoleTail = (consoleTail + text).slice(-CONSOLE_TRACE_CHARS);
+  };
+  const started = Date.now();
+  note(`[sandbox] adapter=${adapter} definition=${def?.ref ?? "?"} provider=${def?.sandbox?.provider ?? "?"} argv=${JSON.stringify(command)}`);
+
+  let outcome;
+  let failure = null;
+  try {
+    outcome = await runSandbox({
+      policy: def.sandbox,
+      command,
+      workspaceDir,
+      timeoutMs,
+      abortSignal,
+      env,
+      onStdout,
+      onStderr: (chunk) => {
+        const text = String(chunk);
+        consoleStream.write(text);
+        consoleTail = (consoleTail + text).slice(-CONSOLE_TRACE_CHARS);
+        onStderr?.(text);
+      },
+    });
+  } catch (err) {
+    failure = err;
+  }
+
+  if (failure && abortSignal?.aborted && failure.code === "sandbox_runner_crashed") {
+    // The runner was torn down mid-run because WE asked for it. A host child
+    // in the same position closes with a null exit code; report the same so
+    // the worker's cancel path cannot tell the two apart.
+    failure = null;
+    outcome = { exitCode: null, timedOut: false, bootMs: null };
+  }
+
+  const elapsed = Date.now() - started;
+  if (failure) {
+    note(`[sandbox] failed after ${elapsed}ms: ${failure.code ?? failure.name}: ${failure.message}`);
+  } else {
+    note(
+      `[sandbox] boot=${outcome.bootMs ?? "?"}ms exit=${outcome.exitCode ?? "null"} timedOut=${outcome.timedOut} elapsed=${elapsed}ms${abortSignal?.aborted ? " cancelled=true" : ""}`,
+    );
+  }
+  await new Promise((done) => consoleStream.end(done));
+
+  try {
+    onTrace?.("lifecycle", {
+      note: "sandbox_console",
+      adapter,
+      bootMs: outcome?.bootMs ?? null,
+      exitCode: outcome?.exitCode ?? null,
+      timedOut: outcome?.timedOut ?? false,
+      ...(failure ? { error: `${failure.code ?? failure.name}: ${failure.message}` } : {}),
+      text: consoleTail,
+    });
+  } catch {
+    // trace is observability, never control flow
+  }
+
+  if (failure) throw failure;
+  return { exitCode: outcome.exitCode ?? null, timedOut: outcome.timedOut === true, bootMs: outcome.bootMs ?? null };
+}

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -239,7 +239,15 @@ export async function runSandboxed({
       `[sandbox] boot=${outcome.bootMs ?? "?"}ms exit=${outcome.exitCode ?? "null"} timedOut=${outcome.timedOut} elapsed=${elapsed}ms${abortSignal?.aborted ? " cancelled=true" : ""}`,
     );
   }
-  await new Promise((done) => consoleStream.end(done));
+  // Settle on close OR error: a stream that already errored (ENOSPC, EACCES)
+  // is not guaranteed to run the end() callback, and an adapter promise that
+  // never settles is a wedged run until the lease reaper (cold review #543).
+  await new Promise((done) => {
+    if (consoleStream.destroyed || consoleStream.closed) return done();
+    consoleStream.once("close", done);
+    consoleStream.once("error", done);
+    consoleStream.end();
+  });
 
   try {
     onTrace?.("lifecycle", {

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -1,0 +1,242 @@
+/**
+ * The sandbox decision seam (WM-313) — and the conformance sweep that makes
+ * "no adapter ignores def.sandbox" a property of the suite rather than a
+ * promise in a comment.
+ *
+ * Nothing here needs a hypervisor: the VM boundary is stubbed at `runSandbox`
+ * exactly where lib/sandbox/gondolin.test.mjs stubs preflight. Real-VM
+ * behaviour is proven in pi.test.mjs behind `preflight()`.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SandboxExecutionError } from "../sandbox/gondolin.mjs";
+import {
+  GUEST_BINARIES,
+  GUEST_HOME,
+  GUEST_PATH,
+  guestBinary,
+  guestEnvironment,
+  refuseSandbox,
+  runSandboxed,
+  SANDBOX_CONSOLE_FILE,
+  sandboxRequested,
+  SandboxUnsupportedError,
+  withStdinFile,
+} from "./sandboxed.mjs";
+
+const ws = () => mkdtempSync(path.join(os.tmpdir(), "evrt-sandboxed-"));
+const sandboxDef = (extra = {}) => ({ ref: "sandboxed@1", sandbox: { provider: "gondolin", allowedHosts: [] }, ...extra });
+
+describe("sandboxRequested / refuseSandbox", () => {
+  test("absent or null means no sandbox; anything else is a request", () => {
+    expect(sandboxRequested({})).toBe(false);
+    expect(sandboxRequested({ sandbox: null })).toBe(false);
+    expect(sandboxRequested({ sandbox: undefined })).toBe(false);
+    expect(sandboxRequested(sandboxDef())).toBe(true);
+    // A malformed block is still a request — it is refused by policy
+    // normalization later, never treated as "off".
+    expect(sandboxRequested({ sandbox: false })).toBe(true);
+    expect(sandboxRequested({ sandbox: "gondolin" })).toBe(true);
+  });
+
+  test("refuseSandbox is a no-op for ordinary definitions and a typed, adapter-naming error for sandboxed ones", () => {
+    expect(() => refuseSandbox("claude", { ref: "x@1" }, "why")).not.toThrow();
+    let caught;
+    try {
+      refuseSandbox("claude", sandboxDef(), "because reasons");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+    expect(caught.code).toBe("sandbox_unsupported");
+    expect(caught.adapter).toBe("claude");
+    expect(caught.message).toContain('adapter "claude" cannot honour a sandbox policy');
+    expect(caught.message).toContain("refused rather than executed on the host");
+    expect(caught.message).toContain("because reasons");
+  });
+});
+
+describe("guest environment and binaries", () => {
+  test("guestEnvironment is built from constants plus locale — the caller's env is not a source", () => {
+    const env = guestEnvironment({ PI_OFFLINE: "1" }, { LANG: "en_US.UTF-8", OPENAI_API_KEY: "sk-fake-not-real", GITHUB_TOKEN: "ghp-fake", HOME: "/Users/someone", PATH: "/opt/homebrew/bin" });
+    expect(env).toEqual({ HOME: GUEST_HOME, PATH: GUEST_PATH, TERM: "dumb", LANG: "en_US.UTF-8", PI_OFFLINE: "1" });
+    expect(GUEST_PATH.split(":")).toContain("/usr/local/bin");
+  });
+
+  test("guestBinary defaults to the image contract path and honours an absolute per-definition override", () => {
+    expect(guestBinary(sandboxDef(), "pi")).toBe(GUEST_BINARIES.pi);
+    expect(guestBinary(sandboxDef({ sandbox: { provider: "gondolin", guestBinaries: { pi: "/opt/tools/pi" } } }), "pi")).toBe("/opt/tools/pi");
+    expect(() => guestBinary(sandboxDef({ sandbox: { provider: "gondolin", guestBinaries: { pi: "pi" } } }), "pi")).toThrow(/absolute guest path/);
+  });
+
+  test("withStdinFile keeps the binary and args as positional parameters and refuses anything but a bare filename", () => {
+    expect(withStdinFile(["/usr/local/bin/pi", "-p", "--mode", "json"], ".prompt.md")).toEqual([
+      "/bin/sh", "-c", 'exec "$0" "$@" < ./.prompt.md', "/usr/local/bin/pi", "-p", "--mode", "json",
+    ]);
+    expect(() => withStdinFile(["/bin/true"], "../escape")).toThrow(/bare workspace filename/);
+    expect(() => withStdinFile(["/bin/true"], "/workspace/x")).toThrow(/bare workspace filename/);
+    expect(() => withStdinFile(["/bin/true"], "a b")).toThrow(/bare workspace filename/);
+  });
+});
+
+describe("runSandboxed", () => {
+  test("refuses a relative guest binary before the VM boundary is touched", async () => {
+    let called = false;
+    await expect(
+      runSandboxed({ adapter: "t", def: sandboxDef(), workspaceDir: ws(), argv: ["pi"], timeoutMs: 1000, runSandbox: async () => { called = true; } }),
+    ).rejects.toThrow(/absolute guest path/);
+    expect(called).toBe(false);
+  });
+
+  test("passes the policy, workspace, timeout, env and (wrapped) argv through, and captures the console", async () => {
+    const workspaceDir = ws();
+    let seen;
+    const trace = [];
+    const outcome = await runSandboxed({
+      adapter: "pi",
+      def: sandboxDef(),
+      workspaceDir,
+      argv: ["/usr/local/bin/pi", "-p"],
+      stdinFile: ".prompt.md",
+      env: { PI_OFFLINE: "1" },
+      timeoutMs: 4321,
+      onTrace: (kind, payload) => trace.push({ kind, payload }),
+      onStdout: () => {},
+      runSandbox: async (request) => {
+        seen = request;
+        request.onStderr("guest said something on stderr\n");
+        return { exitCode: 0, timedOut: false, bootMs: 77 };
+      },
+    });
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false, bootMs: 77 });
+    expect(seen.policy).toEqual(sandboxDef().sandbox);
+    expect(seen.workspaceDir).toBe(workspaceDir);
+    expect(seen.timeoutMs).toBe(4321);
+    expect(seen.env).toEqual({ PI_OFFLINE: "1" });
+    expect(seen.command).toEqual(["/bin/sh", "-c", 'exec "$0" "$@" < ./.prompt.md', "/usr/local/bin/pi", "-p"]);
+
+    const console_ = readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8");
+    expect(console_).toContain("[sandbox] adapter=pi definition=sandboxed@1 provider=gondolin");
+    expect(console_).toContain("guest said something on stderr");
+    expect(console_).toContain("boot=77ms exit=0 timedOut=false");
+    const lifecycle = trace.find((t) => t.kind === "lifecycle" && t.payload.note === "sandbox_console");
+    expect(lifecycle.payload).toMatchObject({ adapter: "pi", bootMs: 77, exitCode: 0, timedOut: false });
+    expect(lifecycle.payload.text).toContain("guest said something on stderr");
+  });
+
+  test("a guest timeout is reported exactly like a host timeout: null exit, timedOut true", async () => {
+    const workspaceDir = ws();
+    const outcome = await runSandboxed({
+      adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/sleep", "999"], timeoutMs: 10,
+      runSandbox: async () => ({ exitCode: null, timedOut: true, bootMs: 5 }),
+    });
+    expect(outcome).toEqual({ exitCode: null, timedOut: true, bootMs: 5 });
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("timedOut=true");
+  });
+
+  test("a cooperative cancel resolves like a SIGTERMed host child, not as a runner crash", async () => {
+    // The real runner is torn down by SIGTERM on abort and therefore never
+    // reports a guest exit code, which gondolin.mjs surfaces as
+    // sandbox_runner_crashed. When WE aborted, that is the expected shape.
+    const ac = new AbortController();
+    const workspaceDir = ws();
+    const pending = runSandboxed({
+      adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/sleep", "999"], timeoutMs: 60_000, abortSignal: ac.signal,
+      runSandbox: ({ abortSignal }) => new Promise((_, reject) => {
+        abortSignal.addEventListener("abort", () => reject(new SandboxExecutionError("sandbox_runner_crashed", "runner exited (null) without reporting a guest exit code")));
+      }),
+    });
+    setTimeout(() => ac.abort(), 5);
+    const outcome = await pending;
+    expect(outcome).toEqual({ exitCode: null, timedOut: false, bootMs: null });
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("cancelled=true");
+  });
+
+  test("the same crash WITHOUT an abort is a failure, rethrown typed and written to the console", async () => {
+    const workspaceDir = ws();
+    const trace = [];
+    await expect(
+      runSandboxed({
+        adapter: "t", def: sandboxDef(), workspaceDir, argv: ["/bin/true"], timeoutMs: 1000,
+        onTrace: (kind, payload) => trace.push({ kind, payload }),
+        runSandbox: async () => { throw new SandboxExecutionError("sandbox_runner_crashed", "runner exited (1)"); },
+      }),
+    ).rejects.toMatchObject({ code: "sandbox_runner_crashed" });
+    expect(readFileSync(path.join(workspaceDir, SANDBOX_CONSOLE_FILE), "utf8")).toContain("failed after");
+    expect(trace.find((t) => t.payload?.note === "sandbox_console").payload.error).toContain("sandbox_runner_crashed");
+  });
+});
+
+/**
+ * The conformance sweep. Every adapter module in this directory is loaded and
+ * handed a sandboxed definition; the only acceptable outcomes are (a) it
+ * called the sandbox boundary, or (b) it threw SandboxUnsupportedError naming
+ * itself. Anything else — a host spawn, a quiet success, a different error —
+ * means the adapter ignored the block, which is the WM-313 defect.
+ */
+describe("every adapter decides about def.sandbox (WM-313 conformance)", () => {
+  const dir = import.meta.dir;
+  const modules = readdirSync(dir)
+    .filter((f) => f.endsWith(".mjs") && !f.endsWith(".test.mjs") && f !== "sandboxed.mjs")
+    .map((f) => f.replace(/\.mjs$/, ""));
+
+  test("the sweep sees the adapters the worker can load", () => {
+    expect(modules).toEqual(expect.arrayContaining(["actions", "agy", "claude", "command", "cursor", "fake", "pi"]));
+  });
+
+  for (const name of modules) {
+    test(`${name}: honours the sandbox or refuses typed — never runs on the host`, async () => {
+      const mod = await import(`./${name}.mjs`);
+      expect(["gondolin", "unsupported"]).toContain(mod.SANDBOX_SUPPORT);
+
+      const workspaceDir = ws();
+      const promptPath = path.join(workspaceDir, "prompt.md");
+      writeFileSync(promptPath, "conformance prompt", "utf8");
+      writeFileSync(path.join(workspaceDir, "input.json"), "{}\n", "utf8");
+      let boundaryHit = false;
+      const runSandbox = async ({ workspaceDir: dirSeen }) => {
+        boundaryHit = true;
+        writeFileSync(path.join(dirSeen, "result.json"), JSON.stringify({ schemaVersion: "factory.agent-result/v1", terminalState: "completed" }));
+        return { exitCode: 0, timedOut: false, bootMs: 1 };
+      };
+      const def = {
+        ref: `${name}-sandboxed@1`,
+        promptPath,
+        mutating: false,
+        // command adapter shape; ignored by the others
+        command: ["/bin/true"],
+        sandbox: { provider: "gondolin", allowedHosts: [] },
+      };
+      let caught = null;
+      try {
+        await mod.execute({
+          spec: { agent: def.ref, input: { repos: ["ok"] } },
+          def,
+          workspaceDir,
+          timeoutMs: 2000,
+          // A PATH with nothing on it: an adapter that ignores the block and
+          // goes looking for its host CLI fails loudly instead of running it.
+          env: { PATH: workspaceDir },
+          runSandbox,
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      if (mod.SANDBOX_SUPPORT === "gondolin") {
+        expect(caught).toBeNull();
+        expect(boundaryHit).toBe(true);
+      } else {
+        expect(boundaryHit).toBe(false);
+        expect(caught).toBeInstanceOf(SandboxUnsupportedError);
+        expect(caught.adapter).toBe(name);
+        expect(caught.code).toBe("sandbox_unsupported");
+        // Refusal happens before anything touches the workspace.
+        expect(existsSync(path.join(workspaceDir, ".transcript.json"))).toBe(false);
+        expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Fixes WM-313

> Attended session, human-authorized (comment on WM-313, 2026-08-17): credential handling touched only through the existing placeholder mechanism; no real secret values in code, fixtures, logs or this PR; tests use fake keys; fail closed, never fall back to host execution. **Reviewer: this PR touches credential handling — read it in full.**

## What / why

`lib/sandbox/` (WM-185) existed but only the `command` adapter honoured a definition's `sandbox` block; `pi` and `claude` — the adapters that spawn LLM agents with a shell — ignored it, so a definition asking for isolation silently got a host process. This lifts the decision out of `command.mjs` into a seam every adapter goes through, and teaches `pi` to execute inside the VM.

- **`lib/adapters/sandboxed.mjs` (new, exception under Owned Paths)** — the shared decision + transport:
  - `sandboxRequested(def)` / `refuseSandbox(adapter, def, reason)` → `SandboxUnsupportedError` (`code: sandbox_unsupported`, `.adapter`) for adapters that cannot execute in-VM. Anything but absent/null `sandbox` is a request (a malformed block is refused by policy normalization, never treated as "off").
  - `runSandboxed(...)` wraps `runInSandbox`: enforces an absolute guest binary, optional stdin-from-workspace-file (`/bin/sh -c 'exec "$0" "$@" < ./<file>' <bin> <args…>` — constant script, positional params, nothing re-parsed), writes the guest console to `.sandbox-console.log` in the workspace + a `lifecycle` trace event (`note: sandbox_console`) on every path, and preserves the host contract: guest timeout → `{exitCode:null, timedOut:true}`, cooperative cancel → `{exitCode:null, timedOut:false}` (the runner's post-abort `sandbox_runner_crashed` is mapped only when *we* aborted; the same crash without an abort is rethrown typed).
  - `guestEnvironment()` is **built, not inherited**: `HOME=/root`, `PATH=/usr/local/bin:…`, `TERM`, locale vars only. The caller's `env` (which for `serve` is all of `process.env`) is never forwarded to the guest. Secret placeholders are added after this by `runner.mjs`, so nothing here can shadow one.
  - `guestBinary(def, adapter)`: `/usr/local/bin/<cli>` per the image contract, overridable via `sandbox.guestBinaries.<adapter>` (must be absolute) — the virtio-fs route to supply a toolchain from a read-only `sandbox.mounts` entry rather than rebuilding per run.
- **`pi.mjs`** — `SANDBOX_SUPPORT = "gondolin"`. `execute()` branches to `executeSandboxed` *before* the host env is assembled or a host CLI is looked for. Prompt (`promptPath` + `PROMPT_SUFFIX`) is written to `.prompt.md` in the workspace and redirected onto stdin inside the guest; cwd is the policy's workspace mount so `./input.json`/`./result.json` are the host workspace the verifier reads (success, failure and timeout — VFS writes land on the host as they happen and `runInSandbox` resolves only after the runner exits). `PI_OFFLINE=1` in the guest. `--fork <session>` is not passed in-guest (sessions are per-VM; a lifecycle note is emitted if a resume was offered). Everything downstream of stdout — transcript, trace, denial detection, usage — is one implementation (`attachOutput`) shared by both paths, so they cannot drift.
- **`claude.mjs`** — **deferred, fail-closed.** `SANDBOX_SUPPORT = "unsupported"`; `refuseSandbox("claude", …)` is the first line of `execute()`, with `SANDBOX_DEFERRAL_REASON` naming what has no guest translation yet: `--mcp-config` points at `FACTORY_ROOT/config/mcp/claude.json` whose only server is `npx`-fetched (a deny-all guest cannot start it); the generated `--settings` for `mutating:false` carries host absolute deny paths and enables Claude Code's own OS sandbox (`sandbox.enabled` + `allowUnsandboxedCommands:false` → every Bash call denied if seatbelt/bubblewrap is absent in Alpine); and auth becomes API-key placeholder mode, a billing profile change (guest-image RFC §4.2). pi shares only the last point. Follow-up filed: **WM-631**.
- **`agy.mjs`, `cursor.mjs`, `actions.mjs`, `fake.mjs`** (exceptions, one import + one guard line + `SANDBOX_SUPPORT` each) — refuse typed. Without these the AC "no adapter ignores the block" is unmet, and the conformance sweep would fail; `fake` refuses so `--adapter-override fake` cannot be the way a sandbox requirement disappears.
- **`command.mjs`** — now goes through `runSandboxed` (absolute-path check, console artifact, cancel parity); behaviour and result contract unchanged; `SANDBOX_SUPPORT = "gondolin"`.

## Secrets

Placeholders only. A policy names host env vars; resolution + substitution stay in `lib/sandbox/policy.mjs`/`runner.mjs` (unchanged). This PR adds no code path that reads a secret value. The real-VM pi test declares a secret backed by a test-only fake value and asserts the guest sees `GONDOLIN_SECRET_…`, and that the fake never appears in the console artifact or transcript.

## Tests (no hypervisor required; real-VM tests gated behind `preflight()`)

- `sandboxed.test.mjs`: unit tests for the seam + a **conformance sweep** that imports every `lib/adapters/*.mjs` and hands it a sandboxed definition: it must either hit the stubbed VM boundary or throw `SandboxUnsupportedError` naming itself, without touching the workspace. Verified negative: reverting `fake.mjs`/`claude.mjs` guards makes exactly those two entries fail.
- `pi.test.mjs`: stubbed-VM contract (argv/guest binary/prompt file/env isolation/transcript/trace/usage/result.json/console), guest-binary override, no host CLI lookup, resume not forked, nonzero exit, timeout parity (partial result.json survives), cancel parity, unavailable host fails typed, invalid policy refused; plus 3 real-VM tests (skipped without QEMU/SDK): pi-shaped stub mounted read-only at `/opt/tools`, prompt on stdin, result.json on host, placeholder key, timeout cap, cooperative cancel.
- `claude.test.mjs`: refusal is typed, names the adapter, happens before any spawn or workspace write.
- `command.test.mjs`: stubbed seam path + cancel parity; existing real-VM tests unchanged.

## Verification

`bun test event-runtime/lib/adapters event-runtime/lib/sandbox && bun test && bun build/emit.mjs --check && bun run format:check`

- `event-runtime/lib/adapters event-runtime/lib/sandbox`: **235 pass, 0 fail** (run three times; real-VM tests executed on this host, not skipped)
- `bun test` (full, machine loaded with live workers): 1759 tests; web tree green after `cd event-runtime/web && bun install --frozen-lockfile` (737 pass); remaining fails were the known load flakes — `bin/worktree-checkout` (WM-619), `merge.test.mjs` "auxiliary check … base-push workflow" (5 s timeout; passes standalone, no diff in that area), and one `command.test.mjs` "reaper run planned from a clock tick" timeout (passes standalone and in both named-directory runs).
- `bun build/emit.mjs --check`: ok — 90 generated files match (floor-delivery warning about other repos' AGENTS.md is informational)
- `bun run format:check`: clean

## Placement / not in this PR

- Placement is enforced by `lib/workers.mjs` `satisfiesPlacement` at claim time (`worker.mjs` L225) against the `sandbox=gondolin` label that `cli/work.mjs` L84–86 advertises only when `preflight()` passes — untouched. Note: `lib/planner.mjs` L87 derives `placement` only from `def.placement`/`mapping.placement`; a definition with `sandbox:` but no `placement.sandbox` can still be claimed by a non-capable worker and then fails typed (`SandboxUnavailableError` → `adapter_error`) — never host execution. Deriving placement from the sandbox block is noted in WM-631 (outside Owned Paths).
- No `sandbox:` block added to any `agents/*.json` (out of scope). Doc updates (§14.1 still says only `command` runs in Gondolin) are outside Owned Paths → WM-631.
