### PR TITLE
feat(event-runtime-web): planner decisions explain themselves — humanized noop/refused reasons on events, reason: facet, per-ticket Decisions block (WM-594)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -422,7 +422,9 @@ describe("ticket journey navigation (WM-595)", () => {
     fireEvent.keyDown(document.body, { key: "k", metaKey: true });
     const input = utils.getByPlaceholderText("Type a command…");
     fireEvent.input(input, { target: { value: "WM-595" } });
-    const command = await utils.findByText("WM-595", { selector: "span.mono" });
+    // Two items name the ticket (WM-594 adds "Why isn't WM-595 running?"); both open the journey.
+    const [command, why] = await utils.findAllByText("WM-595", { selector: "span.mono" });
+    expect(why.closest("[cmdk-item]")!.textContent).toContain("Why isn't");
     fireEvent.click(command.closest("[cmdk-item]")!);
     expect(window.location.hash).toBe("#/tickets/WM-595");
   });

--- a/event-runtime/web/src/components/CommandPalette.tsx
+++ b/event-runtime/web/src/components/CommandPalette.tsx
@@ -268,6 +268,21 @@ export function CommandPalette({
                 <span>Open ticket <span className="mono">{typedTicket}</span></span>
                 <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">ticket journey</span>
               </Command.Item>
+              {/* The question behind most ticket lookups (WM-594): the journey
+                  already lists every planner decision and names the blocking
+                  reason in its next-action line, so it is the answer. */}
+              <Command.Item
+                value={`ticket ${typedTicket} why isn't running decisions`}
+                onSelect={() => {
+                  setOpen(false);
+                  setSearch("");
+                  onJumpTicket(typedTicket);
+                }}
+                className={PALETTE_ITEM_CLASS}
+              >
+                <span>Why isn't <span className="mono">{typedTicket}</span> running?</span>
+                <span className="ml-3 shrink-0 text-[11px] text-(--text-faint)">planner decisions</span>
+              </Command.Item>
             </Command.Group>
           )}
           {typedPr && onJumpPr && (

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -5,11 +5,16 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { api } from "../api";
 import { ARTIFACT_RAW_KEY } from "./ArtifactView";
-import { RunDetailBlocks, isCancellable, modelTierText, pinnedModelText } from "./RunDetailBlocks";
+import { RunDetailBlocks, eventTicket, isCancellable, modelTierText, pinnedModelText } from "./RunDetailBlocks";
+import { TicketDecisions, buildTicketDecisions, decisionHeadline } from "./TicketDecisions";
 import {
   createAgentsFixture,
+  createEventFixture,
   createLifecycleEventFixture,
+  createProposalFixture,
   createRunDetailFixture,
+  createRunListItemFixture,
+  createRunSpecFixture,
   renderWithClient,
   restoreApi,
   stubApi,
@@ -332,5 +337,114 @@ describe("artifact position renders the agent's view (WM-455)", () => {
     expect(r.queryByRole("table")).toBeNull();
     const pre = Array.from(r.container.querySelectorAll("pre")).find((el) => el.textContent?.includes('"issueId": "WM-7"'));
     expect(pre).toBeTruthy();
+  });
+});
+
+describe("Ticket decisions (WM-594)", () => {
+  const T = "WM-542";
+  const t = (offsetSeconds: number) => new Date(Date.UTC(2026, 7, 17, 12, 0, offsetSeconds)).toISOString();
+  const dispatchEvent = (eventId: string, status: string, at: string, subject: string | null = T) =>
+    createEventFixture({
+      source: "linear",
+      eventId,
+      type: "dispatch.requested",
+      subject,
+      status,
+      admittedAt: at,
+      envelope: { schemaVersion: "factory.event/v1", eventId, type: "dispatch.requested", source: "linear", payload: { ticket: T } },
+    });
+  const fixture = () => {
+    const events = [
+      dispatchEvent("evt_plan", "planned", t(0)),
+      dispatchEvent("evt_noop", "noop", t(60)),
+      dispatchEvent("evt_other", "noop", t(70), "WM-999"),
+      dispatchEvent("evt_refused", "planned", t(120)),
+      // Names the ticket only in the payload — subject is a repo.
+      { ...dispatchEvent("evt_payload_only", "admitted", t(200), "factory/repo") },
+    ];
+    const proposals = [
+      createProposalFixture({ id: "prop_plan", decision: "run", status: "approved", created_at: t(1), eventId: "evt_plan", eventSource: "linear", runId: "run_ok" }),
+      createProposalFixture({ id: "prop_noop", decision: "noop", status: "resolved", reason: "owned_paths_overlap", created_at: t(61), eventId: "evt_noop", eventSource: "linear", runId: null }),
+      createProposalFixture({ id: "prop_other", decision: "noop", status: "resolved", reason: "ticket_assigned", created_at: t(71), eventId: "evt_other", eventSource: "linear", runId: null }),
+      createProposalFixture({ id: "prop_refused", decision: "run", status: "approved", created_at: t(121), eventId: "evt_refused", eventSource: "linear", runId: "run_refused" }),
+      // Attached to no listed event; its spec input names the ticket.
+      createProposalFixture({ id: "prop_spec", decision: "noop", status: "resolved", reason: "ticket_security", created_at: t(150), eventId: "evt_missing", eventSource: "chain", runId: null, spec: { ...createRunSpecFixture("run_x"), input: { ticket: T } } }),
+    ];
+    const runs = [
+      createRunListItemFixture({ runId: "run_ok", state: "COMPLETED", reasonCode: "ok", eventId: "evt_plan", eventSource: "linear", updated_at: t(30) }),
+      createRunListItemFixture({ runId: "run_refused", state: "REFUSED", reasonCode: "needs_human", eventId: "evt_refused", eventSource: "linear", updated_at: t(130) }),
+    ];
+    return { events, proposals, runs };
+  };
+
+  test("eventTicket reads the subject, then payload.ticket", () => {
+    expect(eventTicket(dispatchEvent("e", "noop", t(0)))).toBe(T);
+    expect(eventTicket(dispatchEvent("e", "noop", t(0), "factory/repo"))).toBe(T);
+    expect(eventTicket(createEventFixture({ subject: "factory/repo" }))).toBeNull();
+  });
+
+  test("joins events, proposals and refused runs for one ticket, oldest first", () => {
+    const decisions = buildTicketDecisions(T, fixture());
+    // The planner said yes to evt_refused (planned), then the gate said no (refused): both are decisions.
+    expect(decisions.map((d) => [d.outcome, d.reason])).toEqual([
+      ["planned", null],
+      ["noop", "owned_paths_overlap"],
+      ["planned", null],
+      ["refused", "needs_human"],
+      ["noop", "ticket_security"],
+      ["admitted", null],
+    ]);
+    // Excludes WM-999, carries the joins for jump links.
+    expect(decisions.some((d) => d.reason === "ticket_assigned")).toBe(false);
+    expect(decisions[1]).toMatchObject({ proposalId: "prop_noop", event: { eventId: "evt_noop" } });
+    expect(decisions[3]).toMatchObject({ runId: "run_refused", event: { eventId: "evt_refused" } });
+    expect(decisions[5]).toMatchObject({ event: { eventId: "evt_payload_only" }, proposalId: null });
+  });
+
+  test("the headline is the latest decision, humanized", () => {
+    const decisions = buildTicketDecisions(T, fixture());
+    const now = Date.parse(t(260));
+    expect(decisionHeadline(decisions[1], now)).toBe("noop · Owned paths overlap · 3m ago");
+    expect(decisionHeadline(decisions[3], now)).toBe("refused · Needs human · 2m ago");
+  });
+
+  test("renders collapsed with the latest decision, expands to the full list with reason links", async () => {
+    const f = fixture();
+    stubApi({
+      events: mock(async () => ({ events: f.events })),
+      proposalHistory: mock(async () => ({ proposals: f.proposals })),
+      runs: mock(async () => ({ runs: f.runs })),
+    });
+    const onJumpRun = mock(() => {});
+    const r = renderWithClient(<TicketDecisions ticket={T} now={Date.parse(t(260))} onJumpRun={onJumpRun} />);
+    const toggle = await r.findByRole("button", { name: /Show all 6 planner decisions for WM-542/ });
+    expect(r.getByText("6 decisions")).toBeTruthy();
+    // Collapsed: only the headline (latest = the admitted event awaiting the planner).
+    expect(r.getByText("awaiting the planner")).toBeTruthy();
+    expect(r.queryByRole("list", { name: "Planner decisions for WM-542" })).toBeNull();
+    fireEvent.click(toggle);
+    const list = r.getByRole("list", { name: "Planner decisions for WM-542" });
+    expect(list.querySelectorAll("li").length).toBe(6);
+    expect(r.getByText("Owned paths overlap")).toBeTruthy();
+    expect(r.getByText("Needs human")).toBeTruthy();
+    // The run reference on the refused decision jumps to the run.
+    fireEvent.click(r.getAllByTitle("run_refused")[0]);
+    expect(onJumpRun).toHaveBeenCalledWith("run_refused");
+  });
+
+  test("RunDetailBlocks renders the Decisions block for a run whose input names a ticket", async () => {
+    const f = fixture();
+    stubApi({
+      events: mock(async () => ({ events: f.events })),
+      proposalHistory: mock(async () => ({ proposals: f.proposals })),
+      runs: mock(async () => ({ runs: f.runs })),
+    });
+    const r = renderBlocks(detailWith("REFUSED", { repo: "factory", ticket: T }));
+    // TicketDecisions is a lazy chunk (bundle budget) — await the Suspense boundary.
+    expect(await r.findByText("Decisions")).toBeTruthy();
+    await r.findByText("6 decisions");
+    cleanup();
+    const r2 = renderBlocks(detailWith("RUNNING", { repo: "factory" }));
+    expect(r2.queryByText("Decisions")).toBeNull();
   });
 });

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -3,7 +3,8 @@ import { Suspense, lazy, useState, type ReactNode } from "react";
 import { api, artifactUrl } from "../api";
 import { hashPath, hashProject, withProject } from "../hash";
 import { dur } from "../heartbeat";
-import type { ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunSpec, RunState } from "../types";
+import { humanizeReason } from "../reasons";
+import type { AdmittedEvent, ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunSpec, RunState } from "../types";
 import {
   Ago,
   Disclosure,
@@ -29,6 +30,21 @@ import { attrIcon } from "./attrIcons";
  * which is also exactly what an agent without a view gets.
  */
 const ArtifactPanel = lazy(() => import("./ArtifactView").then((m) => ({ default: m.ArtifactPanel })));
+
+/**
+ * The per-ticket Decisions block (WM-594) rides its own chunk for the same
+ * budget reason; `TicketDecisionsPanel` is the Suspense-wrapped handle every
+ * pane renders. Until the chunk lands nothing is shown — a block that answers
+ * "why not" a beat late beats a heavier first paint on every view.
+ */
+const TicketDecisionsLazy = lazy(() => import("./TicketDecisions").then((m) => ({ default: m.TicketDecisions })));
+export function TicketDecisionsPanel(props: Parameters<typeof import("./TicketDecisions").TicketDecisions>[0]) {
+  return (
+    <Suspense fallback={null}>
+      <TicketDecisionsLazy {...props} />
+    </Suspense>
+  );
+}
 
 export const TERMINAL: RunState[] = ["COMPLETED", "REFUSED", "FAILED", "TIMED_OUT", "CANCELLED"];
 export const isCancellable = (state: RunState) => !TERMINAL.includes(state) && state !== "VERIFYING";
@@ -461,6 +477,118 @@ function InputRows({ input }: { input: unknown }) {
   return <KV k="input" v={compactValue(input)} />;
 }
 
+// ---------------------------------------------------------------------------
+// Planner decisions, explained (WM-594)
+// ---------------------------------------------------------------------------
+
+const TICKET_ID = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
+
+/** The ticket id a value names, normalised, or null. */
+export function ticketIdOf(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const t = value.trim().toUpperCase();
+  return TICKET_ID.test(t) ? t : null;
+}
+
+/** The ticket an admitted event is about: its subject, or `payload.ticket`. */
+export function eventTicket(e: Pick<AdmittedEvent, "subject" | "envelope">): string | null {
+  const payload = (e.envelope as { payload?: Record<string, unknown> } | undefined)?.payload;
+  return ticketIdOf(e.subject) ?? ticketIdOf(payload?.ticket) ?? ticketIdOf(payload?.ticketId) ?? null;
+}
+
+export const hashHref = (view: string, ...ids: string[]) =>
+  `#/${withProject(hashPath(view, ...ids), hashProject(window.location.hash))}`;
+
+/**
+ * A reason code as a sentence, with the identifiers in its suffix turned into
+ * jump links (run → onJumpRun, proposal → onJumpProposal, ticket → the ticket
+ * journey). The raw code stays in `title` so nothing is lost to the prose.
+ */
+export function ReasonText({
+  code,
+  onJumpRun,
+  onJumpProposal,
+  onJumpTicket,
+  className = "",
+}: {
+  code: string | null | undefined;
+  onJumpRun?: (runId: string) => void;
+  onJumpProposal?: (id: string) => void;
+  onJumpTicket?: (ticketId: string) => void;
+  className?: string;
+}) {
+  const h = humanizeReason(code);
+  if (!h.text) return null;
+  const refs = h.refs ?? {};
+  // Split the sentence around each reference so the reference itself is a link.
+  const targets: Array<{ id: string; href: string; onClick?: () => void; title: string }> = [];
+  if (refs.runId)
+    targets.push({
+      id: refs.runId,
+      href: hashHref("runs", refs.runId),
+      onClick: onJumpRun ? () => onJumpRun(refs.runId!) : undefined,
+      title: `Open run ${refs.runId}`,
+    });
+  if (refs.proposalId)
+    targets.push({
+      id: refs.proposalId,
+      href: hashHref("proposals", refs.proposalId),
+      onClick: onJumpProposal ? () => onJumpProposal(refs.proposalId!) : undefined,
+      title: `Open proposal ${refs.proposalId}`,
+    });
+  if (refs.ticket)
+    targets.push({
+      id: refs.ticket,
+      href: hashHref("tickets", refs.ticket),
+      onClick: onJumpTicket ? () => onJumpTicket(refs.ticket!) : undefined,
+      title: `Open ticket journey for ${refs.ticket}`,
+    });
+  const parts: ReactNode[] = [];
+  let rest = h.text;
+  let key = 0;
+  while (rest) {
+    let firstAt = -1;
+    let hit: (typeof targets)[number] | null = null;
+    for (const t of targets) {
+      const at = rest.indexOf(t.id);
+      if (at !== -1 && (firstAt === -1 || at < firstAt)) {
+        firstAt = at;
+        hit = t;
+      }
+    }
+    if (!hit) {
+      parts.push(rest);
+      break;
+    }
+    if (firstAt > 0) parts.push(rest.slice(0, firstAt));
+    const target = hit;
+    parts.push(
+      <JumpLink
+        key={key++}
+        href={target.href}
+        onClick={
+          target.onClick
+            ? (ev) => {
+                ev?.preventDefault();
+                target.onClick!();
+              }
+            : undefined
+        }
+        title={target.title}
+        className="text-[inherit]"
+      >
+        {target.id.startsWith("run_") || target.id.startsWith("prop_") ? shortId(target.id) : target.id}
+      </JumpLink>,
+    );
+    rest = rest.slice(firstAt + hit.id.length);
+  }
+  return (
+    <span className={className} title={h.raw ?? undefined}>
+      {parts}
+    </span>
+  );
+}
+
 /**
  * The run detail blocks, shared verbatim between the Runs side panel and the
  * `#/run/:id` full page (WM-129) — one renderer, so the two views cannot
@@ -476,6 +604,8 @@ export function RunDetailBlocks({
   origin,
   onJumpAgent,
   onJumpEvent,
+  onJumpProposal,
+  onJumpRun,
   verbError,
   afterLifecycle,
 }: {
@@ -486,6 +616,9 @@ export function RunDetailBlocks({
   origin: { eventId?: string | null; eventSource?: string | null } | null;
   onJumpAgent: (ref: string) => void;
   onJumpEvent: (source: string, eventId: string) => void;
+  /** Optional: the Decisions block falls back to hash hrefs when these are absent (WM-594). */
+  onJumpProposal?: (id: string) => void;
+  onJumpRun?: (runId: string) => void;
   onCancel?: () => void;
   onRetry?: () => void;
   onForceRetry?: () => void;
@@ -501,6 +634,7 @@ export function RunDetailBlocks({
     ? (d.attempts.find((a) => a.attempt === d.run.attempts) ?? null)
     : null;
   const clocks = current ? deadlinesOf(current, d.run.spec.timeoutSeconds, now) : null;
+  const inputTicket = ticketIdOf((d.run.spec.input as Record<string, unknown> | null | undefined)?.ticket);
 
   // The artifact's view sidecar rides the `/agents` item for this run's agent
   // (WM-454); the same query AgentHoverCard already keeps warm, so no new
@@ -563,6 +697,18 @@ export function RunDetailBlocks({
           <JsonBlock value={d.run.spec} />
         </Disclosure>
       </Section>
+
+      {/* Why the planner ran, held, or refused this ticket (WM-594) — the
+          question a REFUSED run or a re-dispatch prompts, answered in place. */}
+      {inputTicket && (
+        <TicketDecisionsPanel
+          ticket={inputTicket}
+          now={now}
+          onJumpEvent={onJumpEvent}
+          onJumpProposal={onJumpProposal}
+          onJumpRun={onJumpRun}
+        />
+      )}
 
       {/* What a live run is racing, above the verbs: cancelling is the
           answer to a budget about to be spent on a hung agent. */}

--- a/event-runtime/web/src/components/TicketDecisions.tsx
+++ b/event-runtime/web/src/components/TicketDecisions.tsx
@@ -1,0 +1,299 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { api } from "../api";
+import { humanizeReason } from "../reasons";
+import type { AdmittedEvent, Proposal, RunListItem } from "../types";
+import { DECISION_HUES, DisclosureChevron, EVENT_STATUS_HUES, JumpLink, Section, StateBadge, ago, shortId } from "./ui";
+import { ReasonText, eventTicket, hashHref, ticketIdOf } from "./RunDetailBlocks";
+
+/**
+ * The per-ticket "why isn't this running?" answer (WM-594). Split out of
+ * RunDetailBlocks and fetched on demand: the entry chunk is budgeted
+ * (vite.config.ts) and only a pane that names a ticket ever needs this.
+ */
+/** One planner (or dispatch-gate) decision about a ticket, in the order it was made. */
+export interface TicketDecision {
+  at: string;
+  /** `planned` / `noop` / `human_needed` for proposals; `refused` for a REFUSED run; the event status otherwise. */
+  outcome: string;
+  /** Proposal status when the decision was a proposal (`open`, `approved`, `rejected`, …). */
+  status: string | null;
+  /** The raw reason code; humanize with `humanizeReason`. */
+  reason: string | null;
+  event: { source: string; eventId: string; type: string } | null;
+  proposalId: string | null;
+  runId: string | null;
+}
+
+const OUTCOME_HUES: Record<string, string> = {
+  ...EVENT_STATUS_HUES,
+  ...DECISION_HUES,
+  planned: "var(--hue-ok)",
+  refused: "var(--hue-warn)",
+};
+
+/**
+ * Every decision the planner made about one ticket, oldest first, joined on
+ * the client from what the views already fetch: events naming the ticket
+ * (subject / payload.ticket), proposals attached to those events or whose spec
+ * input names it, and the runs those proposals opened. A REFUSED run counts as
+ * a decision too — the dispatch gate said no after the planner said yes.
+ */
+export function buildTicketDecisions(
+  ticket: string,
+  data: { events: readonly AdmittedEvent[]; proposals: readonly Proposal[]; runs: readonly RunListItem[] },
+): TicketDecision[] {
+  const T = ticket.toUpperCase();
+  const eventKey = (source: string | null | undefined, id: string | null | undefined) => `${source}:${id}`;
+  const events = new Map<string, AdmittedEvent>();
+  for (const e of data.events) if (eventTicket(e) === T) events.set(eventKey(e.source, e.eventId), e);
+
+  const proposals = data.proposals.filter((p) => {
+    if (events.has(eventKey(p.eventSource, p.eventId))) return true;
+    const input = (p.spec?.input ?? null) as Record<string, unknown> | null;
+    return ticketIdOf(input?.ticket) === T;
+  });
+  // A proposal whose spec names the ticket links its event even when the event
+  // itself does not (a chain event carrying only the proposal's payload).
+  const eventById = new Map(data.events.map((e) => [eventKey(e.source, e.eventId), e]));
+  for (const p of proposals) {
+    const k = eventKey(p.eventSource, p.eventId);
+    const e = eventById.get(k);
+    if (e && !events.has(k)) events.set(k, e);
+  }
+
+  // Only runs this ticket's planner opened: a noop proposal's runId can be
+  // the *blocking* run of another ticket (`ticket_dispatch_already_live`).
+  const runIds = new Set(
+    proposals.filter((p) => p.decision === "run").map((p) => p.runId).filter((id): id is string => !!id),
+  );
+  const runs = data.runs.filter(
+    (r) => runIds.has(r.runId) || events.has(eventKey(r.eventSource, r.eventId)),
+  );
+
+  const decisions: TicketDecision[] = [];
+  const decidedEvents = new Set(proposals.map((p) => eventKey(p.eventSource, p.eventId)));
+  for (const p of proposals) {
+    const e = eventById.get(eventKey(p.eventSource, p.eventId));
+    decisions.push({
+      at: p.created_at,
+      outcome: p.decision === "run" ? "planned" : p.decision,
+      status: p.status,
+      reason: p.reason,
+      event: e ? { source: e.source, eventId: e.eventId, type: e.type } : null,
+      proposalId: p.id,
+      runId: p.runId,
+    });
+  }
+  // An event the planner has not (or could not) turn into a proposal is still
+  // an answer: admitted = still waiting, dead_lettered = the plan error.
+  for (const [k, e] of events) {
+    if (decidedEvents.has(k)) continue;
+    decisions.push({
+      at: e.admittedAt,
+      outcome: e.status,
+      status: null,
+      reason: e.lastPlanError,
+      event: { source: e.source, eventId: e.eventId, type: e.type },
+      proposalId: e.proposalId,
+      runId: e.runId,
+    });
+  }
+  for (const r of runs) {
+    if (r.state !== "REFUSED") continue;
+    decisions.push({
+      at: r.updated_at,
+      outcome: "refused",
+      status: null,
+      reason: r.reasonCode,
+      event: r.eventSource && r.eventId ? { source: r.eventSource, eventId: r.eventId, type: "" } : null,
+      proposalId: null,
+      runId: r.runId,
+    });
+  }
+  return decisions.sort((a, b) => a.at.localeCompare(b.at));
+}
+
+/** `noop · Owned paths overlap · 3m ago` — the one line an operator reads first. */
+export function decisionHeadline(d: TicketDecision, now: number): string {
+  const reason = humanizeReason(d.reason).text;
+  const status = d.outcome === "planned" && d.status && d.status !== "approved" ? ` (${d.status})` : "";
+  return `${d.outcome}${status}${reason ? ` · ${reason}` : ""} · ${ago(d.at, now)}`;
+}
+
+/**
+ * The per-ticket answer to "why isn't this running?" (WM-594): every planner
+ * decision about the ticket, chronologically, collapsed to its latest one.
+ * Rendered wherever a ticket id appears in a pane — a run's `input.ticket`, an
+ * event's subject. Data comes from the same list queries the views keep warm.
+ */
+export function TicketDecisions({
+  ticket,
+  now,
+  defaultOpen = false,
+  onJumpRun,
+  onJumpProposal,
+  onJumpEvent,
+  onJumpTicket,
+}: {
+  ticket: string;
+  now: number;
+  defaultOpen?: boolean;
+  onJumpRun?: (runId: string) => void;
+  onJumpProposal?: (id: string) => void;
+  onJumpEvent?: (source: string, eventId: string) => void;
+  onJumpTicket?: (ticketId: string) => void;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const eventsQ = useQuery({ queryKey: ["events", "all"], queryFn: () => api.events(), staleTime: 5_000 });
+  const proposalsQ = useQuery({
+    queryKey: ["proposals", "history"],
+    queryFn: () => api.proposalHistory("all"),
+    staleTime: 5_000,
+  });
+  const runsQ = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), staleTime: 5_000 });
+  const decisions = useMemo(
+    () =>
+      buildTicketDecisions(ticket, {
+        events: eventsQ.data?.events ?? [],
+        proposals: proposalsQ.data?.proposals ?? [],
+        runs: runsQ.data?.runs ?? [],
+      }),
+    [ticket, eventsQ.data, proposalsQ.data, runsQ.data],
+  );
+  const loading = eventsQ.isPending || proposalsQ.isPending || runsQ.isPending;
+  const latest = decisions.at(-1) ?? null;
+  const jumpEvent = (source: string, eventId: string) =>
+    onJumpEvent ? onJumpEvent(source, eventId) : (window.location.hash = hashHref("events", source, eventId));
+
+  return (
+    <Section title="Decisions" id="decisions">
+      {loading && !latest ? (
+        <div className="py-1 text-[11px] text-(--text-faint)">Loading planner decisions…</div>
+      ) : !latest ? (
+        <div className="py-1 text-[11px] text-(--text-faint)">No planner decisions recorded for this ticket.</div>
+      ) : (
+        <>
+          {/* The headline is the whole answer for most tickets; the list under
+              it is the audit trail. Links inside the reason stop propagation,
+              so clicking a run id jumps instead of toggling. */}
+          <div
+            className="flex cursor-pointer items-baseline gap-2 py-1"
+            onClick={() => setOpen((o) => !o)}
+            title={decisionHeadline(latest, now)}
+          >
+            <button
+              type="button"
+              aria-expanded={open}
+              aria-label={`${open ? "Hide" : "Show"} all ${decisions.length} planner decisions for ${ticket}`}
+              onClick={(ev) => {
+                ev.stopPropagation();
+                setOpen((o) => !o);
+              }}
+              className="flex shrink-0 cursor-pointer items-center gap-2 self-center hover:text-(--text)"
+            >
+              <DisclosureChevron open={open} />
+              <span className="text-[11px] text-(--text-faint)">last:</span>
+            </button>
+            <StateBadge state={latest.outcome} hues={OUTCOME_HUES} dot={false} />
+            <span className="min-w-0 flex-1 truncate text-[12px] text-(--text-dim)">
+              {latest.outcome === "planned" && latest.status && latest.status !== "approved" && (
+                <span className="text-(--text-faint)">({latest.status}) </span>
+              )}
+              <ReasonText code={latest.reason} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpTicket={onJumpTicket} />
+              {!latest.reason && latest.outcome === "planned" && <span className="text-(--text-faint)">run proposed</span>}
+              {!latest.reason && latest.outcome === "admitted" && <span className="text-(--text-faint)">awaiting the planner</span>}
+            </span>
+            <span className="shrink-0 text-[11px] tabular-nums text-(--text-faint)" title={latest.at}>
+              {ago(latest.at, now)}
+            </span>
+            <span className="shrink-0 text-[11px] tabular-nums text-(--text-faint)">
+              {decisions.length} decision{decisions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          {open && (
+            <ol className="m-0 mt-1 list-none border-t border-(--border) p-0 pt-1" aria-label={`Planner decisions for ${ticket}`}>
+              {decisions.map((d, i) => (
+                <li
+                  key={`${d.proposalId ?? ""}:${d.runId ?? ""}:${d.event?.eventId ?? ""}:${i}`}
+                  className="py-1 text-[11.5px]"
+                >
+                  <div className="flex items-baseline gap-2">
+                    <span className="mono w-[52px] shrink-0 text-[11px] tabular-nums text-(--text-faint)" title={d.at}>
+                      {ago(d.at, now)}
+                    </span>
+                    <StateBadge state={d.outcome} hues={OUTCOME_HUES} dot={false} />
+                    <span className="min-w-0 flex-1 break-words text-(--text-dim)">
+                      {d.outcome === "planned" && d.status && d.status !== "approved" && (
+                        <span className="text-(--text-faint)">({d.status}) </span>
+                      )}
+                      <ReasonText code={d.reason} onJumpRun={onJumpRun} onJumpProposal={onJumpProposal} onJumpTicket={onJumpTicket} />
+                      {!d.reason && d.outcome === "planned" && <span className="text-(--text-faint)">run proposed</span>}
+                      {!d.reason && d.outcome === "admitted" && <span className="text-(--text-faint)">awaiting the planner</span>}
+                    </span>
+                  </div>
+                  {/* The joins on their own line: event ids can be long
+                      (`operator:dispatch:WM-1:<iso>`), and squeezed beside the
+                      reason they left it one character wide. */}
+                  <div className="ml-[60px] flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-0.5 text-[11px] text-(--text-faint)">
+                    {d.event && (
+                      <span className="flex shrink-0 items-baseline gap-1">
+                        <span>event</span>
+                        <JumpLink
+                          onClick={() => jumpEvent(d.event!.source, d.event!.eventId)}
+                          title={`${d.event.source} · ${d.event.eventId}${d.event.type ? ` · ${d.event.type}` : ""}`}
+                          className="inline-block max-w-[11rem] truncate align-bottom"
+                        >
+                          {shortId(d.event.eventId)}
+                        </JumpLink>
+                      </span>
+                    )}
+                    {d.proposalId && (
+                      <span className="flex shrink-0 items-baseline gap-1">
+                        <span>proposal</span>
+                        <JumpLink
+                          href={hashHref("proposals", d.proposalId)}
+                          onClick={
+                            onJumpProposal
+                              ? (ev) => {
+                                  ev?.preventDefault();
+                                  onJumpProposal(d.proposalId!);
+                                }
+                              : undefined
+                          }
+                          title={d.proposalId}
+                        >
+                          {shortId(d.proposalId)}
+                        </JumpLink>
+                      </span>
+                    )}
+                    {d.runId && (
+                      <span className="flex shrink-0 items-baseline gap-1">
+                        <span>run</span>
+                        <JumpLink
+                          href={hashHref("runs", d.runId)}
+                          onClick={
+                            onJumpRun
+                              ? (ev) => {
+                                  ev?.preventDefault();
+                                  onJumpRun(d.runId!);
+                                }
+                              : undefined
+                          }
+                          title={d.runId}
+                        >
+                          {shortId(d.runId)}
+                        </JumpLink>
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+

--- a/event-runtime/web/src/filterQuery.test.ts
+++ b/event-runtime/web/src/filterQuery.test.ts
@@ -283,7 +283,7 @@ describe("chip and input copy", () => {
   test("an impossible chip says so and names what this list does have", () => {
     const q = parseFilterQuery("agent:ci-doctor is:expired", EVENT_FACETS);
     expect(chipHelp(q.chips[0], q)).toBe(
-      "No agent field. event, source, type, subject, status, proposal, run, repo.",
+      "No agent field. event, source, type, subject, status, proposal, run, repo, reason.",
     );
     expect(chipHelp(q.chips[1], q)).toBe("Unknown is:expired. is:stale.");
   });
@@ -394,3 +394,32 @@ describe("getFilterSuggestions", () => {
   });
 });
 
+
+describe("events reason: facet (WM-594)", () => {
+  const rows = [
+    { ...event({ eventId: "evt_a", status: "noop" }), decisionReason: "owned_paths_overlap" },
+    { ...event({ eventId: "evt_b", status: "noop" }), decisionReason: "ticket_dispatch_already_live:run_x:same_ticket_worktree_held" },
+    { ...event({ eventId: "evt_c", status: "planned" }), decisionReason: "auto_approval_ineligible:proposal_expired" },
+    event({ eventId: "evt_d", status: "admitted" }),
+  ];
+
+  test("reason:<code> matches the head code and word starts inside a chained reason", () => {
+    const overlap = parseFilterQuery("reason:owned_paths_overlap", EVENT_FACETS);
+    expect(rows.filter((r) => matchesFilterQuery(r, overlap, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_a"]);
+    const live = parseFilterQuery("reason:ticket_dispatch_already_live", EVENT_FACETS);
+    expect(rows.filter((r) => matchesFilterQuery(r, live, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_b"]);
+    const expired = parseFilterQuery("reason:proposal_expired", EVENT_FACETS);
+    expect(rows.filter((r) => matchesFilterQuery(r, expired, EVENT_FACETS, undefined)).map((r) => r.eventId)).toEqual(["evt_c"]);
+  });
+
+  test("a row without a decision reason never matches reason:", () => {
+    const q = parseFilterQuery("reason:owned", EVENT_FACETS);
+    expect(matchesFilterQuery(rows[3], q, EVENT_FACETS, undefined)).toBe(false);
+  });
+
+  test("reason: is offered as a facet and takes caller-supplied value suggestions", () => {
+    expect(getFilterSuggestions("rea", EVENT_FACETS).map((s) => s.insertText)).toContain("reason:");
+    const facets = { ...EVENT_FACETS, values: { ...EVENT_FACETS.values, reason: ["owned_paths_overlap", "ticket_assigned"] } };
+    expect(getFilterSuggestions("reason:own", facets).map((s) => s.insertText)).toEqual(["reason:owned_paths_overlap "]);
+  });
+});

--- a/event-runtime/web/src/filterQuery.ts
+++ b/event-runtime/web/src/filterQuery.ts
@@ -333,7 +333,14 @@ export const RUN_FACETS: FilterFacets<RunListItem, RunFilterContext> = {
   },
 };
 
-export const EVENT_FACETS: FilterFacets<AdmittedEvent, undefined> = {
+/**
+ * An event row as the Events view filters it: the admitted event plus the
+ * planner's reason for it (WM-594), joined on the client from the proposal /
+ * refused run — the events API does not carry it, so it is optional here.
+ */
+export type EventFilterRow = AdmittedEvent & { decisionReason?: string | null };
+
+export const EVENT_FACETS: FilterFacets<EventFilterRow, undefined> = {
   fields: {
     event: (e) => e.eventId,
     source: (e) => e.source,
@@ -343,6 +350,7 @@ export const EVENT_FACETS: FilterFacets<AdmittedEvent, undefined> = {
     proposal: (e) => e.proposalId,
     run: (e) => e.runId,
     repo: (e) => e.repos,
+    reason: (e) => e.decisionReason,
   },
   flags: {
     stale: {

--- a/event-runtime/web/src/reasons.test.ts
+++ b/event-runtime/web/src/reasons.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { REASONS, humanizeReason } from "./reasons";
+
+describe("humanizeReason (WM-594)", () => {
+  test("known planner and worker codes read as sentences and keep the raw code", () => {
+    expect(humanizeReason("owned_paths_overlap")).toEqual({
+      text: "Owned paths overlap",
+      raw: "owned_paths_overlap",
+    });
+    expect(humanizeReason("needs_human").text).toBe("Needs human");
+    expect(humanizeReason("ticket_security").text).toBe("Ticket is security-labelled");
+    expect(humanizeReason("merge_fix_pr_moved").text).toBe("PR head moved since the plan");
+    expect(humanizeReason("sandbox_unavailable").text).toBe("Sandbox unavailable");
+    expect(humanizeReason("timeout").text).toBe("Timed out");
+    expect(humanizeReason("contract_violation").text).toBe("Output contract violated");
+    expect(humanizeReason("cli_not_found").text).toBe("Agent CLI not found");
+  });
+
+  test("the vocabulary the ticket names is all covered", () => {
+    for (const code of [
+      "owned_paths_overlap",
+      "ticket_assigned",
+      "ticket_dispatch_already_live",
+      "ticket_security",
+      "ticket_escalated",
+      "owned_paths_unknown",
+      "owned_paths_not_closed",
+      "auto_approval_ineligible",
+      "proposal_expired",
+      "repo_unconfigured",
+      "capacity_full",
+      "merge_fix_pr_moved",
+      "needs_human",
+      "contract_violation",
+      "timeout",
+      "cli_not_found",
+      "sandbox_unsupported",
+      "sandbox_unavailable",
+    ]) {
+      expect(REASONS[code]).toBeTruthy();
+    }
+  });
+
+  test("unknown codes fall back to the code with underscores dropped, suffix kept as detail", () => {
+    expect(humanizeReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
+    expect(humanizeReason("some_new_code:extra_detail").text).toBe("some new code — extra detail");
+    // The message after the colon is one free-text fragment, colons and all.
+    expect(humanizeReason("repo_unknown: no repo named x: y").text).toBe(
+      "Repo is not configured — no repo named x: y",
+    );
+  });
+
+  test("agent_exit_N is one family", () => {
+    expect(humanizeReason("agent_exit_1").text).toBe("Agent exited with code 1");
+    expect(humanizeReason("agent_exit_143").text).toBe("Agent exited with code 143");
+  });
+
+  test("chained codes humanize every known fragment", () => {
+    expect(humanizeReason("auto_approval_ineligible:proposal_expired").text).toBe(
+      "Not eligible for auto-approval — Proposal expired",
+    );
+    expect(
+      humanizeReason("ticket_dispatch_already_live:run_6fe0cdb4-bb4b-4bcb-ae3a-638dd704a42d:same_ticket_worktree_held")
+        .text,
+    ).toBe(
+      "A dispatch for this ticket is already live — run_6fe0cdb4-bb4b-4bcb-ae3a-638dd704a42d · its worktree is still held",
+    );
+    expect(humanizeReason("policy_denied:Bash").text).toBe("Policy denied tool — Bash");
+  });
+
+  test("extracts run, proposal and ticket references from the suffix", () => {
+    const live = humanizeReason("ticket_dispatch_already_live:run_abc-123:same_ticket_worktree_held");
+    expect(live.refs).toEqual({ runId: "run_abc-123" });
+    // The identifier survives verbatim inside the sentence, so callers can link it.
+    expect(live.text).toContain("run_abc-123");
+
+    const held = humanizeReason("owned_paths_overlap:held by WM-544 (run_x9)");
+    expect(held.refs).toEqual({ runId: "run_x9", ticket: "WM-544" });
+    expect(held.text).toBe("Owned paths overlap — held by WM-544 (run_x9)");
+
+    const prop = humanizeReason("auto_approval_ineligible:merge_barrier_uncertain:prop_0192abc");
+    expect(prop.refs).toEqual({ proposalId: "prop_0192abc" });
+
+    expect(humanizeReason("owned_paths_overlap").refs).toBeUndefined();
+    expect(humanizeReason("run_cancelled").refs).toBeUndefined();
+  });
+
+  test("free-text reasons come back verbatim, still with refs", () => {
+    const r = humanizeReason("WM-328 is already in flight (duplicate proposal)");
+    expect(r.text).toBe("WM-328 is already in flight (duplicate proposal)");
+    expect(r.raw).toBe("WM-328 is already in flight (duplicate proposal)");
+    expect(r.refs).toEqual({ ticket: "WM-328" });
+  });
+
+  test("null, undefined and blank are empty, not 'null'", () => {
+    expect(humanizeReason(null)).toEqual({ text: "", raw: null });
+    expect(humanizeReason(undefined)).toEqual({ text: "", raw: null });
+    expect(humanizeReason("   ")).toEqual({ text: "", raw: null });
+  });
+});

--- a/event-runtime/web/src/reasons.ts
+++ b/event-runtime/web/src/reasons.ts
@@ -1,0 +1,195 @@
+/**
+ * Planner and worker reason codes, as an operator reads them (WM-594).
+ *
+ * The runtime records *why* it did not run something as a snake_case code —
+ * `owned_paths_overlap` on a noop proposal, `needs_human` on a refused run,
+ * `auto_approval_ineligible:proposal_expired` on an open proposal that aged
+ * out. `humanizeReason()` turns any of them into one sentence and keeps the
+ * raw code beside it (for a tooltip / copy), plus whatever identifiers ride in
+ * the `:`-separated suffix so a caller can render them as jump links.
+ *
+ * Kept small and dependency-free on purpose: the Events pane, the per-ticket
+ * Decisions block, the chain timeline (WM-639) and the PR journeys (WM-640)
+ * all render from this one table, so a new planner code is added here once.
+ */
+
+/** Head codes → sentence-cased phrase. Suffix fragments are appended after ` — `. */
+export const REASONS: Record<string, string> = {
+  // planner: dispatch gate (lib/planner.mjs worktreeDispatchAutoEligibility)
+  owned_paths_overlap: "Owned paths overlap",
+  owned_paths_unknown: "Owned paths unknown",
+  owned_paths_not_closed: "Owned paths not closed",
+  escalate_paths_intersect: "Touches an escalate path",
+  escalate_paths_unverifiable: "Escalate paths could not be verified",
+  ticket_assigned: "Ticket is already assigned",
+  ticket_not_found: "Ticket not found",
+  ticket_not_todo: "Ticket is not in Todo",
+  ticket_not_agent_ready: "Ticket is not agent-ready",
+  ticket_escalated: "Ticket is escalated",
+  ticket_security: "Ticket is security-labelled",
+  ticket_dispatch_already_live: "A dispatch for this ticket is already live",
+  same_ticket_worktree_held: "its worktree is still held",
+  ticket_claim_lost: "Ticket claim was lost",
+  repo_unknown: "Repo is not configured",
+  repo_unconfigured: "Repo is not configured",
+  repo_report_only: "Repo is report-only",
+  no_worktree_scripts: "Repo has no worktree scripts",
+  budget_exhausted: "Budget exhausted",
+  budget_check_failed: "Budget check failed",
+  budget_policy_unavailable: "Budget policy unavailable",
+  capacity_full: "No worker capacity",
+  no_capacity: "No worker capacity",
+  worker_cap_full: "Worker cap reached",
+  worker_cap_policy_invalid: "Worker cap policy invalid",
+  circuit_breaker_tripped: "Circuit breaker tripped",
+  circuit_breaker_policy_invalid: "Circuit breaker policy invalid",
+  runtime_policy_unavailable: "Runtime policy unavailable",
+  runtime_guard_failed: "Runtime guard failed",
+  // planner: proposal outcomes
+  observed: "Observed only — nothing to run",
+  duplicate_run: "Duplicate of an existing run",
+  previous_run_in_flight: "Previous run still in flight",
+  work_scan_already_in_flight: "A work scan is already in flight",
+  superseded_by_ttl_replan: "Superseded by a TTL re-plan",
+  replanned_after_ttl: "Re-planned after TTL",
+  run_cancelled: "Run was cancelled",
+  unregistered_event_type: "No agent registered for this event type",
+  fresh_scan_required: "A fresh scan is required",
+  // planner: auto-approval (lib/auto-approval.mjs)
+  auto_approval_ineligible: "Not eligible for auto-approval",
+  proposal_expired: "Proposal expired",
+  dispatch_ineligible: "Dispatch ineligible",
+  dispatch_recheck_failed: "Dispatch re-check failed",
+  dispatch_recheck_unavailable: "Dispatch re-check unavailable",
+  evidence_changed_since_plan: "evidence changed since plan",
+  event_human_approval_only: "Event requires human approval",
+  merge_barrier_unverified: "Merge barrier unverified",
+  merge_barrier_uncertain: "Merge barrier uncertain",
+  merge_fix_round_not_durable: "Merge-fix round not durable",
+  merge_fix_round_exhausted: "Merge-fix rounds exhausted",
+  merge_fix_not_mechanical_or_in_scope: "Merge-fix not mechanical or out of scope",
+  merge_fix_pr_moved: "PR head moved since the plan",
+  merge_fix_pr_not_open: "PR is no longer open",
+  merge_fix_pr_not_found: "PR not found",
+  merge_fix_run_active: "A merge-fix run is already active",
+  merge_fix_owned_paths_moved: "PR touches paths outside Owned Paths",
+  merge_fix_owned_paths_unknown: "Owned paths unknown",
+  merge_fix_ticket_state: "Ticket is not in a merge-fix state",
+  merge_fix_ticket_escalated: "Ticket is escalated",
+  merge_fix_ticket_security: "Ticket is security-labelled",
+  merge_fix_ticket_not_found: "Ticket not found",
+  // worker / verify (lib/worker.mjs, lib/verify.mjs, adapters)
+  needs_human: "Needs human",
+  missing_input: "Missing input",
+  permission_denied: "Permission denied",
+  unsupported_capability: "Unsupported capability",
+  contract_violation: "Output contract violated",
+  baseline_red: "Baseline was already red",
+  timeout: "Timed out",
+  adapter_error: "Adapter error",
+  lease_expired: "Lease expired",
+  linear_unconfigured: "Linear is not configured",
+  linear_read_failed: "Linear read failed",
+  cli_not_found: "Agent CLI not found",
+  unknown_adapter: "Unknown adapter",
+  agent_definition_mismatch: "Agent definition mismatch",
+  workspace_integrity_violation: "Workspace integrity violated",
+  workspace_provisioning_error: "Workspace provisioning failed",
+  worktree_gate_unknown: "Worktree gate could not decide",
+  claim_lock_contention: "Claim lock contention",
+  claim_lock_starvation: "Claim lock starved",
+  claim_lock_busy: "Claim lock busy",
+  policy_denied: "Policy denied tool",
+  sandbox_unsupported: "Sandbox unsupported on this worker",
+  sandbox_unavailable: "Sandbox unavailable",
+  attempts_exhausted: "Attempts exhausted",
+  transient_retry_exhausted: "Transient retries exhausted",
+  dispatch_gate: "Dispatch gate refused",
+  dispatch_gate_transient: "Dispatch gate deferred",
+  cancelled: "Cancelled",
+  operator_cancel: "Cancelled by operator",
+  ok: "OK",
+};
+
+export interface ReasonRefs {
+  runId?: string;
+  ticket?: string;
+  proposalId?: string;
+}
+
+export interface HumanReason {
+  /** One sentence. Empty string when there was no code. */
+  text: string;
+  /** The code exactly as recorded, for tooltips and copy. */
+  raw: string | null;
+  /** Identifiers found in the suffix, so callers can render jump links. */
+  refs?: ReasonRefs;
+}
+
+const RUN_REF = /\brun_[A-Za-z0-9-]+/;
+const PROPOSAL_REF = /\bprop_[A-Za-z0-9-]+/;
+const TICKET_REF = /\b[A-Z][A-Z0-9]{1,9}-\d+\b/;
+/** `agent_exit_1`, `agent_exit_143` — one family, the number is the detail. */
+const AGENT_EXIT = /^agent_exit_(\d+)$/;
+
+function extractRefs(text: string): ReasonRefs | undefined {
+  const refs: ReasonRefs = {};
+  const run = RUN_REF.exec(text);
+  // `run_cancelled` is a code, not an id: real ids are `run_<uuid>`.
+  if (run && !REASONS[run[0]]) refs.runId = run[0];
+  const prop = PROPOSAL_REF.exec(text);
+  if (prop) refs.proposalId = prop[0];
+  const ticket = TICKET_REF.exec(text);
+  if (ticket) refs.ticket = ticket[0];
+  return Object.keys(refs).length ? refs : undefined;
+}
+
+/** A known head, or the family it belongs to (`agent_exit_143`), or nothing. */
+function phraseFor(code: string): string | null {
+  if (REASONS[code]) return REASONS[code];
+  const exit = AGENT_EXIT.exec(code);
+  if (exit) return `Agent exited with code ${exit[1]}`;
+  return null;
+}
+
+/** Fragment text: a known code reads as its phrase, an unknown one drops its underscores. */
+function fragmentText(fragment: string): string {
+  const phrase = phraseFor(fragment);
+  if (phrase) return phrase;
+  // Free text (a Linear title, an error message) and identifiers are kept verbatim.
+  if (/\s/.test(fragment) || !/^[a-z0-9_]+$/i.test(fragment)) return fragment;
+  if (RUN_REF.test(fragment) || PROPOSAL_REF.test(fragment) || TICKET_REF.test(fragment)) return fragment;
+  return fragment.replace(/_/g, " ");
+}
+
+/**
+ * `owned_paths_overlap` → `Owned paths overlap`;
+ * `ticket_dispatch_already_live:run_x:same_ticket_worktree_held` →
+ * `A dispatch for this ticket is already live — run_x · its worktree is still held`
+ * with `refs.runId = "run_x"`;
+ * `some_new_code:detail` → `some new code — detail`. Free-text reasons
+ * (anything with whitespace before the first colon) come back verbatim.
+ */
+export function humanizeReason(code: string | null | undefined): HumanReason {
+  const raw = code == null ? null : String(code);
+  if (!raw || !raw.trim()) return { text: "", raw: null };
+  const trimmed = raw.trim();
+  const refs = extractRefs(trimmed);
+  const colon = trimmed.indexOf(":");
+  const head = colon === -1 ? trimmed : trimmed.slice(0, colon);
+  const rest = colon === -1 ? "" : trimmed.slice(colon + 1);
+
+  // Not a code at all: an operator wrote this sentence, keep it.
+  if (/\s/.test(head)) return { text: trimmed, raw, ...(refs ? { refs } : {}) };
+
+  const headText = phraseFor(head) ?? head.replace(/_/g, " ");
+  // A suffix that is itself a free-text message (`repo_unknown: no such repo:
+  // here`) stays one fragment; a coded chain gets ` · ` between its links.
+  const fragments = (/\s/.test(rest.trim()) ? [rest] : rest.split(":"))
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .map(fragmentText);
+  const detail = fragments.join(" · ");
+  const text = detail ? `${headText} — ${detail}` : headText;
+  return { text, raw, ...(refs ? { refs } : {}) };
+}

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -5,6 +5,8 @@ import { Events } from "./Events";
 import {
   changeInput,
   createEventFixture,
+  createProposalFixture,
+  createRunListItemFixture,
   createStatusFixture,
   renderWithClient,
   restoreApi,
@@ -791,5 +793,108 @@ describe("Events copy chords and hints (WM-233)", () => {
         expect(written).toBe(window.location.href);
       },
     );
+  });
+});
+
+describe("Planner decisions explain themselves (WM-594)", () => {
+  const noopEvent = stubEvent("evt_noop_1", "noop", {
+    source: "linear",
+    subject: "WM-542",
+    proposalId: "prop_noop_1",
+    envelope: { schemaVersion: "factory.event/v1", eventId: "evt_noop_1", type: "dispatch.requested", source: "linear", payload: { ticket: "WM-542" } },
+  });
+  const liveEvent = stubEvent("evt_noop_2", "noop", {
+    source: "linear",
+    subject: "WM-543",
+    proposalId: "prop_noop_2",
+    envelope: { schemaVersion: "factory.event/v1", eventId: "evt_noop_2", type: "dispatch.requested", source: "linear", payload: { ticket: "WM-543" } },
+  });
+  const refusedEvent = stubEvent("evt_planned_1", "planned", {
+    source: "linear",
+    subject: "WM-544",
+    proposalId: "prop_run_1",
+    runId: "run_refused_1",
+  });
+  const plainEvent = stubEvent("evt_admitted_1", "admitted");
+  const proposals = [
+    createProposalFixture({ id: "prop_noop_1", decision: "noop", status: "resolved", reason: "owned_paths_overlap", eventId: "evt_noop_1", eventSource: "linear", runId: null }),
+    createProposalFixture({ id: "prop_noop_2", decision: "noop", status: "resolved", reason: "ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held", eventId: "evt_noop_2", eventSource: "linear", runId: null }),
+    createProposalFixture({ id: "prop_run_1", decision: "run", status: "approved", eventId: "evt_planned_1", eventSource: "linear", runId: "run_refused_1" }),
+  ];
+  const runs = [
+    createRunListItemFixture({ runId: "run_refused_1", state: "REFUSED", reasonCode: "needs_human", eventId: "evt_planned_1", eventSource: "linear" }),
+  ];
+  const apiWith = () => ({
+    events: async () => ({ events: [noopEvent, liveEvent, refusedEvent, plainEvent] }),
+    proposalHistory: async () => ({ proposals }),
+    runs: async () => ({ runs }),
+    status: async () => createStatusFixture(),
+  });
+
+  test("the event pane shows a decision row under status, humanized with the raw code in title", async () => {
+    await withApi(apiWith(), async () => {
+      const onJumpRun = mock(() => {});
+      const r = renderEvents({ focusEvent: { source: "linear", eventId: "evt_noop_2" }, onJumpRun });
+      const row = await waitFor(() => {
+        const el = r.container.querySelector('[data-testid="event-decision"]');
+        if (!el) throw new Error("decision row not rendered");
+        return el as HTMLElement;
+      });
+      expect(row.textContent).toContain("noop");
+      expect(row.textContent).toContain("A dispatch for this ticket is already live");
+      expect(row.getAttribute("title")).toBe("ticket_dispatch_already_live:run_held-99:same_ticket_worktree_held");
+      // The run reference in the reason is a jump link.
+      // Once on the decision row, once in the Decisions block headline.
+      fireEvent.click(r.getAllByTitle("Open run run_held-99")[0]);
+      expect(onJumpRun).toHaveBeenCalledWith("run_held-99");
+      // And the ticket's Decisions block is on the pane (lazy chunk — await it).
+      expect(await r.findByText("Decisions")).toBeTruthy();
+    });
+  });
+
+  test("a planned event whose run was refused reads `refused · Needs human`", async () => {
+    await withApi(apiWith(), async () => {
+      const r = renderEvents({ focusEvent: { source: "linear", eventId: "evt_planned_1" } });
+      const row = await waitFor(() => {
+        const el = r.container.querySelector('[data-testid="event-decision"]');
+        if (!el) throw new Error("decision row not rendered");
+        return el as HTMLElement;
+      });
+      expect(row.textContent).toContain("refused");
+      expect(row.textContent).toContain("Needs human");
+      // The list badge for that row carries the same answer as its tooltip.
+      const cell = r.container.querySelector('td[title="evt_planned_1"]')!.closest("tr")!;
+      expect(cell.querySelector('[data-decision="refused"]')?.getAttribute("title")).toBe("refused · Needs human\nneeds_human");
+    });
+  });
+
+  test("noop badges carry the humanized reason as tooltip; reason:<code> filters the list", async () => {
+    await withApi(apiWith(), async () => {
+      const r = renderEvents();
+      await waitFor(() => {
+        const badge = r.container.querySelector('td[title="evt_noop_1"]')?.closest("tr")?.querySelector('[data-decision="noop"]');
+        if (!badge?.getAttribute("title")) throw new Error("tooltip not joined yet");
+        expect(badge.getAttribute("title")).toBe("noop · Owned paths overlap\nowned_paths_overlap");
+      });
+      expect(r.container.querySelector('td[title="evt_admitted_1"]')).toBeTruthy();
+
+      const filterInput = r.getByLabelText("Filter events") as HTMLInputElement;
+      act(() => {
+        changeInput(filterInput, "reason:owned_paths_overlap");
+      });
+      await waitFor(() => {
+        expect(r.container.querySelector('td[title="evt_noop_1"]')).toBeTruthy();
+        expect(r.container.querySelector('td[title="evt_noop_2"]')).toBeNull();
+        expect(r.container.querySelector('td[title="evt_admitted_1"]')).toBeNull();
+      });
+      // The refused run's reason code is a reason too.
+      act(() => {
+        changeInput(filterInput, "reason:needs_human");
+      });
+      await waitFor(() => {
+        expect(r.container.querySelector('td[title="evt_planned_1"]')).toBeTruthy();
+        expect(r.container.querySelector('td[title="evt_noop_1"]')).toBeNull();
+      });
+    });
   });
 });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -19,10 +19,18 @@ import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
-import type { AdmittedEvent, EventFocus } from "../types";
+import type { AdmittedEvent, EventFocus, Proposal, RunListItem } from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
-import { EVENT_FACETS, matchesFilterQuery, parseFilterQuery, type FilterToken } from "../filterQuery";
+import {
+  EVENT_FACETS,
+  matchesFilterQuery,
+  parseFilterQuery,
+  type EventFilterRow,
+  type FilterToken,
+} from "../filterQuery";
+import { humanizeReason } from "../reasons";
+import { ReasonText, TicketDecisionsPanel, eventTicket } from "../components/RunDetailBlocks";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import {
   Ago,
@@ -173,9 +181,56 @@ const TAB_LABEL: Record<StatusTab, string> = {
 
 const keyOf = (e: AdmittedEvent) => `${e.source}:${e.eventId}`;
 
+/**
+ * What the planner decided about one event (WM-594): the proposal it opened
+ * (`planned` / `noop` / `human_needed` + reason), or `refused` when the run it
+ * planned was turned away by the dispatch gate, or the plan error on an event
+ * that never got a proposal. `null` when there is nothing to explain yet.
+ */
+export interface EventDecision {
+  outcome: string;
+  status: string | null;
+  reason: string | null;
+}
+
+export function decisionOf(
+  e: AdmittedEvent,
+  proposalsById: ReadonlyMap<string, Proposal>,
+  proposalsByEvent: ReadonlyMap<string, Proposal>,
+  runsById: ReadonlyMap<string, RunListItem>,
+): EventDecision | null {
+  // A noop proposal can point at the *blocking* run (`duplicate_run`,
+  // `ticket_dispatch_already_live`); only a run planned from this very event
+  // makes the event's decision `refused`.
+  const run = e.runId ? runsById.get(e.runId) : undefined;
+  if (run?.state === "REFUSED" && run.eventSource === e.source && run.eventId === e.eventId)
+    return { outcome: "refused", status: null, reason: run.reasonCode };
+  const proposal = (e.proposalId ? proposalsById.get(e.proposalId) : undefined) ?? proposalsByEvent.get(keyOf(e));
+  if (proposal) {
+    return {
+      outcome: proposal.decision === "run" ? "planned" : proposal.decision,
+      status: proposal.status,
+      reason: proposal.reason,
+    };
+  }
+  if (e.lastPlanError) return { outcome: e.status, status: null, reason: e.lastPlanError };
+  return null;
+}
+
+/** `noop · Owned paths overlap` — badge tooltip and the decision row's text. */
+export function decisionText(d: EventDecision | null): string {
+  if (!d) return "";
+  const reason = humanizeReason(d.reason).text;
+  const status = d.outcome === "planned" && d.status && d.status !== "approved" ? ` (${d.status})` : "";
+  return `${d.outcome}${status}${reason ? ` · ${reason}` : ""}`;
+}
+
 function isStatusTab(value: string | undefined): value is StatusTab {
   return !!value && (STATUS_TABS as readonly string[]).includes(value);
 }
+
+/** The list badge can also read `refused` — an event whose planned run the gate turned away. */
+const LIST_STATUS_HUES: Record<string, string> = { ...EVENT_STATUS_HUES, refused: "var(--hue-warn)" };
 
 const rowWash = (s: string) =>
   s === "dead_lettered" ? "row-wash-err" : s === "human_needed" ? "row-wash-warn" : "";
@@ -268,7 +323,36 @@ export function Events({
     refetchInterval: 2000,
   });
   const statusQ = useQuery({ queryKey: ["status"], queryFn: api.status, refetchInterval: 2000 });
-  const rows = list.data?.events ?? [];
+  // The reason behind a noop / refused row lives on the proposal and the run,
+  // not the event (WM-594); both lists are already cached by other views.
+  const proposalsQ = useQuery({
+    queryKey: ["proposals", "history"],
+    queryFn: () => api.proposalHistory("all"),
+    refetchInterval: 10_000,
+  });
+  const runsQ = useQuery({ queryKey: ["runs", "ALL"], queryFn: () => api.runs(), refetchInterval: 10_000 });
+  const decisions = useMemo(() => {
+    const byId = new Map<string, Proposal>();
+    const byEvent = new Map<string, Proposal>();
+    for (const p of proposalsQ.data?.proposals ?? []) {
+      byId.set(p.id, p);
+      const k = `${p.eventSource}:${p.eventId}`;
+      const prev = byEvent.get(k);
+      if (!prev || prev.created_at < p.created_at) byEvent.set(k, p);
+    }
+    const runsById = new Map<string, RunListItem>();
+    for (const r of runsQ.data?.runs ?? []) runsById.set(r.runId, r);
+    return { byId, byEvent, runsById };
+  }, [proposalsQ.data, runsQ.data]);
+  const decisionFor = (e: AdmittedEvent) => decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
+  const rows: EventFilterRow[] = useMemo(
+    () =>
+      (list.data?.events ?? []).map((e) => {
+        const d = decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
+        return d?.reason ? { ...e, decisionReason: d.reason } : e;
+      }),
+    [list.data, decisions],
+  );
   const scoped = useMemo(() => {
     const focusKey =
       focusEvent?.source && focusEvent?.eventId ? `${focusEvent.source}:${focusEvent.eventId}` : null;
@@ -314,6 +398,23 @@ export function Events({
   );
 
   const parsed = useMemo(() => parseFilterQuery(filter, EVENT_FACETS), [filter]);
+
+  // `reason:` value suggestions come from the reasons actually in the loaded
+  // set (head code only, most frequent first) — the vocabulary is the planner's.
+  const facets = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const e of tabScoped) {
+      const raw = e.decisionReason;
+      if (!raw) continue;
+      const head = raw.includes(":") ? raw.slice(0, raw.indexOf(":")) : raw;
+      if (/\s/.test(head)) continue;
+      counts.set(head, (counts.get(head) ?? 0) + 1);
+    }
+    const reasons = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([r]) => r);
+    return { ...EVENT_FACETS, values: { ...EVENT_FACETS.values, reason: reasons } };
+  }, [tabScoped]);
 
   const activeTypes = useMemo(() => {
     return new Set(
@@ -739,9 +840,10 @@ export function Events({
           <FilterInput
             value={filter}
             onChange={setFilter}
-            placeholder="source:… type:… is:stale"
+            placeholder="source:… type:… reason:… is:stale"
             label="Filter events"
             query={parsed}
+            facets={facets}
           />
         </div>
           </>
@@ -771,8 +873,9 @@ export function Events({
           </thead>
           <tbody>
             {(() => {
-              const renderRow = (e: AdmittedEvent) => {
-                const proposalReason = (e as any).proposalReason ?? (e as any).proposal_reason ?? null;
+              const renderRow = (e: EventFilterRow) => {
+                const decision = decisionFor(e);
+                const decisionTitle = decisionText(decision);
                 const isSelected = keyOf(e) === selectedKey;
                 return (
                   <tr
@@ -802,20 +905,37 @@ export function Events({
                     {show.has("status") && (
                       <td
                         className="max-w-44 overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap"
-                        title={e.lastPlanError ?? proposalReason ?? undefined}
+                        title={e.lastPlanError ?? undefined}
                       >
                         <div className="flex min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap">
-                          <span className="shrink-0">
+                          {/* Why, on hover (WM-594): `noop · Owned paths overlap` — the
+                              raw code follows on a second line for copy/grep. */}
+                          <span
+                            className="flex shrink-0 items-center"
+                            title={
+                              decisionTitle
+                                ? decision?.reason && decision.reason !== decisionTitle
+                                  ? `${decisionTitle}\n${decision.reason}`
+                                  : decisionTitle
+                                : undefined
+                            }
+                            data-decision={decision?.outcome ?? undefined}
+                          >
                             <StateBadge state={e.status} hues={EVENT_STATUS_HUES} />
+                            {decision?.outcome === "refused" && (
+                              <span className="ml-1.5">
+                                <StateBadge state="refused" hues={LIST_STATUS_HUES} dot={false} />
+                              </span>
+                            )}
                           </span>
                           {e.planFailures > 0 && (
                             <span className="shrink-0 text-[11px] text-(--hue-err)">
                               {e.planFailures} failure{e.planFailures === 1 ? "" : "s"}
                             </span>
                           )}
-                          {(e.lastPlanError || proposalReason) && (
+                          {e.lastPlanError && (
                             <span className="mono min-w-0 truncate text-(--text-dim)">
-                              {e.lastPlanError ?? proposalReason}
+                              {e.lastPlanError}
                             </span>
                           )}
                         </div>
@@ -962,6 +1082,36 @@ export function Events({
             <KV k="type" v={sel.type} />
             <KV k="subject" v={sel.subject} />
             <KV k="status" v={<StateBadge state={sel.status} hues={EVENT_STATUS_HUES} />} />
+            {(() => {
+              // Why the planner did what it did (WM-594): directly under status,
+              // humanized, raw code in the tooltip, references as jump links.
+              const d = decisionFor(sel);
+              if (!d) return null;
+              return (
+                <KV
+                  k="decision"
+                  v={
+                    <span className="flex min-w-0 flex-wrap items-baseline gap-1.5 whitespace-normal" data-testid="event-decision" title={d.reason ?? undefined}>
+                      <StateBadge state={d.outcome} hues={LIST_STATUS_HUES} dot={false} />
+                      {d.outcome === "planned" && d.status && d.status !== "approved" && (
+                        <span className="text-(--text-faint)">({d.status})</span>
+                      )}
+                      {d.reason && (
+                        <>
+                          <span className="text-(--text-faint)" aria-hidden="true">·</span>
+                          <ReasonText
+                            code={d.reason}
+                            onJumpRun={onJumpRun}
+                            onJumpProposal={onJumpProposal}
+                            className="min-w-0 break-words"
+                          />
+                        </>
+                      )}
+                    </span>
+                  }
+                />
+              );
+            })()}
             <KV
               k="correlationId"
               v={
@@ -1010,15 +1160,26 @@ export function Events({
           </Section>
 
           {(() => {
-            const r = (sel as any).proposalReason ?? (sel as any).proposal_reason ?? null;
-            if (sel.planFailures <= 0 && !sel.lastPlanError && !r) return null;
+            const ticket = eventTicket(sel);
+            if (!ticket) return null;
+            return (
+              <TicketDecisionsPanel
+                ticket={ticket}
+                now={now}
+                onJumpRun={onJumpRun}
+                onJumpProposal={onJumpProposal}
+              />
+            );
+          })()}
+
+          {(() => {
+            if (sel.planFailures <= 0 && !sel.lastPlanError) return null;
             const err = sel.lastPlanError;
-            const hue = err ? "var(--hue-err)" : "var(--hue-warn)";
+            const hue = "var(--hue-err)";
             return (
               <Section title="Planning" icons>
                 {sel.planFailures > 0 && <KV k="planFailures" v={String(sel.planFailures)} />}
-                {r && <KV k="proposalReason" v={r} />}
-                {(err || r) && (
+                {err && (
                   <div
                     className="mt-1.5 rounded-md px-2.5 py-1.5 text-[12px]"
                     style={{
@@ -1026,7 +1187,7 @@ export function Events({
                       background: `color-mix(in oklch, ${hue} 10%, transparent)`,
                     }}
                   >
-                    {err ?? r}
+                    {err}
                   </div>
                 )}
               </Section>


### PR DESCRIPTION
Fixes WM-594

Serves WM-592 job 2: the planner deciding *not* to run something is now explained wherever the operator looks.

## What changed
- **`event-runtime/web/src/reasons.ts`** (new, shared with WM-639/WM-640): `REASONS` table (planner noop/human_needed codes, auto-approval `auto_approval_ineligible:*` chains, worker/verify refusal codes) and `humanizeReason(code) → { text, raw, refs?: { runId, ticket, proposalId } }`. Unknown codes fall back to `code.replace(/_/g," ")`; suffix after `:` kept as detail; free-text reasons come back verbatim; identifiers in the suffix are returned in `refs`.
- **Events pane**: a `decision` row directly under `status` — `noop · A dispatch for this ticket is already live — run_x · its worktree is still held`, `refused · Needs human`, `planned (rejected) · …` — humanized, raw code in `title`, run/proposal/ticket references as jump links.
- **Events list**: `noop`/`planned` badges carry the humanized reason (+ raw code) as tooltip; a `refused` badge appears next to `planned` when the event's own run was turned away by the dispatch gate; the filter box accepts `reason:<code>` with value suggestions from the distinct reasons in the loaded set. Reasons are joined client-side from `/proposals?status=all` + `/runs` (10 s refetch; same query keys the palette/overview use, so usually a cache hit).
- **Decisions block** (`components/TicketDecisions.tsx`, lazy chunk; `TicketDecisionsPanel` handle exported from `RunDetailBlocks.tsx`): every planner decision for a ticket, chronological, built client-side from events (subject / `payload.ticket`) + proposals (event link or `spec.input.ticket`) + REFUSED runs; collapsed to `last: noop · Owned paths overlap · 3m ago · 8 decisions`. Rendered on the run pane (`input.ticket`) and the event pane (subject/payload). No server endpoint added — the join over ~1.7k events / ~1.7k proposals is instant.
- **⌘K**: typing a ticket id offers `Why isn't WM-542 running?` → opens the ticket journey `#/tickets/<id>` (WM-595), which already lists every decision and names the blocking reason in its next-action line.

## Verification
`bun test event-runtime/lib && cd event-runtime/web && bun run build && bun test`
- lib: 948 pass / 2 fail under load (`adapters/command.test.mjs` "reaper run planned from a clock tick", `adapters/cursor.test.mjs` execute-conformance grandchild timeout) — both pass in isolation; known load flakes.
- web: `bun run build` green, entry chunk 573.05 kB (budget 575 kB; the Decisions block is a 6.3 kB lazy chunk); `bun test` 788 pass / 0 fail.

## UX critique
Round 1 against the live API on the worktree dist: the Decisions list squeezed the reason to one character beside long event ids → joins moved to their own wrapping line; a noop event whose proposal points at the *blocking* run was reading `refused` → refused only when the run was planned from that very event. SHIP after 1 round.

## Files outside Owned Paths
- `event-runtime/web/src/components/TicketDecisions.tsx` (new) — the ticket's own instruction: lazy-load the Decisions block rather than raise the budget (upstream growth since the branch base pushed the entry to 578 kB).
- `event-runtime/web/src/App.test.tsx` — one assertion adapted (`findAllByText`) because the palette now offers two items naming the typed ticket.
