### PR TITLE
feat(event-runtime): extend running run deadlines (WM-566)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -644,6 +644,32 @@ timeout discipline (TERM, then KILL) and terminates as `cancelled`. Every
 transition records actor, reason code, attempt, correlation ID, causation ID,
 and policy version. Illegal transitions are rejected rather than repaired.
 
+A `RUNNING` or `VERIFYING` run may be extended through
+`POST /runs/:runId/extend` with `{ "seconds": N }`. Each call is limited to
+3600 seconds and the resulting deadline may not exceed
+`limits.max_run_minutes` from `config/policy.yaml` unless the operator supplies
+`override: true`. The runtime appends an audited `deadline_extended` lifecycle
+record (actor, increment, resulting deadline), moves the attempt lease to the
+new deadline plus grace, and includes those extension records in a terminal
+receipt. Refusals are typed and non-retryable. The CLI equivalent is:
+
+```bash
+bun event-runtime/cli.mjs extend <runId> --seconds 900
+```
+
+The worker re-reads the deadline while the adapter is running. Expiry and
+extension acceptance serialize through the database: an extension committed
+before the old edge postpones adapter TERM/KILL and lease renewal, while expiry
+commits a durable marker before TERM and makes later requests typed refusals
+throughout kill grace. Neither changes the approved `RunSpec`.
+
+The synchronous `actions` adapter is explicitly not extendable: it blocks the
+worker event loop inside bounded child calls and its timeout machinery cannot
+be rescheduled safely from the owned worker/API boundary. The API returns
+`adapter_deadline_not_extendable` rather than accepting an extension it cannot
+honor. Making actions extendable requires a separately owned adapter change to
+use cooperative asynchronous execution.
+
 Delivery is **at least once**, never assumed exactly once:
 
 - unique source event IDs deduplicate intake;

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -24,6 +24,7 @@ const EXPECTED_COMMANDS = [
   "requeue",
   "cancel",
   "retry",
+  "extend",
   "inspect",
   "trace",
   "update-pins",

--- a/event-runtime/cli/commands.mjs
+++ b/event-runtime/cli/commands.mjs
@@ -3,6 +3,7 @@ import approve from "./approve.mjs";
 import cancel from "./cancel.mjs";
 import doctor from "./doctor.mjs";
 import events from "./events.mjs";
+import extend from "./extend.mjs";
 import inbox from "./inbox.mjs";
 import inject from "./inject.mjs";
 import inspect from "./inspect.mjs";
@@ -45,6 +46,7 @@ export const COMMANDS = Object.freeze({
   requeue,
   cancel,
   retry,
+  extend,
   inspect,
   trace,
   "update-pins": updatePins,

--- a/event-runtime/cli/extend.mjs
+++ b/event-runtime/cli/extend.mjs
@@ -1,0 +1,16 @@
+import { fail, withClient } from "./shared.mjs";
+
+export default function extend(args) {
+  const runId = args[0];
+  const secondsAt = args.indexOf("--seconds");
+  const seconds = Number(secondsAt >= 0 ? args[secondsAt + 1] : NaN);
+  if (!runId || !Number.isInteger(seconds) || seconds <= 0 || seconds > 3600) {
+    fail("usage: extend <run-id> --seconds N [--override] (N must be 1..3600)");
+  }
+  return withClient(async (client) => {
+    const outcome = await client.extend(runId, seconds, {
+      override: args.includes("--override"),
+    });
+    console.log(`extended ${runId} by ${seconds}s; deadline ${outcome.deadlineAt}`);
+  });
+}

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -50,6 +50,8 @@ usage: bun event-runtime/cli.mjs <command>
   requeue <source> <event-id>    re-plan a dead-lettered or human_needed event
   cancel <run-id> [reason]       cancel a run before it is RUNNING
   retry <run-id> [--force]       re-queue a FAILED run (--force past maxAttempts)
+  extend <run-id> --seconds N [--override]
+                                 extend a RUNNING/VERIFYING deadline (max 3600s per call)
   inspect <run-id>               spec, lifecycle journal, result, receipt, workspace
   trace <run-id>                 live agent trace: assistant text, tool calls, usage
   update-pins                    re-pin agent definition content hashes (edits repo files)

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1,5 +1,8 @@
 /** Event, proposal, run, journal, outbox, and worker-action endpoints. */
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { artifactHead } from "./api-artifacts.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
 import { runUsage } from "./db.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
@@ -9,7 +12,35 @@ import {
   rejectProposal,
 } from "./proposals.mjs";
 import { traceOf } from "./trace.mjs";
-import { cancelRun, releaseStalledWorkerLease, retryRun } from "./worker.mjs";
+import {
+  attemptDeadline,
+  cancelRun,
+  extendRunDeadline,
+  releaseStalledWorkerLease,
+  retryRun,
+} from "./worker.mjs";
+
+export const MAX_EXTENSION_SECONDS = 3600;
+
+export function policyMaxRunMinutes(root = FACTORY_ROOT) {
+  try {
+    const value = Bun.YAML.parse(
+      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
+    )?.limits?.max_run_minutes;
+    return Number.isFinite(value) && value > 0 ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+function extensionRefusal(send, status, code, detail = {}) {
+  return send(status, {
+    error: code,
+    extended: false,
+    refusal: { code, retryable: false, ...detail },
+  });
+}
+
 
 /** Optional repository names named by a run/event input (OPS-356). */
 export function repoNamesFromInput(input) {
@@ -308,7 +339,8 @@ function runsView(db, state) {
   const where = state ? `WHERE r.state = ?` : ``;
   const rows = db
     .query(
-      `SELECT r.*, a.reason_code, a.terminal_state AS attempt_terminal, p.event_id, p.event_source
+      `SELECT r.*, a.reason_code, a.terminal_state AS attempt_terminal,
+              a.started_at, a.lease_expires_at, p.event_id, p.event_source
        FROM runs r
        LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
        LEFT JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
@@ -332,6 +364,15 @@ function runsView(db, state) {
       updated_at: row.updated_at,
       modelTier: spec.modelTier ?? null,
       model: spec.model ?? null,
+      startedAt: row.started_at ?? null,
+      leaseExpiresAt: row.lease_expires_at ?? null,
+      deadlineAt: row.attempts > 0
+        ? (() => {
+            const deadline = attemptDeadline(db, row.run_id, row.attempts, spec);
+            return Number.isFinite(deadline) ? new Date(deadline).toISOString() : null;
+          })()
+        : null,
+      timeoutSeconds: spec.timeoutSeconds,
       repos: repoNamesFromInput(spec.input),
     };
   });
@@ -428,6 +469,9 @@ function runView(db, runId, { artifactsDir } = {}) {
     (a) => a.kind === "transcript",
   );
   const latest = attempts[attempts.length - 1];
+  const deadline = latest
+    ? attemptDeadline(db, runId, latest.attempt, JSON.parse(row.spec_json))
+    : null;
   return {
     run: {
       runId: row.run_id,
@@ -444,6 +488,7 @@ function runView(db, runId, { artifactsDir } = {}) {
     result,
     receipt: resultRow ? JSON.parse(resultRow.receipt_json) : null,
     workspace: latest?.workspace_path ?? null,
+    deadlineAt: Number.isFinite(deadline) ? new Date(deadline).toISOString() : null,
     observedModel:
       artifactsDir && transcript?.sha256
         ? observedModelFromTranscript(
@@ -596,6 +641,59 @@ export async function handleRunApiRoute({
       return send(200, journey);
     }
     return send(200, { runs: runsView(db, url.searchParams.get("state")) });
+  }
+
+  const runExtend = url.pathname.match(/^\/runs\/([^/]+)\/extend$/);
+  if (req.method === "POST" && runExtend) {
+    const runId = decodeURIComponent(runExtend[1]);
+    const body = parseJson(await readBody(req)).value ?? {};
+    const seconds = Number(body.seconds);
+    if (!Number.isInteger(seconds) || seconds <= 0) {
+      return extensionRefusal(send, 422, "invalid_extension_seconds", {
+        message: "seconds must be a positive integer",
+      });
+    }
+    if (seconds > MAX_EXTENSION_SECONDS) {
+      return extensionRefusal(send, 422, "extension_too_large", {
+        message: `seconds must be <= ${MAX_EXTENSION_SECONDS}`,
+        maxSeconds: MAX_EXTENSION_SECONDS,
+      });
+    }
+
+    const row = db.query(
+      `SELECT r.state, r.attempts, a.started_at
+         FROM runs r
+         LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+        WHERE r.run_id = ?`,
+    ).get(runId);
+    if (!row) return extensionRefusal(send, 404, "unknown_run", { runId });
+
+    const override = body.override === true;
+    const maxMinutes = policyMaxRunMinutes();
+    if (!override && !Number.isFinite(maxMinutes)) {
+      return extensionRefusal(send, 409, "run_limit_policy_unavailable");
+    }
+    const startedMs = Date.parse(row.started_at ?? "");
+    const maxDeadlineMs = Number.isFinite(startedMs) && Number.isFinite(maxMinutes)
+      ? startedMs + maxMinutes * 60 * 1000
+      : null;
+    const outcome = extendRunDeadline(db, runId, {
+      seconds,
+      actor,
+      override,
+      maxDeadlineMs,
+      policyVersion,
+      now: nowMs,
+    });
+    if (outcome.refused) {
+      return extensionRefusal(send, outcome.status ?? 409, outcome.code, {
+        state: outcome.state,
+        adapter: outcome.adapter,
+        deadlineAt: outcome.deadlineAt,
+        maxDeadlineAt: outcome.maxDeadlineAt,
+      });
+    }
+    return send(200, { extended: true, ...outcome });
   }
 
   const runVerb = url.pathname.match(/^\/runs\/([^/]+)\/(cancel|retry)$/);

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -35,6 +35,103 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 
+describe("run deadline extension (WM-566)", () => {
+  const start = Date.parse("2026-08-12T10:00:00Z");
+
+  function insertAttempt(db, runId, { state = "RUNNING", timeoutSeconds = 60, adapter = "fake" } = {}) {
+    const spec = {
+      schemaVersion: "factory.run-spec/v1",
+      runId,
+      agent: "factory-status-report@1",
+      input: { repos: ["ok"] },
+      workspace: { type: "ephemeral" },
+      adapter,
+      outputContract: "factory.status-report/v1",
+      timeoutSeconds,
+      maxAttempts: 1,
+      idempotencyKey: `idem-${runId}`,
+    };
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'sha256:test', ?, 1, ?, ?)`,
+    ).run(runId, spec.idempotencyKey, JSON.stringify(spec), state, new Date(start).toISOString(), new Date(start).toISOString());
+    db.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, started_at, lease_expires_at)
+       VALUES (?, 1, 1, 'worker-test', ?, ?)`,
+    ).run(
+      runId,
+      new Date(start).toISOString(),
+      new Date(start + (timeoutSeconds + 120) * 1000).toISOString(),
+    );
+  }
+
+  test("extends a running deadline, lease, and audited lifecycle", async () => {
+    const s = await makeServer({ now: () => start + 10_000 });
+    try {
+      insertAttempt(s.db, "run-extend-happy");
+      const outcome = await s.client.extend("run-extend-happy", 900);
+      expect(outcome).toEqual({
+        extended: true,
+        runId: "run-extend-happy",
+        seconds: 900,
+        deadlineAt: new Date(start + 960_000).toISOString(),
+        leaseExpiresAt: new Date(start + 1_080_000).toISOString(),
+        override: false,
+      });
+      const lifecycle = s.db.query(
+        `SELECT from_state, to_state, actor, reason FROM lifecycle_events WHERE run_id = ?`,
+      ).get("run-extend-happy");
+      expect(lifecycle.from_state).toBe("RUNNING");
+      expect(lifecycle.to_state).toBe("RUNNING");
+      expect(lifecycle.actor).toBe("operator");
+      expect(JSON.parse(lifecycle.reason)).toEqual({
+        deadlineAt: outcome.deadlineAt,
+        override: false,
+        seconds: 900,
+        type: "deadline_extended",
+      });
+      expect((await s.client.run("run-extend-happy")).deadlineAt).toBe(outcome.deadlineAt);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("returns typed terminal refusals for state, policy cap, and per-call bound", async () => {
+    const s = await makeServer({ now: () => start });
+    try {
+      insertAttempt(s.db, "run-extend-queued", { state: "QUEUED" });
+      const wrongState = await rejection(s.client.extend("run-extend-queued", 60));
+      expect(wrongState.status).toBe(409);
+      expect(wrongState.body.refusal).toMatchObject({ code: "run_not_extendable", retryable: false });
+
+      insertAttempt(s.db, "run-extend-cap", { timeoutSeconds: 5_390 });
+      const capped = await rejection(s.client.extend("run-extend-cap", 20));
+      expect(capped.status).toBe(409);
+      expect(capped.body.refusal).toMatchObject({ code: "policy_run_limit", retryable: false });
+      expect((await s.client.extend("run-extend-cap", 20, { override: true })).override).toBe(true);
+
+      insertAttempt(s.db, "run-extend-actions", { adapter: "actions" });
+      const actions = await rejection(s.client.extend("run-extend-actions", 60));
+      expect(actions.status).toBe(409);
+      expect(actions.body.refusal).toMatchObject({
+        code: "adapter_deadline_not_extendable",
+        retryable: false,
+        adapter: "actions",
+      });
+
+      const bounded = await rejection(s.client.extend("run-extend-cap", 3_601));
+      expect(bounded.status).toBe(422);
+      expect(bounded.body.refusal).toEqual(expect.objectContaining({
+        code: "extension_too_large",
+        retryable: false,
+        maxSeconds: 3_600,
+      }));
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("repoNamesFromInput (OPS-356)", () => {
   test("unscoped is []; repoPin / repo / repos[] (string or {name}); dedupes", () => {
     expect(repoNamesFromInput(null)).toEqual([]);

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -88,5 +88,9 @@ export function apiClient({ port = DEFAULT_PORT, host = API_HOST } = {}) {
       }),
     retry: (id, { force = false } = {}) =>
       call("POST", `/runs/${encodeURIComponent(id)}/retry`, { body: JSON.stringify({ force }) }),
+    extend: (id, seconds, { override = false } = {}) =>
+      call("POST", `/runs/${encodeURIComponent(id)}/extend`, {
+        body: JSON.stringify({ seconds, override }),
+      }),
   };
 }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -37,8 +37,221 @@ import { createWorkspace, destroyWorkspace, PathViolation, safeJoin } from "./wo
  */
 const RUNTIME_ARTIFACTS = [{ kind: "transcript", path: ".transcript.json" }];
 
-/** Grace added to the spec timeout before a lease is considered abandoned. */
-const LEASE_GRACE_SECONDS = 120;
+/** Grace added to the execution deadline before a lease is considered abandoned. */
+export const LEASE_GRACE_SECONDS = 120;
+
+/**
+ * Process adapters keep their own TERM/KILL timer. Give adapters that honor
+ * AbortSignal a ceiling above any normal policy window; the worker's durable
+ * DB-backed deadline monitor is the authoritative timer and can move while an
+ * attempt is running.
+ */
+const DYNAMIC_ADAPTER_TIMEOUT_MS = 2_147_000_000;
+const DYNAMIC_DEADLINE_ADAPTERS = new Set([
+  "agy", "claude", "command", "cursor", "fake", "pi",
+]);
+const DEADLINE_POLL_MS = 100;
+
+function deadlineEventFromReason(reason, type) {
+  if (typeof reason !== "string" || !reason.startsWith("{")) return null;
+  try {
+    const value = JSON.parse(reason);
+    if (
+      value?.type === type &&
+      typeof value.deadlineAt === "string" &&
+      Number.isFinite(Date.parse(value.deadlineAt))
+    ) return value;
+  } catch {}
+  return null;
+}
+
+function deadlineExtensionFromReason(reason) {
+  const value = deadlineEventFromReason(reason, "deadline_extended");
+  return value && Number.isInteger(value.seconds) && value.seconds > 0 ? value : null;
+}
+
+function deadlineExpiredFromReason(reason) {
+  return deadlineEventFromReason(reason, "deadline_expired");
+}
+
+/** Durable attempt deadline: latest extension, then the immutable initial budget. */
+export function attemptDeadline(db, runId, attempt, spec = null) {
+  const extensionRows = db.query(
+    `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+  ).all(runId, attempt);
+  for (const row of extensionRows) {
+    const extension = deadlineExtensionFromReason(row.reason);
+    if (extension) return Date.parse(extension.deadlineAt);
+  }
+  const row = db.query(
+    `SELECT started_at, lease_expires_at FROM attempts WHERE run_id = ? AND attempt = ?`,
+  ).get(runId, attempt);
+  if (!row) return null;
+  const parsedSpec = spec ?? (() => {
+    const run = db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId);
+    return run?.spec_json ? JSON.parse(run.spec_json) : null;
+  })();
+  if (row.started_at && Number.isFinite(Number(parsedSpec?.timeoutSeconds))) {
+    return Date.parse(row.started_at) + Number(parsedSpec.timeoutSeconds) * 1000;
+  }
+  if (row.lease_expires_at) {
+    return Date.parse(row.lease_expires_at) - LEASE_GRACE_SECONDS * 1000;
+  }
+  return null;
+}
+
+export function deadlineExtensions(db, runId) {
+  return db.query(
+    `SELECT seq, actor, reason, at FROM lifecycle_events WHERE run_id = ? ORDER BY seq`,
+  ).all(runId).flatMap((row) => {
+    const extension = deadlineExtensionFromReason(row.reason);
+    return extension ? [{ seq: row.seq, actor: row.actor, at: row.at, ...extension }] : [];
+  });
+}
+
+/** Append an audited extension and move the current attempt's lease atomically. */
+export function extendRunDeadline(db, runId, {
+  seconds,
+  actor,
+  override = false,
+  maxDeadlineMs = null,
+  policyVersion = "unknown",
+  now = Date.now(),
+} = {}) {
+  return txImmediate(db, () => {
+    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(runId);
+    if (!run) return { refused: true, code: "unknown_run", status: 404 };
+    if (!["RUNNING", "VERIFYING"].includes(run.state)) {
+      return { refused: true, code: "run_not_extendable", status: 409, state: run.state };
+    }
+    const spec = JSON.parse(run.spec_json);
+    if (spec.adapter === "actions") {
+      return {
+        refused: true,
+        code: "adapter_deadline_not_extendable",
+        status: 409,
+        adapter: spec.adapter,
+      };
+    }
+    const deadlineRows = db.query(
+      `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+    ).all(runId, run.attempts);
+    if (deadlineRows.some((row) => deadlineExpiredFromReason(row.reason))) {
+      return { refused: true, code: "deadline_already_expired", status: 409 };
+    }
+    const currentDeadline = attemptDeadline(db, runId, run.attempts, spec);
+    if (!Number.isFinite(currentDeadline)) {
+      return { refused: true, code: "deadline_unavailable", status: 409 };
+    }
+    // Serialize the edge decision under the same write lock as worker expiry.
+    // A delayed worker poll must not let an operator revive an already-spent
+    // deadline merely because the durable expiry marker has not landed yet.
+    if (resolveNow(now) >= currentDeadline) {
+      return {
+        refused: true,
+        code: "deadline_already_expired",
+        status: 409,
+        deadlineAt: new Date(currentDeadline).toISOString(),
+      };
+    }
+    const deadlineMs = currentDeadline + seconds * 1000;
+    if (!override && Number.isFinite(maxDeadlineMs) && deadlineMs > maxDeadlineMs) {
+      return {
+        refused: true,
+        code: "policy_run_limit",
+        status: 409,
+        deadlineAt: new Date(currentDeadline).toISOString(),
+        maxDeadlineAt: new Date(maxDeadlineMs).toISOString(),
+      };
+    }
+    const at = iso(now);
+    const deadlineAt = new Date(deadlineMs).toISOString();
+    const leaseExpiresAt = new Date(deadlineMs + LEASE_GRACE_SECONDS * 1000).toISOString();
+    const reason = canonicalJson({
+      type: "deadline_extended",
+      seconds,
+      deadlineAt,
+      override: override === true,
+    });
+    const record = {
+      runId,
+      from: run.state,
+      to: run.state,
+      actor,
+      reason,
+      attempt: run.attempts,
+      policyVersion,
+      at,
+    };
+    db.query(
+      `INSERT INTO lifecycle_events
+         (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+    ).run(
+      runId, run.state, run.state, actor, reason, run.attempts,
+      policyVersion, at, hashJson(record),
+    );
+    db.query(
+      `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
+    ).run(leaseExpiresAt, runId, run.attempts);
+    db.query(`UPDATE runs SET updated_at = ? WHERE run_id = ?`).run(at, runId);
+    return { runId, seconds, deadlineAt, leaseExpiresAt, override: override === true };
+  });
+}
+
+/**
+ * Durably claim expiry before signalling the adapter. This transaction races
+ * the extension transaction under the same SQLite write lock: an extension
+ * that commits first moves the deadline, while an expiry that commits first
+ * makes every later extension a typed refusal throughout TERM/KILL grace.
+ */
+export function expireRunDeadline(db, runId, attempt, fencingToken, {
+  actor,
+  policyVersion = "unknown",
+  now = Date.now(),
+} = {}) {
+  return txImmediate(db, () => {
+    const run = db.query(`SELECT state, attempts, spec_json FROM runs WHERE run_id = ?`).get(runId);
+    if (!run || run.attempts !== attempt || !["RUNNING", "VERIFYING"].includes(run.state)) {
+      return { expired: false, inactive: true };
+    }
+    if (!assertCurrentToken(db, runId, fencingToken)) return { expired: false, fenced: true };
+    const rows = db.query(
+      `SELECT reason FROM lifecycle_events WHERE run_id = ? AND attempt = ? ORDER BY seq DESC`,
+    ).all(runId, attempt);
+    const prior = rows.map((row) => deadlineExpiredFromReason(row.reason)).find(Boolean);
+    if (prior) return { expired: true, deadlineAt: prior.deadlineAt, existing: true };
+
+    const deadlineMs = attemptDeadline(db, runId, attempt, JSON.parse(run.spec_json));
+    const currentNow = resolveNow(now);
+    if (!Number.isFinite(deadlineMs) || currentNow < deadlineMs) {
+      return { expired: false, deadlineMs };
+    }
+
+    const at = iso(currentNow);
+    const deadlineAt = new Date(deadlineMs).toISOString();
+    const reason = canonicalJson({ type: "deadline_expired", deadlineAt });
+    const record = {
+      runId,
+      from: run.state,
+      to: run.state,
+      actor,
+      reason,
+      attempt,
+      policyVersion,
+      at,
+    };
+    db.query(
+      `INSERT INTO lifecycle_events
+         (run_id, from_state, to_state, actor, reason, attempt, correlation_id, causation_id, policy_version, at, record_hash)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)`,
+    ).run(
+      runId, run.state, run.state, actor, reason, attempt,
+      policyVersion, at, hashJson(record),
+    );
+    return { expired: true, deadlineAt };
+  });
+}
 
 /** Infrastructure retries are independent from the agent-error attempt budget. */
 export const DEFAULT_MAX_ENVIRONMENT_RETRIES = 3;
@@ -179,6 +392,14 @@ function latestJournalHash(db, runId) {
   return db
     .query(`SELECT record_hash FROM lifecycle_events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`)
     .get(runId)?.record_hash ?? null;
+}
+
+function receiptWithDeadlineExtensions(db, runId, options) {
+  const receipt = createReceipt(options);
+  const extensions = deadlineExtensions(db, runId);
+  return extensions.length > 0
+    ? { ...receipt, deadlineExtensions: canonicalJson(extensions) }
+    : receipt;
 }
 
 /** The admitted event this run was planned from, via its proposal (may be absent). */
@@ -883,7 +1104,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         runId, to: "REFUSED", expectFrom: "VERIFYING",
         actor: owner, reason: journalReason, attempt, policyVersion, now: currentNow,
       });
-      const receipt = createReceipt({
+      const receipt = receiptWithDeadlineExtensions(db, runId, {
         runId,
         spec,
         def,
@@ -1135,20 +1356,93 @@ export async function executeClaimed(db, registry, adapters, claim, {
     const onUsage = (usage) => {
       attemptUsage = { adapter: adapterKey, ...(usage ?? {}) };
     };
+
+    // The extension endpoint changes the durable deadline while this promise
+    // is in flight. Re-read it both on a short cadence and at the timer edge:
+    // an extension committed just before the old edge must win the race.
+    const logicalBase = nowFn();
+    const wallBase = Date.now();
+    const logicalNow = () => logicalBase + (Date.now() - wallBase);
+    let deadlineTimer = null;
+    let deadlinePoll = null;
+    let deadlineExpired = false;
+    const refreshDeadline = () => {
+      if (abortController.signal.aborted) return;
+      const deadlineMs = attemptDeadline(db, runId, attempt, spec);
+      if (!Number.isFinite(deadlineMs)) return;
+      try {
+        const leaseExpiresAt = new Date(
+          deadlineMs + LEASE_GRACE_SECONDS * 1000,
+        ).toISOString();
+        db.query(
+          `UPDATE attempts SET lease_expires_at = ?
+            WHERE run_id = ? AND attempt = ? AND fencing_token = ?
+              AND (lease_expires_at IS NULL OR lease_expires_at < ?)`,
+        ).run(
+          leaseExpiresAt,
+          runId,
+          attempt,
+          fencingToken,
+          leaseExpiresAt,
+        );
+      } catch {}
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      const leftMs = deadlineMs - logicalNow();
+      if (leftMs <= 0) {
+        const expiry = expireRunDeadline(db, runId, attempt, fencingToken, {
+          actor: owner,
+          policyVersion,
+          now: logicalNow(),
+        });
+        if (expiry.expired) {
+          deadlineExpired = true;
+          abortController.abort("deadline_expired");
+          return;
+        }
+        if (Number.isFinite(expiry.deadlineMs)) {
+          deadlineTimer = setTimeout(refreshDeadline, Math.max(1, expiry.deadlineMs - logicalNow()));
+          deadlineTimer.unref?.();
+        }
+        return;
+      }
+      deadlineTimer = setTimeout(refreshDeadline, leftMs);
+      deadlineTimer.unref?.();
+    };
+    refreshDeadline();
+    deadlinePoll = setInterval(refreshDeadline, DEADLINE_POLL_MS);
+    deadlinePoll.unref?.();
+    const stopDeadlineMonitor = () => {
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      if (deadlinePoll) clearInterval(deadlinePoll);
+      deadlineTimer = null;
+      deadlinePoll = null;
+    };
+
     let outcome;
     try {
       outcome = await adapter.execute({
-        spec, def, workspaceDir, timeoutMs: spec.timeoutSeconds * 1000, env, onTrace, onUsage,
+        spec,
+        def,
+        workspaceDir,
+        timeoutMs: DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)
+          ? DYNAMIC_ADAPTER_TIMEOUT_MS
+          : spec.timeoutSeconds * 1000,
+        env,
+        onTrace,
+        onUsage,
         resume: created.resume ?? null,
-        abortSignal: abortController.signal, signal: abortController.signal,
+        abortSignal: abortController.signal,
+        signal: abortController.signal,
       });
     } finally {
+      stopDeadlineMonitor();
       stopCancellationMonitor();
     }
 
     if (outcome?.usage) attemptUsage = { adapter: adapterKey, ...outcome.usage };
+    if (deadlineExpired) outcome = { ...(outcome ?? {}), timedOut: true };
 
-    if (abortController.signal.aborted) {
+    if (abortController.signal.aborted && !deadlineExpired) {
       if (mayMutateClaimedTicket()) {
         try { unclaimTicketFn({ repo: repoName, ticket: ticketId, why: "cancelled", log: null }); } catch {}
       }
@@ -1338,7 +1632,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           runId, to: "REFUSED", expectFrom: "VERIFYING",
           actor: owner, reason: verified.reasonCode, attempt, policyVersion, now: currentNow,
         });
-        const receipt = createReceipt({
+        const receipt = receiptWithDeadlineExtensions(db, runId, {
           runId,
           spec,
           def,
@@ -1376,7 +1670,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         return { fenced: true };
       }
 
-      const receipt = createReceipt({
+      const receipt = receiptWithDeadlineExtensions(db, runId, {
         runId,
         spec,
         def,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -20,7 +20,7 @@ import { transcriptSessionId } from "./transcripts.mjs";
 import {
   acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
   createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
-  executeClaimed, classifyFailureCause, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
+  executeClaimed, classifyFailureCause, expireRunDeadline, extendRunDeadline, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
   repositoryStatus, resolveLinearApiKey, retryRun, runLinearCli, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
@@ -395,6 +395,160 @@ describe("worker", () => {
     expect(summary.terminalState).toBe("TIMED_OUT");
     expect(summary.reasonCode).toBe("timeout");
     expect(runState(db, spec.runId)).toBe("TIMED_OUT");
+  });
+
+  test("a running adapter honors a DB deadline extension past its original timeout (WM-566)", async () => {
+    const db = openDb(":memory:");
+    const completesAfterOriginalDeadline = {
+      async execute({ workspaceDir, abortSignal }) {
+        return new Promise((resolve) => {
+          const timer = setTimeout(() => {
+            writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
+              schemaVersion: "factory.agent-result/v1",
+              terminalState: "completed",
+              artifact: {
+                repos: [{ name: "extended", triage: 1, agentReady: 2, inProgress: 0, blocked: 0 }],
+                recommendedAction: "dispatch",
+              },
+              evidence: { queries: ["fake"] },
+            }));
+            resolve({ exitCode: 0, timedOut: false });
+          }, 120);
+          abortSignal.addEventListener("abort", () => {
+            clearTimeout(timer);
+            resolve({ exitCode: null, timedOut: false });
+          }, { once: true });
+        });
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 0.05 }));
+    const running = runOnce(db, registry, { fake: completesAfterOriginalDeadline }, opts());
+
+    for (let i = 0; i < 50 && runState(db, spec.runId) !== "RUNNING"; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(runState(db, spec.runId)).toBe("RUNNING");
+    const extension = extendRunDeadline(db, spec.runId, {
+      seconds: 1,
+      actor: "operator",
+      policyVersion: "test",
+      now: T0 + 20,
+    });
+    expect(extension.deadlineAt).toBe(new Date(T0 + 1_050).toISOString());
+
+    const summary = await running;
+    expect(summary).toMatchObject({ terminalState: "COMPLETED", reasonCode: "ok" });
+    const receipt = JSON.parse(
+      db.query(`SELECT receipt_json FROM results WHERE run_id = ?`).get(spec.runId).receipt_json,
+    );
+    expect(JSON.parse(receipt.deadlineExtensions)).toEqual([
+      expect.objectContaining({
+        actor: "operator",
+        seconds: 1,
+        deadlineAt: extension.deadlineAt,
+        type: "deadline_extended",
+      }),
+    ]);
+    expect(db.query(`SELECT lease_expires_at FROM attempts WHERE run_id = ?`).get(spec.runId).lease_expires_at)
+      .toBe(new Date(T0 + 121_050).toISOString());
+  });
+
+  test("expiry wins atomically and refuses extension throughout adapter kill grace (WM-566)", async () => {
+    const db = openDb(":memory:");
+    let releaseKillGrace;
+    const killGrace = new Promise((resolve) => { releaseKillGrace = resolve; });
+    let termStarted;
+    const term = new Promise((resolve) => { termStarted = resolve; });
+    const ignoresTermBriefly = {
+      async execute({ abortSignal }) {
+        abortSignal.addEventListener("abort", () => termStarted(), { once: true });
+        await killGrace;
+        return { exitCode: null, timedOut: false };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 0.03 }));
+    const running = runOnce(db, registry, { fake: ignoresTermBriefly }, opts());
+
+    await term;
+    expect(runState(db, spec.runId)).toBe("RUNNING");
+    const refused = extendRunDeadline(db, spec.runId, {
+      seconds: 1,
+      actor: "operator",
+      policyVersion: "test",
+      now: T0 + 40,
+    });
+    expect(refused).toMatchObject({
+      refused: true,
+      code: "deadline_already_expired",
+      status: 409,
+    });
+    const expiryRows = lifecycleOf(db, spec.runId).filter((row) => {
+      try { return JSON.parse(row.reason)?.type === "deadline_expired"; } catch { return false; }
+    });
+    expect(expiryRows).toHaveLength(1);
+
+    releaseKillGrace();
+    const summary = await running;
+    expect(summary).toMatchObject({ terminalState: "TIMED_OUT", reasonCode: "timeout" });
+  });
+
+  test("extension refuses after the edge even before the worker records expiry", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ timeoutSeconds: 1 }));
+    const claim = claimNext(db, opts());
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      expectFrom: "LEASED",
+      actor: "w1",
+      attempt: claim.attempt,
+      now: T0,
+    });
+    db.query(`UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`)
+      .run(new Date(T0).toISOString(), spec.runId, claim.attempt);
+
+    expect(extendRunDeadline(db, spec.runId, {
+      seconds: 1,
+      actor: "operator",
+      policyVersion: "test",
+      now: T0 + 1_001,
+    })).toMatchObject({
+      refused: true,
+      code: "deadline_already_expired",
+      status: 409,
+      deadlineAt: new Date(T0 + 1_000).toISOString(),
+    });
+    expect(lifecycleOf(db, spec.runId).some((row) => {
+      try { return JSON.parse(row.reason)?.type === "deadline_extended"; } catch { return false; }
+    })).toBe(false);
+  });
+
+  test("expire transaction observes an extension that committed before the old edge", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ timeoutSeconds: 1 }));
+    const claim = claimNext(db, opts());
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      expectFrom: "LEASED",
+      actor: "w1",
+      attempt: claim.attempt,
+      now: T0,
+    });
+    db.query(`UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`)
+      .run(new Date(T0).toISOString(), spec.runId, claim.attempt);
+    const extension = extendRunDeadline(db, spec.runId, {
+      seconds: 1,
+      actor: "operator",
+      policyVersion: "test",
+      now: T0 + 999,
+    });
+    expect(extension.refused).toBeUndefined();
+    expect(expireRunDeadline(db, spec.runId, claim.attempt, claim.fencingToken, {
+      actor: "w1",
+      policyVersion: "test",
+      now: T0 + 1_001,
+    })).toMatchObject({ expired: false, deadlineMs: T0 + 2_000 });
   });
 
   test("timeout accepts a valid result.json written before the adapter hangs (WM-538)", async () => {

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -160,6 +160,18 @@ export interface ScheduleItem {
   error: string | null;
 }
 
+export const extendRun = (id: string, seconds: number, override = false) =>
+  call<ExtendOutcome>("POST", `/runs/${encodeURIComponent(id)}/extend`, { seconds, override });
+
+export interface ExtendOutcome {
+  extended: true;
+  runId: string;
+  seconds: number;
+  deadlineAt: string;
+  leaseExpiresAt: string;
+  override: boolean;
+}
+
 export interface TriggerOutcome {
   admitted: boolean;
   duplicate: boolean;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -143,6 +143,11 @@ export interface RunListItem {
    */
   modelTier?: string | null;
   model?: string | null;
+  /** Current execution and lease deadlines, null before the first claim. */
+  startedAt?: string | null;
+  leaseExpiresAt?: string | null;
+  deadlineAt?: string | null;
+  timeoutSeconds?: number;
   /** Repos the spec input names. Empty if unscoped. */
   repos: string[];
 }
@@ -268,6 +273,21 @@ export interface ArtifactInventoryItem {
   references: ArtifactReference[];
 }
 
+export interface DeadlineExtensionReceipt {
+  seq: number;
+  actor: string;
+  at: string;
+  type: "deadline_extended";
+  seconds: number;
+  deadlineAt: string;
+  override: boolean;
+}
+
+export type RunReceipt = Record<string, string | null> & {
+  /** Canonical JSON array of DeadlineExtensionReceipt records. */
+  readonly deadlineExtensions?: string;
+};
+
 export interface RunDetail {
   run: {
     runId: string;
@@ -289,8 +309,10 @@ export interface RunDetail {
     artifacts?: ArtifactRef[];
     evidence?: unknown;
   } | null;
-  receipt: Record<string, string | null> | null;
+  receipt: RunReceipt | null;
   workspace: string | null;
+  /** Mutable execution deadline; extensions do not change the immutable RunSpec. */
+  deadlineAt?: string | null;
   /**
    * What the harness reported it actually ran on, read out of the stored
    * transcript (WM-221) — the only source for a run whose spec pins the

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import { ApiError } from "../api";
 import { RunFull } from "./RunFull";
 import {
+  changeInput,
   createEventFixture,
   createRunDetailFixture,
   createRunListItemFixture,
@@ -22,11 +23,11 @@ afterEach(() => {
 const noop = () => {};
 const CANCEL_409 = "illegal transition CANCELLED → CANCELLED";
 
-function renderRunFull(runId: string) {
+function renderRunFull(runId: string, connected = true) {
   return renderWithClient(
     <RunFull
       runId={runId}
-      connected={true}
+      connected={connected}
       onBack={noop}
       onJumpAgent={noop}
       onJumpEvent={noop}
@@ -110,6 +111,119 @@ describe("RunFull header (WM-193)", () => {
         expect(sidebar?.textContent).toContain("header-agent@1");
         expect(sidebar?.textContent).toContain("header-adapter");
         expect(sidebar?.textContent).toContain("2/5");
+      },
+    );
+  });
+});
+
+describe("RunFull deadline extension (WM-566)", () => {
+  test("shows remaining time and extends by preset or custom increments", async () => {
+    const runId = "run_extend_controls";
+    const deadlineAt = new Date(Date.now() + 30 * 60_000).toISOString();
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+    });
+    detail.deadlineAt = deadlineAt;
+    const calls: number[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      calls.push(body.seconds);
+      return new Response(JSON.stringify({
+        extended: true,
+        runId,
+        seconds: body.seconds,
+        deadlineAt: new Date(Date.parse(deadlineAt) + body.seconds * 1000).toISOString(),
+        leaseExpiresAt: new Date(Date.parse(deadlineAt) + (body.seconds + 120) * 1000).toISOString(),
+        override: false,
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    try {
+      await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt })],
+        }),
+      },
+      async () => {
+        const { getByRole, getByText, getByLabelText } = renderRunFull(runId);
+        await waitFor(() => getByText(/Remaining/));
+        expect(getByText(/Remaining/).textContent).toContain("30m");
+
+        fireEvent.click(getByRole("button", { name: "+15m" }));
+        await waitFor(() => expect(calls).toEqual([900]));
+        expect(getByText(/Run extended by 15 minutes/)).toBeTruthy();
+
+        fireEvent.click(getByRole("button", { name: "Custom…" }));
+        const input = getByLabelText("Extension minutes");
+        changeInput(input as HTMLInputElement, "0");
+        expect(input.getAttribute("aria-invalid")).toBe("true");
+        expect(getByText("Enter a whole number from 1 to 60.")).toBeTruthy();
+        expect(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }).hasAttribute("disabled")).toBe(true);
+        changeInput(input as HTMLInputElement, "20");
+        expect(input.getAttribute("aria-invalid")).toBe("false");
+        fireEvent.click(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }));
+        await waitFor(() => expect(calls).toEqual([900, 1200]));
+      },
+    );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("preset refusal is visible without opening the custom dialog", async () => {
+    const runId = "run_extend_refused";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+    });
+    detail.deadlineAt = new Date(Date.now() + 60_000).toISOString();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      error: "deadline_already_expired",
+      extended: false,
+      refusal: { code: "deadline_already_expired", retryable: false },
+    }), { status: 409, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+    try {
+      await withApi(
+        {
+          run: async () => detail,
+          runs: async () => ({
+            runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt: detail.deadlineAt })],
+          }),
+        },
+        async () => {
+          const { getByRole, getByText, queryByRole } = renderRunFull(runId);
+          await waitFor(() => getByRole("button", { name: "+30m" }));
+          fireEvent.click(getByRole("button", { name: "+30m" }));
+          await waitFor(() => getByText("deadline_already_expired"));
+          expect(queryByRole("dialog")).toBeNull();
+        },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("custom extension submit is disabled while disconnected", async () => {
+    const runId = "run_extend_disconnected";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+    });
+    detail.deadlineAt = new Date(Date.now() + 60_000).toISOString();
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "RUNNING", deadlineAt: detail.deadlineAt })],
+        }),
+      },
+      async () => {
+        const { getByRole } = renderRunFull(runId, false);
+        const custom = await waitFor(() => getByRole("button", { name: "Custom…" }));
+        expect(custom.hasAttribute("disabled")).toBe(false);
+        fireEvent.click(custom);
+        expect(within(getByRole("dialog")).getByRole("button", { name: "Extend run" }).hasAttribute("disabled")).toBe(true);
       },
     );
   });

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import { api, ApiError } from "../api";
+import { api, ApiError, extendRun } from "../api";
 import { keyGuard, useNow } from "../hooks";
 import { hashPath, hashProject, withProject } from "../hash";
 import { setContextActions } from "../palette";
@@ -57,6 +57,9 @@ export function RunFull({
   const queryClient = useQueryClient();
   const [confirm, setConfirm] = useState<"cancel" | "force-retry" | null>(null);
   const [confirmApprove, setConfirmApprove] = useState(false);
+  const [customExtend, setCustomExtend] = useState(false);
+  const [customMinutes, setCustomMinutes] = useState("15");
+  const [extendNotice, setExtendNotice] = useState<string | null>(null);
   const [cancelReason, setCancelReason] = useState("");
 
   const detail = useQuery({
@@ -117,6 +120,12 @@ export function RunFull({
     : false;
   const unknownRun =
     detail.isError && (detail.error as ApiError).status === 404;
+  const customMinutesNumber = Number(customMinutes);
+  const customMinutesValid =
+    customMinutes.trim() !== "" &&
+    Number.isInteger(customMinutesNumber) &&
+    customMinutesNumber >= 1 &&
+    customMinutesNumber <= 60;
 
   const invalidate = () => queryClient.invalidateQueries();
 
@@ -130,6 +139,23 @@ export function RunFull({
       setCancelReason("");
     },
     onError: invalidate,
+  });
+
+  const extend = useMutation({
+    mutationFn: ({ id, seconds }: { id: string; seconds: number }) =>
+      extendRun(id, seconds),
+    onSuccess: (outcome) => {
+      invalidate();
+      const minutes = Math.round(outcome.seconds / 60);
+      const message = `Run extended by ${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+      setExtendNotice(message);
+      notify(`${message} (${outcome.runId})`, "ok");
+      setCustomExtend(false);
+    },
+    onError: () => {
+      setExtendNotice(null);
+      invalidate();
+    },
   });
 
   const retry = useMutation({
@@ -376,6 +402,43 @@ export function RunFull({
                 </span>
               </Button>
             )}
+            {d && ["RUNNING", "VERIFYING"].includes(d.run.state) && (
+              <div className="flex flex-wrap items-center gap-1.5 text-[12px] text-(--text-dim)">
+                <span
+                  className="mr-1 tabular-nums"
+                  title="Current execution deadline. The sidebar budget meter preserves the original approved RunSpec; its lease clock reflects extensions."
+                >
+                  Remaining{" "}
+                  {d.deadlineAt
+                    ? (() => {
+                        const left = Math.max(0, Date.parse(d.deadlineAt) - now);
+                        const minutes = Math.ceil(left / 60_000);
+                        return minutes >= 60
+                          ? `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+                          : `${minutes}m`;
+                      })()
+                    : "—"}
+                </span>
+                <Button
+                  disabled={!connected || extend.isPending}
+                  onClick={() => extend.mutate({ id: d.run.runId, seconds: 15 * 60 })}
+                >
+                  +15m
+                </Button>
+                <Button
+                  disabled={!connected || extend.isPending}
+                  onClick={() => extend.mutate({ id: d.run.runId, seconds: 30 * 60 })}
+                >
+                  +30m
+                </Button>
+                <Button
+                  disabled={extend.isPending}
+                  onClick={() => setCustomExtend(true)}
+                >
+                  Custom…
+                </Button>
+              </div>
+            )}
             {d && d.run.state === "FAILED" &&
               (attemptsExhausted ? (
                 <Button
@@ -419,6 +482,12 @@ export function RunFull({
             </Button>
           </div>
         </div>
+        {extend.error && !customExtend && <VerbError error={extend.error} />}
+        {extendNotice && (
+          <div className="mt-1 text-[12px] text-(--hue-ok)" role="status">
+            {extendNotice}. The Remaining clock is the current execution deadline; the sidebar budget preserves the original approved RunSpec.
+          </div>
+        )}
         <div className="flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
           <CopyActions
             id={runId}
@@ -633,6 +702,55 @@ export function RunFull({
               }}
             >
               Approve and queue <span className="mono ml-1 opacity-80" aria-hidden="true">↵</span>
+            </Button>
+          </div>
+        </Dialog>
+      )}
+
+      {customExtend && d && (
+        <Dialog title={`Extend ${d.run.runId}`} onClose={() => setCustomExtend(false)}>
+          <div className="mb-3 text-[12px] text-(--text-dim)">
+            Add up to 60 minutes per request. The policy run limit still applies.
+          </div>
+          <VerbError error={extend.error} />
+          <label className="mb-3 block text-[12px] text-(--text-dim)">
+            Minutes
+            <input
+              aria-label="Extension minutes"
+              aria-describedby="extension-minutes-help"
+              aria-invalid={!customMinutesValid}
+              type="number"
+              min="1"
+              max="60"
+              step="1"
+              value={customMinutes}
+              onChange={(e) => setCustomMinutes(e.target.value)}
+              className="mt-1 w-full rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-(--text) outline-none focus:border-(--accent)"
+            />
+            <span
+              id="extension-minutes-help"
+              className={customMinutesValid ? "mt-1 block text-(--text-faint)" : "mt-1 block text-(--hue-err)"}
+            >
+              Enter a whole number from 1 to 60.
+            </span>
+          </label>
+          <div className="flex justify-end gap-2">
+            <Button onClick={() => setCustomExtend(false)}>Cancel</Button>
+            <Button
+              variant="primary"
+              disabled={
+                !connected ||
+                extend.isPending ||
+                !customMinutesValid
+              }
+              onClick={() =>
+                extend.mutate({
+                  id: d.run.runId,
+                  seconds: customMinutesNumber * 60,
+                })
+              }
+            >
+              Extend run
             </Button>
           </div>
         </Dialog>

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -163,6 +163,7 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   sorts: [
     { key: "run", label: "Run", get: (r) => r.runId, column: "run" },
     { key: "state", label: "State", get: (r) => r.state, column: "state" },
+    { key: "remaining", label: "Remaining", get: (r) => r.deadlineAt ?? "", column: "remaining" },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
     { key: "adapter", label: "Adapter", get: (r) => r.adapter, column: "adapter" },
     { key: "model", label: "Model", get: rowModel, column: "model" },
@@ -180,6 +181,7 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   columns: [
     { key: "run", label: "Run", always: true },
     { key: "state", label: "State" },
+    { key: "remaining", label: "Remaining" },
     { key: "agent", label: "Agent" },
     { key: "adapter", label: "Adapter" },
     { key: "model", label: "Model" },
@@ -190,9 +192,21 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   ],
 };
 
+function RemainingCell({ deadlineAt, now }: { deadlineAt?: string | null; now: number }) {
+  if (!deadlineAt) return <span>—</span>;
+  const left = Math.max(0, Date.parse(deadlineAt) - now);
+  if (!Number.isFinite(left)) return <span>—</span>;
+  const minutes = Math.ceil(left / 60_000);
+  return <span title={deadlineAt}>{minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`}</span>;
+}
+
 function RowDeadlines({ r, now }: { r: RunListItem; now: number }) {
-  const { startedAt, leaseExpiresAt, timeoutSeconds = 0 } = r as { startedAt?: string | null; leaseExpiresAt?: string | null; timeoutSeconds?: number };
-  const t = startedAt && timeoutSeconds > 0 ? clockTo(startedAt, timeoutSeconds * 1000, now) : null;
+  const { startedAt, leaseExpiresAt, deadlineAt, timeoutSeconds = 0 } = r;
+  const t = deadlineAt
+    ? clockTo(deadlineAt, 0, now)
+    : startedAt && timeoutSeconds > 0
+      ? clockTo(startedAt, timeoutSeconds * 1000, now)
+      : null;
   const l = leaseExpiresAt ? clockTo(leaseExpiresAt, 0, now) : null;
   const hasT = t && t.kind !== "off";
   const hasL = l && l.kind !== "off";
@@ -424,7 +438,7 @@ export function Runs({
   // decision-bearing columns instead of forcing a horizontal scrollbar; the
   // pane and the unselected list retain every configured column.
   const listCols = sel
-    ? cols.filter((c) => ["run", "state", "reason", "origin", "updated"].includes(c.key))
+    ? cols.filter((c) => ["run", "state", "remaining", "reason", "origin", "updated"].includes(c.key))
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
 
@@ -770,6 +784,11 @@ export function Runs({
                         })()}
                       </div>
                       {IN_FLIGHT.includes(r.state) && <RowDeadlines r={r} now={now} />}
+                    </td>
+                  )}
+                  {show.has("remaining") && (
+                    <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                      {IN_FLIGHT.includes(r.state) ? <RemainingCell deadlineAt={r.deadlineAt} now={now} /> : ""}
                     </td>
                   )}
                   {show.has("agent") && (


### PR DESCRIPTION
## Summary
- add a bounded, policy-aware `POST /runs/:runId/extend` API plus client and CLI command
- make cooperative worker adapters honor durable DB-backed deadline changes, lease updates, expiry races, and receipt/lifecycle auditing
- add Runs/RunFull remaining-time UI with preset/custom extension controls, validation, and visible feedback

## Verification
- `bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/worker.test.mjs && (cd event-runtime/web && bun test src/views/RunFull.test.tsx && bunx tsc --noEmit)` — pass (113 runtime tests, 12 RunFull tests, TypeScript clean)

UX critique: required — SHIP (round 2); evidence: http://127.0.0.1:7392/?ux-round=2-evidence#/run/run_4df6d3f6-6c5b-4ce3-a83d-0a7770632e8c and /var/folders/pd/h5j5j7953dx5h5l9q2jxdwch0000gn/T/pi-chrome-devtools-screenshot-0b99e2c6-1fb1-4ebd-80d7-cc115d2203f0.png

## Follow-ups
- WM-641: make the synchronous actions adapter cooperatively extendable; this PR returns a typed refusal instead of false success
- WM-643: make the shared sidebar deadline meter consume the mutable deadline

Fixes WM-566