### PR TITLE
Fix responsive primary navigation (WM-175)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -252,6 +252,65 @@ describe("Graph proposal navigation (WM-165)", () => {
   });
 });
 
+describe("responsive primary navigation (WM-175)", () => {
+  test("mobile toggle opens and closes the overlay navigation accessibly", async () => {
+    const utils = renderApp();
+    const nav = utils.getByRole("navigation", { name: "Primary" });
+    const main = utils.getByRole("main");
+    const statusBar = utils.getByRole("contentinfo", { name: "Status bar" });
+    const toggle = utils.getByRole("button", { name: "Open navigation" });
+
+    expect(toggle.getAttribute("aria-controls")).toBe("primary-navigation");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(nav.className).toContain("hidden");
+    expect(nav.className).toContain("md:flex");
+    expect(nav.className).toContain("md:w-52");
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(nav.className).toContain("flex");
+    expect(nav.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+    const close = utils.getByRole("button", { name: "Close navigation" });
+    await waitFor(() => expect(document.activeElement).toBe(close));
+    expect(main.hasAttribute("inert")).toBe(true);
+    expect(main.getAttribute("aria-hidden")).toBe("true");
+    expect(statusBar.hasAttribute("inert")).toBe(true);
+
+    const navButtons = within(nav).getAllByRole("button");
+    const first = navButtons[0]!;
+    const last = navButtons.at(-1)!;
+    last.focus();
+    fireEvent.keyDown(last, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+    first.focus();
+    fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(nav.className).toMatch(/(^|\s)hidden(\s|$)/);
+    expect(main.hasAttribute("inert")).toBe(false);
+    expect(main.hasAttribute("aria-hidden")).toBe(false);
+    await waitFor(() => expect(document.activeElement).toBe(toggle));
+  });
+
+  test("choosing a destination closes the mobile navigation and preserves its landmark", () => {
+    const utils = renderApp();
+    const toggle = utils.getByRole("button", { name: "Open navigation" });
+
+    fireEvent.click(toggle);
+    fireEvent.click(utils.sidebar.getByRole("button", { name: "Events" }));
+
+    expect(window.location.hash).toBe("#/events");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      utils.getByRole("navigation", { name: "Primary" }).getAttribute("id"),
+    ).toBe("primary-navigation");
+  });
+});
+
 describe("bottom status bar", () => {
   test("stale-only fleet agrees with the Workers badge instead of saying no workers (WM-159)", async () => {
     currentStatus = {

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -213,6 +213,7 @@ export function App() {
   }, [openRepos, project]);
 
   const [theme, cycleTheme] = useTheme();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [injectOpen, setInjectOpen] = useState(false);
   const [injectSeed, setInjectSeed] = useState<
     Record<string, unknown> | undefined
@@ -224,7 +225,62 @@ export function App() {
   const [filterFocus, setFilterFocus] = useState(false);
   const [viewAnnouncement, setViewAnnouncement] = useState("");
   const mainRef = useRef<HTMLElement>(null);
+  const mobileNavToggleRef = useRef<HTMLButtonElement>(null);
+  const mobileNavCloseRef = useRef<HTMLButtonElement>(null);
+  const mobileNavRef = useRef<HTMLElement>(null);
+  const mobileNavWasOpenRef = useRef(false);
   const previousViewRef = useRef(view);
+
+  useEffect(() => {
+    function closeMobileNavOnDesktopResize() {
+      if (window.innerWidth >= 768) setMobileNavOpen(false);
+    }
+    window.addEventListener("resize", closeMobileNavOnDesktopResize);
+    return () =>
+      window.removeEventListener("resize", closeMobileNavOnDesktopResize);
+  }, []);
+
+  useEffect(() => {
+    if (!mobileNavOpen) {
+      if (mobileNavWasOpenRef.current) mobileNavToggleRef.current?.focus();
+      mobileNavWasOpenRef.current = false;
+      return;
+    }
+    mobileNavWasOpenRef.current = true;
+    mobileNavCloseRef.current?.focus();
+
+    function handleMobileNavKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setMobileNavOpen(false);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        mobileNavRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!mobileNavRef.current?.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener("keydown", handleMobileNavKey);
+    return () => window.removeEventListener("keydown", handleMobileNavKey);
+  }, [mobileNavOpen]);
 
   useEffect(() => {
     const root = mainRef.current;
@@ -505,6 +561,7 @@ export function App() {
   useEffect(() => {
     if (previousViewRef.current === view) return;
     previousViewRef.current = view;
+    setMobileNavOpen(false);
     setViewAnnouncement(`${viewLabel} view`);
     // `/` intentionally sends focus to the destination view's filter instead.
     // Fall back to main when a lazy destination has not mounted its filter yet.
@@ -519,6 +576,7 @@ export function App() {
       if (goPrefixActive()) return;
       if (e.key === "i") {
         e.preventDefault();
+        setMobileNavOpen(false);
         setInjectOpen(true);
       } else if (e.key === "?") {
         e.preventDefault();
@@ -616,23 +674,39 @@ export function App() {
 
   return (
     <div className="flex h-screen flex-col">
-      <ContextTabs
-        repos={reposQ.data?.repos ?? []}
-        reposError={reposQ.isError}
-        openRepos={openRepos}
-        active={context}
-        onSelect={selectContext}
-        onOpen={openRepo}
-        onClose={closeRepo}
-        goArmed={goArmed}
-      />
-      <div className="flex min-h-0 flex-1">
+      <div
+        aria-hidden={mobileNavOpen ? true : undefined}
+        inert={mobileNavOpen ? true : undefined}
+      >
+        <ContextTabs
+          repos={reposQ.data?.repos ?? []}
+          reposError={reposQ.isError}
+          openRepos={openRepos}
+          active={context}
+          onSelect={selectContext}
+          onOpen={openRepo}
+          onClose={closeRepo}
+          goArmed={goArmed}
+        />
+      </div>
+      <div className="relative flex min-h-0 flex-1">
+        {mobileNavOpen && (
+          <button
+            type="button"
+            aria-label="Dismiss navigation"
+            tabIndex={-1}
+            className="absolute inset-0 z-10 bg-black/45 md:hidden"
+            onClick={() => setMobileNavOpen(false)}
+          />
+        )}
         <nav
+          ref={mobileNavRef}
+          id="primary-navigation"
           aria-label="Primary"
-          className="flex w-52 shrink-0 flex-col border-r border-(--border) bg-(--surface-1)"
+          className={`${mobileNavOpen ? "flex" : "hidden"} absolute inset-y-0 left-0 z-20 w-64 shrink-0 flex-col overflow-y-auto border-r border-(--border) bg-(--surface-1) shadow-xl md:static md:flex md:w-52 md:overflow-y-visible md:shadow-none`}
         >
           <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <img
                 src="/watt-mind-logo.svg"
                 alt="Watt Mind"
@@ -640,25 +714,38 @@ export function App() {
               />
               <span className="display text-[14px] font-semibold">factory</span>
             </div>
-            <PrimitiveButton
-              bare
-              type="button"
-              className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
-              title={
-                env
-                  ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
-                  : healthPending
-                    ? "connecting to the runtime…"
-                    : "runtime unreachable"
-              }
-              style={{
-                color: envHue,
-                background: `color-mix(in oklch, ${envHue} 15%, transparent)`,
-              }}
-              onClick={() => env?.home && copyText(env.home, "runtime home")}
-            >
-              {envLabel}
-            </PrimitiveButton>
+            <div className="flex items-center gap-1">
+              <PrimitiveButton
+                bare
+                type="button"
+                className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
+                title={
+                  env
+                    ? `${env.home} · policy ${health.data?.policyVersion} — click to copy home`
+                    : healthPending
+                      ? "connecting to the runtime…"
+                      : "runtime unreachable"
+                }
+                style={{
+                  color: envHue,
+                  background: `color-mix(in oklch, ${envHue} 15%, transparent)`,
+                }}
+                onClick={() => env?.home && copyText(env.home, "runtime home")}
+              >
+                {envLabel}
+              </PrimitiveButton>
+              {mobileNavOpen && (
+                <button
+                  ref={mobileNavCloseRef}
+                  type="button"
+                  aria-label="Close navigation"
+                  className="flex size-11 items-center justify-center rounded text-lg text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text) md:hidden"
+                  onClick={() => setMobileNavOpen(false)}
+                >
+                  <span aria-hidden="true">×</span>
+                </button>
+              )}
+            </div>
           </div>
           <div className="flex-1 px-2">
             {NAV.map((n) => {
@@ -673,8 +760,11 @@ export function App() {
                   aria-describedby={
                     badge.count > 0 ? `nav-badge-${n.key}` : undefined
                   }
-                  onClick={() => navigate(n.key)}
-                  className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] ${
+                  onClick={() => {
+                    setMobileNavOpen(false);
+                    navigate(n.key);
+                  }}
+                  className={`flex min-h-11 w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] md:min-h-0 ${
                     current
                       ? "bg-(--surface-3) font-medium text-(--text)"
                       : "text-(--text-dim) hover:bg-(--surface-2)"
@@ -683,10 +773,10 @@ export function App() {
                   <span>{n.label}</span>
                   {badge.count > 0 && (
                     /* aria-hidden keeps the count out of the accessible name —
-                     "Events" must not announce as "Events 6" — while the
-                     aria-describedby reference above still reads it back as
-                     the button's description (accname spec includes hidden
-                     nodes referenced by labelledby/describedby). */
+                       "Events" must not announce as "Events 6" — while the
+                       aria-describedby reference above still reads it back as
+                       the button's description (accname spec includes hidden
+                       nodes referenced by labelledby/describedby). */
                     <NavCount id={`nav-badge-${n.key}`} badge={badge} />
                   )}
                 </PrimitiveButton>
@@ -695,8 +785,11 @@ export function App() {
             <PrimitiveButton
               bare
               type="button"
-              onClick={() => setInjectOpen(true)}
-              className="mt-2 w-full rounded-md px-2.5 py-1.5 text-left text-[13px] text-(--text-dim) hover:bg-(--surface-2)"
+              onClick={() => {
+                setMobileNavOpen(false);
+                setInjectOpen(true);
+              }}
+              className="mt-2 min-h-11 w-full rounded-md px-2.5 py-1.5 text-left text-[13px] text-(--text-dim) hover:bg-(--surface-2) md:min-h-0"
             >
               Inject event…{" "}
               <span className="mono ml-1 text-(--text-faint)">i</span>
@@ -707,8 +800,28 @@ export function App() {
         <main
           ref={mainRef}
           tabIndex={-1}
+          aria-hidden={mobileNavOpen ? true : undefined}
+          inert={mobileNavOpen ? true : undefined}
           className="flex min-w-0 flex-1 flex-col focus:outline-none"
         >
+          <div className="flex h-12 shrink-0 items-center gap-3 border-b border-(--border) bg-(--surface-1) px-2 md:hidden">
+            <button
+              ref={mobileNavToggleRef}
+              type="button"
+              aria-label="Open navigation"
+              aria-controls="primary-navigation"
+              aria-expanded={mobileNavOpen}
+              className="flex size-11 items-center justify-center rounded-md text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
+              onClick={() => setMobileNavOpen(true)}
+            >
+              <span aria-hidden="true" className="text-lg leading-none">
+                ☰
+              </span>
+            </button>
+            <span className="display truncate text-[13px] font-semibold">
+              {viewLabel}
+            </span>
+          </div>
           <div aria-live="polite" aria-atomic="true" className="sr-only">
             {viewAnnouncement}
           </div>
@@ -1033,9 +1146,11 @@ export function App() {
       <footer
         role="contentinfo"
         aria-label="Status bar"
-        className="flex h-7 shrink-0 items-center justify-between border-t border-(--border) bg-(--surface-1) px-3 text-[11px] select-none"
+        aria-hidden={mobileNavOpen ? true : undefined}
+        inert={mobileNavOpen ? true : undefined}
+        className="flex h-7 shrink-0 items-center justify-between overflow-hidden border-t border-(--border) bg-(--surface-1) px-3 text-[11px] select-none"
       >
-        <div className="flex items-center gap-2 text-(--text-dim)">
+        <div className="flex min-w-0 items-center gap-2 whitespace-nowrap text-(--text-dim)">
           <div className="flex items-center gap-1.5">
             <span
               className="size-2 shrink-0 rounded-full"
@@ -1085,7 +1200,7 @@ export function App() {
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="text-(--text-faint)">
+          <div className="hidden text-(--text-faint) md:block">
             <span className="mono">⌘K</span> commands ·{" "}
             <span className="mono">i</span> inject ·{" "}
             <span className="mono">g</span> go · <span className="mono">?</span>{" "}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -673,7 +673,7 @@ function RecentOutcomesStrip({
       title="Recent outcomes (newest on the right)"
     >
       <SectionTitle title="Recent outcomes" meta={`last ${outcomes.length}`} />
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex min-w-0 flex-wrap items-center gap-1.5">
           {chrono.map((o) => {
             const hue =
@@ -1235,7 +1235,7 @@ export function Overview({
   };
 
   return (
-    <div className="h-full min-w-0 overflow-auto p-5">
+    <div className="h-full min-w-0 overflow-auto p-3 sm:p-5">
       <div className="mb-4 flex items-baseline justify-between gap-3">
         <h1 className="display text-lg font-semibold">Overview</h1>
       </div>
@@ -1563,7 +1563,7 @@ export function Overview({
           />
         </div>
       ) : (
-        <div className="mb-5 flex items-center justify-between rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim)">
+        <div className="mb-5 flex flex-col items-start gap-2 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim) sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2">
             <span className="size-2 rounded-full bg-(--hue-ok)" />
             <span className="font-medium text-(--text)">
@@ -1694,7 +1694,7 @@ export function Overview({
                   type="button"
                   onClick={() => onNavigate("inbox")}
                   aria-label={`Waiting on you: ${s.inbox.open} open inbox item${s.inbox.open === 1 ? "" : "s"} — open the inbox`}
-                  className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-(--border) bg-(--surface-1) px-3 py-1.5 text-left hover:bg-(--surface-2)"
+                  className="flex w-full cursor-pointer items-start gap-3 rounded-md border border-(--border) bg-(--surface-1) px-3 py-2 text-left hover:bg-(--surface-2) sm:items-center sm:py-1.5"
                 >
                   <span
                     className="display text-xl tabular-nums"
@@ -1706,7 +1706,7 @@ export function Overview({
                   >
                     {s.inbox.open}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-[11px] text-(--text-faint)">
+                  <span className="min-w-0 flex-1 break-words text-[11px] text-(--text-faint)">
                     {s.inbox.open > 0 && s.inbox.byKind
                       ? (() => {
                           const kinds = Object.entries(s.inbox.byKind!)
@@ -1727,7 +1727,7 @@ export function Overview({
                         })()
                       : "Nothing needs a decision right now."}
                   </span>
-                  <span className="mono text-[11px] text-(--text-faint)">
+                  <span className="mono shrink-0 self-center text-[11px] text-(--text-faint)">
                     g n →
                   </span>
                 </PrimitiveButton>


### PR DESCRIPTION
## Summary
- replace the fixed mobile sidebar with an accessible overlay drawer while preserving the 208px desktop navigation
- contain keyboard focus, restore focus on close, and keep background regions inert while the drawer is open
- improve 390px Overview wrapping, mobile navigation touch targets, and status-bar behavior
- add DOM coverage for drawer state, navigation accessibility, focus boundaries, and route-close behavior

## Verification
- `bun test event-runtime/web` — pass, 788 tests
- `cd event-runtime/web && bunx tsc --noEmit` — pass

## UX critique
UX critique: required — FIX-FIRST unresolved after the two-round cap. Round 1 focus containment, status-bar, and touch-target findings were resolved and browser-confirmed in round 2. The round-2 Waiting on you truncation finding was fixed afterward but could not receive a third critic round, so this PR remains draft for reviewer confirmation.

Evidence:
- http://127.0.0.1:7411/#/overview
- `/Users/hdkiller/.pi/agent/sessions/--Users-hdkiller-.factory-event-runtime-workspaces-run_d399e7cc-bffd-40c2-b8ea-1b923d5e1a26-a1--/subagent-artifacts/outputs/call_9VSQsKZsmbvNmtjVg4ucTciM|fc_0820fd74a6d604ad016a836a935cf487d09fcececbb5685751/wm-175-r2-mobile-waiting-card.png`
- `/Users/hdkiller/.pi/agent/sessions/--Users-hdkiller-.factory-event-runtime-workspaces-run_d399e7cc-bffd-40c2-b8ea-1b923d5e1a26-a1--/subagent-artifacts/outputs/call_9VSQsKZsmbvNmtjVg4ucTciM|fc_0820fd74a6d604ad016a836a935cf487d09fcececbb5685751/wm-175-r2-desktop-overview.png`

Fixes WM-175