### PR TITLE
fix(factory): untrack committed .claude/commands symlinks (WM-652)

### DIFF
--- a/.claude/commands/factory-audit.md
+++ b/.claude/commands/factory-audit.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-audit.md

--- a/.claude/commands/factory-capture.md
+++ b/.claude/commands/factory-capture.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-capture.md

--- a/.claude/commands/factory-friction.md
+++ b/.claude/commands/factory-friction.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-friction.md

--- a/.claude/commands/factory-merge.md
+++ b/.claude/commands/factory-merge.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-merge.md

--- a/.claude/commands/factory-next.md
+++ b/.claude/commands/factory-next.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-next.md

--- a/.claude/commands/factory-retro.md
+++ b/.claude/commands/factory-retro.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-retro.md

--- a/.claude/commands/factory-ship.md
+++ b/.claude/commands/factory-ship.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-ship.md

--- a/.claude/commands/factory-sweep.md
+++ b/.claude/commands/factory-sweep.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-sweep.md

--- a/.claude/commands/factory-ticket.md
+++ b/.claude/commands/factory-ticket.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-ticket.md

--- a/.claude/commands/factory-triage.md
+++ b/.claude/commands/factory-triage.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-triage.md

--- a/.claude/commands/factory-unblock.md
+++ b/.claude/commands/factory-unblock.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-unblock.md

--- a/.claude/commands/factory-work.md
+++ b/.claude/commands/factory-work.md
@@ -1,1 +1,0 @@
-/Users/hdkiller/Develop/factory/plugins/core/commands/factory-work.md

--- a/lib/factory-gitignore.test.mjs
+++ b/lib/factory-gitignore.test.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -36,4 +37,20 @@ test("splice replaces stale marked block", () => {
   const out = spliceHarnessGitignore(stale);
   expect(out).toContain(".cursor/commands/factory-*.md");
   expect(harnessGitignoreIsCurrent(out)).toBe(true);
+});
+
+// The block above is a promise the index can silently break: gitignore does
+// not untrack what is already staged. Twelve of these symlinks were committed
+// before the block existed, with macOS-absolute targets, so every non-macOS
+// checkout got a dangling link that `factory emit --link-repos` could only fix
+// by leaving the tree permanently dirty — and headless dispatch, which reads
+// <repo>/.claude/commands directly, could not resolve /factory-* at all
+// (WM-652, same failure shape as OPS-69). Nothing else notices the drift.
+test("this repo tracks no factory command symlinks", () => {
+  const root = path.resolve(import.meta.dir, "..");
+  const tracked = execFileSync("git", ["ls-files", "--", ".claude/commands", ".cursor/commands"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  expect(tracked).toBe("");
 });


### PR DESCRIPTION
Fixes WM-652

## What

`git rm --cached` on the twelve `.claude/commands/factory-*.md` symlinks, plus a regression test that keeps them out of the index.

The `FACTORY:HARNES` block in `.gitignore` already excludes the pattern, but gitignore does not untrack what is already staged. These twelve were committed before the block existed, with macOS-absolute targets:

```
$ git cat-file -p HEAD:.claude/commands/factory-audit.md
/Users/hdkiller/Develop/factory/plugins/core/commands/factory-audit.md
```

## Why it matters

Found while bringing a migrated factory instance up on Linux (`runner`). Every one of the twelve dangled there, and `bun orchestrator/doctor.mjs` flagged both halves:

```
✗ /factory-* commands linked        12/13 missing or broken
✗ no tracked factory command files  fix: git rm --cached the listed paths
```

Two consequences, both silent:

- **Headless dispatch could not resolve `/factory-*`.** `runners/run-agent.sh` invokes `claude -p`, which reads `<repo>/.claude/commands` directly rather than through the marketplace plugin (SETUP.md §2). A fresh clone on any non-macOS host reproduces OPS-69 — `Unknown command: /factory-unblock` — at dispatch time.
- **The main checkout could not be kept clean.** `factory emit --link-repos` repairs the links, but because they were tracked that left twelve permanently-modified files. A dirty main checkout is what stops the live stack from being restarted onto new code (ORCHESTRATOR.md, Loop 4).

Untracking only — the links stay on disk, and `factory emit --link-repos` recreates them per machine. That is exactly what makes them machine-local install artifacts rather than repo content.

## Handoff

- PR: this one
- Verification: `bun test lib/ && bun build/emit.mjs --check && test -z "$(git ls-files .claude/commands)"` — pass. 1024 pass / 9 skip / 0 fail across 77 files; emit reports `ok — 90 generated files match shared/`; index empty.
- Negative test: the new case was observed **failing before the fix**, listing all twelve tracked paths (`Expected -1 / Received +12`). It is not vacuous.
- UX critique: skipped — no user-facing surface; this is repo index hygiene.
- Files: 2 changed (12 index deletions + `lib/factory-gitignore.test.mjs`), all within Owned Paths as amended on the ticket.
- Risks: anyone with an existing clone keeps their on-disk links; they simply become untracked. Anyone who has *not* run `factory emit --link-repos` on a fresh clone now gets no `.claude/commands/factory-*.md` at all until they do — which is the documented install step, and strictly better than a dangling link that fails at dispatch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQK32AbeCKYCMfEiH8dgtP
