### PR TITLE
ci: build event-runtime web before tests (WM-647)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,11 @@ jobs:
       - name: Install event-runtime/web deps
         run: cd event-runtime/web && bun install --frozen-lockfile
 
+      # Run tsc + Vite before tests so broken TSX imports and entry-chunk budget
+      # regressions fail Verify immediately instead of reaching a later build.
+      - name: Typecheck and build event-runtime/web
+        run: cd event-runtime/web && bun run build
+
       - name: Formatting check (prettier)
         run: bun run format:check
 
@@ -283,11 +288,6 @@ jobs:
         # else. If this fails, the fix is to move the rule into shared/ and
         # regenerate — never to edit the generated file.
         run: bun build/emit.mjs --check
-
-      # Agents already typecheck/build the web UI locally; a green Verify on a
-      # TSX PR said nothing about compilation until this step existed (OPS-243).
-      - name: Typecheck and build event-runtime/web
-        run: cd event-runtime/web && bun run build
 
       - name: Schedule renders match deploy/launchd
         run: bun deploy/gen.mjs && git diff --exit-code deploy/launchd/


### PR DESCRIPTION
## Summary
- move the existing event-runtime web typecheck/build immediately after its frozen-lockfile install
- fail Verify on TSX import or Vite entry-budget errors before test execution
- preserve the existing Verify runtime by reordering rather than adding another build

## Verification
- `actionlint .github/workflows/ci.yml`

UX critique: skipped — CI-only workflow change with no user-facing surface

Fixes WM-647