### PR TITLE
feat(event-runtime-web): inbox-first Overview

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -546,7 +546,9 @@ export function App() {
     const id = route.length > 1 ? route[route.length - 1] : null;
     const typeQ = hashSearch(window.location.hash).get("type");
     const detail = id ?? typeQ;
-    const pageTitle = detail ? `factory · ${viewLabel} · ${detail}` : `factory · ${viewLabel}`;
+    const pageTitle = detail
+      ? `factory · ${viewLabel} · ${detail}`
+      : `factory · ${viewLabel}`;
     document.title = inboxOpen > 0 ? `(${inboxOpen}) ${pageTitle}` : pageTitle;
   }, [inboxOpen, route, viewLabel]);
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -546,10 +546,9 @@ export function App() {
     const id = route.length > 1 ? route[route.length - 1] : null;
     const typeQ = hashSearch(window.location.hash).get("type");
     const detail = id ?? typeQ;
-    document.title = detail
-      ? `factory · ${viewLabel} · ${detail}`
-      : `factory · ${viewLabel}`;
-  }, [route, viewLabel]);
+    const pageTitle = detail ? `factory · ${viewLabel} · ${detail}` : `factory · ${viewLabel}`;
+    document.title = inboxOpen > 0 ? `(${inboxOpen}) ${pageTitle}` : pageTitle;
+  }, [inboxOpen, route, viewLabel]);
 
   useEffect(() => {
     if (!filterFocus) return;

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -349,6 +349,217 @@ export function inboxAge(iso: string, now: number): string {
   return `${days}d ${hours}h ago`;
 }
 
+/**
+ * The compact attention grammar shared by Inbox-adjacent surfaces.  Overview
+ * intentionally owns neither another inbox list nor another kind palette:
+ * it supplies the navigation/action wiring while this component keeps the
+ * visual and keyboard semantics aligned with the Inbox ledger.
+ */
+export interface NeedsYouRowProps {
+  kind: string;
+  title: string;
+  age?: React.ReactNode;
+  hue?: string;
+  selected?: boolean;
+  onOpen?: () => void;
+  primaryAction?: { label: string; onClick: () => void };
+  onAck?: () => void;
+  children?: React.ReactNode;
+}
+
+export function NeedsYouRow({
+  kind,
+  title,
+  age,
+  hue,
+  selected = false,
+  onOpen,
+  primaryAction,
+  onAck,
+  children,
+}: NeedsYouRowProps) {
+  const hues = hue ? { ...INBOX_KIND_HUES, [kind]: hue } : INBOX_KIND_HUES;
+  const open = () => onOpen?.();
+  return (
+    <div
+      role={onOpen ? "button" : undefined}
+      tabIndex={onOpen ? 0 : undefined}
+      aria-selected={onOpen ? selected : undefined}
+      onClick={open}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" || !onOpen) return;
+        event.preventDefault();
+        open();
+      }}
+      className={`group flex min-w-0 items-center gap-2 border-b border-(--border) px-3 py-2 last:border-0 ${
+        onOpen ? "cursor-pointer hover:bg-(--surface-2) focus-visible:outline-2 focus-visible:outline-(--accent)" : ""
+      } ${selected ? "row-selected" : ""}`}
+    >
+      <StateBadge state={kind} hues={hues} dot={false} />
+      <span className="min-w-0 flex-1 truncate text-[12px] text-(--text)" title={title}>{title}</span>
+      {age && <span className="mono shrink-0 text-[11px] text-(--text-faint)">{age}</span>}
+      {primaryAction && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            primaryAction.onClick();
+          }}
+          className="shrink-0 cursor-pointer rounded bg-(--surface-3) px-2 py-1 text-[11px] font-medium text-(--text) hover:bg-(--accent) hover:text-(--surface-0) focus-visible:outline-2 focus-visible:outline-(--accent)"
+        >
+          {primaryAction.label}
+        </button>
+      )}
+      {onAck && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onAck();
+          }}
+          className="shrink-0 cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-faint) hover:bg-(--surface-3) hover:text-(--text) focus-visible:outline-2 focus-visible:outline-(--accent)"
+        >
+          ack
+        </button>
+      )}
+      {children}
+    </div>
+  );
+}
+
+export function NeedsYouGroup({
+  label,
+  hue,
+  count,
+  moreHref = "#/inbox",
+  children,
+}: {
+  label: string;
+  hue: string;
+  count: number;
+  moreHref?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-md border border-(--border) bg-(--surface-1)">
+      <div className="flex items-center gap-2 border-b border-(--border) px-3 py-1.5 text-[11px]">
+        <span className="size-1.5 rounded-full" style={{ background: hue }} />
+        <h3 className="font-semibold text-(--text-dim)">{label}</h3>
+        <span className="mono text-(--text-faint)">{count}</span>
+        {count > 5 && (
+          <a href={moreHref} className="ml-auto cursor-pointer text-(--text-faint) hover:text-(--text) hover:underline">
+            {count - 5} more →
+          </a>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export interface OverviewNeedsYouProps {
+  items: InboxItem[];
+  runtimeItems: Array<{
+    id: string;
+    title: string;
+    primaryAction?: { label: string; onClick: () => void };
+  }>;
+  now: number;
+  lastDecision: string | null;
+  runtimeLabel?: string;
+  connected: boolean;
+  onOpenItem: (id: string) => void;
+  onAck: (id: string) => void;
+}
+
+/**
+ * Overview is deliberately a thin, lazy consumer of the Inbox's compact
+ * grammar. Keeping this with the ledger avoids a second row implementation
+ * while retaining the Inbox view as its own bundle.
+ */
+export function OverviewNeedsYou({
+  items,
+  runtimeItems,
+  now,
+  lastDecision,
+  runtimeLabel = "Runtime",
+  connected,
+  onOpenItem,
+  onAck,
+}: OverviewNeedsYouProps) {
+  const groups = useMemo(() => groupItems(items), [items]);
+  const navigable = useMemo(
+    () => [
+      ...groups.flatMap(({ items: groupItems }) =>
+        groupItems.slice(0, 5).map((item) => ({ id: item.id, open: () => onOpenItem(item.id) })),
+      ),
+      ...runtimeItems.slice(0, 5).flatMap((item) =>
+        item.primaryAction ? [{ id: item.id, open: item.primaryAction.onClick }] : [],
+      ),
+    ],
+    [groups, onOpenItem, runtimeItems],
+  );
+  const [selected, setSelected] = useState(0);
+  const selectedIndex = Math.min(selected, Math.max(0, navigable.length - 1));
+  useListKeys({
+    count: navigable.length,
+    selected: selectedIndex,
+    onSelect: setSelected,
+    onOpen: () => navigable[selectedIndex]?.open(),
+  });
+
+  return (
+    <section className="mb-6" aria-label="Needs you">
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <h2>
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">Needs you</span>
+        </h2>
+        {items.length > 0 && <span className="text-[11px] text-(--text-faint)">{items.length} open</span>}
+      </div>
+      {items.length === 0 && runtimeItems.length === 0 ? (
+        <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-(--text-muted)">
+          <span className="size-1.5 rounded-full bg-(--hue-ok)" />
+          Nothing needs you · last decision {lastDecision ? <Ago iso={lastDecision} now={now} /> : "—"}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {groups.map(({ group, items: groupItems }) => (
+            <NeedsYouGroup key={group.id} label={group.label} hue={group.hue} count={groupItems.length}>
+              {groupItems.slice(0, 5).map((item) => (
+                <NeedsYouRow
+                  key={item.id}
+                  kind={item.kind}
+                  title={item.title}
+                  age={<Ago iso={item.createdAt} now={now} />}
+                  selected={navigable[selectedIndex]?.id === item.id}
+                  onOpen={() => onOpenItem(item.id)}
+                  primaryAction={{ label: "Open", onClick: () => onOpenItem(item.id) }}
+                  onAck={connected ? () => onAck(item.id) : undefined}
+                />
+              ))}
+            </NeedsYouGroup>
+          ))}
+          {runtimeItems.length > 0 && (
+            <NeedsYouGroup label={runtimeLabel} hue="var(--hue-warn)" count={runtimeItems.length}>
+              {runtimeItems.slice(0, 5).map((item) => (
+                <NeedsYouRow
+                  key={item.id}
+                  kind="Runtime"
+                  hue="var(--hue-warn)"
+                  title={item.title}
+                  selected={navigable[selectedIndex]?.id === item.id}
+                  onOpen={item.primaryAction?.onClick}
+                  primaryAction={item.primaryAction}
+                />
+              ))}
+            </NeedsYouGroup>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
 const isTypingTarget = (target: EventTarget | null): boolean =>
   target instanceof HTMLElement &&
   Boolean(target.closest("input, textarea, select, [contenteditable=true]"));

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -1,5 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { api } from "../api";
 import {
   keyGuard,
@@ -349,6 +356,9 @@ export function inboxAge(iso: string, now: number): string {
   return `${days}d ${hours}h ago`;
 }
 
+/** How many rows a single Needs-you group shows before deferring to the Inbox. */
+export const NEEDS_YOU_CAP = 5;
+
 /**
  * The compact attention grammar shared by Inbox-adjacent surfaces.  Overview
  * intentionally owns neither another inbox list nor another kind palette:
@@ -358,24 +368,29 @@ export function inboxAge(iso: string, now: number): string {
 export interface NeedsYouRowProps {
   kind: string;
   title: string;
-  age?: React.ReactNode;
+  /** Full, unabridged title for the tooltip; defaults to the visible title. */
+  tooltip?: string;
+  age?: ReactNode;
   hue?: string;
   selected?: boolean;
   onOpen?: () => void;
   primaryAction?: { label: string; onClick: () => void };
   onAck?: () => void;
-  children?: React.ReactNode;
+  ackDisabled?: boolean;
+  children?: ReactNode;
 }
 
 export function NeedsYouRow({
   kind,
   title,
+  tooltip,
   age,
   hue,
   selected = false,
   onOpen,
   primaryAction,
   onAck,
+  ackDisabled = false,
   children,
 }: NeedsYouRowProps) {
   const hues = hue ? { ...INBOX_KIND_HUES, [kind]: hue } : INBOX_KIND_HUES;
@@ -384,7 +399,7 @@ export function NeedsYouRow({
     <div
       role={onOpen ? "button" : undefined}
       tabIndex={onOpen ? 0 : undefined}
-      aria-selected={onOpen ? selected : undefined}
+      aria-current={onOpen && selected ? "true" : undefined}
       onClick={open}
       onKeyDown={(event) => {
         if (event.key !== "Enter" || !onOpen) return;
@@ -400,7 +415,7 @@ export function NeedsYouRow({
       <StateBadge state={kind} hues={hues} dot={false} />
       <span
         className="min-w-0 flex-1 truncate text-[12px] text-(--text)"
-        title={title}
+        title={tooltip ?? title}
       >
         {title}
       </span>
@@ -424,11 +439,12 @@ export function NeedsYouRow({
       {onAck && (
         <button
           type="button"
+          disabled={ackDisabled}
           onClick={(event) => {
             event.stopPropagation();
             onAck();
           }}
-          className="shrink-0 cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-faint) hover:bg-(--surface-3) hover:text-(--text) focus-visible:outline-2 focus-visible:outline-(--accent)"
+          className="shrink-0 cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-faint) hover:bg-(--surface-3) hover:text-(--text) focus-visible:outline-2 focus-visible:outline-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
         >
           ack
         </button>
@@ -442,14 +458,14 @@ export function NeedsYouGroup({
   label,
   hue,
   count,
-  moreHref = "#/inbox",
+  onMore,
   children,
 }: {
   label: string;
   hue: string;
   count: number;
-  moreHref?: string;
-  children: React.ReactNode;
+  onMore?: () => void;
+  children: ReactNode;
 }) {
   return (
     <section className="rounded-md border border-(--border) bg-(--surface-1)">
@@ -457,13 +473,14 @@ export function NeedsYouGroup({
         <span className="size-1.5 rounded-full" style={{ background: hue }} />
         <h3 className="font-semibold text-(--text-dim)">{label}</h3>
         <span className="mono text-(--text-faint)">{count}</span>
-        {count > 5 && (
-          <a
-            href={moreHref}
+        {count > NEEDS_YOU_CAP && onMore && (
+          <button
+            type="button"
+            onClick={onMore}
             className="ml-auto cursor-pointer text-(--text-faint) hover:text-(--text) hover:underline"
           >
-            {count - 5} more →
-          </a>
+            {count - NEEDS_YOU_CAP} more →
+          </button>
         )}
       </div>
       {children}
@@ -482,8 +499,13 @@ export interface OverviewNeedsYouProps {
   lastDecision: string | null;
   runtimeLabel?: string;
   connected: boolean;
+  /** An ack is in flight: keep the verb visible but inert. */
+  ackPending?: boolean;
+  /** The ledger has not answered yet — say nothing rather than "all clear". */
+  isPending?: boolean;
   onOpenItem: (id: string) => void;
   onAck: (id: string) => void;
+  onMore: () => void;
 }
 
 /**
@@ -498,19 +520,22 @@ export function OverviewNeedsYou({
   lastDecision,
   runtimeLabel = "Runtime",
   connected,
+  ackPending = false,
+  isPending = false,
   onOpenItem,
   onAck,
+  onMore,
 }: OverviewNeedsYouProps) {
   const groups = useMemo(() => groupItems(items), [items]);
   const navigable = useMemo(
     () => [
       ...groups.flatMap(({ items: groupItems }) =>
         groupItems
-          .slice(0, 5)
+          .slice(0, NEEDS_YOU_CAP)
           .map((item) => ({ id: item.id, open: () => onOpenItem(item.id) })),
       ),
       ...runtimeItems
-        .slice(0, 5)
+        .slice(0, NEEDS_YOU_CAP)
         .flatMap((item) =>
           item.primaryAction
             ? [{ id: item.id, open: item.primaryAction.onClick }]
@@ -528,6 +553,8 @@ export function OverviewNeedsYou({
     onOpen: () => navigable[selectedIndex]?.open(),
   });
 
+  const empty = items.length === 0 && runtimeItems.length === 0;
+
   return (
     <section className="mb-6" aria-label="Needs you">
       <div className="mb-2 flex items-baseline justify-between gap-3">
@@ -542,8 +569,13 @@ export function OverviewNeedsYou({
           </span>
         )}
       </div>
-      {items.length === 0 && runtimeItems.length === 0 ? (
-        <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-(--text-muted)">
+      {empty && isPending ? (
+        <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-(--text-faint)">
+          <span className="size-1.5 rounded-full bg-(--hue-idle)" />
+          Checking what needs you
+        </div>
+      ) : empty ? (
+        <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-(--text-faint)">
           <span className="size-1.5 rounded-full bg-(--hue-ok)" />
           Nothing needs you · last decision{" "}
           {lastDecision ? <Ago iso={lastDecision} now={now} /> : "—"}
@@ -556,12 +588,14 @@ export function OverviewNeedsYou({
               label={group.label}
               hue={group.hue}
               count={groupItems.length}
+              onMore={onMore}
             >
-              {groupItems.slice(0, 5).map((item) => (
+              {groupItems.slice(0, NEEDS_YOU_CAP).map((item) => (
                 <NeedsYouRow
                   key={item.id}
                   kind={item.kind}
-                  title={item.title}
+                  title={displayTitle(item)}
+                  tooltip={item.title}
                   age={<Ago iso={item.createdAt} now={now} />}
                   selected={navigable[selectedIndex]?.id === item.id}
                   onOpen={() => onOpenItem(item.id)}
@@ -569,7 +603,8 @@ export function OverviewNeedsYou({
                     label: "Open",
                     onClick: () => onOpenItem(item.id),
                   }}
-                  onAck={connected ? () => onAck(item.id) : undefined}
+                  onAck={() => onAck(item.id)}
+                  ackDisabled={!connected || ackPending}
                 />
               ))}
             </NeedsYouGroup>
@@ -580,7 +615,7 @@ export function OverviewNeedsYou({
               hue="var(--hue-warn)"
               count={runtimeItems.length}
             >
-              {runtimeItems.slice(0, 5).map((item) => (
+              {runtimeItems.slice(0, NEEDS_YOU_CAP).map((item) => (
                 <NeedsYouRow
                   key={item.id}
                   kind="Runtime"

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -392,12 +392,23 @@ export function NeedsYouRow({
         open();
       }}
       className={`group flex min-w-0 items-center gap-2 border-b border-(--border) px-3 py-2 last:border-0 ${
-        onOpen ? "cursor-pointer hover:bg-(--surface-2) focus-visible:outline-2 focus-visible:outline-(--accent)" : ""
+        onOpen
+          ? "cursor-pointer hover:bg-(--surface-2) focus-visible:outline-2 focus-visible:outline-(--accent)"
+          : ""
       } ${selected ? "row-selected" : ""}`}
     >
       <StateBadge state={kind} hues={hues} dot={false} />
-      <span className="min-w-0 flex-1 truncate text-[12px] text-(--text)" title={title}>{title}</span>
-      {age && <span className="mono shrink-0 text-[11px] text-(--text-faint)">{age}</span>}
+      <span
+        className="min-w-0 flex-1 truncate text-[12px] text-(--text)"
+        title={title}
+      >
+        {title}
+      </span>
+      {age && (
+        <span className="mono shrink-0 text-[11px] text-(--text-faint)">
+          {age}
+        </span>
+      )}
       {primaryAction && (
         <button
           type="button"
@@ -447,7 +458,10 @@ export function NeedsYouGroup({
         <h3 className="font-semibold text-(--text-dim)">{label}</h3>
         <span className="mono text-(--text-faint)">{count}</span>
         {count > 5 && (
-          <a href={moreHref} className="ml-auto cursor-pointer text-(--text-faint) hover:text-(--text) hover:underline">
+          <a
+            href={moreHref}
+            className="ml-auto cursor-pointer text-(--text-faint) hover:text-(--text) hover:underline"
+          >
             {count - 5} more →
           </a>
         )}
@@ -491,11 +505,17 @@ export function OverviewNeedsYou({
   const navigable = useMemo(
     () => [
       ...groups.flatMap(({ items: groupItems }) =>
-        groupItems.slice(0, 5).map((item) => ({ id: item.id, open: () => onOpenItem(item.id) })),
+        groupItems
+          .slice(0, 5)
+          .map((item) => ({ id: item.id, open: () => onOpenItem(item.id) })),
       ),
-      ...runtimeItems.slice(0, 5).flatMap((item) =>
-        item.primaryAction ? [{ id: item.id, open: item.primaryAction.onClick }] : [],
-      ),
+      ...runtimeItems
+        .slice(0, 5)
+        .flatMap((item) =>
+          item.primaryAction
+            ? [{ id: item.id, open: item.primaryAction.onClick }]
+            : [],
+        ),
     ],
     [groups, onOpenItem, runtimeItems],
   );
@@ -512,19 +532,31 @@ export function OverviewNeedsYou({
     <section className="mb-6" aria-label="Needs you">
       <div className="mb-2 flex items-baseline justify-between gap-3">
         <h2>
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">Needs you</span>
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-(--text-faint)">
+            Needs you
+          </span>
         </h2>
-        {items.length > 0 && <span className="text-[11px] text-(--text-faint)">{items.length} open</span>}
+        {items.length > 0 && (
+          <span className="text-[11px] text-(--text-faint)">
+            {items.length} open
+          </span>
+        )}
       </div>
       {items.length === 0 && runtimeItems.length === 0 ? (
         <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-(--text-muted)">
           <span className="size-1.5 rounded-full bg-(--hue-ok)" />
-          Nothing needs you · last decision {lastDecision ? <Ago iso={lastDecision} now={now} /> : "—"}
+          Nothing needs you · last decision{" "}
+          {lastDecision ? <Ago iso={lastDecision} now={now} /> : "—"}
         </div>
       ) : (
         <div className="space-y-2">
           {groups.map(({ group, items: groupItems }) => (
-            <NeedsYouGroup key={group.id} label={group.label} hue={group.hue} count={groupItems.length}>
+            <NeedsYouGroup
+              key={group.id}
+              label={group.label}
+              hue={group.hue}
+              count={groupItems.length}
+            >
               {groupItems.slice(0, 5).map((item) => (
                 <NeedsYouRow
                   key={item.id}
@@ -533,14 +565,21 @@ export function OverviewNeedsYou({
                   age={<Ago iso={item.createdAt} now={now} />}
                   selected={navigable[selectedIndex]?.id === item.id}
                   onOpen={() => onOpenItem(item.id)}
-                  primaryAction={{ label: "Open", onClick: () => onOpenItem(item.id) }}
+                  primaryAction={{
+                    label: "Open",
+                    onClick: () => onOpenItem(item.id),
+                  }}
                   onAck={connected ? () => onAck(item.id) : undefined}
                 />
               ))}
             </NeedsYouGroup>
           ))}
           {runtimeItems.length > 0 && (
-            <NeedsYouGroup label={runtimeLabel} hue="var(--hue-warn)" count={runtimeItems.length}>
+            <NeedsYouGroup
+              label={runtimeLabel}
+              hue="var(--hue-warn)"
+              count={runtimeItems.length}
+            >
               {runtimeItems.slice(0, 5).map((item) => (
                 <NeedsYouRow
                   key={item.id}

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,12 +1,6 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Overview,
@@ -16,7 +10,6 @@ import {
   groupDeadLetters,
   stripAnomalyKindPrefix,
 } from "./Overview";
-import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
@@ -462,7 +455,7 @@ describe("Overview keyboard navigation (WM-292)", () => {
     }
   });
 
-  test(". cycles anomaly focus and r requeues only a focused dead-letter event", async () => {
+  test("Runtime attention rows open their linked targets", async () => {
     const restore = stubOverviewApis(
       baseStatus({
         expiredOpenProposals: ["prop_expired"],
@@ -475,39 +468,13 @@ describe("Overview keyboard navigation (WM-292)", () => {
         ],
       }),
     );
-    const requeue = mock(
-      (_source: string, _eventId: string) =>
-        new Promise<{ requeued: boolean }>(() => {}),
-    );
-    api.requeue = requeue;
+    const onJumpEvents = mock(() => {});
 
     try {
-      const view = renderOverview();
-      await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
-
-      const first = view
-        .getByRole("button", { name: "expired open" })
-        .closest('[tabindex="-1"]');
-      const second = view
-        .getByRole("button", { name: /github.*planner failed/ })
-        .closest('[tabindex="-1"]');
-      expect(first).toBeTruthy();
-      expect(second).toBeTruthy();
-
-      fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(first);
-      fireEvent.keyDown(document.body, { key: "r" });
-      expect(requeue).not.toHaveBeenCalled();
-
-      fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(second);
-      fireEvent.keyDown(document.body, { key: "r" });
-      await waitFor(() =>
-        expect(requeue).toHaveBeenCalledWith("github", "evt_dead"),
-      );
-
-      fireEvent.keyDown(document.body, { key: "." });
-      expect(document.activeElement).toBe(first);
+      const view = renderOverview({ kind: "all" }, { onJumpEvents });
+      await waitFor(() => view.getByRole("button", { name: /github.*planner failed/ }));
+      fireEvent.click(view.getByRole("button", { name: "View event" }));
+      expect(onJumpEvents).toHaveBeenCalledWith({ source: "github", eventId: "evt_dead" });
     } finally {
       restore();
     }
@@ -515,7 +482,7 @@ describe("Overview keyboard navigation (WM-292)", () => {
 });
 
 describe("Overview anomaly deck (WM-95)", () => {
-  test("enriches an expired-proposal row with agent, decision/reason, origin, and age; demotes the raw id", async () => {
+  test("folds expired proposals into the Runtime group", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
@@ -525,91 +492,47 @@ describe("Overview anomaly deck (WM-95)", () => {
     api.proposals = async () => ({ proposals: [stubProposal] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
-
-    try {
-      const { getByText, queryByTitle } = renderOverview();
-
-      await waitFor(() => getByText(/agent: triage-scan/));
-
-      expect(getByText(/agent: triage-scan/)).toBeTruthy();
-      expect(getByText(/human_needed/)).toBeTruthy();
-      expect(getByText(/ambiguous repo pin/)).toBeTruthy();
-      const originId = queryByTitle("evt-789");
-      expect(originId).toBeTruthy();
-      expect(originId?.parentElement?.textContent).toBe(
-        "origin github/evt-789",
-      );
-
-      // Raw id is demoted to secondary, copyable text rather than the primary label.
-      const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
-      expect(idNode).toBeTruthy();
-      expect(idNode?.textContent).toBe(shortId(stubProposal.id));
-    } finally {
-      api.status = origStatus;
-      api.proposals = origProposals;
-      api.outbox = origOutbox;
-      api.journal = origJournal;
-    }
-  });
-
-  test("rejects an expired proposal only after collecting a non-empty reason", async () => {
-    const origStatus = api.status;
-    const origProposals = api.proposals;
-    const origOutbox = api.outbox;
-    const origJournal = api.journal;
-    const origReject = api.reject;
-    api.status = async () =>
-      baseStatus({ expiredOpenProposals: [stubProposal.id] });
-    api.proposals = async () => ({ proposals: [stubProposal] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-
-    const rejectedCalls: { id: string; why?: string }[] = [];
-    api.reject = async (id: string, why?: string) => {
-      rejectedCalls.push({ id, why });
-      return { rejected: true };
-    };
 
     try {
       const view = renderOverview();
-      const reject = await waitFor(() =>
-        view.getByRole("button", { name: "Reject…" }),
-      );
-
-      expect(view.queryByRole("button", { name: "Dismiss" })).toBeNull();
-      fireEvent.click(reject);
-
-      const confirm = view.getByRole("button", {
-        name: "Reject proposal",
-      }) as HTMLButtonElement;
-      const reasonInput = view.getByLabelText(
-        "Rejection reason",
-      ) as HTMLInputElement;
-      expect(reasonInput.placeholder).toMatch(/Reason \(required/i);
-      expect(confirm.disabled).toBe(true);
-
-      await act(async () => changeInput(reasonInput, "   "));
-      fireEvent.click(confirm);
-      expect(rejectedCalls).toEqual([]);
-
-      await act(async () => changeInput(reasonInput, " No longer actionable "));
-      await waitFor(() => expect(confirm.disabled).toBe(false));
-      await act(async () => fireEvent.click(confirm));
-      await waitFor(() =>
-        expect(rejectedCalls).toEqual([
-          { id: stubProposal.id, why: "No longer actionable" },
-        ]),
-      );
+      await waitFor(() => view.getByText(`expired open proposal ${stubProposal.id}`));
+      expect(view.getByRole("heading", { name: "Runtime" })).toBeTruthy();
+      expect(view.getByRole("button", { name: "View proposal" })).toBeTruthy();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
       api.outbox = origOutbox;
       api.journal = origJournal;
-      api.reject = origReject;
     }
   });
 
-  test("shows a fallback for a proposal id with no match in the proposals list", async () => {
+  test("Runtime proposals have a single primary navigation verb", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    const onJumpProposal = mock(() => {});
+
+    try {
+      const view = renderOverview({ kind: "all" }, { onJumpProposal });
+      fireEvent.click(await waitFor(() => view.getByRole("button", { name: "View proposal" })));
+      expect(onJumpProposal).toHaveBeenCalledWith(stubProposal.id);
+      expect(view.queryByRole("button", { name: "Reject…" })).toBeNull();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("renders unmatched proposal ids in the Runtime group", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
@@ -621,12 +544,9 @@ describe("Overview anomaly deck (WM-95)", () => {
     api.journal = async () => ({ entries: [], head: 0 });
 
     try {
-      const { getByText, queryByTitle } = renderOverview();
-
-      await waitFor(() => queryByTitle("prop_missing — click to copy"));
-
-      expect(getByText(/agent: —/)).toBeTruthy();
-      expect(getByText(/origin —\/—/)).toBeTruthy();
+      const view = renderOverview();
+      await waitFor(() => view.getByText("expired open proposal prop_missing"));
+      expect(view.getByRole("heading", { name: "Runtime" })).toBeTruthy();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;
@@ -635,7 +555,7 @@ describe("Overview anomaly deck (WM-95)", () => {
     }
   });
 
-  test("collapses matching dead letters, expands short event ids, and confirms bulk actions with the count", async () => {
+  test("groups matching dead letters as Runtime rows", async () => {
     const originals = {
       status: api.status,
       proposals: api.proposals,
@@ -669,32 +589,9 @@ describe("Overview anomaly deck (WM-95)", () => {
 
     try {
       const view = renderOverview({ kind: "all" }, { onJumpEvents });
-      const group = await waitFor(() =>
-        view.getByRole("button", {
-          name: /3 dead-lettered.*chain.*duplicate key/,
-        }),
-      );
-
-      expect(
-        view.getByText(/Anomalies · 2 active issues · \(4 events\)/),
-      ).toBeTruthy();
-      expect(group.getAttribute("aria-expanded")).toBe("false");
-      fireEvent.click(group);
-      expect(group.getAttribute("aria-expanded")).toBe("true");
-
-      const firstEvent = view.getByTitle(eventIds[0]!);
-      expect(firstEvent.textContent).toBe(shortId(eventIds[0]!));
-      fireEvent.click(firstEvent);
-      expect(onJumpEvents).toHaveBeenCalledWith({
-        source: "chain",
-        eventId: eventIds[0],
-      });
-
-      fireEvent.click(view.getByRole("button", { name: "Archive all" }));
-      expect(view.getByText("Archive 3 dead-lettered events?")).toBeTruthy();
-      expect(
-        view.getByRole("button", { name: "Archive 3 events" }),
-      ).toBeTruthy();
+      await waitFor(() => view.getByText(/3 dead-lettered · chain · duplicate key/));
+      fireEvent.click(view.getAllByRole("button", { name: "View event" })[0]!);
+      expect(onJumpEvents).toHaveBeenCalledWith({ source: "chain", eventId: eventIds[0] });
     } finally {
       api.status = originals.status;
       api.proposals = originals.proposals;
@@ -793,7 +690,7 @@ describe("Overview anomaly deck (WM-95)", () => {
     }
   });
 
-  test("archives dead letters and releases stalled worker leases, removing both rows (WM-326)", async () => {
+  test("keeps runtime anomalies inside the shared compact grammar", async () => {
     const mutableApi = api as typeof api & {
       archive: (
         source: string,
@@ -858,24 +755,10 @@ describe("Overview anomaly deck (WM-95)", () => {
 
     try {
       const view = renderOverview();
-      await waitFor(() => view.getByRole("button", { name: "Archive" }));
-
-      expect(
-        view.getByRole("button", { name: /github.*historical failure/ }),
-      ).toBeTruthy();
-      view.getByRole("button", { name: "Archive" }).click();
-      await waitFor(() =>
-        expect(
-          view.queryByRole("button", { name: /github.*historical failure/ }),
-        ).toBeNull(),
-      );
-
-      const releaseLease = await waitFor(() =>
-        view.getByRole("button", { name: "Release lease" }),
-      );
-      releaseLease.click();
-      await waitFor(() => view.getByText(/Doctor: All systems nominal/));
-      expect(view.queryByText(/stalled worker worker-1/)).toBeNull();
+      await waitFor(() => view.getByText(/github · historical failure/));
+      expect(view.getByText(/stalled worker worker-1/)).toBeTruthy();
+      expect(view.queryByRole("button", { name: "Archive" })).toBeNull();
+      expect(view.queryByRole("button", { name: "Release lease" })).toBeNull();
     } finally {
       api.status = originals.status;
       api.proposals = originals.proposals;
@@ -1152,24 +1035,20 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     }
   });
 
-  test("repo tab: anomaly deck heading is marked factory-wide; All is not", async () => {
+  test("repo tab: Runtime remains visible alongside the scope notice", async () => {
     const restore = stubApis({
       status: baseStatus({ staleLeases: 1 }),
     });
 
     try {
       const repo = renderOverview({ kind: "repo", name: "bj29" });
-      await waitFor(() => repo.getByText(/Anomalies ·/));
-      expect(repo.getByText(/Anomalies ·/).textContent?.toLowerCase()).toMatch(
-        /factory-wide/,
-      );
+      await waitFor(() => repo.getByRole("heading", { name: /Runtime/ }));
+      expect(repo.getByRole("heading", { name: /Runtime/ })).toBeTruthy();
       repo.unmount();
 
       const all = renderOverview({ kind: "all" });
-      await waitFor(() => all.getByText(/Anomalies ·/));
-      expect(
-        all.getByText(/Anomalies ·/).textContent?.toLowerCase(),
-      ).not.toMatch(/factory-wide/);
+      await waitFor(() => all.getByRole("heading", { name: "Runtime" }));
+      expect(all.getByRole("heading", { name: "Runtime" })).toBeTruthy();
     } finally {
       restore();
     }
@@ -1346,7 +1225,7 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     });
   });
 
-  test("renders nominal status banner when no anomalies are present", async () => {
+  test("renders a calm Needs-you line when no anomalies are present", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;
     const origOutbox = api.outbox;
@@ -1357,10 +1236,9 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     api.journal = async () => ({ entries: [], head: 0 });
 
     try {
-      const { getByText } = renderOverview();
-      await waitFor(() => getByText(/Doctor: All systems nominal/));
-      expect(getByText(/Doctor: All systems nominal/)).toBeTruthy();
-      expect(getByText(/scope: all repos/)).toBeTruthy();
+      const { getByText, queryByText } = renderOverview();
+      await waitFor(() => getByText(/Nothing needs you · last decision/));
+      expect(queryByText(/Doctor: All systems nominal/)).toBeNull();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -472,131 +472,91 @@ describe("Overview keyboard navigation (WM-292)", () => {
 
     try {
       const view = renderOverview({ kind: "all" }, { onJumpEvents });
-      await waitFor(() => view.getByRole("button", { name: /github.*planner failed/ }));
+      await waitFor(() =>
+        view.getByRole("button", { name: /github.*planner failed/ }),
+      );
       fireEvent.click(view.getByRole("button", { name: "View event" }));
-      expect(onJumpEvents).toHaveBeenCalledWith({ source: "github", eventId: "evt_dead" });
+      expect(onJumpEvents).toHaveBeenCalledWith({
+        source: "github",
+        eventId: "evt_dead",
+      });
     } finally {
       restore();
     }
   });
 });
 
-describe("Overview anomaly deck (WM-95)", () => {
-  test("folds expired proposals into the Runtime group", async () => {
-    const origStatus = api.status;
-    const origProposals = api.proposals;
-    const origOutbox = api.outbox;
-    const origJournal = api.journal;
-    api.status = async () =>
-      baseStatus({ expiredOpenProposals: [stubProposal.id] });
-    api.proposals = async () => ({ proposals: [stubProposal] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-
-    try {
-      const view = renderOverview();
-      await waitFor(() => view.getByText(`expired open proposal ${stubProposal.id}`));
-      expect(view.getByRole("heading", { name: "Runtime" })).toBeTruthy();
-      expect(view.getByRole("button", { name: "View proposal" })).toBeTruthy();
-    } finally {
-      api.status = origStatus;
-      api.proposals = origProposals;
-      api.outbox = origOutbox;
-      api.journal = origJournal;
-    }
-  });
-
-  test("Runtime proposals have a single primary navigation verb", async () => {
-    const origStatus = api.status;
-    const origProposals = api.proposals;
-    const origOutbox = api.outbox;
-    const origJournal = api.journal;
-    api.status = async () =>
-      baseStatus({ expiredOpenProposals: [stubProposal.id] });
-    api.proposals = async () => ({ proposals: [stubProposal] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-
-    const onJumpProposal = mock(() => {});
-
-    try {
-      const view = renderOverview({ kind: "all" }, { onJumpProposal });
-      fireEvent.click(await waitFor(() => view.getByRole("button", { name: "View proposal" })));
-      expect(onJumpProposal).toHaveBeenCalledWith(stubProposal.id);
-      expect(view.queryByRole("button", { name: "Reject…" })).toBeNull();
-    } finally {
-      api.status = origStatus;
-      api.proposals = origProposals;
-      api.outbox = origOutbox;
-      api.journal = origJournal;
-    }
-  });
-
-  test("renders unmatched proposal ids in the Runtime group", async () => {
-    const origStatus = api.status;
-    const origProposals = api.proposals;
-    const origOutbox = api.outbox;
-    const origJournal = api.journal;
-    api.status = async () =>
-      baseStatus({ expiredOpenProposals: ["prop_missing"] });
-    api.proposals = async () => ({ proposals: [] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-
-    try {
-      const view = renderOverview();
-      await waitFor(() => view.getByText("expired open proposal prop_missing"));
-      expect(view.getByRole("heading", { name: "Runtime" })).toBeTruthy();
-    } finally {
-      api.status = origStatus;
-      api.proposals = origProposals;
-      api.outbox = origOutbox;
-      api.journal = origJournal;
-    }
-  });
-
-  test("groups matching dead letters as Runtime rows", async () => {
-    const originals = {
+describe("Overview needs you (WM-596)", () => {
+  const originalInbox = api.inbox;
+  function inboxItem(id: string, kind: string, createdAt: string): InboxItem {
+    return {
+      id,
+      kind,
+      severity: "normal",
+      title: `Attention ${id}`,
+      body: null,
+      refs: {},
+      source: "test",
+      createdAt,
+      ackedAt: null,
+      resolvedAt: null,
+      resolvedBy: null,
+      delivery: {},
+    };
+  }
+  function stubNeedsYou(items: InboxItem[], status = baseStatus()) {
+    const restore = {
       status: api.status,
       proposals: api.proposals,
       outbox: api.outbox,
       journal: api.journal,
     };
-    const eventIds = [
-      "chain-run_abcdef123456",
-      "chain-run_bcdefa234567",
-      "chain-run_cdefab345678",
-    ];
-    api.status = async () =>
-      baseStatus({
-        deadLettered: [
-          ...eventIds.map((eventId) => ({
-            source: "chain",
-            eventId,
-            lastError: "duplicate key",
-          })),
-          {
-            source: "chain",
-            eventId: "chain-run_timeout123456",
-            lastError: "timeout",
-          },
-        ],
-      });
+    api.status = async () => ({
+      ...status,
+      inbox: { open: items.length, acked: 0, byKind: {} },
+    });
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
-    const onJumpEvents = mock((_focus: EventFocus) => {});
-
+    api.inbox = async () => ({ items });
+    return () => {
+      api.status = restore.status;
+      api.proposals = restore.proposals;
+      api.outbox = restore.outbox;
+      api.journal = restore.journal;
+      api.inbox = originalInbox;
+    };
+  }
+  test("leads with capped oldest-first inbox groups and opens the selected row", async () => {
+    const items = Array.from({ length: 6 }, (_, index) =>
+      inboxItem(
+        `blocked-${index}`,
+        "BLOCKED",
+        `2026-08-17T0${index}:00:00.000Z`,
+      ),
+    );
+    const restore = stubNeedsYou(items);
+    const onNavigate = mock(() => {});
     try {
-      const view = renderOverview({ kind: "all" }, { onJumpEvents });
-      await waitFor(() => view.getByText(/3 dead-lettered · chain · duplicate key/));
-      fireEvent.click(view.getAllByRole("button", { name: "View event" })[0]!);
-      expect(onJumpEvents).toHaveBeenCalledWith({ source: "chain", eventId: eventIds[0] });
+      const view = renderOverview({ kind: "all" }, { onNavigate });
+      await waitFor(() =>
+        expect(view.getByRole("heading", { name: "Needs you" })).toBeTruthy(),
+      );
+      expect(
+        view
+          .getAllByRole("heading")
+          .map((heading) => heading.textContent)
+          .slice(0, 2),
+      ).toEqual(["Overview", "Needs you"]);
+      expect(view.getAllByTitle(/Attention blocked-/)).toHaveLength(5);
+      expect(view.queryByTitle("Attention blocked-5")).toBeNull();
+      expect(
+        view.getByRole("link", { name: "1 more →" }).getAttribute("href"),
+      ).toBe("#/inbox");
+      fireEvent.keyDown(document.body, { key: "Enter" });
+      expect(onNavigate).toHaveBeenCalledWith("inbox/blocked-0");
     } finally {
-      api.status = originals.status;
-      api.proposals = originals.proposals;
-      api.outbox = originals.outbox;
-      api.journal = originals.journal;
+      restore();
     }
   });
 
@@ -690,108 +650,33 @@ describe("Overview anomaly deck (WM-95)", () => {
     }
   });
 
-  test("keeps runtime anomalies inside the shared compact grammar", async () => {
-    const mutableApi = api as typeof api & {
-      archive: (
-        source: string,
-        eventId: string,
-      ) => Promise<{ archived: boolean }>;
-      releaseWorker: (
-        workerId: string,
-        runId: string,
-      ) => Promise<{ released: boolean; runId: string }>;
-    };
-    const originals = {
-      status: api.status,
-      proposals: api.proposals,
-      outbox: api.outbox,
-      journal: api.journal,
-      archive: mutableApi.archive,
-      releaseWorker: mutableApi.releaseWorker,
-    };
-    let deadLettered = true;
-    let stalled = true;
-    api.status = async () =>
-      baseStatus({
-        deadLettered: deadLettered
-          ? [
-              {
-                source: "github",
-                eventId: "dead-1",
-                lastError: "historical failure",
-              },
-            ]
-          : [],
-        stalledWorkers: stalled
-          ? [
-              {
-                workerId: "worker-1",
-                runId: "run-1",
-                host: "lab",
-                lastSeen: new Date(0).toISOString(),
-              },
-            ]
-          : [],
-      });
-    api.proposals = async () => ({ proposals: [] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-    mutableApi.archive = async (source, eventId) => {
-      expect({ source, eventId }).toEqual({
-        source: "github",
-        eventId: "dead-1",
-      });
-      deadLettered = false;
-      return { archived: true };
-    };
-    mutableApi.releaseWorker = async (workerId, runId) => {
-      expect({ workerId, runId }).toEqual({
-        workerId: "worker-1",
-        runId: "run-1",
-      });
-      stalled = false;
-      return { released: true, runId };
-    };
-
+  test("renders Runtime anomalies in the shared compact grammar", async () => {
+    const onJumpRuns = mock(() => {});
+    const restore = stubNeedsYou([], baseStatus({ staleLeases: 1 }));
+    try {
+      const view = renderOverview({ kind: "all" }, { onJumpRuns });
+      await waitFor(() => view.getByRole("heading", { name: "Runtime" }));
+      expect(view.queryByText(/Anomalies ·/)).toBeNull();
+      fireEvent.click(view.getByRole("button", { name: "View leased runs" }));
+      expect(onJumpRuns).toHaveBeenCalledWith("LEASED");
+    } finally {
+      restore();
+    }
+  });
+  test("uses the unfenced calm line when the ledger and runtime are clear", async () => {
+    const restore = stubNeedsYou([]);
     try {
       const view = renderOverview();
-      await waitFor(() => view.getByText(/github · historical failure/));
-      expect(view.getByText(/stalled worker worker-1/)).toBeTruthy();
-      expect(view.queryByRole("button", { name: "Archive" })).toBeNull();
-      expect(view.queryByRole("button", { name: "Release lease" })).toBeNull();
+      await waitFor(() =>
+        expect(
+          view.getByText(/Nothing needs you · last decision/),
+        ).toBeTruthy(),
+      );
+      const needsYou = view.getByLabelText("Needs you");
+      expect(needsYou.querySelector("table")).toBeNull();
+      expect(needsYou.querySelector(".border")).toBeNull();
     } finally {
-      api.status = originals.status;
-      api.proposals = originals.proposals;
-      api.outbox = originals.outbox;
-      api.journal = originals.journal;
-      mutableApi.archive = originals.archive;
-      mutableApi.releaseWorker = originals.releaseWorker;
-    }
-    // Two 2s status polls plus the waitFor budgets put this right at bun's
-    // default 5s — it passed on develop by ~100ms. Give it its real budget.
-  }, 15_000);
-
-  test("other anomaly kinds (stale leases, unpublished outbox) render unchanged", async () => {
-    const origStatus = api.status;
-    const origProposals = api.proposals;
-    const origOutbox = api.outbox;
-    const origJournal = api.journal;
-    api.status = async () =>
-      baseStatus({ staleLeases: 3, unpublishedOutbox: 2 });
-    api.proposals = async () => ({ proposals: [] });
-    api.outbox = async () => ({ outbox: [] });
-    api.journal = async () => ({ entries: [], head: 0 });
-
-    try {
-      const { getByText } = renderOverview();
-
-      await waitFor(() => getByText(/stale leases: 3/));
-      expect(getByText(/unpublished outbox rows: 2/)).toBeTruthy();
-    } finally {
-      api.status = origStatus;
-      api.proposals = origProposals;
-      api.outbox = origOutbox;
-      api.journal = origJournal;
+      restore();
     }
   });
 });

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1,6 +1,13 @@
 import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Overview,
@@ -10,12 +17,14 @@ import {
   groupDeadLetters,
   stripAnomalyKindPrefix,
 } from "./Overview";
+import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import { changeInput, withApi } from "../test-render";
 import type {
   AdmittedEvent,
+  EventFocus,
   InboxItem,
   JournalEntry,
   Proposal,
@@ -188,6 +197,14 @@ function renderOverview(
       onInject={noop}
     />,
   );
+}
+
+/**
+ * Scope a query to the anomaly remediation deck. Needs-you (WM-596) repeats the
+ * same anomaly text above it, so unscoped text/role queries are ambiguous.
+ */
+function deck(view: ReturnType<typeof renderOverview>) {
+  return within(view.getByLabelText("Anomalies"));
 }
 
 /** Build a journal entry; the feed keeps entries newest-first, so tests pass them that way. */
@@ -455,7 +472,7 @@ describe("Overview keyboard navigation (WM-292)", () => {
     }
   });
 
-  test("Runtime attention rows open their linked targets", async () => {
+  test(". cycles anomaly focus and r requeues only a focused dead-letter event", async () => {
     const restore = stubOverviewApis(
       baseStatus({
         expiredOpenProposals: ["prop_expired"],
@@ -468,32 +485,373 @@ describe("Overview keyboard navigation (WM-292)", () => {
         ],
       }),
     );
-    const onJumpEvents = mock(() => {});
+    const requeue = mock(
+      (_source: string, _eventId: string) =>
+        new Promise<{ requeued: boolean }>(() => {}),
+    );
+    api.requeue = requeue;
 
     try {
-      const view = renderOverview({ kind: "all" }, { onJumpEvents });
+      const view = renderOverview();
+      await waitFor(() => view.getByText(/Anomalies · 2 active issues/));
+
+      const first = deck(view)
+        .getByRole("button", { name: "expired open" })
+        .closest('[tabindex="-1"]');
+      const second = deck(view)
+        .getByRole("button", { name: /github.*planner failed/ })
+        .closest('[tabindex="-1"]');
+      expect(first).toBeTruthy();
+      expect(second).toBeTruthy();
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(first);
+      fireEvent.keyDown(document.body, { key: "r" });
+      expect(requeue).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(second);
+      fireEvent.keyDown(document.body, { key: "r" });
       await waitFor(() =>
-        view.getByRole("button", { name: /github.*planner failed/ }),
+        expect(requeue).toHaveBeenCalledWith("github", "evt_dead"),
       );
-      fireEvent.click(view.getByRole("button", { name: "View event" }));
-      expect(onJumpEvents).toHaveBeenCalledWith({
-        source: "github",
-        eventId: "evt_dead",
-      });
+
+      fireEvent.keyDown(document.body, { key: "." });
+      expect(document.activeElement).toBe(first);
     } finally {
       restore();
     }
   });
 });
 
+describe("Overview anomaly deck (WM-95)", () => {
+  test("enriches an expired-proposal row with agent, decision/reason, origin, and age; demotes the raw id", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText, queryByTitle } = renderOverview();
+
+      await waitFor(() => getByText(/agent: triage-scan/));
+
+      expect(getByText(/agent: triage-scan/)).toBeTruthy();
+      expect(getByText(/human_needed/)).toBeTruthy();
+      expect(getByText(/ambiguous repo pin/)).toBeTruthy();
+      const originId = queryByTitle("evt-789");
+      expect(originId).toBeTruthy();
+      expect(originId?.parentElement?.textContent).toBe(
+        "origin github/evt-789",
+      );
+
+      // Raw id is demoted to secondary, copyable text rather than the primary label.
+      const idNode = queryByTitle(`${stubProposal.id} — click to copy`);
+      expect(idNode).toBeTruthy();
+      expect(idNode?.textContent).toBe(shortId(stubProposal.id));
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("rejects an expired proposal only after collecting a non-empty reason", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    const origReject = api.reject;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: [stubProposal.id] });
+    api.proposals = async () => ({ proposals: [stubProposal] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    const rejectedCalls: { id: string; why?: string }[] = [];
+    api.reject = async (id: string, why?: string) => {
+      rejectedCalls.push({ id, why });
+      return { rejected: true };
+    };
+
+    try {
+      const view = renderOverview();
+      const reject = await waitFor(() =>
+        view.getByRole("button", { name: "Reject…" }),
+      );
+
+      expect(view.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      fireEvent.click(reject);
+
+      const confirm = view.getByRole("button", {
+        name: "Reject proposal",
+      }) as HTMLButtonElement;
+      const reasonInput = view.getByLabelText(
+        "Rejection reason",
+      ) as HTMLInputElement;
+      expect(reasonInput.placeholder).toMatch(/Reason \(required/i);
+      expect(confirm.disabled).toBe(true);
+
+      await act(async () => changeInput(reasonInput, "   "));
+      fireEvent.click(confirm);
+      expect(rejectedCalls).toEqual([]);
+
+      await act(async () => changeInput(reasonInput, " No longer actionable "));
+      await waitFor(() => expect(confirm.disabled).toBe(false));
+      await act(async () => fireEvent.click(confirm));
+      await waitFor(() =>
+        expect(rejectedCalls).toEqual([
+          { id: stubProposal.id, why: "No longer actionable" },
+        ]),
+      );
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+      api.reject = origReject;
+    }
+  });
+
+  test("shows a fallback for a proposal id with no match in the proposals list", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ expiredOpenProposals: ["prop_missing"] });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const { getByText, queryByTitle } = renderOverview();
+
+      await waitFor(() => queryByTitle("prop_missing — click to copy"));
+
+      expect(getByText(/agent: —/)).toBeTruthy();
+      expect(getByText(/origin —\/—/)).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+
+  test("collapses matching dead letters, expands short event ids, and confirms bulk actions with the count", async () => {
+    const originals = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+    };
+    const eventIds = [
+      "chain-run_abcdef123456",
+      "chain-run_bcdefa234567",
+      "chain-run_cdefab345678",
+    ];
+    api.status = async () =>
+      baseStatus({
+        deadLettered: [
+          ...eventIds.map((eventId) => ({
+            source: "chain",
+            eventId,
+            lastError: "duplicate key",
+          })),
+          {
+            source: "chain",
+            eventId: "chain-run_timeout123456",
+            lastError: "timeout",
+          },
+        ],
+      });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    const onJumpEvents = mock((_focus: EventFocus) => {});
+
+    try {
+      const view = renderOverview({ kind: "all" }, { onJumpEvents });
+      const group = await waitFor(() =>
+        deck(view).getByRole("button", {
+          name: /3 dead-lettered.*chain.*duplicate key/,
+        }),
+      );
+
+      expect(
+        view.getByText(/Anomalies · 2 active issues · \(4 events\)/),
+      ).toBeTruthy();
+      expect(group.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(group);
+      expect(group.getAttribute("aria-expanded")).toBe("true");
+
+      const firstEvent = deck(view).getByTitle(eventIds[0]!);
+      expect(firstEvent.textContent).toBe(shortId(eventIds[0]!));
+      fireEvent.click(firstEvent);
+      expect(onJumpEvents).toHaveBeenCalledWith({
+        source: "chain",
+        eventId: eventIds[0],
+      });
+
+      fireEvent.click(view.getByRole("button", { name: "Archive all" }));
+      expect(view.getByText("Archive 3 dead-lettered events?")).toBeTruthy();
+      expect(
+        view.getByRole("button", { name: "Archive 3 events" }),
+      ).toBeTruthy();
+    } finally {
+      api.status = originals.status;
+      api.proposals = originals.proposals;
+      api.outbox = originals.outbox;
+      api.journal = originals.journal;
+    }
+  });
+
+  test("archives dead letters and releases stalled worker leases, removing both rows (WM-326)", async () => {
+    const mutableApi = api as typeof api & {
+      archive: (
+        source: string,
+        eventId: string,
+      ) => Promise<{ archived: boolean }>;
+      releaseWorker: (
+        workerId: string,
+        runId: string,
+      ) => Promise<{ released: boolean; runId: string }>;
+    };
+    const originals = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+      archive: mutableApi.archive,
+      releaseWorker: mutableApi.releaseWorker,
+    };
+    let deadLettered = true;
+    let stalled = true;
+    api.status = async () =>
+      baseStatus({
+        deadLettered: deadLettered
+          ? [
+              {
+                source: "github",
+                eventId: "dead-1",
+                lastError: "historical failure",
+              },
+            ]
+          : [],
+        stalledWorkers: stalled
+          ? [
+              {
+                workerId: "worker-1",
+                runId: "run-1",
+                host: "lab",
+                lastSeen: new Date(0).toISOString(),
+              },
+            ]
+          : [],
+      });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+    mutableApi.archive = async (source, eventId) => {
+      expect({ source, eventId }).toEqual({
+        source: "github",
+        eventId: "dead-1",
+      });
+      deadLettered = false;
+      return { archived: true };
+    };
+    mutableApi.releaseWorker = async (workerId, runId) => {
+      expect({ workerId, runId }).toEqual({
+        workerId: "worker-1",
+        runId: "run-1",
+      });
+      stalled = false;
+      return { released: true, runId };
+    };
+
+    try {
+      const view = renderOverview();
+      await waitFor(() => view.getByRole("button", { name: "Archive" }));
+
+      expect(
+        deck(view).getByRole("button", { name: /github.*historical failure/ }),
+      ).toBeTruthy();
+      view.getByRole("button", { name: "Archive" }).click();
+      await waitFor(() =>
+        expect(
+          deck(view).queryByRole("button", {
+            name: /github.*historical failure/,
+          }),
+        ).toBeNull(),
+      );
+
+      const releaseLease = await waitFor(() =>
+        view.getByRole("button", { name: "Release lease" }),
+      );
+      releaseLease.click();
+      // Both anomalies are gone, so the deck unmounts entirely.
+      await waitFor(() =>
+        expect(view.queryByLabelText("Anomalies")).toBeNull(),
+      );
+      expect(view.queryByText(/stalled worker worker-1/)).toBeNull();
+    } finally {
+      api.status = originals.status;
+      api.proposals = originals.proposals;
+      api.outbox = originals.outbox;
+      api.journal = originals.journal;
+      mutableApi.archive = originals.archive;
+      mutableApi.releaseWorker = originals.releaseWorker;
+    }
+    // Two 2s status polls plus the waitFor budgets put this right at bun's
+    // default 5s — it passed on develop by ~100ms. Give it its real budget.
+  }, 30_000);
+
+  test("other anomaly kinds (stale leases, unpublished outbox) render unchanged", async () => {
+    const origStatus = api.status;
+    const origProposals = api.proposals;
+    const origOutbox = api.outbox;
+    const origJournal = api.journal;
+    api.status = async () =>
+      baseStatus({ staleLeases: 3, unpublishedOutbox: 2 });
+    api.proposals = async () => ({ proposals: [] });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    try {
+      const view = renderOverview();
+
+      await waitFor(() => deck(view).getByText(/stale leases: 3/));
+      expect(deck(view).getByText(/unpublished outbox rows: 2/)).toBeTruthy();
+    } finally {
+      api.status = origStatus;
+      api.proposals = origProposals;
+      api.outbox = origOutbox;
+      api.journal = origJournal;
+    }
+  });
+});
+
 describe("Overview needs you (WM-596)", () => {
   const originalInbox = api.inbox;
-  function inboxItem(id: string, kind: string, createdAt: string): InboxItem {
+
+  function inboxItem(
+    id: string,
+    kind: string,
+    createdAt: string,
+    title?: string,
+  ): InboxItem {
     return {
       id,
       kind,
       severity: "normal",
-      title: `Attention ${id}`,
+      title: title ?? `Attention ${id}`,
       body: null,
       refs: {},
       source: "test",
@@ -504,21 +862,26 @@ describe("Overview needs you (WM-596)", () => {
       delivery: {},
     };
   }
-  function stubNeedsYou(items: InboxItem[], status = baseStatus()) {
+
+  function stubNeedsYou(
+    items: InboxItem[] | (() => Promise<{ items: InboxItem[] }>),
+    status = baseStatus(),
+  ) {
     const restore = {
       status: api.status,
       proposals: api.proposals,
       outbox: api.outbox,
       journal: api.journal,
     };
+    const list = Array.isArray(items) ? items : [];
     api.status = async () => ({
       ...status,
-      inbox: { open: items.length, acked: 0, byKind: {} },
+      inbox: { open: list.length, acked: 0, byKind: {} },
     });
     api.proposals = async () => ({ proposals: [] });
     api.outbox = async () => ({ outbox: [] });
     api.journal = async () => ({ entries: [], head: 0 });
-    api.inbox = async () => ({ items });
+    api.inbox = Array.isArray(items) ? async () => ({ items }) : items;
     return () => {
       api.status = restore.status;
       api.proposals = restore.proposals;
@@ -527,6 +890,7 @@ describe("Overview needs you (WM-596)", () => {
       api.inbox = originalInbox;
     };
   }
+
   test("leads with capped oldest-first inbox groups and opens the selected row", async () => {
     const items = Array.from({ length: 6 }, (_, index) =>
       inboxItem(
@@ -536,7 +900,8 @@ describe("Overview needs you (WM-596)", () => {
       ),
     );
     const restore = stubNeedsYou(items);
-    const onNavigate = mock(() => {});
+    const onNavigate = mock((_path: string) => {});
+
     try {
       const view = renderOverview({ kind: "all" }, { onNavigate });
       await waitFor(() =>
@@ -550,9 +915,10 @@ describe("Overview needs you (WM-596)", () => {
       ).toEqual(["Overview", "Needs you"]);
       expect(view.getAllByTitle(/Attention blocked-/)).toHaveLength(5);
       expect(view.queryByTitle("Attention blocked-5")).toBeNull();
-      expect(
-        view.getByRole("link", { name: "1 more →" }).getAttribute("href"),
-      ).toBe("#/inbox");
+
+      fireEvent.click(view.getByRole("button", { name: "1 more →" }));
+      expect(onNavigate).toHaveBeenCalledWith("inbox");
+
       fireEvent.keyDown(document.body, { key: "Enter" });
       expect(onNavigate).toHaveBeenCalledWith("inbox/blocked-0");
     } finally {
@@ -650,21 +1016,95 @@ describe("Overview needs you (WM-596)", () => {
     }
   });
 
+  test("rows read the display title and keep the raw title as the tooltip", async () => {
+    const restore = stubNeedsYou([
+      inboxItem(
+        "blocked-1",
+        "BLOCKED",
+        "2026-08-17T00:00:00.000Z",
+        "BLOCKED needs a decision",
+      ),
+    ]);
+
+    try {
+      const view = renderOverview();
+      const row = await waitFor(() =>
+        view.getByTitle("BLOCKED needs a decision"),
+      );
+      expect(row.textContent).toBe("needs a decision");
+    } finally {
+      restore();
+    }
+  });
+
   test("renders Runtime anomalies in the shared compact grammar", async () => {
-    const onJumpRuns = mock(() => {});
+    const onJumpRuns = mock((_state?: string) => {});
     const restore = stubNeedsYou([], baseStatus({ staleLeases: 1 }));
+
     try {
       const view = renderOverview({ kind: "all" }, { onJumpRuns });
-      await waitFor(() => view.getByRole("heading", { name: "Runtime" }));
-      expect(view.queryByText(/Anomalies ·/)).toBeNull();
-      fireEvent.click(view.getByRole("button", { name: "View leased runs" }));
+      const needsYou = await waitFor(() => view.getByLabelText("Needs you"));
+      within(needsYou).getByRole("heading", { name: "Runtime" });
+      fireEvent.click(
+        within(needsYou).getByRole("button", { name: "View leased runs" }),
+      );
       expect(onJumpRuns).toHaveBeenCalledWith("LEASED");
     } finally {
       restore();
     }
   });
+
+  test("keeps the ack verb visible but inert while an ack is in flight", async () => {
+    const origAck = api.ackInbox;
+    const restore = stubNeedsYou([
+      inboxItem("blocked-1", "BLOCKED", "2026-08-17T00:00:00.000Z"),
+    ]);
+    api.ackInbox = () => new Promise(() => {});
+
+    try {
+      const view = renderOverview();
+      const needsYou = await waitFor(() => view.getByLabelText("Needs you"));
+      const ack = within(needsYou).getByRole("button", {
+        name: "ack",
+      }) as HTMLButtonElement;
+      expect(ack.disabled).toBe(false);
+      fireEvent.click(ack);
+      await waitFor(() =>
+        expect(
+          (
+            within(needsYou).getByRole("button", {
+              name: "ack",
+            }) as HTMLButtonElement
+          ).disabled,
+        ).toBe(true),
+      );
+      expect(
+        within(needsYou).getByRole("button", { name: "Open" }),
+      ).toBeTruthy();
+    } finally {
+      api.ackInbox = origAck;
+      restore();
+    }
+  });
+
+  test("waits for the ledger before claiming nothing needs you", async () => {
+    const restore = stubNeedsYou(() => new Promise(() => {}));
+
+    try {
+      const view = renderOverview();
+      const needsYou = await waitFor(() => view.getByLabelText("Needs you"));
+      expect(
+        within(needsYou).getByText(/Checking what needs you/),
+      ).toBeTruthy();
+      expect(view.queryByText(/Nothing needs you · last decision/)).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
   test("uses the unfenced calm line when the ledger and runtime are clear", async () => {
     const restore = stubNeedsYou([]);
+
     try {
       const view = renderOverview();
       await waitFor(() =>
@@ -920,20 +1360,24 @@ describe("Overview scoped tiles and factory-wide labels (WM-147)", () => {
     }
   });
 
-  test("repo tab: Runtime remains visible alongside the scope notice", async () => {
+  test("repo tab: anomaly deck heading is marked factory-wide; All is not", async () => {
     const restore = stubApis({
       status: baseStatus({ staleLeases: 1 }),
     });
 
     try {
       const repo = renderOverview({ kind: "repo", name: "bj29" });
-      await waitFor(() => repo.getByRole("heading", { name: /Runtime/ }));
-      expect(repo.getByRole("heading", { name: /Runtime/ })).toBeTruthy();
+      await waitFor(() => repo.getByText(/Anomalies ·/));
+      expect(repo.getByText(/Anomalies ·/).textContent?.toLowerCase()).toMatch(
+        /factory-wide/,
+      );
       repo.unmount();
 
       const all = renderOverview({ kind: "all" });
-      await waitFor(() => all.getByRole("heading", { name: "Runtime" }));
-      expect(all.getByRole("heading", { name: "Runtime" })).toBeTruthy();
+      await waitFor(() => all.getByText(/Anomalies ·/));
+      expect(
+        all.getByText(/Anomalies ·/).textContent?.toLowerCase(),
+      ).not.toMatch(/factory-wide/);
     } finally {
       restore();
     }
@@ -1121,9 +1565,10 @@ describe("Overview 4-Band layout & telemetry (WM-205)", () => {
     api.journal = async () => ({ entries: [], head: 0 });
 
     try {
-      const { getByText, queryByText } = renderOverview();
+      const { getByText, queryByText, queryByLabelText } = renderOverview();
       await waitFor(() => getByText(/Nothing needs you · last decision/));
       expect(queryByText(/Doctor: All systems nominal/)).toBeNull();
+      expect(queryByLabelText("Anomalies")).toBeNull();
     } finally {
       api.status = origStatus;
       api.proposals = origProposals;

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -16,7 +16,7 @@ import { scopedCount, scopedTally } from "../context";
 import { changeInput, withApi } from "../test-render";
 import type {
   AdmittedEvent,
-  EventFocus,
+  InboxItem,
   JournalEntry,
   Proposal,
   RunListItem,

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1312,16 +1312,24 @@ export function Overview({
           now={now}
           lastDecision={lastDecision}
           runtimeLabel={feedsUnscoped ? "Runtime · factory-wide" : "Runtime"}
-          connected={connected && !ackInbox.isPending}
+          connected={connected}
+          ackPending={ackInbox.isPending}
+          isPending={inbox.isPending || status.isPending}
           onOpenItem={(id) => onNavigate(`inbox/${id}`)}
           onAck={(id) => ackInbox.mutate(id)}
+          onMore={() => onNavigate("inbox")}
         />
       </Suspense>
 
-      {/* Superseded by the Runtime group above. Kept temporarily while the
-          old action dialogs are removed in the follow-up anomaly-action work. */}
-      {hasAnomalies && false ? (
-        <div
+      {/*
+        Band A: the anomaly remediation deck (WM-205). Needs-you above surfaces
+        these same anomalies as one-click jumps, but every remediation verb
+        (archive, requeue, release lease, reject) still lives only here. It stays
+        until those actions move onto the Runtime rows.
+      */}
+      {hasAnomalies ? (
+        <section
+          aria-label="Anomalies"
           className="mb-5 rounded-lg border p-3"
           style={{
             borderColor: "var(--hue-warn)",
@@ -1639,7 +1647,7 @@ export function Overview({
               requeue.error
             }
           />
-        </div>
+        </section>
       ) : null}
 
       {/* Band B: Unified Stage Cards (WM-205) */}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard, refetchIntervals, useNow, useRequeuePoll } from "../hooks";
@@ -32,6 +32,10 @@ import {
 import { Button as PrimitiveButton } from "../components/ui";
 
 const FEED_CAP = 50;
+
+const OverviewNeedsYou = lazy(() =>
+  import("./Inbox").then(({ OverviewNeedsYou }) => ({ default: OverviewNeedsYou })),
+);
 
 export function SectionTitle({
   title,
@@ -858,6 +862,14 @@ export function Overview({
     queryFn: api.status,
     ...refetchIntervals.primary,
   });
+  // Overview uses the ledger itself rather than a status summary so rows stay
+  // in the exact Inbox order and acknowledgement never needs an optimistic
+  // local rewrite.
+  const inbox = useQuery({
+    queryKey: ["inbox", "all"],
+    queryFn: () => api.inbox("all"),
+    ...refetchIntervals.primary,
+  });
   const outbox = useQuery({
     queryKey: ["outbox"],
     queryFn: () => api.outbox(15),
@@ -998,6 +1010,16 @@ export function Overview({
     reject.mutate({ proposalId: rejectingProposalId, why: rejectReason });
   };
 
+  const ackInbox = useMutation({
+    mutationFn: (id: string) => api.ackInbox(id),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["inbox"] }),
+        queryClient.invalidateQueries({ queryKey: ["status"] }),
+      ]),
+    onError: (error) => notify(`Ack failed: ${(error as Error).message}`, "err"),
+  });
+
   const s = useMemo(() => normalizeStatus(status.data), [status.data]);
   const anomalies = s?.anomalies;
   const proposalsById = useMemo(() => {
@@ -1035,6 +1057,25 @@ export function Overview({
   const hasAnomalies = anomalyRows.length > 0;
   const deadLetterEventCount = anomalies?.deadLettered?.length ?? 0;
   const anomalyRowRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  const openInboxItems = useMemo(
+    () => (inbox.data?.items ?? []).filter((item) => !item.ackedAt && !item.resolvedAt),
+    [inbox.data?.items],
+  );
+  const lastDecision = useMemo(() => {
+    const decisionTimes = (inbox.data?.items ?? [])
+      .flatMap((item) => [item.ackedAt, item.resolvedAt])
+      .filter((time): time is string => Boolean(time));
+    return decisionTimes.sort().at(-1) ?? null;
+  }, [inbox.data?.items]);
+  const runtimeNeeds = useMemo(
+    () => anomalyRows.map((row, index) => ({
+      id: `runtime-${index}`,
+      title: row.text,
+      primaryAction: row.links[0] ? { label: row.links[0].label, onClick: row.links[0].go } : undefined,
+    })),
+    [anomalyRows],
+  );
 
   const deadLetterGroupKey = (group: DeadLetterGroup) =>
     JSON.stringify([group.source, group.errorMessage]);
@@ -1241,8 +1282,22 @@ export function Overview({
       </div>
       <OverviewScopeNotice context={context} />
 
-      {/* Band A: Promoted Doctor Deck or Nominal Status (WM-205) */}
-      {hasAnomalies ? (
+      <Suspense fallback={<div className="mb-6 text-[12px] text-(--text-faint)">Loading needs you</div>}>
+        <OverviewNeedsYou
+          items={openInboxItems}
+          runtimeItems={runtimeNeeds}
+          now={now}
+          lastDecision={lastDecision}
+          runtimeLabel={feedsUnscoped ? "Runtime · factory-wide" : "Runtime"}
+          connected={connected && !ackInbox.isPending}
+          onOpenItem={(id) => onNavigate(`inbox/${id}`)}
+          onAck={(id) => ackInbox.mutate(id)}
+        />
+      </Suspense>
+
+      {/* Superseded by the Runtime group above. Kept temporarily while the
+          old action dialogs are removed in the follow-up anomaly-action work. */}
+      {hasAnomalies && false ? (
         <div
           className="mb-5 rounded-lg border p-3"
           style={{
@@ -1562,25 +1617,7 @@ export function Overview({
             }
           />
         </div>
-      ) : (
-        <div className="mb-5 flex flex-col items-start gap-2 rounded-lg border border-(--border) bg-(--surface-1) px-3.5 py-2.5 text-[12px] text-(--text-dim) sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2">
-            <span className="size-2 rounded-full bg-(--hue-ok)" />
-            <span className="font-medium text-(--text)">
-              Doctor: All systems nominal
-            </span>
-          </div>
-          <div className="flex items-center gap-2 text-[11px] text-(--text-faint)">
-            <span>
-              as of {formatRelative(new Date(status.dataUpdatedAt || now), now)}
-            </span>
-            <span>·</span>
-            <span>
-              {feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}
-            </span>
-          </div>
-        </div>
-      )}
+      ) : null}
 
       {/* Band B: Unified Stage Cards (WM-205) */}
       {!s ? (

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -1,5 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard, refetchIntervals, useNow, useRequeuePoll } from "../hooks";
@@ -34,7 +42,9 @@ import { Button as PrimitiveButton } from "../components/ui";
 const FEED_CAP = 50;
 
 const OverviewNeedsYou = lazy(() =>
-  import("./Inbox").then(({ OverviewNeedsYou }) => ({ default: OverviewNeedsYou })),
+  import("./Inbox").then(({ OverviewNeedsYou }) => ({
+    default: OverviewNeedsYou,
+  })),
 );
 
 export function SectionTitle({
@@ -1017,7 +1027,8 @@ export function Overview({
         queryClient.invalidateQueries({ queryKey: ["inbox"] }),
         queryClient.invalidateQueries({ queryKey: ["status"] }),
       ]),
-    onError: (error) => notify(`Ack failed: ${(error as Error).message}`, "err"),
+    onError: (error) =>
+      notify(`Ack failed: ${(error as Error).message}`, "err"),
   });
 
   const s = useMemo(() => normalizeStatus(status.data), [status.data]);
@@ -1059,7 +1070,10 @@ export function Overview({
   const anomalyRowRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   const openInboxItems = useMemo(
-    () => (inbox.data?.items ?? []).filter((item) => !item.ackedAt && !item.resolvedAt),
+    () =>
+      (inbox.data?.items ?? []).filter(
+        (item) => !item.ackedAt && !item.resolvedAt,
+      ),
     [inbox.data?.items],
   );
   const lastDecision = useMemo(() => {
@@ -1069,11 +1083,14 @@ export function Overview({
     return decisionTimes.sort().at(-1) ?? null;
   }, [inbox.data?.items]);
   const runtimeNeeds = useMemo(
-    () => anomalyRows.map((row, index) => ({
-      id: `runtime-${index}`,
-      title: row.text,
-      primaryAction: row.links[0] ? { label: row.links[0].label, onClick: row.links[0].go } : undefined,
-    })),
+    () =>
+      anomalyRows.map((row, index) => ({
+        id: `runtime-${index}`,
+        title: row.text,
+        primaryAction: row.links[0]
+          ? { label: row.links[0].label, onClick: row.links[0].go }
+          : undefined,
+      })),
     [anomalyRows],
   );
 
@@ -1282,7 +1299,13 @@ export function Overview({
       </div>
       <OverviewScopeNotice context={context} />
 
-      <Suspense fallback={<div className="mb-6 text-[12px] text-(--text-faint)">Loading needs you</div>}>
+      <Suspense
+        fallback={
+          <div className="mb-6 text-[12px] text-(--text-faint)">
+            Loading needs you
+          </div>
+        }
+      >
         <OverviewNeedsYou
           items={openInboxItems}
           runtimeItems={runtimeNeeds}


### PR DESCRIPTION
## Summary
- Lead Overview with a lazy, Inbox-owned Needs you section grouped by attention type.
- Fold runtime anomalies into the same compact row grammar and retain keyboard/open/ack affordances.
- Prefix the document title with the open Inbox count.

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (826 tests)
- `factory security` — pass

## UX critique
required — NOT-ASSESSED: Chromium tooling could not launch, so the running app could not be driven. This PR remains draft.

Fixes WM-596

