### PR TITLE
ops(event-runtime): move merge-scan and merge-fix off cursor to pi/terra (WM-662)

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -5,7 +5,7 @@
   "input_schema": "schemas/merge-fix.input.json",
   "output_schema": "schemas/merge-fix.output.json",
   "output_contract": "factory.merge-fix-result/v1",
-  "model_tier": "strong",
+  "model_tier": "standard",
   "gate": "merge-fix",
   "workspace": {
     "type": "worktree",

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -5,7 +5,7 @@
   "input_schema": "schemas/merge-scan.input.json",
   "output_schema": "schemas/merge-scan.output.json",
   "output_contract": "factory.merge-plan/v2",
-  "model_tier": "strong",
+  "model_tier": "standard",
   "workspace": {
     "type": "repository",
     "checkoutDir": "repo",

--- a/event-runtime/event-types.json
+++ b/event-runtime/event-types.json
@@ -155,7 +155,7 @@
   },
   "factory.merge.requested": {
     "agent": "merge-scan@2",
-    "adapter": "cursor",
+    "adapter": "pi",
     "idempotencyScope": [
       "correlationId",
       "inputHash"
@@ -180,7 +180,7 @@
   },
   "factory.merge-fix.requested": {
     "agent": "merge-fix@1",
-    "adapter": "cursor",
+    "adapter": "pi",
     "idempotencyScope": [
       "inputHash"
     ],

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -327,11 +327,11 @@ describe("durable autonomous merge registry (WM-398/WM-403)", () => {
   test("central mappings register scan, bounded fix, deterministic apply, landed verify, and explicit verify", () => {
     expect(registry.eventTypes["factory.merge.requested"]).toMatchObject({
       agent: "merge-scan@2",
-      adapter: "cursor",
+      adapter: "pi",
     });
     expect(registry.eventTypes["factory.merge-fix.requested"]).toMatchObject({
       agent: "merge-fix@1",
-      adapter: "cursor",
+      adapter: "pi",
     });
     expect(registry.eventTypes["factory.merge-apply.requested"].agent).toBe(
       "merge-apply@2",
@@ -629,7 +629,7 @@ describe("merge-scan repository workspace and result contract (WM-425)", () => {
       const summary = await runOnce(
         db,
         registry,
-        { cursor: adapter },
+        { pi: adapter },
         { workspacesRoot: workspaces, owner: "merge-test", policyVersion: PV },
       );
 


### PR DESCRIPTION
Fixes WM-662

## What

Points the two merge-loop agents at the `pi` adapter on the terra model, per operator instruction (2026-08-17): stop using cursor for now.

| event type | agent | adapter | model |
| --- | --- | --- | --- |
| `factory.merge.requested` | `merge-scan@2` | `cursor` → **`pi`** | `openai-codex/gpt-5.6-terra` |
| `factory.merge-fix.requested` | `merge-fix@1` | `cursor` → **`pi`** | `openai-codex/gpt-5.6-terra` |

Terra is selected by dropping both agents from `model_tier: strong` to `standard` — `config/policy.yaml` already maps `pi.standard: openai-codex/gpt-5.6-terra` (`pi.strong` is `sol`).

## Why

`merge-scan@2` died at the 21:45 `merge-factory` tick:

```
RetriableError: [resource_exhausted] Error
```

(run `run_dacb3e97-c420-4e9f-bed9-7b0f3d56778f`, model `Cursor Grok 4.6 High`). The 21:15 tick completed normally, so this is provider-side subscription exhaustion.

Because `merge-scan` declares `attempts: 1`, the retriable classification has no effect and the run is terminal — tracked separately as WM-656. Since `merge-factory` is the only enabled schedule on this instance, the entire merge pipeline was down and every PR had to be landed by hand.

## Deliberately not changed

- **`config/policy.yaml`** — the `pi.standard → terra` mapping it needs already exists, and the file is inside in-flight [WM-470](https://linear.app/watt-mind/issue/WM-470)'s Owned Paths. Not touching it avoids a collision.
- **`factory.cursor-smoke.requested` → `cursor-smoke@1`** stays on `cursor`. Its entire purpose is exercising the cursor adapter; pointing it at pi would make it vacuous. It is not on any enabled schedule, so it will not fire on its own.
- The WM-585/WM-603 decision comment in `config/policy.yaml` about which *cursor variant* to use is untouched — these agents simply stop consulting that mapping. Reverting is a two-line adapter flip.

## Owned Paths amendment

The ticket declared `event-runtime/event-types.json` and the two agent definitions. **`event-runtime/merge.test.mjs` was added** — it asserts both mappings directly (`adapter: "cursor"`) and injects its stub adapter under the `cursor` key (`{ cursor: adapter }`), so it fails unless updated with the change. Recording the amendment rather than letting it land silently.

## Handoff

- PR: this one
- Verification: `bun test` → **2387 pass, 9 skip, 0 fail** across 172 files; `bun build/emit.mjs --check` → **exit 0**, "ok — 90 generated files match shared/". `bun event-runtime/cli.mjs update-pins` → "pins already current" (no drift — the pins cover prompt/schema content, which is unchanged).
- Resolution verified explicitly: `factory.merge.requested` and `factory.merge-fix.requested` both resolve to `adapter=pi`, `tier=standard`, `model=openai-codex/gpt-5.6-terra`; `factory.cursor-smoke.requested` still resolves to `adapter=cursor`.
- Note: a first full-suite run showed 36 failures, all `Cannot find module 'react/jsx-dev-runtime'` — a fresh worktree needs `bun install` in both the root and `event-runtime/web`. After installing, 0 fail. Environment artifact, not a code failure.
- `emit --check` also prints a non-fatal "floor delivery" warning about `AGENTS.md` in two repos and still exits 0. Pre-existing and environmental — reproduces on the develop baseline.
- UX critique: skipped — no user-facing surface; this is adapter/model routing.
- Files: 4 changed (2 agent defs, `event-types.json`, `merge.test.mjs`).
- Risks: terra is a lower tier than the sol/strong these agents previously implied. `config/policy.yaml` records that merge-scan has timed out at 900s and 1500s before under load on cursor's strong tier with 20-25 open PRs; if terra proves too slow for a large PR set, the follow-up is `pi.strong` (sol) rather than a return to cursor.

## Rollout

Requires a **full** stack restart (`bin/live-stack.sh down && up`), not a serve-only restart. The adapter resolves at plan time inside `serve`, but a `policyVersion` change makes existing workers refuse newly planned runs as `registry_stale` — observed earlier today as a hot refusal loop. Drain first; two dispatch runs were in flight when this was authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz