### PR TITLE
feat(event-runtime-web): chain Timeline mode — chronological narrative with humanized reasons, durations and next scheduled retry (WM-639)

### DIFF
--- a/event-runtime/web/src/chainTimeline.test.ts
+++ b/event-runtime/web/src/chainTimeline.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, test } from "bun:test";
+import type { ScheduleItem } from "./api";
+import {
+  buildChainTimeline,
+  chainNeedsRevisit,
+  chainViewModeFromQuery,
+  coveringSchedule,
+  formatDelta,
+  formatUntil,
+  humanizeRunReason,
+  loadChainViewMode,
+  saveChainViewMode,
+  specInputRefs,
+  CHAIN_VIEW_STORAGE_KEY,
+} from "./chainTimeline";
+import type { ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
+
+// Fixture: the real 2026-08-17 19:06 case from the ticket — a merge sweep
+// (origin clock tick → merge-scan run) that emitted a merge-fix request for
+// PR #541 / WM-627, planned into run_643c2c35, auto-approved by chain
+// policy, claimed by a worker and refused `merge_fix_pr_moved`.
+const CORR = "clock:merge-factory:2026-08-17T18:45:00.000Z";
+const SCAN_RUN = "run_30f0f8b7-9635-403a-8f83-b17e8d87bfa1";
+const FIX_RUN = "run_643c2c35-838d-47fd-ae37-4051214269ba";
+const FIX_EVENT = "chain-run_30f0f8b7-fix-541-93230d81";
+const FIX_PROPOSAL = "prop_2149ec46-e661-446b-996d-fc38762b57a4";
+
+function chain(overrides?: Partial<ChainView>): ChainView {
+  return {
+    correlationId: CORR,
+    events: [
+      {
+        source: "clock",
+        eventId: CORR,
+        type: "factory.merge.requested",
+        subject: "factory",
+        status: "planned",
+        occurredAt: "2026-08-17T18:45:00.000Z",
+        receivedAt: "2026-08-17T18:45:00.400Z",
+        admittedAt: "2026-08-17T18:45:00.445Z",
+        correlationId: CORR,
+        causationId: null,
+        proposalId: "prop_scan",
+        proposalStatus: "approved",
+        proposalDecision: "run",
+        runId: SCAN_RUN,
+        repos: ["factory"],
+      },
+      {
+        source: "chain",
+        eventId: FIX_EVENT,
+        type: "factory.merge-fix.requested",
+        subject: "factory",
+        status: "planned",
+        occurredAt: "2026-08-17T19:05:58.000Z",
+        receivedAt: "2026-08-17T19:05:58.100Z",
+        admittedAt: "2026-08-17T19:05:58.283Z",
+        correlationId: CORR,
+        causationId: SCAN_RUN,
+        proposalId: FIX_PROPOSAL,
+        proposalStatus: "approved",
+        proposalDecision: "run",
+        runId: FIX_RUN,
+        repos: ["factory"],
+      },
+    ],
+    runs: [
+      {
+        runId: SCAN_RUN,
+        state: "COMPLETED",
+        attempts: 1,
+        agent: "merge-scan@2",
+        adapter: "pi",
+        reasonCode: "ok",
+        eventId: CORR,
+        eventSource: "clock",
+        created_at: "2026-08-17T18:45:00.445Z",
+        updated_at: "2026-08-17T19:05:57.939Z",
+        startedAt: "2026-08-17T18:45:06.198Z",
+        finishedAt: "2026-08-17T19:05:57.939Z",
+        repos: ["factory"],
+      },
+      {
+        runId: FIX_RUN,
+        state: "REFUSED",
+        attempts: 1,
+        agent: "merge-fix@1",
+        adapter: "pi",
+        reasonCode: "merge_fix_pr_moved",
+        eventId: FIX_EVENT,
+        eventSource: "chain",
+        created_at: "2026-08-17T19:06:04.284Z",
+        updated_at: "2026-08-17T19:06:07.657Z",
+        startedAt: "2026-08-17T19:06:05.105Z",
+        finishedAt: "2026-08-17T19:06:07.657Z",
+        repos: ["factory"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function lc(seq: number, from: string | null, to: string, actor: string, reason: string | null, at: string, attempt: number | null = null): LifecycleEvent {
+  return { seq, run_id: FIX_RUN, from_state: from, to_state: to, actor, reason, attempt, at };
+}
+
+function fixRunDetail(): RunDetail {
+  return {
+    run: {
+      runId: FIX_RUN,
+      state: "REFUSED",
+      attempts: 1,
+      idempotencyKey: "idem",
+      specHash: "sha256:spec",
+      created_at: "2026-08-17T19:06:04.284Z",
+      updated_at: "2026-08-17T19:06:07.657Z",
+      spec: {
+        schemaVersion: "factory.run/v1",
+        runId: FIX_RUN,
+        agent: "merge-fix@1",
+        input: { github: "watt-mind/factory", pr: 541, ticket: "WM-627", headSha: "6dbaab46a7f362ea66f907b630e57849e2631915", repo: "factory" },
+        inputHash: "sha256:in",
+        workspace: { type: "worktree" },
+        adapter: "pi",
+        promptVersion: "1",
+        policyVersion: "git:f1ec757",
+        outputContract: "factory.merge-fix-result/v1",
+        capabilities: [],
+        timeoutSeconds: 600,
+        maxAttempts: 1,
+        idempotencyKey: "idem",
+      },
+    },
+    lifecycle: [
+      lc(4749, null, "PROPOSED", "planner", "planned", "2026-08-17T19:06:04.284Z"),
+      lc(4755, "PROPOSED", "APPROVED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
+      lc(4756, "APPROVED", "QUEUED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
+      lc(4765, "QUEUED", "LEASED", "worker_30596_69", "claimed", "2026-08-17T19:06:05.102Z", 1),
+      lc(4766, "LEASED", "RUNNING", "worker_30596_69", "started", "2026-08-17T19:06:05.105Z", 1),
+      lc(4772, "RUNNING", "VERIFYING", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z", 1),
+      lc(4773, "VERIFYING", "REFUSED", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z", 1),
+    ],
+    attempts: [],
+    result: { terminalState: "refused", reasonCode: "merge_fix_pr_moved" },
+    receipt: null,
+    workspace: null,
+    observedModel: null,
+  };
+}
+
+function proposal(overrides?: Partial<Proposal>): Proposal {
+  return {
+    id: FIX_PROPOSAL,
+    decision: "run",
+    status: "approved",
+    expired: false,
+    created_at: "2026-08-17T19:06:04.284Z",
+    ttl_seconds: 1800,
+    decided_at: "2026-08-17T19:06:04.284Z",
+    decided_by: "chain-auto-approval",
+    reason: null,
+    runId: FIX_RUN,
+    eventId: FIX_EVENT,
+    eventSource: "chain",
+    agent: "merge-fix@1",
+    spec: null,
+    repos: ["factory"],
+    ...overrides,
+  };
+}
+
+function schedule(overrides?: Partial<ScheduleItem>): ScheduleItem {
+  return {
+    loop: "merge-factory",
+    repo: "factory",
+    every: "15m",
+    cadenceSeconds: 900,
+    eventType: "factory.merge.requested",
+    approval: "auto",
+    catchUp: "last",
+    singleton: true,
+    enabled: true,
+    lastSlot: "2026-08-17T19:00:00.000Z",
+    lastCompletedSlot: "2026-08-17T19:00:00.000Z",
+    neverCompleted: false,
+    nextDue: "2026-08-17T19:15:00.000Z",
+    intervalsLate: 0,
+    stopped: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+const NOW = Date.parse("2026-08-17T19:06:30.000Z");
+
+function build(extra?: Partial<Parameters<typeof buildChainTimeline>[0]>) {
+  return buildChainTimeline({
+    chain: chain(),
+    runDetails: { [FIX_RUN]: fixRunDetail() },
+    proposals: [proposal()],
+    schedules: [schedule()],
+    inbox: [],
+    now: NOW,
+    ...extra,
+  });
+}
+
+describe("buildChainTimeline", () => {
+  test("orders oldest first, one row per step, with a Δ gutter and the refusal humanized", () => {
+    const { rows } = build();
+    const badges = rows.map((r) => `${r.badge}${r.at ? "" : ""}`);
+    // origin admitted → planned scan → scan LEASED (fallback rows: no detail
+    // loaded for the scan run) → scan COMPLETED → fix admitted → fix planned
+    // → fix LEASED → fix REFUSED → next
+    expect(badges).toEqual(["admitted", "planned", "RUNNING", "COMPLETED", "admitted", "planned", "LEASED", "REFUSED", "next"]);
+    const ats = rows.filter((r) => r.kind !== "next").map((r) => Date.parse(r.at!));
+    expect([...ats].sort((a, b) => a - b)).toEqual(ats);
+
+    const admitted = rows[4];
+    expect(admitted.actor).toBe("chain");
+    expect(admitted.what).toBe("factory.merge-fix.requested (PR #541, WM-627)");
+    expect(admitted.refs.map((r) => r.kind)).toEqual(["event", "pr", "ticket"]);
+    expect(admitted.refs.find((r) => r.kind === "pr")?.href).toBe("https://github.com/watt-mind/factory/pull/541");
+
+    const planned = rows[5];
+    expect(planned.actor).toBe("planner");
+    expect(planned.what).toBe("merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)");
+    expect(planned.nodeId).toBe(`run:${FIX_RUN}`);
+    expect(planned.refs.map((r) => r.kind)).toEqual(["proposal", "run", "agent"]);
+    expect(formatDelta(planned.deltaMs)).toBe("+6s");
+
+    const leased = rows[6];
+    expect(leased.actor).toBe("worker_30596_69");
+    expect(formatDelta(leased.deltaMs)).toBe("+<1s");
+
+    const refused = rows[7];
+    expect(refused.badge).toBe("REFUSED");
+    expect(refused.actor).toBe("merge-fix@1");
+    expect(refused.reason).toEqual({ text: "PR head moved after the plan (planned at 6dbaab4)", raw: "merge_fix_pr_moved" });
+    expect(formatDelta(refused.deltaMs)).toBe("+3s");
+    // APPROVED / QUEUED / RUNNING(+3ms) / VERIFYING(same instant as REFUSED) are folded.
+    expect(rows.filter((r) => ["APPROVED", "QUEUED", "RUNNING", "VERIFYING"].includes(r.badge) && r.nodeId === `run:${FIX_RUN}`)).toEqual([]);
+  });
+
+  test("first row has no Δ; the next-step row carries none", () => {
+    const { rows } = build();
+    expect(rows[0].deltaMs).toBeNull();
+    expect(rows.at(-1)!.kind).toBe("next");
+    expect(rows.at(-1)!.deltaMs).toBeNull();
+  });
+
+  test("next-step row names the covering schedule and its nextDue", () => {
+    const { rows } = build();
+    const next = rows.at(-1)!;
+    expect(next.kind).toBe("next");
+    expect(next.actor).toBe("merge-factory");
+    expect(next.what).toMatch(/^re-examines at \d{2}:\d{2} \(in 8m 30s\)$/);
+    expect(next.refs).toEqual([{ kind: "schedule", label: "merge-factory", id: "merge-factory" }]);
+    expect(next.muted).toBe(true);
+  });
+
+  test("uncovered chain: no automatic retry, linking the open inbox item when one references it", () => {
+    const item: InboxItem = {
+      id: "inbox_1",
+      kind: "decision_needed",
+      severity: "warn",
+      title: "merge-fix refused for PR #541",
+      body: null,
+      refs: { runId: FIX_RUN },
+      source: "cli",
+      createdAt: "2026-08-17T19:06:10.000Z",
+      ackedAt: null,
+      resolvedAt: null,
+      resolvedBy: null,
+      delivery: {},
+    };
+    const disabled = build({ schedules: [schedule({ enabled: false })], inbox: [item] });
+    const next = disabled.rows.at(-1)!;
+    expect(next.kind).toBe("next");
+    expect(next.what).toBe("no automatic retry — needs a decision");
+    expect(next.refs).toEqual([{ kind: "inbox", label: item.title, id: "inbox_1" }]);
+
+    const otherRepo = build({ schedules: [schedule({ repo: "cashsaas" })] });
+    expect(otherRepo.rows.at(-1)!.what).toBe("no automatic retry — needs a decision");
+    expect(otherRepo.rows.at(-1)!.refs).toEqual([]);
+  });
+
+  test("no next-step row when the chain completed or is still running", () => {
+    const completed = chain();
+    completed.runs[1] = { ...completed.runs[1], state: "COMPLETED", reasonCode: "ok" };
+    expect(chainNeedsRevisit(completed)).toBe(false);
+    expect(build({ chain: completed, runDetails: {} }).rows.some((r) => r.kind === "next")).toBe(false);
+
+    const running = chain();
+    running.runs[1] = { ...running.runs[1], state: "RUNNING", finishedAt: null, reasonCode: null };
+    expect(chainNeedsRevisit(running)).toBe(false);
+    expect(build({ chain: running, runDetails: {} }).rows.some((r) => r.kind === "next")).toBe(false);
+  });
+
+  test("noop decisions render the planner's reason humanized with the raw code in title", () => {
+    const view = chain();
+    view.events[1] = { ...view.events[1], status: "noop", proposalDecision: "noop", proposalStatus: "resolved", runId: null };
+    view.runs = [view.runs[0]];
+    const { rows } = build({
+      chain: view,
+      runDetails: {},
+      proposals: [proposal({ decision: "noop", status: "resolved", reason: "ticket_assigned", runId: null, decided_at: null })],
+    });
+    const noop = rows.find((r) => r.badge === "noop")!;
+    expect(noop.actor).toBe("planner");
+    expect(noop.what).toBe("the ticket is already assigned");
+    expect(noop.reason).toEqual({ text: "the ticket is already assigned", raw: "ticket_assigned" });
+    expect(noop.nodeId).toBe(`event:chain:${FIX_EVENT}`);
+    expect(rows.at(-1)!.kind).toBe("next");
+  });
+
+  test("falls back to chain summary rows while a run's lifecycle is loading and flags partial", () => {
+    const { rows, partial } = build({ runDetails: {} });
+    expect(partial).toBe(true);
+    const refused = rows.find((r) => r.badge === "REFUSED")!;
+    expect(refused.reason?.text).toBe("PR head moved after the plan");
+    // Without the spec input the event row cannot name the PR / ticket.
+    expect(rows[4].what).toBe("factory.merge-fix.requested");
+  });
+
+  test("nodeOrder lists distinct nodes in narrative order for j/k", () => {
+    const { nodeOrder } = build();
+    expect(nodeOrder).toEqual([`event:clock:${CORR}`, `run:${SCAN_RUN}`, `event:chain:${FIX_EVENT}`, `run:${FIX_RUN}`]);
+  });
+});
+
+describe("helpers", () => {
+  test("humanizeRunReason keeps the suffix and de-snakes unknown codes", () => {
+    expect(humanizeRunReason("auto_approved:chain-policy@1")).toEqual({ text: "auto-approved: chain-policy@1", raw: "auto_approved:chain-policy@1" });
+    expect(humanizeRunReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
+    expect(humanizeRunReason(null)).toBeNull();
+  });
+
+  test("formatDelta / formatUntil", () => {
+    expect(formatDelta(null)).toBe("");
+    expect(formatDelta(0)).toBe("+0s");
+    expect(formatDelta(400)).toBe("+<1s");
+    expect(formatDelta(6_000)).toBe("+6s");
+    expect(formatDelta(65_000)).toBe("+1m 5s");
+    expect(formatUntil(NOW + 9 * 60_000, NOW)).toBe("in 9m");
+    expect(formatUntil(NOW - 3 * 60_000, NOW)).toBe("overdue by 3m");
+    expect(formatUntil(NOW + 5_000, NOW)).toBe("now");
+  });
+
+  test("specInputRefs picks PR + ticket out of a merge-fix input", () => {
+    expect(specInputRefs({ github: "watt-mind/factory", pr: 541, ticket: "WM-627" })).toEqual([
+      { kind: "pr", label: "PR #541", id: "https://github.com/watt-mind/factory/pull/541", href: "https://github.com/watt-mind/factory/pull/541" },
+      { kind: "ticket", label: "WM-627", id: "WM-627" },
+    ]);
+    expect(specInputRefs(null)).toEqual([]);
+  });
+
+  test("coveringSchedule ignores disabled/stopped loops and matches repo", () => {
+    const origin = chain().events[0];
+    expect(coveringSchedule(origin, [schedule({ stopped: true })])).toBeNull();
+    expect(coveringSchedule(origin, [schedule({ repo: null })])?.loop).toBe("merge-factory");
+    expect(coveringSchedule(origin, [schedule({ eventType: "factory.work.requested" })])).toBeNull();
+  });
+
+  test("view mode persists and ?view= parses", () => {
+    const store = new Map<string, string>();
+    const storage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => void store.set(k, v) };
+    expect(loadChainViewMode(storage)).toBe("graph");
+    saveChainViewMode("timeline", storage);
+    expect(store.get(CHAIN_VIEW_STORAGE_KEY)).toBe("timeline");
+    expect(loadChainViewMode(storage)).toBe("timeline");
+    store.set(CHAIN_VIEW_STORAGE_KEY, "bogus");
+    expect(loadChainViewMode(storage)).toBe("graph");
+    expect(chainViewModeFromQuery(new URLSearchParams("view=timeline&node=x"))).toBe("timeline");
+    expect(chainViewModeFromQuery(new URLSearchParams("view=nope"))).toBeNull();
+    expect(chainViewModeFromQuery(new URLSearchParams(""))).toBeNull();
+  });
+});

--- a/event-runtime/web/src/chainTimeline.test.ts
+++ b/event-runtime/web/src/chainTimeline.test.ts
@@ -227,6 +227,8 @@ describe("buildChainTimeline", () => {
     expect(planned.what).toBe("merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)");
     expect(planned.nodeId).toBe(`run:${FIX_RUN}`);
     expect(planned.refs.map((r) => r.kind)).toEqual(["proposal", "run", "agent"]);
+    expect(rows[6].refs.map((r) => r.kind)).toEqual(["run"]);
+    expect(rows[7].refs.map((r) => r.kind)).toEqual(["run", "pr", "ticket"]);
     expect(formatDelta(planned.deltaMs)).toBe("+6s");
 
     const leased = rows[6];

--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -399,15 +399,15 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
   for (const run of chain.runs) {
     const nodeId = runNodeId(run.runId);
     const detail = runDetails[run.runId];
-    const refs = dedupeRefs([
-      { kind: "run", label: shortRunId(run.runId), id: run.runId },
-      ...(run.agent ? [{ kind: "agent" as const, label: run.agent, id: run.agent }] : []),
-      ...runRefs(run.runId),
-    ]);
+    // Every lifecycle row links its run; only the terminal row repeats the
+    // PR / ticket it decided about — the actor column already names the agent.
+    const runRef: TimelineRef = { kind: "run", label: shortRunId(run.runId), id: run.runId };
+    const stepRefs = [runRef];
+    const outcomeRefs = dedupeRefs([runRef, ...runRefs(run.runId)]);
     const actorLabel = run.agent ?? shortRunId(run.runId);
     if (!detail) {
       partial = true;
-      drafts.push(...fallbackRunRows(run, nodeId, refs, decidedRuns.has(run.runId), actorLabel));
+      drafts.push(...fallbackRunRows(run, nodeId, stepRefs, decidedRuns.has(run.runId), actorLabel));
       continue;
     }
     const lifecycle = [...detail.lifecycle].sort((a, b) => a.at.localeCompare(b.at) || a.seq - b.seq);
@@ -459,7 +459,7 @@ export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
           actor,
           what,
           reason,
-          refs,
+          refs: TERMINAL.has(entry.to_state) ? outcomeRefs : stepRefs,
           muted: false,
         },
       });

--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -1,0 +1,589 @@
+/**
+ * Chain timeline (WM-639): the chronological narrative of one correlation id.
+ *
+ * The chain graph (WM-527) answers "what is connected to what"; this module
+ * answers "what happened, in what order, and what happens next". It is a
+ * pure client-side join of:
+ *   - `GET /chain/:correlationId` — every event and run in the chain,
+ *   - `GET /runs/:id` per run — the lifecycle rows (LEASED, REFUSED, …),
+ *   - `GET /proposals?status=all` — planner decisions with their timestamps,
+ *   - `GET /schedules` — which loop will re-examine a refused/noop chain,
+ *   - `GET /inbox?status=open` — the decision the operator owes when none will.
+ * Everything here is pure so the row grammar can be tested from fixtures.
+ */
+import type { ScheduleItem } from "./api";
+import { eventNodeId, runNodeId } from "./graph/chainModel";
+import { formatDuration } from "./ticketJourney";
+import type { ChainEvent, ChainRun, ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
+
+// ---------------------------------------------------------------------------
+// View mode (Graph | Timeline), persisted like the other display options.
+// ---------------------------------------------------------------------------
+
+export type ChainViewMode = "graph" | "timeline";
+export const CHAIN_VIEW_MODES: readonly ChainViewMode[] = ["graph", "timeline"];
+export const CHAIN_VIEW_STORAGE_KEY = "evrt-chain-view";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function isChainViewMode(value: unknown): value is ChainViewMode {
+  return value === "graph" || value === "timeline";
+}
+
+/** Persisted mode; graph when nothing (or garbage) is stored. */
+export function loadChainViewMode(storage: StorageLike | null = defaultStorage()): ChainViewMode {
+  try {
+    const raw = storage?.getItem(CHAIN_VIEW_STORAGE_KEY);
+    return isChainViewMode(raw) ? raw : "graph";
+  } catch {
+    return "graph";
+  }
+}
+
+export function saveChainViewMode(mode: ChainViewMode, storage: StorageLike | null = defaultStorage()): void {
+  try {
+    storage?.setItem(CHAIN_VIEW_STORAGE_KEY, mode);
+  } catch {
+    // Private mode / quota: the toggle still works for the session.
+  }
+}
+
+/** `?view=timeline` on a chain deep link; null when absent or unknown. */
+export function chainViewModeFromQuery(query: URLSearchParams): ChainViewMode | null {
+  const raw = query.get("view");
+  return isChainViewMode(raw) ? raw : null;
+}
+
+function defaultStorage(): StorageLike | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reasons. Local table until WM-594 lands `src/reasons.ts` (humanizeReason);
+// this folds into that map on rebase.
+// ---------------------------------------------------------------------------
+
+export const RUN_REASONS: Record<string, string> = {
+  // lifecycle actors' own reasons
+  planned: "planned",
+  claimed: "claimed",
+  started: "started",
+  ok: "completed",
+  auto_approved: "auto-approved",
+  approved: "approved",
+  observed: "observed — nothing to do",
+  duplicate_run: "a run for this input already exists",
+  previous_run_in_flight: "the previous run is still in flight",
+  proposal_expired: "the proposal expired before anyone approved it",
+  needs_human: "needs a human decision",
+  attempts_exhausted: "attempts are exhausted",
+  timeout: "timed out",
+  cancelled: "cancelled by the operator",
+  // planner refusals (lib/planner.mjs)
+  capacity_full: "capacity is full for this repo",
+  ticket_assigned: "the ticket is already assigned",
+  ticket_dispatch_already_live: "a dispatch is already live for this ticket",
+  same_ticket_worktree_held: "the ticket worktree is still held",
+  ticket_escalated: "the ticket is escalated",
+  ticket_not_agent_ready: "the ticket is not agent-ready",
+  ticket_not_found: "the ticket was not found in Linear",
+  ticket_not_todo: "the ticket is not in Todo",
+  ticket_security: "the ticket is security-labelled — humans only",
+  owned_paths_overlap: "owned paths overlap a live run",
+  owned_paths_not_closed: "owned paths are not a closed set",
+  owned_paths_unknown: "owned paths are unknown",
+  no_worktree_scripts: "the repo ships no worktree scripts",
+  repo_report_only: "the repo is report-only",
+  repo_unconfigured: "the repo is not configured for Linear",
+  merge_fix_pr_moved: "PR head moved after the plan",
+  merge_fix_pr_not_found: "the PR was not found",
+  merge_fix_pr_not_open: "the PR is no longer open",
+  merge_fix_pr_read_failed: "the PR could not be read from GitHub",
+  merge_fix_run_active: "another run is already working on this PR",
+  merge_fix_run_check_failed: "could not check for competing runs",
+  merge_fix_owned_paths_moved: "the fix touches paths outside the ticket's owned paths",
+  merge_fix_owned_paths_unknown: "the ticket's owned paths could not be parsed",
+  merge_fix_ticket_escalated: "the ticket is escalated",
+  merge_fix_ticket_not_found: "the ticket was not found in Linear",
+  merge_fix_ticket_read_failed: "the ticket could not be read from Linear",
+  merge_fix_ticket_security: "the ticket is security-labelled — humans only",
+  merge_fix_ticket_state: "the ticket is not In Review / In Progress",
+  // worker / verify (lib/worker.mjs, lib/verify.mjs)
+  agent_definition_mismatch: "the agent definition changed since the plan",
+  claim_lock_contention: "another worker held the claim lock",
+  claim_lock_starvation: "could not win the claim lock",
+  contract_violation: "the output violated its contract",
+  linear_unconfigured: "Linear is not configured",
+  unknown_adapter: "unknown adapter",
+  workspace_integrity_violation: "the workspace was modified outside the run",
+  worktree_gate_unknown: "the worktree gate could not decide",
+};
+
+export interface HumanReason {
+  text: string;
+  raw: string;
+}
+
+/**
+ * `code[:suffix]` → sentence, keeping any suffix (policy version, detail)
+ * as a mono-ish tail. Unknown codes are de-snaked rather than hidden.
+ */
+export function humanizeRunReason(reason: string | null | undefined): HumanReason | null {
+  if (!reason) return null;
+  const [code, ...suffix] = reason.split(":");
+  const words = RUN_REASONS[code] ?? code.replaceAll("_", " ").trim();
+  const tail = suffix.join(":").trim();
+  return { text: tail ? `${words}: ${tail}` : words, raw: reason };
+}
+
+// ---------------------------------------------------------------------------
+// Rows
+// ---------------------------------------------------------------------------
+
+export type TimelineRefKind = "event" | "run" | "proposal" | "pr" | "ticket" | "agent" | "schedule" | "inbox";
+
+export interface TimelineRef {
+  kind: TimelineRefKind;
+  /** Short display label ("PR #541", "WM-627", "run_643c2c35"). */
+  label: string;
+  /** The object id — run id, proposal id, ticket id, loop, inbox id, PR URL. */
+  id: string;
+  /** Companion id where one is not enough (event source). */
+  source?: string;
+  /** Absolute href when the object lives outside the SPA (PR URL). */
+  href?: string;
+}
+
+export type TimelineRowKind = "event" | "decision" | "lifecycle" | "next";
+export type TimelineHues = "event" | "decision" | "run" | "muted";
+
+export interface ChainTimelineRow {
+  id: string;
+  kind: TimelineRowKind;
+  /** Chain graph node this row belongs to — Enter opens its pane. */
+  nodeId: string | null;
+  at: string | null;
+  /** Milliseconds since the previous row; null on the first row / the next-step row. */
+  deltaMs: number | null;
+  badge: string;
+  hues: TimelineHues;
+  actor: string | null;
+  what: string;
+  reason: HumanReason | null;
+  refs: TimelineRef[];
+  muted: boolean;
+}
+
+export interface ChainTimeline {
+  rows: ChainTimelineRow[];
+  /** Distinct node ids in row order — j/k traversal in timeline mode. */
+  nodeOrder: string[];
+  /** True when at least one run's lifecycle is still being fetched. */
+  partial: boolean;
+}
+
+export interface ChainTimelineInput {
+  chain: ChainView;
+  /** `GET /runs/:id` per run in the chain; missing while loading. */
+  runDetails: Record<string, RunDetail | undefined>;
+  proposals: Proposal[];
+  schedules: ScheduleItem[];
+  inbox: InboxItem[];
+  /** Wall clock (ms) — drives "in 9m" on the next-step row. */
+  now: number;
+}
+
+const TERMINAL = new Set(["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"]);
+const REVISIT_STATES = new Set(["REFUSED", "FAILED", "TIMED_OUT"]);
+const REVISIT_EVENT_STATUSES = new Set(["noop", "human_needed", "dead_lettered"]);
+
+function ms(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+export function shortRunId(runId: string): string {
+  const m = runId.match(/^(run_[0-9a-f]{8})/);
+  return m ? m[1] : runId.length > 16 ? `${runId.slice(0, 16)}…` : runId;
+}
+
+export function shortSha(sha: string): string {
+  return /^[0-9a-f]{12,}$/i.test(sha) ? sha.slice(0, 7) : sha;
+}
+
+/** `+6s`, `+<1s`, `+1m 5s` — the Δ gutter. */
+export function formatDelta(deltaMs: number | null): string {
+  if (deltaMs == null || !Number.isFinite(deltaMs) || deltaMs < 0) return "";
+  if (deltaMs === 0) return "+0s";
+  if (deltaMs < 1000) return "+<1s";
+  return `+${formatDuration(deltaMs)}`;
+}
+
+/** `in 9m`, `now`, `overdue by 3m`. */
+export function formatUntil(atMs: number, now: number): string {
+  const diff = atMs - now;
+  if (Math.abs(diff) < 30_000) return "now";
+  return diff > 0 ? `in ${formatDuration(diff)}` : `overdue by ${formatDuration(-diff)}`;
+}
+
+/** Ticket + PR references named by a run's spec input (merge-fix, dispatch, …). */
+export function specInputRefs(input: unknown): TimelineRef[] {
+  const refs: TimelineRef[] = [];
+  if (!input || typeof input !== "object") return refs;
+  const record = input as Record<string, unknown>;
+  const github = typeof record.github === "string" && /^[^/]+\/[^/]+$/.test(record.github) ? record.github : null;
+  const pr = record.pr ?? record.prNumber ?? record.pullRequestNumber;
+  const prNumber = typeof pr === "number" ? pr : typeof pr === "string" && /^\d+$/.test(pr) ? Number(pr) : null;
+  const prUrl =
+    typeof record.prUrl === "string" && /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(record.prUrl)
+      ? record.prUrl
+      : prNumber != null && github
+        ? `https://github.com/${github}/pull/${prNumber}`
+        : null;
+  if (prNumber != null || prUrl) {
+    const number = prNumber ?? Number(prUrl!.match(/\/pull\/(\d+)/)?.[1]);
+    refs.push({ kind: "pr", label: `PR #${number}`, id: prUrl ?? String(number), href: prUrl ?? undefined });
+  }
+  for (const key of ["ticket", "ticketId", "issue", "issueId"]) {
+    const value = record[key];
+    if (typeof value === "string" && /^[A-Z][A-Z0-9]{1,9}-\d+$/.test(value.trim().toUpperCase())) {
+      refs.push({ kind: "ticket", label: value.trim().toUpperCase(), id: value.trim().toUpperCase() });
+      break;
+    }
+  }
+  return refs;
+}
+
+function dedupeRefs(refs: TimelineRef[]): TimelineRef[] {
+  const seen = new Set<string>();
+  return refs.filter((ref) => {
+    const key = `${ref.kind}:${ref.id}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function approvalNote(lifecycle: LifecycleEvent[], proposal: Proposal | undefined): string | null {
+  const approved = lifecycle.find((entry) => entry.to_state === "APPROVED");
+  if (approved) {
+    const reason = approved.reason ?? "";
+    if (reason.startsWith("auto_approved")) {
+      const policy = reason.split(":").slice(1).join(":");
+      const by = approved.actor.replace(/-auto-approval$/, "");
+      return `auto-approved: ${policy || by}`;
+    }
+    return `approved by ${approved.actor}`;
+  }
+  if (proposal?.status === "approved") return `approved by ${proposal.decided_by ?? "operator"}`;
+  if (proposal?.status === "rejected") return `rejected by ${proposal.decided_by ?? "operator"}`;
+  if (proposal?.status === "open") return "awaiting approval";
+  return null;
+}
+
+/** Reason detail the row can add from the spec: which PR head the plan saw. */
+function reasonDetail(code: string | null, input: unknown): string | null {
+  if (!code || !input || typeof input !== "object") return null;
+  const record = input as Record<string, unknown>;
+  if (code === "merge_fix_pr_moved" && typeof record.headSha === "string") {
+    return `planned at ${shortSha(record.headSha)}`;
+  }
+  return null;
+}
+
+interface Draft {
+  row: Omit<ChainTimelineRow, "deltaMs">;
+  atMs: number;
+  /** Tie-break for equal timestamps: event < decision < lifecycle(seq). */
+  rank: number;
+}
+
+export function buildChainTimeline(input: ChainTimelineInput): ChainTimeline {
+  const { chain, runDetails, proposals, schedules, inbox, now } = input;
+  const drafts: Draft[] = [];
+  const runsById = new Map(chain.runs.map((run) => [run.runId, run]));
+  const proposalsById = new Map(proposals.map((p) => [p.id, p]));
+  const proposalsByEvent = new Map<string, Proposal>();
+  for (const p of proposals) {
+    if (p.eventId && p.eventSource) {
+      const key = `${p.eventSource}:${p.eventId}`;
+      // History is newest-first; keep the latest decision per event.
+      if (!proposalsByEvent.has(key)) proposalsByEvent.set(key, p);
+    }
+  }
+  const runInput = (runId: string | null | undefined): unknown =>
+    runId ? runDetails[runId]?.run.spec.input : undefined;
+  const runRefs = (runId: string | null | undefined): TimelineRef[] => specInputRefs(runInput(runId));
+
+  const decidedRuns = new Set<string>();
+  let partial = false;
+
+  // --- events + decisions -------------------------------------------------
+  for (const event of chain.events) {
+    const nodeId = eventNodeId(event.source, event.eventId);
+    const admittedMs = ms(event.admittedAt) ?? ms(event.occurredAt) ?? 0;
+    const refs = dedupeRefs([
+      { kind: "event", label: event.type, id: event.eventId, source: event.source },
+      ...runRefs(event.runId),
+    ]);
+    const suffix = refs
+      .filter((r) => r.kind === "pr" || r.kind === "ticket")
+      .map((r) => r.label)
+      .join(", ");
+    drafts.push({
+      atMs: admittedMs,
+      rank: 0,
+      row: {
+        id: `${nodeId}:admitted`,
+        kind: "event",
+        nodeId,
+        at: event.admittedAt ?? event.occurredAt,
+        badge: "admitted",
+        hues: "event",
+        actor: event.causationId ? "chain" : event.source,
+        what: suffix ? `${event.type} (${suffix})` : event.type,
+        reason: null,
+        refs,
+        muted: false,
+      },
+    });
+
+    const proposal =
+      (event.proposalId ? proposalsById.get(event.proposalId) : undefined) ??
+      proposalsByEvent.get(`${event.source}:${event.eventId}`);
+    const decision = proposal?.decision ?? event.proposalDecision ?? null;
+    const status = event.status;
+    const run = event.runId ? runsById.get(event.runId) : proposal?.runId ? runsById.get(proposal.runId) : undefined;
+    const decisionAt = proposal?.created_at ?? run?.created_at ?? null;
+    if (decision || REVISIT_EVENT_STATUSES.has(status)) {
+      const kindLabel = decision === "run" ? "planned" : (decision ?? status);
+      const detail = run ? runDetails[run.runId] : undefined;
+      const note = run ? approvalNote(detail?.lifecycle ?? [], proposal) : null;
+      const reason = decision === "run" ? null : humanizeRunReason(proposal?.reason ?? null);
+      const rowRefs = dedupeRefs([
+        ...(proposal ? [{ kind: "proposal" as const, label: proposal.id.slice(0, 13), id: proposal.id }] : []),
+        ...(run ? [{ kind: "run" as const, label: shortRunId(run.runId), id: run.runId }] : []),
+        ...(run?.agent ? [{ kind: "agent" as const, label: run.agent, id: run.agent }] : []),
+      ]);
+      const what = run
+        ? `${run.agent ? `${run.agent} → ` : ""}${shortRunId(run.runId)}${note ? ` (${note})` : ""}`
+        : (reason?.text ?? kindLabel);
+      if (run) decidedRuns.add(run.runId);
+      const at = decisionAt ?? event.admittedAt;
+      drafts.push({
+        atMs: ms(at) ?? admittedMs,
+        rank: 1,
+        row: {
+          id: `${nodeId}:decision`,
+          kind: "decision",
+          nodeId: run ? runNodeId(run.runId) : nodeId,
+          at,
+          badge: kindLabel,
+          hues: "decision",
+          actor: "planner",
+          what,
+          reason: run ? null : reason,
+          refs: rowRefs,
+          muted: false,
+        },
+      });
+    }
+  }
+
+  // --- run lifecycles -----------------------------------------------------
+  for (const run of chain.runs) {
+    const nodeId = runNodeId(run.runId);
+    const detail = runDetails[run.runId];
+    const refs = dedupeRefs([
+      { kind: "run", label: shortRunId(run.runId), id: run.runId },
+      ...(run.agent ? [{ kind: "agent" as const, label: run.agent, id: run.agent }] : []),
+      ...runRefs(run.runId),
+    ]);
+    const actorLabel = run.agent ?? shortRunId(run.runId);
+    if (!detail) {
+      partial = true;
+      drafts.push(...fallbackRunRows(run, nodeId, refs, decidedRuns.has(run.runId), actorLabel));
+      continue;
+    }
+    const lifecycle = [...detail.lifecycle].sort((a, b) => a.at.localeCompare(b.at) || a.seq - b.seq);
+    const input = detail.run.spec.input;
+    let lastEmitted: LifecycleEvent | null = null;
+    lifecycle.forEach((entry, index) => {
+      const next = lifecycle[index + 1];
+      const state = entry.to_state;
+      if (state === "PROPOSED") {
+        if (decidedRuns.has(run.runId)) return;
+        push(entry, "planned", "decision", "planner", `${actorLabel} → ${shortRunId(run.runId)}`, null);
+        return;
+      }
+      if (state === "APPROVED") return; // folded into the planned row's note
+      if (state === "QUEUED" && (entry.from_state === "APPROVED" || entry.from_state === null)) return;
+      if (state === "RUNNING" && lastEmitted?.to_state === "LEASED" && (ms(entry.at) ?? 0) - (ms(lastEmitted.at) ?? 0) < 1000) return;
+      if (state === "VERIFYING" && next && TERMINAL.has(next.to_state)) return;
+      const reason = humanizeRunReason(entry.reason);
+      const detailText = TERMINAL.has(state) ? reasonDetail(entry.reason, input) : null;
+      const shown = reason && detailText ? { ...reason, text: `${reason.text} (${detailText})` } : reason;
+      const actor = state === "QUEUED" || TERMINAL.has(state) ? actorLabel : entry.actor;
+      const what = TERMINAL.has(state)
+        ? entry.actor && entry.actor !== actorLabel && !entry.actor.startsWith("worker_") ? `by ${entry.actor}` : ""
+        : state === "LEASED" && entry.attempt != null && entry.attempt > 1
+          ? `attempt ${entry.attempt}`
+          : "";
+      push(entry, state, "run", actor, what, shown);
+    });
+
+    function push(
+      entry: LifecycleEvent,
+      badge: string,
+      hues: TimelineHues,
+      actor: string,
+      what: string,
+      reason: HumanReason | null,
+    ) {
+      lastEmitted = entry;
+      drafts.push({
+        atMs: ms(entry.at) ?? 0,
+        rank: 2 + entry.seq / 1e9,
+        row: {
+          id: `${nodeId}:lc:${entry.seq}`,
+          kind: "lifecycle",
+          nodeId,
+          at: entry.at,
+          badge,
+          hues,
+          actor,
+          what,
+          reason,
+          refs,
+          muted: false,
+        },
+      });
+    }
+  }
+
+  drafts.sort((a, b) => a.atMs - b.atMs || a.rank - b.rank || a.row.id.localeCompare(b.row.id));
+
+  const rows: ChainTimelineRow[] = drafts.map((draft, index) => ({
+    ...draft.row,
+    deltaMs: index === 0 ? null : Math.max(0, draft.atMs - drafts[index - 1].atMs),
+  }));
+
+  const nextRow = nextStepRow(chain, schedules, inbox, now);
+  if (nextRow) rows.push(nextRow);
+
+  const nodeOrder: string[] = [];
+  for (const row of rows) {
+    if (row.nodeId && !nodeOrder.includes(row.nodeId)) nodeOrder.push(row.nodeId);
+  }
+  return { rows, nodeOrder, partial };
+}
+
+/** Rows from the chain summary alone, while `GET /runs/:id` is still loading. */
+function fallbackRunRows(run: ChainRun, nodeId: string, refs: TimelineRef[], decided: boolean, actorLabel: string): Draft[] {
+  const out: Draft[] = [];
+  const base = {
+    kind: "lifecycle" as const,
+    nodeId,
+    refs,
+    muted: false,
+  };
+  if (!decided) {
+    out.push({
+      atMs: ms(run.created_at) ?? 0,
+      rank: 2,
+      row: { ...base, id: `${nodeId}:planned`, at: run.created_at, badge: "planned", hues: "decision", actor: "planner", what: `${actorLabel} → ${shortRunId(run.runId)}`, reason: null },
+    });
+  }
+  if (run.startedAt) {
+    out.push({
+      atMs: ms(run.startedAt) ?? 0,
+      rank: 2.5,
+      row: { ...base, id: `${nodeId}:started`, at: run.startedAt, badge: TERMINAL.has(run.state) || run.state === "RUNNING" || run.state === "VERIFYING" ? "RUNNING" : run.state, hues: "run", actor: "worker", what: "", reason: null },
+    });
+  }
+  if (run.finishedAt && TERMINAL.has(run.state)) {
+    out.push({
+      atMs: ms(run.finishedAt) ?? 0,
+      rank: 3,
+      row: { ...base, id: `${nodeId}:finished`, at: run.finishedAt, badge: run.state, hues: "run", actor: actorLabel, what: "", reason: humanizeRunReason(run.reasonCode) },
+    });
+  }
+  return out;
+}
+
+/** The chain's origin: the earliest event with no causation parent. */
+export function chainOriginEvent(chain: Pick<ChainView, "events">): ChainEvent | null {
+  const roots = chain.events.filter((e) => !e.causationId);
+  const pool = roots.length ? roots : chain.events;
+  return [...pool].sort((a, b) => a.admittedAt.localeCompare(b.admittedAt))[0] ?? null;
+}
+
+/** The enabled schedule that will re-emit this chain's origin event, if any. */
+export function coveringSchedule(origin: ChainEvent | null, schedules: ScheduleItem[]): ScheduleItem | null {
+  if (!origin) return null;
+  const candidates = schedules.filter(
+    (s) =>
+      s.enabled &&
+      !s.stopped &&
+      s.eventType === origin.type &&
+      (s.repo == null || origin.repos.length === 0 || origin.repos.includes(s.repo)),
+  );
+  candidates.sort((a, b) => (a.nextDue ?? "￿").localeCompare(b.nextDue ?? "￿"));
+  return candidates[0] ?? null;
+}
+
+/** Whether the chain ended somewhere a loop or a human must revisit. */
+export function chainNeedsRevisit(chain: ChainView): boolean {
+  if (chain.runs.some((run) => !TERMINAL.has(run.state))) return false;
+  return (
+    chain.runs.some((run) => REVISIT_STATES.has(run.state)) ||
+    chain.events.some((event) => REVISIT_EVENT_STATUSES.has(event.status))
+  );
+}
+
+function inboxItemFor(chain: ChainView, inbox: InboxItem[]): InboxItem | null {
+  const runIds = new Set(chain.runs.map((r) => r.runId));
+  const eventIds = new Set(chain.events.map((e) => e.eventId));
+  const proposalIds = new Set(chain.events.map((e) => e.proposalId).filter(Boolean) as string[]);
+  return (
+    inbox.find(
+      (item) =>
+        (item.refs.runId && runIds.has(item.refs.runId)) ||
+        (item.refs.eventId && eventIds.has(item.refs.eventId)) ||
+        (item.refs.proposalId && proposalIds.has(item.refs.proposalId)),
+    ) ?? null
+  );
+}
+
+function nextStepRow(chain: ChainView, schedules: ScheduleItem[], inbox: InboxItem[], now: number): ChainTimelineRow | null {
+  if (!chainNeedsRevisit(chain)) return null;
+  const origin = chainOriginEvent(chain);
+  const schedule = coveringSchedule(origin, schedules);
+  const base = { id: "next", kind: "next" as const, nodeId: null, deltaMs: null, hues: "muted" as const, reason: null, muted: true };
+  if (schedule && schedule.nextDue) {
+    const dueMs = ms(schedule.nextDue);
+    const clock = dueMs == null ? schedule.nextDue : new Date(dueMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+    return {
+      ...base,
+      at: schedule.nextDue,
+      badge: "next",
+      actor: schedule.loop,
+      what: `re-examines at ${clock}${dueMs == null ? "" : ` (${formatUntil(dueMs, now)})`}`,
+      refs: [{ kind: "schedule", label: schedule.loop, id: schedule.loop }],
+    };
+  }
+  const item = inboxItemFor(chain, inbox);
+  return {
+    ...base,
+    at: null,
+    badge: "next",
+    actor: null,
+    what: "no automatic retry — needs a decision",
+    refs: item ? [{ kind: "inbox", label: item.title, id: item.id }] : [],
+  };
+}

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -1,0 +1,226 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { Chain } from "./Chain";
+import { CHAIN_VIEW_STORAGE_KEY } from "../chainTimeline";
+import { createRunDetailFixture, renderWithClient, restoreApi } from "../test-render";
+import type { ChainView, LifecycleEvent, Proposal } from "../types";
+
+const CORR = "clock:merge-factory:2026-08-17T18:45:00.000Z";
+const FIX_RUN = "run_643c2c35-838d-47fd-ae37-4051214269ba";
+const FIX_EVENT = "chain-run_30f0f8b7-fix-541";
+
+function chainView(): ChainView {
+  return {
+    correlationId: CORR,
+    events: [
+      {
+        source: "chain",
+        eventId: FIX_EVENT,
+        type: "factory.merge-fix.requested",
+        subject: "factory",
+        status: "planned",
+        occurredAt: "2026-08-17T19:05:58.000Z",
+        receivedAt: "2026-08-17T19:05:58.100Z",
+        admittedAt: "2026-08-17T19:05:58.283Z",
+        correlationId: CORR,
+        causationId: null,
+        proposalId: "prop_1",
+        proposalStatus: "approved",
+        proposalDecision: "run",
+        runId: FIX_RUN,
+        repos: ["factory"],
+      },
+    ],
+    runs: [
+      {
+        runId: FIX_RUN,
+        state: "REFUSED",
+        attempts: 1,
+        agent: "merge-fix@1",
+        adapter: "pi",
+        reasonCode: "merge_fix_pr_moved",
+        eventId: FIX_EVENT,
+        eventSource: "chain",
+        created_at: "2026-08-17T19:06:04.284Z",
+        updated_at: "2026-08-17T19:06:07.657Z",
+        startedAt: "2026-08-17T19:06:05.105Z",
+        finishedAt: "2026-08-17T19:06:07.657Z",
+        repos: ["factory"],
+      },
+    ],
+  };
+}
+
+function lc(seq: number, from: string | null, to: string, actor: string, reason: string | null, at: string): LifecycleEvent {
+  return { seq, run_id: FIX_RUN, from_state: from, to_state: to, actor, reason, attempt: null, at };
+}
+
+const runDetail = createRunDetailFixture({
+  run: {
+    runId: FIX_RUN,
+    state: "REFUSED",
+    spec: { agent: "merge-fix@1", input: { github: "watt-mind/factory", pr: 541, ticket: "WM-627", headSha: "6dbaab46a7f362ea66f907b630e57849e2631915" } },
+  } as any,
+  lifecycle: [
+    lc(1, null, "PROPOSED", "planner", "planned", "2026-08-17T19:06:04.284Z"),
+    lc(2, "PROPOSED", "APPROVED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
+    lc(3, "APPROVED", "QUEUED", "chain-auto-approval", "auto_approved:chain-policy@1", "2026-08-17T19:06:04.284Z"),
+    lc(4, "QUEUED", "LEASED", "worker_30596_69", "claimed", "2026-08-17T19:06:05.102Z"),
+    lc(5, "LEASED", "RUNNING", "worker_30596_69", "started", "2026-08-17T19:06:05.105Z"),
+    lc(6, "RUNNING", "VERIFYING", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z"),
+    lc(7, "VERIFYING", "REFUSED", "worker_30596_69", "merge_fix_pr_moved", "2026-08-17T19:06:07.657Z"),
+  ],
+});
+
+const proposal: Proposal = {
+  id: "prop_1",
+  decision: "run",
+  status: "approved",
+  expired: false,
+  created_at: "2026-08-17T19:06:04.284Z",
+  ttl_seconds: 1800,
+  decided_at: "2026-08-17T19:06:04.284Z",
+  decided_by: "chain-auto-approval",
+  reason: null,
+  runId: FIX_RUN,
+  eventId: FIX_EVENT,
+  eventSource: "chain",
+  agent: "merge-fix@1",
+  spec: null,
+  repos: ["factory"],
+};
+
+function renderChain(props: Partial<React.ComponentProps<typeof Chain>> = {}) {
+  const selected: Array<string | null> = [];
+  const view = renderWithClient(
+    <Chain
+      correlationId={CORR}
+      focusNodeId={null}
+      onSelectNode={(id) => selected.push(id)}
+      onJumpEvent={() => {}}
+      onJumpRun={() => {}}
+      onOpenRunFull={() => {}}
+      onJumpProposal={() => {}}
+      onJumpAgent={() => {}}
+      {...props}
+    />,
+    {
+      apiMocks: {
+        chain: async () => chainView(),
+        run: async () => runDetail,
+        proposalHistory: async () => ({ proposals: [proposal] }),
+        schedules: async () => ({
+          schedules: [
+            {
+              loop: "merge-factory",
+              repo: "factory",
+              every: "15m",
+              cadenceSeconds: 900,
+              eventType: "factory.merge.requested",
+              approval: "auto",
+              catchUp: "last",
+              singleton: true,
+              enabled: true,
+              lastSlot: null,
+              lastCompletedSlot: null,
+              neverCompleted: false,
+              nextDue: new Date(Date.now() + 9 * 60_000).toISOString(),
+              intervalsLate: 0,
+              stopped: false,
+              error: null,
+            },
+          ],
+        }),
+        inbox: async () => ({ items: [] }),
+      },
+    },
+  );
+  return { ...view, selected };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  window.location.hash = `#/chain/${encodeURIComponent(CORR)}`;
+});
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+  localStorage.clear();
+  window.location.hash = "";
+});
+
+describe("Chain view — Timeline mode (WM-639)", () => {
+  test("Graph | Timeline toggle persists and renders the narrative rows", async () => {
+    const view = renderChain();
+    const timelineTab = await view.findByRole("tab", { name: "Timeline" });
+    expect(view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.click(timelineTab);
+    expect(localStorage.getItem(CHAIN_VIEW_STORAGE_KEY)).toBe("timeline");
+
+    const list = await view.findByRole("list", { name: "Chain timeline" });
+    await waitFor(() => expect(list.textContent).toContain("PR head moved after the plan"));
+    const text = list.textContent ?? "";
+    expect(text).toContain("factory.merge-fix.requested (PR #541, WM-627)");
+    expect(text).toContain("merge-fix@1 → run_643c2c35 (auto-approved: chain-policy@1)");
+    expect(text).toContain("worker_30596_69");
+    expect(text).toContain("+6s");
+    // origin is a merge-fix request (not the schedule's event type) → uncovered.
+    expect(text).toContain("no automatic retry — needs a decision");
+    // Raw reason code rides the title for the humanized text.
+    expect(view.getByTitle("merge_fix_pr_moved")).toBeTruthy();
+    // Jump links: PR opens GitHub, ticket opens the journey.
+    const prLinks = view.getAllByTitle("https://github.com/watt-mind/factory/pull/541") as HTMLAnchorElement[];
+    expect(prLinks.length).toBeGreaterThan(0);
+    expect(prLinks[0].href).toBe("https://github.com/watt-mind/factory/pull/541");
+    const ticketLinks = view.getAllByTitle("Open ticket journey WM-627") as HTMLAnchorElement[];
+    expect(ticketLinks[0].getAttribute("href")).toBe("#/tickets/WM-627");
+  });
+
+  test("`t` toggles the mode and the persisted mode is restored on mount", async () => {
+    localStorage.setItem(CHAIN_VIEW_STORAGE_KEY, "timeline");
+    const view = renderChain();
+    await view.findByRole("list", { name: "Chain timeline" });
+    expect(view.getByRole("tab", { name: "Timeline" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(document.body, { key: "t" });
+    await waitFor(() => expect(view.getByRole("tab", { name: "Graph" }).getAttribute("aria-selected")).toBe("true"));
+    expect(localStorage.getItem(CHAIN_VIEW_STORAGE_KEY)).toBe("graph");
+    expect(view.queryByRole("list", { name: "Chain timeline" })).toBeNull();
+  });
+
+  test("deep link ?view=timeline&node= opens the timeline, lifts the node into the selection, and highlights its rows", async () => {
+    const nodeId = `run:${FIX_RUN}`;
+    window.location.hash = `#/chain/${encodeURIComponent(CORR)}?view=timeline&node=${encodeURIComponent(nodeId)}`;
+    const view = renderChain({ focusNodeId: null });
+    await view.findByRole("list", { name: "Chain timeline" });
+    expect(view.selected).toEqual([nodeId]);
+    // The mode came from the URL, not the store — the persisted preference is untouched.
+    expect(localStorage.getItem(CHAIN_VIEW_STORAGE_KEY)).toBeNull();
+
+    cleanup();
+    const focused = renderChain({ focusNodeId: nodeId });
+    const list = await focused.findByRole("list", { name: "Chain timeline" });
+    await waitFor(() => expect(list.querySelectorAll('[aria-current="true"]').length).toBeGreaterThan(0));
+    for (const li of list.querySelectorAll('[aria-current="true"]')) {
+      expect(li.getAttribute("data-node-id")).toBe(nodeId);
+    }
+    // Enter re-asserts the selection (opens the pane as in graph mode).
+    fireEvent.keyDown(document.body, { key: "Enter" });
+    expect(focused.selected).toContain(nodeId);
+    // The detail pane shows the run, with the reveal action renamed for the mode.
+    expect(await focused.findByRole("button", { name: /Show in timeline/ })).toBeTruthy();
+    expect(focused.getByRole("button", { name: "Open run" })).toBeTruthy();
+  });
+
+  test("j/k in timeline mode walk the narrative order of nodes", async () => {
+    localStorage.setItem(CHAIN_VIEW_STORAGE_KEY, "timeline");
+    const view = renderChain();
+    const list = await view.findByRole("list", { name: "Chain timeline" });
+    await waitFor(() => expect(list.textContent).toContain("REFUSED"));
+    fireEvent.keyDown(document.body, { key: "j" });
+    expect(view.selected).toEqual([`event:chain:${FIX_EVENT}`]);
+  });
+});

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -27,6 +27,7 @@ import {
   buildChainTimeline,
   chainViewModeFromQuery,
   formatDelta,
+  humanizeRunReason,
   loadChainViewMode,
   saveChainViewMode,
   type ChainTimeline,
@@ -226,6 +227,13 @@ export function Chain({
     lastIdentityRef.current = null;
     didInitialFit.current = false;
   }, [correlationId]);
+  // The canvas unmounts in timeline mode; fit it again when it comes back.
+  useEffect(() => {
+    if (timelineOn) {
+      flowRef.current = null;
+      didInitialFit.current = false;
+    }
+  }, [timelineOn]);
 
   useEffect(() => {
     if (!graph) return;
@@ -391,8 +399,10 @@ export function Chain({
 
   return (
     <div className="flex h-full min-w-0">
-      <div className="relative min-w-0 flex-1">
-        <div className="absolute top-4 left-5 z-10 max-w-[60%]">
+      <div className={timelineOn ? "flex min-w-0 flex-1 flex-col" : "relative min-w-0 flex-1"}>
+        {/* Timeline mode keeps the header in flow so scrolled rows never slide under it. */}
+        <div className={timelineOn ? "flex shrink-0 items-start justify-between gap-4 px-5 pt-4 pb-3" : "contents"}>
+        <div className={timelineOn ? "min-w-0 max-w-[60%]" : "absolute top-4 left-5 z-10 max-w-[60%]"}>
           <h1 className="display text-lg font-semibold">Chain</h1>
           <div className="mono truncate text-[11px] text-(--text-faint)" title={correlationId}>
             {correlationId}
@@ -418,7 +428,7 @@ export function Chain({
             </div>
           )}
         </div>
-        <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
+        <div className={timelineOn ? "flex shrink-0 flex-col items-end gap-2" : "absolute top-4 right-4 z-10 flex flex-col items-end gap-2"}>
           <div className="flex items-center gap-2">
             <CopyActions id={correlationId} idLabel="correlation id" />
             <Tabs
@@ -456,6 +466,7 @@ export function Chain({
               <div className="text-[11px] text-(--text-faint)">left border = event status / run state</div>
             </div>
           )}
+        </div>
         </div>
         {timelineOn ? (
           <ChainTimelineList
@@ -589,7 +600,16 @@ export function Chain({
                 />
                 <KV k="adapter" v={selected.run.adapter} />
                 <KV k="attempts" v={String(selected.run.attempts)} />
-                {selected.run.reasonCode && <KV k="reason" v={selected.run.reasonCode} />}
+                {selected.run.reasonCode && (
+                  <KV
+                    k="reason"
+                    v={
+                      <span title={selected.run.reasonCode}>
+                        {humanizeRunReason(selected.run.reasonCode)?.text ?? selected.run.reasonCode}
+                      </span>
+                    }
+                  />
+                )}
                 <KV k="depth" v={`${selected.depth} hop${selected.depth === 1 ? "" : "s"} from origin`} />
                 <KV k="created" v={<Ago iso={selected.run.created_at} now={now} />} />
                 <KV k="started" v={<Ago iso={selected.run.startedAt} now={now} />} />
@@ -723,7 +743,7 @@ function ChainTimelineList({
     }
   };
   return (
-    <div className="h-full overflow-auto pt-24 pb-10 pl-5 pr-5">
+    <div className="min-h-0 flex-1 overflow-auto px-5 pt-1 pb-10">
       {rows.length === 0 ? (
         <div className="text-[12px] text-(--text-faint)">{emptyCopy ?? "No steps recorded for this chain yet."}</div>
       ) : (

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -9,10 +9,11 @@ import {
   type NodeChange,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError } from "../api";
 import { keyGuard, useNow } from "../hooks";
+import { hashSearch } from "../hash";
 import {
   buildChainGraph,
   chainOriginLabel,
@@ -23,9 +24,21 @@ import {
 } from "../graph/chainModel";
 import { CHAIN_EDGE_STYLES, chainNodeTypes } from "../graph/chainNodes";
 import {
+  buildChainTimeline,
+  chainViewModeFromQuery,
+  formatDelta,
+  loadChainViewMode,
+  saveChainViewMode,
+  type ChainTimeline,
+  type ChainTimelineRow,
+  type ChainViewMode,
+  type TimelineRef,
+} from "../chainTimeline";
+import {
   Ago,
   Button,
   CopyActions,
+  DECISION_HUES,
   DetailPane,
   EVENT_STATUS_HUES,
   JumpLink,
@@ -33,10 +46,35 @@ import {
   STATE_HUES,
   Section,
   StateBadge,
+  Tabs,
   shortId,
 } from "../components/ui";
+import type { RunDetail } from "../types";
 
 const INITIAL_FIT_MIN_ZOOM = 0.4;
+
+const TIMELINE_DECISION_HUES: Record<string, string> = { ...DECISION_HUES, planned: DECISION_HUES.run };
+const TIMELINE_EVENT_HUES: Record<string, string> = EVENT_STATUS_HUES;
+const TIMELINE_MUTED_HUES: Record<string, string> = { next: "var(--hue-idle)" };
+
+function huesFor(row: ChainTimelineRow): Record<string, string> {
+  switch (row.hues) {
+    case "event":
+      return TIMELINE_EVENT_HUES;
+    case "decision":
+      return TIMELINE_DECISION_HUES;
+    case "muted":
+      return TIMELINE_MUTED_HUES;
+    default:
+      return STATE_HUES;
+  }
+}
+
+function rowTime(at: string | null): string {
+  if (!at) return "";
+  const t = new Date(at);
+  return Number.isNaN(t.getTime()) ? at : t.toLocaleTimeString([], { hour12: false });
+}
 
 function flowEdges(graph: ChainGraph): Edge[] {
   return graph.edges.map((edge) => ({
@@ -88,6 +126,81 @@ export function Chain({
   const notFound = chainQ.isError && chainQ.error instanceof ApiError && chainQ.error.status === 404;
 
   const graph = useMemo(() => (chainQ.data ? buildChainGraph(chainQ.data) : null), [chainQ.data]);
+
+  // Graph | Timeline (WM-639). `?view=` on a deep link wins for this visit;
+  // the toggle itself persists like the other display options.
+  const [mode, setModeState] = useState<ChainViewMode>(
+    () => chainViewModeFromQuery(hashSearch(window.location.hash)) ?? loadChainViewMode(),
+  );
+  const setMode = useCallback((next: ChainViewMode) => {
+    saveChainViewMode(next);
+    setModeState(next);
+  }, []);
+  // `?node=` is the timeline's deep-link spelling of the path segment; lift it
+  // into the selection so the row highlights and Enter opens the pane.
+  const deepLinkNodeRef = useRef<string | null>(hashSearch(window.location.hash).get("node"));
+  useEffect(() => {
+    const node = deepLinkNodeRef.current;
+    if (!node || focusNodeId) return;
+    deepLinkNodeRef.current = null;
+    onSelectNode(node);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const timelineOn = mode === "timeline";
+  const runIds = useMemo(() => (chainQ.data?.runs ?? []).map((r) => r.runId), [chainQ.data]);
+  const runQs = useQueries({
+    queries: runIds.map((id) => ({
+      queryKey: ["run", id],
+      queryFn: () => api.run(id),
+      enabled: timelineOn,
+      refetchInterval: 3000,
+      retry: 1,
+    })),
+  });
+  const proposalsQ = useQuery({
+    queryKey: ["proposals", "history"],
+    queryFn: () => api.proposalHistory("all"),
+    enabled: timelineOn,
+    refetchInterval: 5000,
+  });
+  const schedulesQ = useQuery({
+    queryKey: ["schedules"],
+    queryFn: api.schedules,
+    enabled: timelineOn,
+    refetchInterval: 10000,
+  });
+  const inboxQ = useQuery({
+    queryKey: ["inbox", "open"],
+    queryFn: () => api.inbox("open"),
+    enabled: timelineOn,
+    refetchInterval: 5000,
+  });
+  // One stable key per fetch generation so the memo below has a fixed-size dep
+  // list whatever the chain's run count is.
+  const runDetailsKey = runQs.map((q) => q.dataUpdatedAt).join(",");
+  const runDetails = useMemo(() => {
+    const out: Record<string, RunDetail | undefined> = {};
+    runIds.forEach((id, i) => {
+      out[id] = runQs[i]?.data;
+    });
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runIds, runDetailsKey]);
+  const timeline: ChainTimeline | null = useMemo(
+    () =>
+      timelineOn && chainQ.data
+        ? buildChainTimeline({
+            chain: chainQ.data,
+            runDetails,
+            proposals: proposalsQ.data?.proposals ?? [],
+            schedules: schedulesQ.data?.schedules ?? [],
+            inbox: inboxQ.data?.items ?? [],
+            now,
+          })
+        : null,
+    [timelineOn, chainQ.data, runDetails, proposalsQ.data, schedulesQ.data, inboxQ.data, now],
+  );
 
   const [positioned, setPositioned] = useState<{ nodes: Node[]; edges: Edge[] } | null>(null);
   const [layoutError, setLayoutError] = useState<string | null>(null);
@@ -181,8 +294,20 @@ export function Chain({
 
   const selected: ChainNode | undefined = graph?.nodes.find((n) => n.id === focusNodeId);
 
+  const timelineListRef = useRef<HTMLOListElement | null>(null);
   const revealSelected = () => {
-    if (!focusNodeId || !flowRef.current) return;
+    if (!focusNodeId) return;
+    if (timelineOn) {
+      const rows = timelineListRef.current?.querySelectorAll<HTMLElement>("[data-node-id]") ?? [];
+      for (const row of rows) {
+        if (row.dataset.nodeId === focusNodeId) {
+          row.scrollIntoView?.({ block: "nearest" });
+          break;
+        }
+      }
+      return;
+    }
+    if (!flowRef.current) return;
     const zoom = flowRef.current.getZoom();
     flowRef.current.fitView({ nodes: [{ id: focusNodeId }], padding: 0.45, duration: 180, minZoom: zoom, maxZoom: zoom });
   };
@@ -196,7 +321,7 @@ export function Chain({
   useEffect(() => {
     revealSelected();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [focusNodeId, flowReady, positioned]);
+  }, [focusNodeId, flowReady, positioned, timelineOn, timeline?.rows.length]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -205,16 +330,30 @@ export function Chain({
         onSelectNode(null);
         return;
       }
+      if (e.key === "t") {
+        e.preventDefault();
+        setMode(timelineOn ? "graph" : "timeline");
+        return;
+      }
       if (e.key === "z" && focusNodeId) {
         e.preventDefault();
         revealSelected();
         return;
       }
-      const order = positioned
-        ? [...positioned.nodes]
-            .sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y)
-            .map((n) => n.id)
-        : [];
+      if (e.key === "Enter" && timelineOn && focusNodeId) {
+        // The pane already follows the selection; Enter re-asserts it for a
+        // row reached by deep link, matching graph mode's click-to-open.
+        e.preventDefault();
+        onSelectNode(focusNodeId);
+        return;
+      }
+      const order = timelineOn
+        ? (timeline?.nodeOrder ?? [])
+        : positioned
+          ? [...positioned.nodes]
+              .sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y)
+              .map((n) => n.id)
+          : [];
       if (!order.length) return;
       if (e.key === "j" || e.key === "ArrowDown" || e.key === "ArrowRight") {
         e.preventDefault();
@@ -229,7 +368,7 @@ export function Chain({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onSelectNode, focusNodeId, positioned]);
+  }, [onSelectNode, focusNodeId, positioned, timelineOn, timeline]);
 
   const origin = graph ? chainOriginLabel(graph) : null;
   const eventCount = graph?.nodes.filter((n) => n.kind === "chainEvent").length ?? 0;
@@ -282,11 +421,20 @@ export function Chain({
         <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
           <div className="flex items-center gap-2">
             <CopyActions id={correlationId} idLabel="correlation id" />
-            {positioned && graph && graph.nodes.length > 0 && (
+            <Tabs
+              label="Chain view"
+              active={mode}
+              onSelect={(id) => setMode(id as ChainViewMode)}
+              tabs={[
+                { id: "graph", label: "Graph", title: "Instance graph — t toggles" },
+                { id: "timeline", label: "Timeline", title: "Chronological narrative — t toggles" },
+              ]}
+            />
+            {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
               <Button onClick={() => setLayoutEpoch((n) => n + 1)}>Reset layout</Button>
             )}
           </div>
-          {positioned && graph && graph.nodes.length > 0 && (
+          {!timelineOn && positioned && graph && graph.nodes.length > 0 && (
             <div
               className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
               role="img"
@@ -309,7 +457,19 @@ export function Chain({
             </div>
           )}
         </div>
-        {positioned && graph && graph.nodes.length > 0 ? (
+        {timelineOn ? (
+          <ChainTimelineList
+            listRef={timelineListRef}
+            timeline={timeline}
+            focusNodeId={focusNodeId}
+            emptyCopy={notFound ? emptyCopy : chainQ.isPending ? "Loading chain…" : chainQ.isError ? emptyCopy : null}
+            onSelectNode={onSelectNode}
+            onJumpEvent={onJumpEvent}
+            onJumpProposal={onJumpProposal}
+            onJumpAgent={onJumpAgent}
+            onOpenRunFull={onOpenRunFull}
+          />
+        ) : positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow
             nodes={nodes}
             edges={positioned.edges}
@@ -351,7 +511,8 @@ export function Chain({
           title={selected.kind === "chainEvent" ? selected.event.type : (selected.run.agent ?? selected.run.runId)}
           actions={
             <Button onClick={revealSelected}>
-              Show on canvas <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
+              {timelineOn ? "Show in timeline" : "Show on canvas"}{" "}
+              <span className="mono ml-1 text-(--text-faint)" aria-hidden="true">z</span>
             </Button>
           }
           utility={
@@ -463,4 +624,176 @@ export function Chain({
 function badgeHues(state: string, count: number): Record<string, string> {
   const hue = STATE_HUES[state] ?? "var(--hue-idle)";
   return { ...STATE_HUES, [`${state} ×${count}`]: hue };
+}
+
+/**
+ * Timeline mode (WM-639): one vertical list, oldest first, one row per step —
+ * `HH:MM:SS · +Δ · [badge] · actor · what` — reusing the run Lifecycle row
+ * grammar so the chain reads like the run detail the operator already knows.
+ */
+function ChainTimelineList({
+  listRef,
+  timeline,
+  focusNodeId,
+  emptyCopy,
+  onSelectNode,
+  onJumpEvent,
+  onJumpProposal,
+  onJumpAgent,
+  onOpenRunFull,
+}: {
+  listRef: React.MutableRefObject<HTMLOListElement | null>;
+  timeline: ChainTimeline | null;
+  focusNodeId: string | null;
+  emptyCopy: string | null;
+  onSelectNode: (id: string | null) => void;
+  onJumpEvent: (source: string, eventId: string) => void;
+  onJumpProposal: (id: string) => void;
+  onJumpAgent: (ref: string) => void;
+  onOpenRunFull: (runId: string) => void;
+}) {
+  if (!timeline) {
+    return (
+      <div className="flex h-full items-center justify-center px-8 text-center text-(--text-faint)">
+        {emptyCopy ?? "Loading chain…"}
+      </div>
+    );
+  }
+  const rows = timeline.rows;
+  const refLink = (ref: TimelineRef, rowNodeId: string | null) => {
+    switch (ref.kind) {
+      case "event":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpEvent(ref.source ?? "", ref.id)} title={`Open in Events · ${ref.id}`}>
+            event ↗
+          </JumpLink>
+        );
+      case "run":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onOpenRunFull(ref.id)} title={`Open run · ${ref.id}`}>
+            {ref.label} ↗
+          </JumpLink>
+        );
+      case "proposal":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpProposal(ref.id)} title={`Open proposal · ${ref.id}`}>
+            proposal ↗
+          </JumpLink>
+        );
+      case "agent":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} onClick={() => onJumpAgent(ref.id)} title="Open in Agents">
+            {ref.label}
+          </JumpLink>
+        );
+      case "pr":
+        return ref.href ? (
+          <a
+            key={`${ref.kind}:${ref.id}`}
+            href={ref.href}
+            target="_blank"
+            rel="noreferrer"
+            className="mono hover:text-(--accent)"
+            title={ref.href}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {ref.label} ↗
+          </a>
+        ) : null;
+      case "ticket":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/tickets/${encodeURIComponent(ref.id)}`} title={`Open ticket journey ${ref.id}`}>
+            {ref.label}
+          </JumpLink>
+        );
+      case "schedule":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/schedules/${encodeURIComponent(ref.id)}`} title={`Open schedule ${ref.id}`}>
+            schedule ↗
+          </JumpLink>
+        );
+      case "inbox":
+        return (
+          <JumpLink key={`${ref.kind}:${ref.id}`} href={`#/inbox/${encodeURIComponent(ref.id)}`} title={ref.label}>
+            inbox: {ref.label} ↗
+          </JumpLink>
+        );
+      default:
+        return rowNodeId ? null : null;
+    }
+  };
+  return (
+    <div className="h-full overflow-auto pt-24 pb-10 pl-5 pr-5">
+      {rows.length === 0 ? (
+        <div className="text-[12px] text-(--text-faint)">{emptyCopy ?? "No steps recorded for this chain yet."}</div>
+      ) : (
+        <ol ref={listRef} className="m-0 max-w-5xl list-none p-0" aria-label="Chain timeline">
+          {rows.map((row, i) => {
+            const hue = huesFor(row)[row.badge] ?? "var(--hue-idle)";
+            const selected = row.nodeId != null && row.nodeId === focusNodeId;
+            const time = rowTime(row.at);
+            const clickable = row.nodeId != null;
+            return (
+              <li
+                key={row.id}
+                data-node-id={row.nodeId ?? undefined}
+                data-row-kind={row.kind}
+                aria-current={selected ? "true" : undefined}
+                onClick={clickable ? () => onSelectNode(row.nodeId) : undefined}
+                onKeyDown={
+                  clickable
+                    ? (e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          onSelectNode(row.nodeId);
+                        }
+                      }
+                    : undefined
+                }
+                tabIndex={clickable ? 0 : undefined}
+                className={`flex gap-2.5 rounded px-1.5 py-1 ${clickable ? "cursor-pointer hover:bg-(--surface-2)" : ""} ${
+                  selected ? "bg-(--surface-2) ring-1 ring-(--accent)" : ""
+                } ${row.muted ? "opacity-80" : ""}`}
+              >
+                <span className="mono w-[62px] shrink-0 pt-0.5 text-[11px] tabular-nums text-(--text-faint)" title={row.at ?? undefined}>
+                  {time}
+                </span>
+                <span className="mono w-[52px] shrink-0 pt-0.5 text-right text-[10px] tabular-nums text-(--text-faint)">
+                  {row.kind === "next" ? "" : formatDelta(row.deltaMs)}
+                </span>
+                <span className="relative flex w-2 shrink-0 justify-center" aria-hidden="true">
+                  {i < rows.length - 1 && <span className="absolute top-2.5 bottom-[-6px] w-px bg-(--border)" />}
+                  <span className="relative mt-[7px] size-1.5 shrink-0 rounded-full" style={{ background: hue }} />
+                </span>
+                <span className="flex min-w-0 flex-1 items-start gap-x-2">
+                  <span className="flex w-[100px] shrink-0 items-center">
+                    <StateBadge state={row.badge} hues={huesFor(row)} dot={false} />
+                  </span>
+                  <span className="min-w-0 flex-1 break-words text-[11.5px] leading-relaxed text-(--text-dim)">
+                    {row.actor && <span className="mono text-(--text)">{row.actor}</span>}
+                    {row.actor && (row.what || row.reason) ? " · " : ""}
+                    {row.what && <span className={row.kind === "next" ? "text-(--text-faint)" : ""}>{row.what}</span>}
+                    {row.what && row.reason ? " · " : ""}
+                    {row.reason && (
+                      <span className="text-(--text-faint)" title={row.reason.raw}>
+                        {row.reason.text}
+                      </span>
+                    )}
+                    {row.refs.length > 0 && (
+                      <span className="ml-2 inline-flex flex-wrap gap-x-2 text-[11px] text-(--text-faint)">
+                        {row.refs.map((ref) => refLink(ref, row.nodeId))}
+                      </span>
+                    )}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+      {timeline.partial && (
+        <div className="mt-3 text-[11px] text-(--text-faint)">Loading run lifecycles…</div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
Fixes WM-639

## What
- `#/chain/<correlation>` gains a **Graph | Timeline** toggle (persisted in `localStorage` `evrt-chain-view`; `t` toggles). Timeline = one vertical list, oldest first, one row per step: `HH:MM:SS · +Δ · [badge] · actor · what`, reusing the run Lifecycle row grammar.
- Rows are a client-side join of `GET /chain/:id` (events), `GET /runs/:id` per run (lifecycle; PROPOSED/APPROVED/QUEUED-from-APPROVED fold into the `planned` row with an approval note, VERIFYING folds into the terminal row, RUNNING folds into LEASED when <1s), and `GET /proposals?status=all` (decision time + noop/human_needed reason). No server projection needed — the 8-run real chain builds in well under 200 ms.
- Reasons humanized via a local `RUN_REASONS` table in `chainTimeline.ts` (raw code in `title`); event rows name the PR / ticket from the planned run's spec input (`factory.merge-fix.requested (PR #541, WM-627)`).
- Every row links its objects: row click / Enter opens the existing pane; refs jump to run (full view), proposal, event, PR (GitHub), ticket (`#/tickets/<id>`), schedule, inbox.
- **What happens next**: for a chain with refused/failed runs or noop/human_needed events and nothing still active, a muted final row `next: <loop> re-examines at HH:MM (in 9m)` from the covering enabled schedule (origin type + repo), else `no automatic retry — needs a decision` linking an open inbox item whose refs match.
- Deep link `#/chain/<id>?view=timeline&node=<id>` opens the timeline, lifts the node into the selection (rows highlighted, `Enter` opens the pane); `#/chain/<id>/<node>` graph links unchanged. Pane "reason" now humanized too.

## Coordination
WM-594's `src/reasons.ts` is not on develop yet, so the reason strings live in `RUN_REASONS` in `event-runtime/web/src/chainTimeline.ts` (`humanizeRunReason`) — folds into WM-594's `humanizeReason` map when it lands.

## Verification
`bun test event-runtime/lib/api-chain.test.mjs && cd event-runtime/web && bun run build && bun test` — 4 + 786 tests pass, entry chunk 563 kB (< 575 kB budget; Chain stays a lazy chunk).

## UX critique
One round against the live API on the real refused chain (`clock:merge-factory:2026-08-17T18:45:00.000Z`): fixed the header floating over scrolled rows (in-flow header in timeline mode), trimmed repeated PR/ticket/agent refs on non-terminal rows, humanized the pane reason, re-fit the canvas when switching back to Graph. Verdict SHIP.