### PR TITLE
fix(event-runtime-web): recover stale lazy chunks (WM-220)

### DIFF
--- a/event-runtime/web/serve.mjs
+++ b/event-runtime/web/serve.mjs
@@ -56,6 +56,12 @@ Bun.serve({
     if (!resolved.startsWith(DIST)) return new Response("not found", { status: 404 });
     const file = Bun.file(resolved === DIST ? path.join(DIST, "index.html") : resolved);
     if (await file.exists()) return new Response(file);
+    // A stale content-hashed import must fail as a missing module. Returning the
+    // SPA document here disguises it as JavaScript and produces a misleading
+    // MIME error before the route error boundary can recover.
+    if (url.pathname === "/assets" || url.pathname.startsWith("/assets/")) {
+      return new Response("asset not found", { status: 404 });
+    }
     return new Response(Bun.file(path.join(DIST, "index.html")));
   },
 });

--- a/event-runtime/web/serve.test.mjs
+++ b/event-runtime/web/serve.test.mjs
@@ -105,6 +105,22 @@ afterAll(async () => {
   }
 });
 
+describe("event-runtime web static files", () => {
+  test("returns an honest 404 for a stale content-hashed asset", async () => {
+    const response = await fetch(`http://127.0.0.1:${webPort}/assets/Proposals-stale.js`);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("asset not found");
+  });
+
+  test("keeps the SPA fallback for client-side routes", async () => {
+    const response = await fetch(`http://127.0.0.1:${webPort}/proposals`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+  });
+});
+
 describe("event-runtime web API proxy", () => {
   test.each([
     ["GET", undefined],

--- a/event-runtime/web/src/components/ErrorBoundary.test.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import {
+  CHUNK_RELOAD_STORAGE_KEY,
+  ErrorBoundary,
+  claimChunkReload,
+  isChunkLoadError,
+} from "./ErrorBoundary";
+
+afterEach(cleanup);
+
+function chunkFailure() {
+  return new TypeError(
+    "Failed to fetch dynamically imported module: http://127.0.0.1:7667/assets/Proposals-stale.js",
+  );
+}
+
+function BrokenRoute({ error = chunkFailure() }: { error?: Error }): null {
+  throw error;
+}
+
+describe("chunk-load recovery", () => {
+  test("recognizes browser and bundler chunk-load failures", () => {
+    expect(isChunkLoadError(chunkFailure())).toBe(true);
+    expect(isChunkLoadError(Object.assign(new Error("chunk missing"), { name: "ChunkLoadError" }))).toBe(
+      true,
+    );
+    expect(isChunkLoadError(new Error("ordinary render failure"))).toBe(false);
+  });
+
+  test("claims only one automatic reload for the same route and failure window", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const error = chunkFailure();
+
+    expect(claimChunkReload(error, storage, "/#/proposals", 1_000)).toBe(true);
+    expect(claimChunkReload(error, storage, "/#/proposals", 1_001)).toBe(false);
+    expect(claimChunkReload(error, storage, "/#/agents", 1_001)).toBe(true);
+    expect(values.has(CHUNK_RELOAD_STORAGE_KEY)).toBe(true);
+  });
+
+  test("reloads exactly once, then renders the text fallback on a repeated failure", async () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    let reloads = 0;
+    const reload = () => {
+      reloads += 1;
+    };
+
+    const first = render(
+      <ErrorBoundary storage={storage} route="/#/proposals" now={() => 1_000} reload={reload}>
+        <BrokenRoute />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => expect(reloads).toBe(1));
+    expect(first.getByRole("alert").textContent).toContain("Refreshing this tab once");
+    first.unmount();
+
+    const second = render(
+      <ErrorBoundary storage={storage} route="/#/proposals" now={() => 1_001} reload={reload}>
+        <BrokenRoute />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => {
+      expect(second.getByRole("heading", { name: "New version deployed" })).toBeTruthy();
+    });
+    expect(second.getByRole("alert").textContent).toContain(
+      "This tab could not load the updated files. Reload to try again.",
+    );
+    expect(second.getByRole("button", { name: "Reload" })).toBeTruthy();
+    expect(reloads).toBe(1);
+  });
+});

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,120 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+export const CHUNK_RELOAD_STORAGE_KEY = "factory.chunkReload";
+const CHUNK_RELOAD_WINDOW_MS = 5 * 60 * 1000;
+
+type ReloadMarker = {
+  route: string;
+  at: number;
+};
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "ChunkLoadError" ||
+    /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Loading chunk .+ failed/i.test(
+      error.message,
+    )
+  );
+}
+
+function currentRoute(): string {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+/**
+ * Atomically claims the one automatic reload allowed for a route's chunk
+ * failure. Keeping the marker briefly across the reload prevents a broken
+ * deployment from entering a reload loop; route changes and later deploys can
+ * recover independently.
+ */
+export function claimChunkReload(
+  error: unknown,
+  storage: StorageLike,
+  route: string,
+  now = Date.now(),
+): boolean {
+  if (!isChunkLoadError(error)) return false;
+
+  try {
+    const raw = storage.getItem(CHUNK_RELOAD_STORAGE_KEY);
+    if (raw) {
+      const previous = JSON.parse(raw) as Partial<ReloadMarker>;
+      if (
+        previous.route === route &&
+        typeof previous.at === "number" &&
+        now - previous.at < CHUNK_RELOAD_WINDOW_MS
+      ) {
+        return false;
+      }
+    }
+    storage.setItem(CHUNK_RELOAD_STORAGE_KEY, JSON.stringify({ route, at: now }));
+    return true;
+  } catch {
+    // Without a durable guard, an automatic reload could loop forever. Leave
+    // the operator on the explicit fallback instead.
+    return false;
+  }
+}
+
+type Props = {
+  children: ReactNode;
+  reload?: () => void;
+  storage?: StorageLike;
+  route?: string;
+  now?: () => number;
+};
+
+type State = {
+  error: Error | null;
+  reloading: boolean;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, reloading: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, _info: ErrorInfo) {
+    const storage = this.props.storage ?? window.sessionStorage;
+    const route = this.props.route ?? currentRoute();
+    if (claimChunkReload(error, storage, route, this.props.now?.())) {
+      this.setState({ reloading: true }, () => (this.props.reload ?? (() => window.location.reload()))());
+    }
+  }
+
+  render() {
+    const { error, reloading } = this.state;
+    if (!error) return this.props.children;
+
+    const chunkFailure = isChunkLoadError(error);
+    const title = chunkFailure ? "New version deployed" : "The control plane could not render";
+    const detail = reloading
+      ? "Refreshing this tab once to load the new version…"
+      : chunkFailure
+        ? "This tab could not load the updated files. Reload to try again."
+        : "Reload the page to recover. If the problem continues, check the runtime logs.";
+
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-(--surface-0) p-6 text-(--text)">
+        <section role="alert" className="max-w-lg border-l-2 border-(--hue-warn) pl-4">
+          <h1 className="display text-lg font-semibold">{title}</h1>
+          <p className="mt-2 text-sm text-(--text-dim)">{detail}</p>
+          {!reloading && (
+            <button
+              type="button"
+              className="mt-4 rounded-md border border-(--border-strong) px-3 py-1.5 text-sm font-medium hover:bg-(--surface-2)"
+              onClick={() => (this.props.reload ?? (() => window.location.reload()))()}
+            >
+              Reload
+            </button>
+          )}
+        </section>
+      </main>
+    );
+  }
+}

--- a/event-runtime/web/src/main.tsx
+++ b/event-runtime/web/src/main.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./theme.css";
 
 // Polling, not push (webui spec §1): 2 s on focused views, paused in hidden
@@ -19,8 +20,10 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- catch stale lazy-route chunk failures at the root error boundary
- reload once per route, then render an operator-readable recovery surface
- return 404 for missing `/assets/*` files instead of the SPA document

## Verification
- `bun test event-runtime/web` — 743 pass, 0 fail
- `bun run build` in `event-runtime/web` — pass

UX critique: required — SHIP

Fixes WM-220