### PR TITLE
fix(web): restore develop web build — chainTimeline imports ./subjectJourney (WM-644)

### DIFF
--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -13,7 +13,7 @@
  */
 import type { ScheduleItem } from "./api";
 import { eventNodeId, runNodeId } from "./graph/chainModel";
-import { formatDuration } from "./ticketJourney";
+import { formatDuration } from "./subjectJourney";
 import type { ChainEvent, ChainRun, ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes WM-644

One-line forward fix: `chainTimeline.ts` (from #547 / WM-639) imported `formatDuration` from `./ticketJourney`, which #549 / WM-640 renamed to `./subjectJourney`. #549's PR CI ran before #547 landed and was merged without a re-run, so develop CI on 1ccbc67 is red (`TS2307 Cannot find module './ticketJourney'`).

## Verification
- `cd event-runtime/web && bun run build` — green
- `bun test src/chainTimeline.test.ts` — 13 pass

## Handoff
- Process finding: Verify does build the web UI, but PR CI is not re-run when the base advances (no "require branches to be up to date" rule), so semantic conflicts between concurrently-merged web PRs slip through. Consider requiring up-to-date branches or a merge-queue for `develop`.