### PR TITLE
fix(event-runtime-web): chainTimeline imports subjectJourney after the #549 rename — develop web build red (WM-645)

### DIFF
--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -13,7 +13,7 @@
  */
 import type { ScheduleItem } from "./api";
 import { eventNodeId, runNodeId } from "./graph/chainModel";
-import { formatDuration } from "./ticketJourney";
+import { formatDuration } from "./subjectJourney";
 import type { ChainEvent, ChainRun, ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes WM-645

#547 (WM-639) added `chainTimeline.ts` importing `./ticketJourney`; #549 (WM-640) renamed it to `subjectJourney.ts`. Both were green on their own bases; develop's `bun run build` (tsc) is red (`TS2307`), Verify run 32063591253 failed. `bun test` does not typecheck, which is why Fast unit tests stayed green.

One-line fix. Verified: `cd event-runtime/web && bun run build` clean (0 TS errors), `bun test src/chainTimeline.test.ts src/views/Chain.test.tsx` 17/17.

Follow-up: add the web tsc build to the CI Verify job so a rename cannot merge green again.