### PR TITLE
fix(test): make the OPS-404 reaper-tick command-adapter test load-independent (WM-629)

### DIFF
--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -247,10 +247,16 @@ describe("command-adapter registry (OPS-404)", () => {
 
   test("a reaper run planned from a clock tick resolves its argv and executes", async () => {
     const db = openDb(path.join(mkdtempSync(path.join(os.tmpdir(), "evrt-reaper-")), "runtime.db"));
+    // Only the reaper schedule may tick here (WM-629). Spreading the shipped
+    // schedules pulled in every enabled one — e.g. merge-factory — whose
+    // repository-workspace agent makes planAdmittedEvents run pinRepo(), i.e.
+    // a real `git fetch` against ~/.factory/event-runtime/mirrors/factory.git,
+    // twice (planEvent + buildRunSpec). ~1.2 s idle, >5 s under load: 5
+    // VERIFYING failures on 2026-08-17 (WM-616/625/549/618/627, 5003-5390 ms).
+    // The reaper is an ephemeral-workspace command agent: no pin, no git.
     const withReaper = {
       ...registry,
       schedules: {
-        ...registry.schedules,
         reaper: { ...registry.schedules.reaper, enabled: true, approval: "auto" },
       },
     };


### PR DESCRIPTION
Fixes WM-629

## Root cause
The test built its registry with `...registry.schedules`, so every shipped enabled schedule ticked — including `merge-factory`, whose `merge-scan@2` agent has a repository workspace. `planAdmittedEvents` therefore ran `pinRepo()` → `syncMirror()` → a real `git fetch` against `~/.factory/event-runtime/mirrors/factory.git`, twice (planEvent + buildRunSpec). ~1.2 s idle, >5 s under load (5 VERIFYING failures 2026-08-17: WM-616/625/549/618/627 at 5003-5390 ms). The reaper itself is an ephemeral-workspace command agent; the executed command was already a trivial `test -f`.

## Change
Only the reaper schedule is enabled in the test registry — no repo pin, no git, no touching the real runtime home. Test time 628 ms → 122 ms.

## Handoff
Verification: `bun test event-runtime/lib/adapters/command.test.mjs event-runtime/lib/registry.test.mjs` run 10x with two concurrent `bun test event-runtime/lib` loops in other shells — 10/10 pass (36 pass, 0 fail each; suite wall 5.0-13.7 s dominated by WM-185 sandbox tests, the reaper test itself ~120 ms).

UX critique: n/a