### PR TITLE
fix(repos): factory verify gate --timeout 20000 (WM-651)

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -411,7 +411,16 @@ repos:
     # demo/, web/, bin/, orchestrator/ and stay CI-only). Measured 70-72s wall
     # on the loaded host, 0 failures over repeated runs. `emit.mjs --check` is
     # the contract check that must never be skipped locally.
-    verify: bun test event-runtime/lib && bun build/emit.mjs --check
+    #
+    # `--timeout 20000` (WM-651): bun's default 5 s per-test timeout kept
+    # failing VERIFYING on the loaded host for spawn/timing tests that pass in
+    # CI — 2026-08-17: WM-616/625/549/618/627 on the OPS-404 reaper-tick test
+    # (fixed WM-629), WM-563 on 'execute conformance (OPS-427) > abort kills a
+    # real long-lived grandchild (WM-263)' at 5000 ms, WM-551/538 on
+    # api-schedules. CI already runs with a higher timeout (WM-600). Tests that
+    # are genuine liveness bounds keep their explicit shorter timeouts; this
+    # only raises the default for tests that don't set one.
+    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
 
     # Owned Paths closure rules for this repo's control-plane ticket types.
     owned_paths_policy:

--- a/orchestrator/repos-config.test.mjs
+++ b/orchestrator/repos-config.test.mjs
@@ -46,13 +46,15 @@ test("factory routes to WM / Factory and caps in-flight at 20", () => {
   expect(factory.maxInFlight).toBe(20);
 });
 
-test("factory branches are unchanged by OPS-463; verify is the fast lib-only gate (WM-528)", () => {
+test("factory branches are unchanged by OPS-463; verify is the fast lib-only gate (WM-528, WM-651)", () => {
   expect(factory.base).toBe("develop");
   expect(factory.deployBranch).toBe("main");
   // The local VERIFYING gate is deliberately a strict subset of CI: unit-only
   // event-runtime/lib (no daemons/ports/demo seed) plus the emit contract check.
   // The full `bun test` stays in .github/workflows/ci.yml, the real merge gate.
+  // `--timeout 20000` (WM-651) lifts bun's 5 s per-test default so spawn/timing
+  // tests don't go red under host load; explicit per-test timeouts still win.
   expect(factory.verify).toBe(
-    "bun test event-runtime/lib && bun build/emit.mjs --check",
+    "bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check",
   );
 });


### PR DESCRIPTION
Fixes WM-651

Bun's default 5 s per-test timeout kept failing the factory VERIFYING gate on the loaded host for spawn/timing tests that are green in CI (2026-08-17: WM-616/625/549/618/627 on the OPS-404 reaper-tick test [fixed WM-629], WM-563 on 'execute conformance (OPS-427) > abort kills a real long-lived grandchild (WM-263)' at 5000 ms, WM-551/538 on api-schedules). CI already uses a higher timeout (WM-600).

- `config/repos.yaml`: factory `verify:` -> `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`, comment extended with the rationale. Explicit per-test liveness timeouts still win.
- `orchestrator/repos-config.test.mjs`: exact-string assertion updated.

Verification: `bun test orchestrator/repos-config.test.mjs` -> 5 pass, 0 fail. `bun test event-runtime/lib/triage.test.mjs --timeout 20000` on bun 1.3.14 -> flag accepted, 11 pass.

## Handoff
UX critique: n/a (config-only, no user-facing surface).