### PR TITLE
feat(event-runtime-web): add historical graph overlays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       # if this fails on a warning-count bump, burn down warnings or bump the
       # number deliberately in the same PR, never drop the flag.
       - name: Lint (eslint)
-        run: bun run lint --max-warnings=621
+        run: bun run lint --max-warnings=627
 
       # Run tsc + Vite before tests so broken TSX imports and entry-chunk budget
       # regressions fail Verify immediately instead of reaching a later build.

--- a/event-runtime/web/src/displayOptions.test.ts
+++ b/event-runtime/web/src/displayOptions.test.ts
@@ -396,10 +396,19 @@ describe("state transitions & custom columns (WM-214)", () => {
 describe("persistence", () => {
   test("graph overlay and window round-trip tolerantly", () => {
     saveGraphDisplayOptions({ overlay: "health", window: "7d" });
-    expect(loadGraphDisplayOptions()).toEqual({ overlay: "health", window: "7d" });
+    expect(loadGraphDisplayOptions()).toEqual({
+      overlay: "health",
+      window: "7d",
+    });
 
-    localStorage.setItem("evrt-display-graph", JSON.stringify({ overlay: "unknown", window: "forever" }));
-    expect(loadGraphDisplayOptions()).toEqual({ overlay: "live", window: "24h" });
+    localStorage.setItem(
+      "evrt-display-graph",
+      JSON.stringify({ overlay: "unknown", window: "forever" }),
+    );
+    expect(loadGraphDisplayOptions()).toEqual({
+      overlay: "live",
+      window: "24h",
+    });
   });
 
   test("round-trips through localStorage with customColumns", () => {

--- a/event-runtime/web/src/displayOptions.test.ts
+++ b/event-runtime/web/src/displayOptions.test.ts
@@ -8,10 +8,12 @@ import {
   cycleColumnSort,
   defaultDisplayState,
   flattenSections,
+  loadGraphDisplayOptions,
   isDefaultDisplayState,
   loadDisplayState,
   removeCustomColumn,
   saveDisplayState,
+  saveGraphDisplayOptions,
   sortRows,
   toggleCollapsed,
   toggleColumn,
@@ -392,6 +394,14 @@ describe("state transitions & custom columns (WM-214)", () => {
 });
 
 describe("persistence", () => {
+  test("graph overlay and window round-trip tolerantly", () => {
+    saveGraphDisplayOptions({ overlay: "health", window: "7d" });
+    expect(loadGraphDisplayOptions()).toEqual({ overlay: "health", window: "7d" });
+
+    localStorage.setItem("evrt-display-graph", JSON.stringify({ overlay: "unknown", window: "forever" }));
+    expect(loadGraphDisplayOptions()).toEqual({ overlay: "live", window: "24h" });
+  });
+
   test("round-trips through localStorage with customColumns", () => {
     const original = state({
       groupBy: "state",

--- a/event-runtime/web/src/displayOptions.ts
+++ b/event-runtime/web/src/displayOptions.ts
@@ -15,7 +15,13 @@ import { extractRowValue } from "./pathExtractor";
 /** Graph-specific display state (WM-291). Kept beside the table display
  * options so every operator display preference uses the same tolerant
  * localStorage boundary. */
-export const GRAPH_OVERLAYS = ["live", "activity", "health", "cost", "latency"] as const;
+export const GRAPH_OVERLAYS = [
+  "live",
+  "activity",
+  "health",
+  "cost",
+  "latency",
+] as const;
 export const GRAPH_WINDOWS = ["1h", "24h", "7d", "30d"] as const;
 export type GraphOverlay = (typeof GRAPH_OVERLAYS)[number];
 export type GraphWindow = (typeof GRAPH_WINDOWS)[number];
@@ -25,25 +31,38 @@ export interface GraphDisplayOptions {
   window: GraphWindow;
 }
 
-export const DEFAULT_GRAPH_DISPLAY: GraphDisplayOptions = { overlay: "live", window: "24h" };
+export const DEFAULT_GRAPH_DISPLAY: GraphDisplayOptions = {
+  overlay: "live",
+  window: "24h",
+};
 const GRAPH_DISPLAY_STORAGE_KEY = "evrt-display-graph";
 
 export function isGraphOverlay(value: unknown): value is GraphOverlay {
-  return typeof value === "string" && (GRAPH_OVERLAYS as readonly string[]).includes(value);
+  return (
+    typeof value === "string" &&
+    (GRAPH_OVERLAYS as readonly string[]).includes(value)
+  );
 }
 
 export function isGraphWindow(value: unknown): value is GraphWindow {
-  return typeof value === "string" && (GRAPH_WINDOWS as readonly string[]).includes(value);
+  return (
+    typeof value === "string" &&
+    (GRAPH_WINDOWS as readonly string[]).includes(value)
+  );
 }
 
 export function loadGraphDisplayOptions(): GraphDisplayOptions {
   try {
-    const parsed = JSON.parse(localStorage.getItem(GRAPH_DISPLAY_STORAGE_KEY) ?? "null") as
-      | Record<string, unknown>
-      | null;
+    const parsed = JSON.parse(
+      localStorage.getItem(GRAPH_DISPLAY_STORAGE_KEY) ?? "null",
+    ) as Record<string, unknown> | null;
     return {
-      overlay: isGraphOverlay(parsed?.overlay) ? parsed.overlay : DEFAULT_GRAPH_DISPLAY.overlay,
-      window: isGraphWindow(parsed?.window) ? parsed.window : DEFAULT_GRAPH_DISPLAY.window,
+      overlay: isGraphOverlay(parsed?.overlay)
+        ? parsed.overlay
+        : DEFAULT_GRAPH_DISPLAY.overlay,
+      window: isGraphWindow(parsed?.window)
+        ? parsed.window
+        : DEFAULT_GRAPH_DISPLAY.window,
     };
   } catch {
     return { ...DEFAULT_GRAPH_DISPLAY };

--- a/event-runtime/web/src/displayOptions.ts
+++ b/event-runtime/web/src/displayOptions.ts
@@ -12,6 +12,52 @@
  */
 import { extractRowValue } from "./pathExtractor";
 
+/** Graph-specific display state (WM-291). Kept beside the table display
+ * options so every operator display preference uses the same tolerant
+ * localStorage boundary. */
+export const GRAPH_OVERLAYS = ["live", "activity", "health", "cost", "latency"] as const;
+export const GRAPH_WINDOWS = ["1h", "24h", "7d", "30d"] as const;
+export type GraphOverlay = (typeof GRAPH_OVERLAYS)[number];
+export type GraphWindow = (typeof GRAPH_WINDOWS)[number];
+
+export interface GraphDisplayOptions {
+  overlay: GraphOverlay;
+  window: GraphWindow;
+}
+
+export const DEFAULT_GRAPH_DISPLAY: GraphDisplayOptions = { overlay: "live", window: "24h" };
+const GRAPH_DISPLAY_STORAGE_KEY = "evrt-display-graph";
+
+export function isGraphOverlay(value: unknown): value is GraphOverlay {
+  return typeof value === "string" && (GRAPH_OVERLAYS as readonly string[]).includes(value);
+}
+
+export function isGraphWindow(value: unknown): value is GraphWindow {
+  return typeof value === "string" && (GRAPH_WINDOWS as readonly string[]).includes(value);
+}
+
+export function loadGraphDisplayOptions(): GraphDisplayOptions {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(GRAPH_DISPLAY_STORAGE_KEY) ?? "null") as
+      | Record<string, unknown>
+      | null;
+    return {
+      overlay: isGraphOverlay(parsed?.overlay) ? parsed.overlay : DEFAULT_GRAPH_DISPLAY.overlay,
+      window: isGraphWindow(parsed?.window) ? parsed.window : DEFAULT_GRAPH_DISPLAY.window,
+    };
+  } catch {
+    return { ...DEFAULT_GRAPH_DISPLAY };
+  }
+}
+
+export function saveGraphDisplayOptions(options: GraphDisplayOptions): void {
+  try {
+    localStorage.setItem(GRAPH_DISPLAY_STORAGE_KEY, JSON.stringify(options));
+  } catch {
+    // Private mode / quota: graph controls still work for this load.
+  }
+}
+
 export interface ColumnDef {
   key: string;
   label: string;

--- a/event-runtime/web/src/graph/model.test.ts
+++ b/event-runtime/web/src/graph/model.test.ts
@@ -537,8 +537,20 @@ describe("applyHistoricalOverlay (WM-291)", () => {
       view({
         agents: [agent({ ref: "doctor@1" }), agent({ ref: "idle@1" })],
         eventTypes: [
-          { type: "ci.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
-          { type: "ci.idle", agent: "idle@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+          {
+            type: "ci.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.idle",
+            agent: "idle@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
         ],
         edges: {
           "doctor@1": {
@@ -555,16 +567,22 @@ describe("applyHistoricalOverlay (WM-291)", () => {
       eventTypes: { rows: [{ key: "ci.failed", value: 12 }] },
       edges: { rows: [{ key: "doctor@1→ci.idle", value: 3 }] },
     });
-    expect(graph.nodes.find((n) => n.id === "agent:doctor@1")?.historical).toMatchObject({
+    expect(
+      graph.nodes.find((n) => n.id === "agent:doctor@1")?.historical,
+    ).toMatchObject({
       formatted: "12",
       intensity: 1,
       faint: false,
     });
-    expect(graph.nodes.find((n) => n.id === "agent:idle@1")?.historical).toMatchObject({
+    expect(
+      graph.nodes.find((n) => n.id === "agent:idle@1")?.historical,
+    ).toMatchObject({
       value: 0,
       faint: true,
     });
-    expect(graph.edges.find((e) => e.kind === "recommends")?.historical).toMatchObject({
+    expect(
+      graph.edges.find((e) => e.kind === "recommends")?.historical,
+    ).toMatchObject({
       value: 3,
       intensity: 0.25,
     });
@@ -579,20 +597,248 @@ describe("applyHistoricalOverlay (WM-291)", () => {
       edges: { rows: [{ key: "doctor@1→ci.idle", value: 1 }] },
       edgeRuns: { rows: [{ key: "doctor@1→ci.idle", value: 2 }] },
     });
-    expect(health.nodes.find((n) => n.id === "agent:doctor@1")?.historical).toMatchObject({
+    expect(
+      health.nodes.find((n) => n.id === "agent:doctor@1")?.historical,
+    ).toMatchObject({
       value: 0.25,
       formatted: "25%",
     });
-    expect(health.edges.find((e) => e.kind === "recommends")?.historical?.formatted).toBe("50%");
+    expect(
+      health.edges.find((e) => e.kind === "recommends")?.historical?.formatted,
+    ).toBe("50%");
 
     const cost = applyHistoricalOverlay(topology(), "cost", {
       agents: { rows: [{ key: "doctor@1", value: 1.25 }] },
     });
-    expect(cost.nodes.find((n) => n.id === "agent:doctor@1")?.historical?.formatted).toBe("$1.25");
+    expect(
+      cost.nodes.find((n) => n.id === "agent:doctor@1")?.historical?.formatted,
+    ).toBe("$1.25");
 
     const latency = applyHistoricalOverlay(topology(), "latency", {
       agents: { rows: [{ key: "doctor@1", value: 2500 }] },
     });
-    expect(latency.nodes.find((n) => n.id === "agent:doctor@1")?.historical?.formatted).toBe("2.5s");
+    expect(
+      latency.nodes.find((n) => n.id === "agent:doctor@1")?.historical
+        ?.formatted,
+    ).toBe("2.5s");
+  });
+});
+
+describe("applyHistoricalOverlay guards (WM-291 review)", () => {
+  // A topology with an open proposal: two ghost edges (event → proposal,
+  // proposal → agent) alongside the routing and recommendation edges.
+  const withProposal = () =>
+    buildCapabilityGraph(
+      view({
+        agents: [agent({ ref: "doctor@1" }), agent({ ref: "rerun@1" })],
+        eventTypes: [
+          {
+            type: "ci.failed",
+            agent: "doctor@1",
+            adapter: "claude",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+          {
+            type: "ci.rerun",
+            agent: "rerun@1",
+            adapter: "command",
+            idempotencyScope: [],
+            proposalTtlSeconds: null,
+          },
+        ],
+        edges: {
+          "doctor@1": {
+            recommendationField: "verdict",
+            edges: { FLAKE: { eventType: "ci.rerun", input: {} } },
+          },
+        },
+      }),
+      {
+        events: [
+          {
+            source: "factory.chain",
+            eventId: "ev-1",
+            type: "ci.rerun",
+            subject: null,
+            status: "planned",
+            occurredAt: "",
+            receivedAt: "",
+            correlationId: null,
+            planFailures: 0,
+            lastPlanError: null,
+            admittedAt: "",
+            proposalId: "prop-1",
+            runId: null,
+            envelope: {},
+            repos: [],
+          } as any,
+        ],
+        proposals: [
+          {
+            id: "prop-1",
+            decision: "run",
+            status: "open",
+            expired: false,
+            created_at: new Date().toISOString(),
+            ttl_seconds: 600,
+            decided_at: null,
+            decided_by: null,
+            reason: null,
+            runId: "run-1",
+            eventId: "ev-1",
+            eventSource: "factory.chain",
+            agent: "rerun@1",
+            spec: null,
+            repos: [],
+          } as any,
+        ],
+      },
+    );
+
+  test("proposal edges take no overlay value — pending is not the healthy end of the ramp", () => {
+    const graph = applyHistoricalOverlay(withProposal(), "health", {
+      agents: { rows: [{ key: "doctor@1", value: 1 }] },
+      agentRuns: { rows: [{ key: "doctor@1", value: 4 }] },
+      eventTypes: { rows: [{ key: "ci.failed", value: 1 }] },
+      eventTypeRuns: { rows: [{ key: "ci.failed", value: 4 }] },
+      edges: { rows: [{ key: "doctor@1→ci.rerun", value: 1 }] },
+      edgeRuns: { rows: [{ key: "doctor@1→ci.rerun", value: 4 }] },
+    });
+
+    const proposalEdges = graph.edges.filter((e) => e.kind === "proposal");
+    expect(proposalEdges.length).toBeGreaterThan(0);
+    for (const edge of proposalEdges) expect(edge.historical).toBeUndefined();
+    // The measurable edges still get their reading.
+    expect(
+      graph.edges.find((e) => e.kind === "recommends")?.historical?.formatted,
+    ).toBe("25%");
+  });
+
+  test("proposal nodes and edges stay unmeasured under every overlay", () => {
+    for (const mode of ["activity", "health", "cost", "latency"] as const) {
+      const graph = applyHistoricalOverlay(withProposal(), mode, {
+        agents: { rows: [{ key: "doctor@1", value: 3 }] },
+        agentRuns: { rows: [{ key: "doctor@1", value: 3 }] },
+      });
+      expect(
+        graph.nodes.find((n) => n.kind === "proposal")?.historical,
+      ).toBeUndefined();
+      expect(
+        graph.edges
+          .filter((e) => e.kind === "proposal")
+          .every((e) => !e.historical),
+      ).toBe(true);
+    }
+  });
+
+  test("a node with no runs reads as no data, not as a perfect score", () => {
+    const health = applyHistoricalOverlay(withProposal(), "health", {
+      agents: { rows: [{ key: "doctor@1", value: 1 }] },
+      agentRuns: { rows: [{ key: "doctor@1", value: 4 }] },
+      eventTypes: { rows: [] },
+      eventTypeRuns: { rows: [] },
+      edges: { rows: [] },
+      edgeRuns: { rows: [] },
+    });
+    // rerun@1 never ran in the window: no denominator, so no failure rate.
+    expect(
+      health.nodes.find((n) => n.id === "agent:rerun@1")?.historical,
+    ).toMatchObject({
+      formatted: "—",
+      noData: true,
+      faint: true,
+      intensity: 0,
+    });
+    // doctor@1 did run — a measured 25% is still shown.
+    expect(
+      health.nodes.find((n) => n.id === "agent:doctor@1")?.historical,
+    ).toMatchObject({
+      formatted: "25%",
+      noData: false,
+      faint: false,
+    });
+  });
+
+  test("a measured zero is still a measurement — only a missing denominator is no data", () => {
+    const health = applyHistoricalOverlay(withProposal(), "health", {
+      agents: { rows: [] },
+      agentRuns: { rows: [{ key: "rerun@1", value: 9 }] },
+    });
+    expect(
+      health.nodes.find((n) => n.id === "agent:rerun@1")?.historical,
+    ).toMatchObject({
+      value: 0,
+      formatted: "0%",
+      noData: false,
+      faint: false,
+    });
+  });
+
+  test("latency and cost report no data rather than the fastest/cheapest reading", () => {
+    const latency = applyHistoricalOverlay(withProposal(), "latency", {
+      agents: { rows: [{ key: "doctor@1", value: 2500 }] },
+      eventTypes: { rows: [] },
+      edges: { rows: [] },
+    });
+    expect(
+      latency.nodes.find((n) => n.id === "agent:rerun@1")?.historical,
+    ).toMatchObject({
+      formatted: "—",
+      noData: true,
+      faint: true,
+    });
+    expect(
+      latency.nodes.find((n) => n.id === "agent:doctor@1")?.historical
+        ?.formatted,
+    ).toBe("2.5s");
+
+    const cost = applyHistoricalOverlay(withProposal(), "cost", {
+      agents: { rows: [{ key: "doctor@1", value: 1.25 }] },
+    });
+    expect(
+      cost.nodes.find((n) => n.id === "agent:rerun@1")?.historical?.formatted,
+    ).toBe("—");
+
+    // Activity keeps its zeroes: a missing row there really is "no runs".
+    const activity = applyHistoricalOverlay(withProposal(), "activity", {
+      agents: { rows: [{ key: "doctor@1", value: 7 }] },
+    });
+    expect(
+      activity.nodes.find((n) => n.id === "agent:rerun@1")?.historical,
+    ).toMatchObject({
+      formatted: "0",
+      noData: false,
+      faint: true,
+    });
+  });
+
+  test("health is clamped to 100% — the server counts failures and runs on different clocks", () => {
+    const health = applyHistoricalOverlay(withProposal(), "health", {
+      // lib/metrics.mjs buckets failures by updated_at and runs by created_at,
+      // so a run that started before the window and failed inside it makes the
+      // ratio exceed 1.0. That must never render as "140%".
+      agents: { rows: [{ key: "doctor@1", value: 14 }] },
+      agentRuns: { rows: [{ key: "doctor@1", value: 10 }] },
+    });
+    expect(
+      health.nodes.find((n) => n.id === "agent:doctor@1")?.historical,
+    ).toMatchObject({
+      value: 1,
+      formatted: "100%",
+    });
+  });
+
+  test("a negative ratio cannot drag the ramp below zero either", () => {
+    const health = applyHistoricalOverlay(withProposal(), "health", {
+      agents: { rows: [{ key: "doctor@1", value: -3 }] },
+      agentRuns: { rows: [{ key: "doctor@1", value: 10 }] },
+    });
+    expect(
+      health.nodes.find((n) => n.id === "agent:doctor@1")?.historical,
+    ).toMatchObject({
+      value: 0,
+      formatted: "0%",
+    });
   });
 });

--- a/event-runtime/web/src/graph/model.test.ts
+++ b/event-runtime/web/src/graph/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildCapabilityGraph } from "./model";
+import { applyHistoricalOverlay, buildCapabilityGraph } from "./model";
 import type { AgentsView, RunListItem, RunState } from "../types";
 
 // The topology rules are pure data — tested without React or a browser.
@@ -528,5 +528,71 @@ describe("buildCapabilityGraph", () => {
     );
     expect(propToAgentEdge).toBeDefined();
     expect(propToAgentEdge?.kind).toBe("proposal");
+  });
+});
+
+describe("applyHistoricalOverlay (WM-291)", () => {
+  const topology = () =>
+    buildCapabilityGraph(
+      view({
+        agents: [agent({ ref: "doctor@1" }), agent({ ref: "idle@1" })],
+        eventTypes: [
+          { type: "ci.failed", agent: "doctor@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+          { type: "ci.idle", agent: "idle@1", adapter: "claude", idempotencyScope: [], proposalTtlSeconds: null },
+        ],
+        edges: {
+          "doctor@1": {
+            recommendationField: "verdict",
+            edges: { RETRY: { eventType: "ci.idle", input: {} } },
+          },
+        },
+      }),
+    );
+
+  test("maps activity counts and explicitly fades zero-activity nodes", () => {
+    const graph = applyHistoricalOverlay(topology(), "activity", {
+      agents: { rows: [{ key: "doctor@1", value: 12 }] },
+      eventTypes: { rows: [{ key: "ci.failed", value: 12 }] },
+      edges: { rows: [{ key: "doctor@1→ci.idle", value: 3 }] },
+    });
+    expect(graph.nodes.find((n) => n.id === "agent:doctor@1")?.historical).toMatchObject({
+      formatted: "12",
+      intensity: 1,
+      faint: false,
+    });
+    expect(graph.nodes.find((n) => n.id === "agent:idle@1")?.historical).toMatchObject({
+      value: 0,
+      faint: true,
+    });
+    expect(graph.edges.find((e) => e.kind === "recommends")?.historical).toMatchObject({
+      value: 3,
+      intensity: 0.25,
+    });
+  });
+
+  test("maps health as failures divided by runs and formats latency/cost units", () => {
+    const health = applyHistoricalOverlay(topology(), "health", {
+      agents: { rows: [{ key: "doctor@1", value: 2 }] },
+      agentRuns: { rows: [{ key: "doctor@1", value: 8 }] },
+      eventTypes: { rows: [{ key: "ci.failed", value: 1 }] },
+      eventTypeRuns: { rows: [{ key: "ci.failed", value: 4 }] },
+      edges: { rows: [{ key: "doctor@1→ci.idle", value: 1 }] },
+      edgeRuns: { rows: [{ key: "doctor@1→ci.idle", value: 2 }] },
+    });
+    expect(health.nodes.find((n) => n.id === "agent:doctor@1")?.historical).toMatchObject({
+      value: 0.25,
+      formatted: "25%",
+    });
+    expect(health.edges.find((e) => e.kind === "recommends")?.historical?.formatted).toBe("50%");
+
+    const cost = applyHistoricalOverlay(topology(), "cost", {
+      agents: { rows: [{ key: "doctor@1", value: 1.25 }] },
+    });
+    expect(cost.nodes.find((n) => n.id === "agent:doctor@1")?.historical?.formatted).toBe("$1.25");
+
+    const latency = applyHistoricalOverlay(topology(), "latency", {
+      agents: { rows: [{ key: "doctor@1", value: 2500 }] },
+    });
+    expect(latency.nodes.find((n) => n.id === "agent:doctor@1")?.historical?.formatted).toBe("2.5s");
   });
 });

--- a/event-runtime/web/src/graph/model.ts
+++ b/event-runtime/web/src/graph/model.ts
@@ -5,6 +5,7 @@ import type {
   RunListItem,
   StatusView,
 } from "../types";
+import type { GraphOverlay } from "../displayOptions";
 
 // The capability map: what this runtime can do, derived from the registry,
 // overlaid with live runtime state (OPS-227 phase 2): active run state badges,
@@ -13,7 +14,19 @@ import type {
 // Kept as plain data, separate from React Flow, so it stays testable and the
 // rendering layer can be swapped without touching the topology rules.
 
-export type GraphNode =
+export interface HistoricalOverlayValue {
+  mode: Exclude<GraphOverlay, "live">;
+  /** Value displayed to the operator: count, rate, dollars, or milliseconds. */
+  value: number;
+  /** 0–1 position within this response's visible ramp. */
+  intensity: number;
+  formatted: string;
+  label: string;
+  /** Activity alone deliberately fades zero-use topology. */
+  faint: boolean;
+}
+
+export type GraphNode = (
   | {
       id: string;
       kind: "eventType";
@@ -47,7 +60,7 @@ export type GraphNode =
       agentRef: string | null;
       eventType: string | null;
       proposal: Proposal;
-    };
+    }) & { historical?: HistoricalOverlayValue };
 
 export type GraphEdge = {
   id: string;
@@ -56,6 +69,7 @@ export type GraphEdge = {
   kind: "routes" | "recommends" | "proposal";
   label?: string;
   invocations?: number;
+  historical?: HistoricalOverlayValue;
 };
 
 export interface CapabilityGraph {
@@ -70,9 +84,125 @@ export interface LiveGraphState {
   status?: StatusView;
 }
 
+export interface BreakdownRows {
+  rows: Array<{ key: string; value: number }>;
+}
+
+/** All server-side aggregates needed for one historical overlay refresh. */
+export interface HistoricalBreakdowns {
+  agents?: BreakdownRows;
+  eventTypes?: BreakdownRows;
+  edges?: BreakdownRows;
+  agentRuns?: BreakdownRows;
+  eventTypeRuns?: BreakdownRows;
+  edgeRuns?: BreakdownRows;
+}
+
 export const eventNodeId = (type: string) => `event:${type}`;
 export const agentNodeId = (ref: string) => `agent:${ref}`;
 export const proposalNodeId = (id: string) => `proposal:${id}`;
+
+const rowsMap = (data?: BreakdownRows) =>
+  new Map((data?.rows ?? []).map((row) => [row.key, Number(row.value) || 0]));
+
+function overlayFormat(mode: Exclude<GraphOverlay, "live">, value: number): string {
+  if (mode === "health") return `${Math.round(value * 100)}%`;
+  if (mode === "cost") return `$${value < 0.01 ? value.toFixed(3) : value.toFixed(2)}`;
+  if (mode === "latency") return `${value < 1000 ? (value / 1000).toFixed(2) : (value / 1000).toFixed(1)}s`;
+  return String(Math.round(value));
+}
+
+const overlayLabel = (mode: Exclude<GraphOverlay, "live">) =>
+  mode === "activity"
+    ? "runs"
+    : mode === "health"
+      ? "failure rate"
+      : mode === "cost"
+        ? "spend"
+        : "p95 execution";
+
+function valueFor(
+  mode: Exclude<GraphOverlay, "live">,
+  values: Map<string, number>,
+  totals: Map<string, number>,
+  key: string,
+): number {
+  const value = values.get(key) ?? 0;
+  return mode === "health" ? (totals.get(key) ?? 0) > 0 ? value / totals.get(key)! : 0 : value;
+}
+
+function overlayValues(
+  mode: Exclude<GraphOverlay, "live">,
+  keyed: Array<{ key: string; value: number }>,
+): Map<string, HistoricalOverlayValue> {
+  const max = Math.max(0, ...keyed.map((entry) => entry.value));
+  const min = Math.min(...keyed.map((entry) => entry.value), 0);
+  const span = max - min;
+  return new Map(
+    keyed.map(({ key, value }) => [
+      key,
+      {
+        mode,
+        value,
+        intensity: span > 0 ? (value - min) / span : 0,
+        formatted: overlayFormat(mode, value),
+        label: overlayLabel(mode),
+        faint: mode === "activity" && value === 0,
+      },
+    ]),
+  );
+}
+
+/**
+ * Add a historical overlay without changing topology. Missing rows are real
+ * zeroes (the breakdown endpoint omits empty groups), which is what makes dead
+ * routes visible instead of silently leaving them uncoloured.
+ */
+export function applyHistoricalOverlay(
+  graph: CapabilityGraph,
+  mode: Exclude<GraphOverlay, "live">,
+  breakdowns: HistoricalBreakdowns,
+): CapabilityGraph {
+  const agents = rowsMap(breakdowns.agents);
+  const eventTypes = rowsMap(breakdowns.eventTypes);
+  const edgeValues = rowsMap(breakdowns.edges);
+  const agentRuns = rowsMap(breakdowns.agentRuns);
+  const eventTypeRuns = rowsMap(breakdowns.eventTypeRuns);
+  const edgeRuns = rowsMap(breakdowns.edgeRuns);
+
+  const rawNodes = graph.nodes.map((node) => {
+    const eligible = node.kind === "agent" || node.kind === "eventType";
+    const key = node.label;
+    const value =
+      node.kind === "agent"
+        ? valueFor(mode, agents, agentRuns, key)
+        : node.kind === "eventType"
+          ? valueFor(mode, eventTypes, eventTypeRuns, key)
+          : 0;
+    return { node, key: node.id, value, eligible };
+  });
+  const nodeOverlay = overlayValues(mode, rawNodes.filter(({ eligible }) => eligible).map(({ key, value }) => ({ key, value })));
+
+  const rawEdges = graph.edges.map((edge) => {
+    let metricKey = "";
+    if (edge.kind === "recommends") {
+      const source = edge.source.replace(/^agent:/, "");
+      const target = edge.target.replace(/^event:/, "");
+      metricKey = `${source}→${target}`;
+    } else if (edge.kind === "routes") {
+      metricKey = edge.source.replace(/^event:/, "");
+    }
+    const values = edge.kind === "routes" ? eventTypes : edgeValues;
+    const totals = edge.kind === "routes" ? eventTypeRuns : edgeRuns;
+    return { edge, key: edge.id, value: valueFor(mode, values, totals, metricKey) };
+  });
+  const edgeOverlay = overlayValues(mode, rawEdges.map(({ key, value }) => ({ key, value })));
+
+  return {
+    nodes: rawNodes.map(({ node, eligible }) => eligible ? { ...node, historical: nodeOverlay.get(node.id) } : node),
+    edges: rawEdges.map(({ edge }) => ({ ...edge, historical: edgeOverlay.get(edge.id) })),
+  };
+}
 
 /** How an agent actually executes — the honest distinction for the map. */
 function executionOf(

--- a/event-runtime/web/src/graph/model.ts
+++ b/event-runtime/web/src/graph/model.ts
@@ -22,8 +22,16 @@ export interface HistoricalOverlayValue {
   intensity: number;
   formatted: string;
   label: string;
-  /** Activity alone deliberately fades zero-use topology. */
+  /** Activity fades zero-use topology; every overlay fades a no-data node. */
   faint: boolean;
+  /**
+   * The window produced no measurement for this key (no runs at all, or — for
+   * Health — a zero denominator). Distinct from a measured zero: `0%` at the
+   * healthy end of the ramp and `0.00s` at the fastest end are both claims the
+   * data does not support, so these render `—`, stay out of the legend ramp,
+   * and never take a ramp colour.
+   */
+  noData: boolean;
 }
 
 export type GraphNode = (
@@ -60,7 +68,8 @@ export type GraphNode = (
       agentRef: string | null;
       eventType: string | null;
       proposal: Proposal;
-    }) & { historical?: HistoricalOverlayValue };
+    }
+) & { historical?: HistoricalOverlayValue };
 
 export type GraphEdge = {
   id: string;
@@ -105,10 +114,15 @@ export const proposalNodeId = (id: string) => `proposal:${id}`;
 const rowsMap = (data?: BreakdownRows) =>
   new Map((data?.rows ?? []).map((row) => [row.key, Number(row.value) || 0]));
 
-function overlayFormat(mode: Exclude<GraphOverlay, "live">, value: number): string {
+function overlayFormat(
+  mode: Exclude<GraphOverlay, "live">,
+  value: number,
+): string {
   if (mode === "health") return `${Math.round(value * 100)}%`;
-  if (mode === "cost") return `$${value < 0.01 ? value.toFixed(3) : value.toFixed(2)}`;
-  if (mode === "latency") return `${value < 1000 ? (value / 1000).toFixed(2) : (value / 1000).toFixed(1)}s`;
+  if (mode === "cost")
+    return `$${value < 0.01 ? value.toFixed(3) : value.toFixed(2)}`;
+  if (mode === "latency")
+    return `${value < 1000 ? (value / 1000).toFixed(2) : (value / 1000).toFixed(1)}s`;
   return String(Math.round(value));
 }
 
@@ -121,42 +135,65 @@ const overlayLabel = (mode: Exclude<GraphOverlay, "live">) =>
         ? "spend"
         : "p95 execution";
 
+/**
+ * The measured value for one key, or `null` when the window measured nothing.
+ *
+ * Activity is the one overlay where an absent row is a real answer — the
+ * breakdown endpoint omits empty groups, and "0 runs" is exactly what makes a
+ * dead route visible. Every other overlay has no honest reading without a
+ * denominator: a missing Health row is not a 0% failure rate, and a missing
+ * Latency row is not a 0.00s p95.
+ */
 function valueFor(
   mode: Exclude<GraphOverlay, "live">,
   values: Map<string, number>,
   totals: Map<string, number>,
   key: string,
-): number {
-  const value = values.get(key) ?? 0;
-  return mode === "health" ? (totals.get(key) ?? 0) > 0 ? value / totals.get(key)! : 0 : value;
+): number | null {
+  if (mode === "activity") return values.get(key) ?? 0;
+  if (mode === "health") {
+    const runs = totals.get(key) ?? 0;
+    if (runs <= 0) return null;
+    // The server counts failures by `updated_at` and runs by `created_at`
+    // (lib/metrics.mjs), so the ratio can exceed 1.0 across a window boundary.
+    // Clamp rather than render "140%" — the server-side fix is separate.
+    return Math.min(1, Math.max(0, (values.get(key) ?? 0) / runs));
+  }
+  return values.has(key) ? values.get(key)! : null;
 }
 
 function overlayValues(
   mode: Exclude<GraphOverlay, "live">,
-  keyed: Array<{ key: string; value: number }>,
+  keyed: Array<{ key: string; value: number | null }>,
 ): Map<string, HistoricalOverlayValue> {
-  const max = Math.max(0, ...keyed.map((entry) => entry.value));
-  const min = Math.min(...keyed.map((entry) => entry.value), 0);
+  const measured = keyed.flatMap((entry) =>
+    entry.value == null ? [] : [entry.value],
+  );
+  const max = Math.max(0, ...measured);
+  const min = Math.min(...measured, 0);
   const span = max - min;
   return new Map(
     keyed.map(({ key, value }) => [
       key,
       {
         mode,
-        value,
-        intensity: span > 0 ? (value - min) / span : 0,
-        formatted: overlayFormat(mode, value),
+        value: value ?? 0,
+        intensity: value == null || span <= 0 ? 0 : (value - min) / span,
+        formatted: value == null ? "—" : overlayFormat(mode, value),
         label: overlayLabel(mode),
-        faint: mode === "activity" && value === 0,
+        faint: value == null || (mode === "activity" && value === 0),
+        noData: value == null,
       },
     ]),
   );
 }
 
 /**
- * Add a historical overlay without changing topology. Missing rows are real
- * zeroes (the breakdown endpoint omits empty groups), which is what makes dead
- * routes visible instead of silently leaving them uncoloured.
+ * Add a historical overlay without changing topology. Under Activity a missing
+ * row is a real zero (the breakdown endpoint omits empty groups), which is what
+ * makes dead routes visible instead of silently leaving them uncoloured; under
+ * every other overlay it is no data, and says so rather than inventing a
+ * best-in-class reading (see `valueFor`).
  */
 export function applyHistoricalOverlay(
   graph: CapabilityGraph,
@@ -178,12 +215,22 @@ export function applyHistoricalOverlay(
         ? valueFor(mode, agents, agentRuns, key)
         : node.kind === "eventType"
           ? valueFor(mode, eventTypes, eventTypeRuns, key)
-          : 0;
+          : null;
     return { node, key: node.id, value, eligible };
   });
-  const nodeOverlay = overlayValues(mode, rawNodes.filter(({ eligible }) => eligible).map(({ key, value }) => ({ key, value })));
+  const nodeOverlay = overlayValues(
+    mode,
+    rawNodes
+      .filter(({ eligible }) => eligible)
+      .map(({ key, value }) => ({ key, value })),
+  );
 
+  // Only routing and recommendation edges carry a server-side metric. A ghost
+  // proposal edge has no key in any breakdown, so it has no reading — mirroring
+  // the node guard above. Left unmeasured it kept its `var(--hue-info)` stroke;
+  // colouring it would paint "pending" as the healthy end of the Health ramp.
   const rawEdges = graph.edges.map((edge) => {
+    const eligible = edge.kind === "recommends" || edge.kind === "routes";
     let metricKey = "";
     if (edge.kind === "recommends") {
       const source = edge.source.replace(/^agent:/, "");
@@ -194,13 +241,27 @@ export function applyHistoricalOverlay(
     }
     const values = edge.kind === "routes" ? eventTypes : edgeValues;
     const totals = edge.kind === "routes" ? eventTypeRuns : edgeRuns;
-    return { edge, key: edge.id, value: valueFor(mode, values, totals, metricKey) };
+    return {
+      edge,
+      key: edge.id,
+      value: eligible ? valueFor(mode, values, totals, metricKey) : null,
+      eligible,
+    };
   });
-  const edgeOverlay = overlayValues(mode, rawEdges.map(({ key, value }) => ({ key, value })));
+  const edgeOverlay = overlayValues(
+    mode,
+    rawEdges
+      .filter(({ eligible }) => eligible)
+      .map(({ key, value }) => ({ key, value })),
+  );
 
   return {
-    nodes: rawNodes.map(({ node, eligible }) => eligible ? { ...node, historical: nodeOverlay.get(node.id) } : node),
-    edges: rawEdges.map(({ edge }) => ({ ...edge, historical: edgeOverlay.get(edge.id) })),
+    nodes: rawNodes.map(({ node, eligible }) =>
+      eligible ? { ...node, historical: nodeOverlay.get(node.id) } : node,
+    ),
+    edges: rawEdges.map(({ edge, eligible }) =>
+      eligible ? { ...edge, historical: edgeOverlay.get(edge.id) } : edge,
+    ),
   };
 }
 

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -405,7 +405,9 @@ describe("Graph view inspect loop", () => {
         overlay: "health",
         window: "7d",
       }),
-    ).toBe("#/graph/agent%3Adoctor%401?project=factory&overlay=health&window=7d");
+    ).toBe(
+      "#/graph/agent%3Adoctor%401?project=factory&overlay=health&window=7d",
+    );
     expect(
       graphDisplayFromHash("#/graph?overlay=latency&window=30d", {
         overlay: "activity",
@@ -414,25 +416,66 @@ describe("Graph view inspect loop", () => {
     ).toEqual({ overlay: "latency", window: "30d" });
   });
 
+  // WM-291 review: Live is the prior behaviour byte for byte. An operator who
+  // never opens the overlay picker must not find `?overlay=live&window=24h`
+  // appended to every graph URL they copy.
+  test("Live writes no query of its own and strips a stale one", () => {
+    expect(
+      graphHashWithDisplay("#/graph", { overlay: "live", window: "24h" }),
+    ).toBe("#/graph");
+    expect(
+      graphHashWithDisplay("#/graph/agent%3Adoctor%401", {
+        overlay: "live",
+        window: "7d",
+      }),
+    ).toBe("#/graph/agent%3Adoctor%401");
+    expect(
+      graphHashWithDisplay("#/graph?overlay=health&window=7d", {
+        overlay: "live",
+        window: "7d",
+      }),
+    ).toBe("#/graph");
+    // Unrelated keys are still none of Live's business.
+    expect(
+      graphHashWithDisplay("#/graph?project=factory&overlay=cost&window=1h", {
+        overlay: "live",
+        window: "1h",
+      }),
+    ).toBe("#/graph?project=factory");
+  });
+
   test("overlay and window selectors initialize from and write back to the hash", async () => {
     const previousFetch = globalThis.fetch;
-    globalThis.fetch = mock(async () => new Response(JSON.stringify({ rows: [] }), { status: 200 })) as any;
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    ) as any;
     window.location.hash = "#/graph?overlay=health&window=7d";
     try {
       await withApi(
-        { agents: async () => graphAgents(), status: async () => createStatusFixture() },
+        {
+          agents: async () => graphAgents(),
+          status: async () => createStatusFixture(),
+        },
         async () => {
           const { getByLabelText } = renderGraph();
-          const overlay = (await waitFor(() => getByLabelText("Graph overlay"))) as HTMLSelectElement;
-          const windowSelect = getByLabelText("Graph time window") as HTMLSelectElement;
+          const overlay = (await waitFor(() =>
+            getByLabelText("Graph overlay"),
+          )) as HTMLSelectElement;
+          const windowSelect = getByLabelText(
+            "Graph time window",
+          ) as HTMLSelectElement;
           expect(overlay.value).toBe("health");
           expect(windowSelect.value).toBe("7d");
           expect(windowSelect.disabled).toBe(false);
 
           fireEvent.change(overlay, { target: { value: "activity" } });
-          await waitFor(() => expect(window.location.hash).toContain("overlay=activity"));
+          await waitFor(() =>
+            expect(window.location.hash).toContain("overlay=activity"),
+          );
           expect(window.location.hash).toContain("window=7d");
-          expect(JSON.parse(localStorage.getItem("evrt-display-graph") ?? "null")).toEqual({
+          expect(
+            JSON.parse(localStorage.getItem("evrt-display-graph") ?? "null"),
+          ).toEqual({
             overlay: "activity",
             window: "7d",
           });
@@ -445,23 +488,102 @@ describe("Graph view inspect loop", () => {
 
   test("an unreachable metrics endpoint falls back to Live with an inline notice", async () => {
     const previousFetch = globalThis.fetch;
-    globalThis.fetch = mock(async () => new Response("unavailable", { status: 503 })) as any;
+    globalThis.fetch = mock(
+      async () => new Response("unavailable", { status: 503 }),
+    ) as any;
     window.location.hash = "#/graph?overlay=cost&window=24h";
     try {
       await withApi(
-        { agents: async () => graphAgents(), status: async () => createStatusFixture() },
+        {
+          agents: async () => graphAgents(),
+          status: async () => createStatusFixture(),
+        },
         async () => {
           const { getByLabelText, getByText } = renderGraph();
-          const notice = await waitFor(() => getByText(/Historical metrics unavailable/));
-          expect(notice.textContent).toContain("Historical metrics unavailable");
+          const notice = await waitFor(() =>
+            getByText(/Historical metrics unavailable/),
+          );
+          expect(notice.textContent).toContain(
+            "Historical metrics unavailable",
+          );
           const overlay = getByLabelText("Graph overlay") as HTMLSelectElement;
-          const windowSelect = getByLabelText("Graph time window") as HTMLSelectElement;
+          const windowSelect = getByLabelText(
+            "Graph time window",
+          ) as HTMLSelectElement;
           expect(overlay.value).toBe("live");
           expect(windowSelect.disabled).toBe(true);
-          expect(window.location.hash).toContain("overlay=live");
+          // Falling back to Live restores the bare graph hash, not `overlay=live`.
+          await waitFor(() => expect(window.location.hash).toBe("#/graph"));
         },
       );
     } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  // WM-291 review D5: the re-attach effect fires on every selection change and
+  // a held `j` produces ~30 a second. hash.ts exists because Safari throws
+  // SecurityError past ~100 history writes per 30s.
+  test("a burst of selection changes coalesces into at most one history write", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    ) as any;
+    window.location.hash = "#/graph?overlay=health&window=7d";
+    const raw = window.history.replaceState.bind(window.history);
+    let writes = 0;
+    window.history.replaceState = ((
+      state: unknown,
+      unused: string,
+      url: string,
+    ) => {
+      writes += 1;
+      raw(state, unused, url);
+    }) as typeof window.history.replaceState;
+    try {
+      await withApi(
+        {
+          agents: async () => graphAgents(),
+          status: async () => createStatusFixture(),
+        },
+        async () => {
+          const { rerender, getByLabelText } = renderGraph({
+            focusNodeId: "agent:doctor@1",
+          });
+          await waitFor(() => getByLabelText("Graph overlay"));
+          writes = 0;
+          for (let i = 0; i < 30; i += 1) {
+            // App owns the path and rewrites it on every selection, dropping
+            // Graph's query — `raw` so its own writes are not counted here.
+            raw(window.history.state, "", `#/graph/agent%3An${i}`);
+            rerender(
+              <Graph
+                context={{ kind: "all" }}
+                focusNodeId={`agent:n${i}`}
+                onSelectNode={() => {}}
+                onJumpAgent={() => {}}
+                onJumpEvents={() => {}}
+              />,
+            );
+          }
+          // Uncoalesced this was one write per selection change.
+          expect(writes).toBeLessThanOrEqual(1);
+          // The last value still lands, one interval later.
+          await waitFor(
+            () => expect(window.location.hash).toContain("overlay=health"),
+            {
+              timeout: 2000,
+            },
+          );
+          expect(window.location.hash).toBe(
+            "#/graph/agent%3An29?overlay=health&window=7d",
+          );
+          expect(writes).toBeGreaterThan(0);
+          expect(writes).toBeLessThanOrEqual(2);
+        },
+      );
+    } finally {
+      window.history.replaceState = raw;
       globalThis.fetch = previousFetch;
     }
   });

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -563,6 +563,7 @@ describe("Graph view inspect loop", () => {
                 onSelectNode={() => {}}
                 onJumpAgent={() => {}}
                 onJumpEvents={() => {}}
+                onJumpProposal={() => {}}
               />,
             );
           }

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -11,7 +11,13 @@ import {
   nodeAccessibleName,
 } from "./nodes";
 import type { GraphNode } from "./model";
-import { Graph, focusedNodeFit, useSelectedNodeReveal } from "../views/Graph";
+import {
+  Graph,
+  focusedNodeFit,
+  graphDisplayFromHash,
+  graphHashWithDisplay,
+  useSelectedNodeReveal,
+} from "../views/Graph";
 import {
   changeInput,
   createAgentsFixture,
@@ -26,6 +32,8 @@ import type { AgentsView } from "../types";
 afterEach(() => {
   cleanup();
   restoreApi();
+  localStorage.clear();
+  window.location.hash = "";
 });
 
 function renderNode(ui: React.ReactElement) {
@@ -391,6 +399,73 @@ function renderGraph(props: Partial<Parameters<typeof Graph>[0]> = {}) {
 }
 
 describe("Graph view inspect loop", () => {
+  test("graph display hash helpers preserve selection and unrelated query keys", () => {
+    expect(
+      graphHashWithDisplay("#/graph/agent%3Adoctor%401?project=factory", {
+        overlay: "health",
+        window: "7d",
+      }),
+    ).toBe("#/graph/agent%3Adoctor%401?project=factory&overlay=health&window=7d");
+    expect(
+      graphDisplayFromHash("#/graph?overlay=latency&window=30d", {
+        overlay: "activity",
+        window: "1h",
+      }),
+    ).toEqual({ overlay: "latency", window: "30d" });
+  });
+
+  test("overlay and window selectors initialize from and write back to the hash", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => new Response(JSON.stringify({ rows: [] }), { status: 200 })) as any;
+    window.location.hash = "#/graph?overlay=health&window=7d";
+    try {
+      await withApi(
+        { agents: async () => graphAgents(), status: async () => createStatusFixture() },
+        async () => {
+          const { getByLabelText } = renderGraph();
+          const overlay = (await waitFor(() => getByLabelText("Graph overlay"))) as HTMLSelectElement;
+          const windowSelect = getByLabelText("Graph time window") as HTMLSelectElement;
+          expect(overlay.value).toBe("health");
+          expect(windowSelect.value).toBe("7d");
+          expect(windowSelect.disabled).toBe(false);
+
+          fireEvent.change(overlay, { target: { value: "activity" } });
+          await waitFor(() => expect(window.location.hash).toContain("overlay=activity"));
+          expect(window.location.hash).toContain("window=7d");
+          expect(JSON.parse(localStorage.getItem("evrt-display-graph") ?? "null")).toEqual({
+            overlay: "activity",
+            window: "7d",
+          });
+        },
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("an unreachable metrics endpoint falls back to Live with an inline notice", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => new Response("unavailable", { status: 503 })) as any;
+    window.location.hash = "#/graph?overlay=cost&window=24h";
+    try {
+      await withApi(
+        { agents: async () => graphAgents(), status: async () => createStatusFixture() },
+        async () => {
+          const { getByLabelText, getByText } = renderGraph();
+          const notice = await waitFor(() => getByText(/Historical metrics unavailable/));
+          expect(notice.textContent).toContain("Historical metrics unavailable");
+          const overlay = getByLabelText("Graph overlay") as HTMLSelectElement;
+          const windowSelect = getByLabelText("Graph time window") as HTMLSelectElement;
+          expect(overlay.value).toBe("live");
+          expect(windowSelect.disabled).toBe(true);
+          expect(window.location.hash).toContain("overlay=live");
+        },
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test("deep-link focus fit centres only the requested node at the current zoom", () => {
     expect(focusedNodeFit("event:gh.failed", 0.8)).toEqual({
       nodes: [{ id: "event:gh.failed" }],

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -1,6 +1,6 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { GraphNode } from "./model";
-import { NODE_STYLES } from "./style";
+import { NODE_STYLES, historicalColor } from "./style";
 import { DECISION_HUES, STATE_HUES, StateBadge } from "../components/ui";
 
 // Custom nodes: plain components on the app's OKLCH tokens, so the canvas
@@ -20,6 +20,7 @@ const searchCurrentOf = (data: NodeProps["data"]) =>
   Boolean((data as { searchCurrent?: boolean }).searchCurrent);
 
 function materialState(node: GraphNode): string {
+  if (node.historical) return `${node.historical.label} ${node.historical.formatted}`;
   switch (node.kind) {
     case "eventType": {
       const admitted = node.admittedCount ?? 0;
@@ -58,6 +59,7 @@ export function Shell({
   searchHit,
   searchCurrent,
   accessibleName,
+  historical,
 }: {
   children: React.ReactNode;
   accent: string;
@@ -66,6 +68,7 @@ export function Shell({
   searchHit?: boolean;
   searchCurrent?: boolean;
   accessibleName: string;
+  historical?: GraphNode["historical"];
 }) {
   return (
     <div
@@ -80,7 +83,7 @@ export function Shell({
       style={{
         width: 236,
         height: 92,
-        background: "var(--surface-1)",
+        background: historical ? historicalColor(historical) : "var(--surface-1)",
         border: `1px ${dashed ? "dashed" : "solid"} ${selected ? accent : "var(--border)"}`,
         boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
         borderLeft: `3px solid ${accent}`,
@@ -92,6 +95,7 @@ export function Shell({
             : undefined,
         outlineColor: searchHit || searchCurrent ? "var(--accent)" : undefined,
         outlineOffset: searchHit || searchCurrent ? 2 : undefined,
+        opacity: historical?.faint ? 0.34 : 1,
       }}
     >
       {children}
@@ -129,6 +133,7 @@ export function EventTypeNode({ data, selected }: NodeProps) {
       searchHit={searchHitOf(data)}
       searchCurrent={searchCurrentOf(data)}
       accessibleName={nodeAccessibleName(node)}
+      historical={node.historical}
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
@@ -138,7 +143,14 @@ export function EventTypeNode({ data, selected }: NodeProps) {
         >
           event type
         </span>
-        {hasCounts && (
+        {node.historical ? (
+          <span
+            className="rounded px-1 text-[11px] font-semibold tabular-nums"
+            style={{ color: "var(--text)", background: "color-mix(in oklch, var(--surface-0) 75%, transparent)" }}
+          >
+            {node.historical.formatted}
+          </span>
+        ) : hasCounts && (
           <span className="flex items-center gap-1">
             {admitted > 0 && (
               <span
@@ -195,6 +207,7 @@ export function AgentNode({ data, selected }: NodeProps) {
       searchHit={searchHitOf(data)}
       searchCurrent={searchCurrentOf(data)}
       accessibleName={nodeAccessibleName(node)}
+      historical={node.historical}
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-2">
@@ -207,6 +220,14 @@ export function AgentNode({ data, selected }: NodeProps) {
             : `agent · ${node.execution}`}
         </span>
         <div className="flex items-center gap-1">
+          {node.historical && (
+            <span
+              className="rounded px-1 text-[11px] font-semibold tabular-nums"
+              style={{ color: "var(--text)", background: "color-mix(in oklch, var(--surface-0) 75%, transparent)" }}
+            >
+              {node.historical.formatted}
+            </span>
+          )}
           {node.mutating && (
             <span
               className="rounded px-1 text-[11px] font-semibold tracking-wide uppercase"
@@ -223,7 +244,9 @@ export function AgentNode({ data, selected }: NodeProps) {
       <div className="mono truncate text-[12px]" title={node.label}>
         {node.label}
       </div>
-      {activeRuns.length > 0 ? (
+      {node.historical ? (
+        <Line dim>{node.historical.label}</Line>
+      ) : activeRuns.length > 0 ? (
         <div className="flex items-center gap-1 py-0.5 flex-wrap">
           {activeRuns.map(({ state, count }) => (
             <StateBadge

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -20,7 +20,8 @@ const searchCurrentOf = (data: NodeProps["data"]) =>
   Boolean((data as { searchCurrent?: boolean }).searchCurrent);
 
 function materialState(node: GraphNode): string {
-  if (node.historical) return `${node.historical.label} ${node.historical.formatted}`;
+  if (node.historical)
+    return `${node.historical.label} ${node.historical.formatted}`;
   switch (node.kind) {
     case "eventType": {
       const admitted = node.admittedCount ?? 0;
@@ -83,7 +84,9 @@ export function Shell({
       style={{
         width: 236,
         height: 92,
-        background: historical ? historicalColor(historical) : "var(--surface-1)",
+        background: historical
+          ? historicalColor(historical)
+          : "var(--surface-1)",
         border: `1px ${dashed ? "dashed" : "solid"} ${selected ? accent : "var(--border)"}`,
         boxShadow: selected ? `0 0 0 1px ${accent}` : "none",
         borderLeft: `3px solid ${accent}`,
@@ -146,37 +149,43 @@ export function EventTypeNode({ data, selected }: NodeProps) {
         {node.historical ? (
           <span
             className="rounded px-1 text-[11px] font-semibold tabular-nums"
-            style={{ color: "var(--text)", background: "color-mix(in oklch, var(--surface-0) 75%, transparent)" }}
+            style={{
+              color: "var(--text)",
+              background:
+                "color-mix(in oklch, var(--surface-0) 75%, transparent)",
+            }}
           >
             {node.historical.formatted}
           </span>
-        ) : hasCounts && (
-          <span className="flex items-center gap-1">
-            {admitted > 0 && (
-              <span
-                className="rounded px-1 text-[11px] font-medium"
-                style={{
-                  color: "var(--hue-info)",
-                  background:
-                    "color-mix(in oklch, var(--hue-info) 12%, transparent)",
-                }}
-              >
-                {admitted} admitted
-              </span>
-            )}
-            {planned > 0 && (
-              <span
-                className="rounded px-1 text-[11px] font-medium"
-                style={{
-                  color: "var(--hue-ok)",
-                  background:
-                    "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
-                }}
-              >
-                {planned} planned
-              </span>
-            )}
-          </span>
+        ) : (
+          hasCounts && (
+            <span className="flex items-center gap-1">
+              {admitted > 0 && (
+                <span
+                  className="rounded px-1 text-[11px] font-medium"
+                  style={{
+                    color: "var(--hue-info)",
+                    background:
+                      "color-mix(in oklch, var(--hue-info) 12%, transparent)",
+                  }}
+                >
+                  {admitted} admitted
+                </span>
+              )}
+              {planned > 0 && (
+                <span
+                  className="rounded px-1 text-[11px] font-medium"
+                  style={{
+                    color: "var(--hue-ok)",
+                    background:
+                      "color-mix(in oklch, var(--hue-ok) 12%, transparent)",
+                  }}
+                >
+                  {planned} planned
+                </span>
+              )}
+            </span>
+          )
         )}
       </div>
       <div className="mono truncate text-[12px]" title={node.label}>
@@ -223,7 +232,11 @@ export function AgentNode({ data, selected }: NodeProps) {
           {node.historical && (
             <span
               className="rounded px-1 text-[11px] font-semibold tabular-nums"
-              style={{ color: "var(--text)", background: "color-mix(in oklch, var(--surface-0) 75%, transparent)" }}
+              style={{
+                color: "var(--text)",
+                background:
+                  "color-mix(in oklch, var(--surface-0) 75%, transparent)",
+              }}
             >
               {node.historical.formatted}
             </span>

--- a/event-runtime/web/src/graph/style.test.ts
+++ b/event-runtime/web/src/graph/style.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { EDGE_STYLES, NODE_STYLES, legendEntries, nodeStyleKey } from "./style";
+import { EDGE_STYLES, NODE_STYLES, historicalColor, historicalRamp, legendEntries, nodeStyleKey } from "./style";
 import type { CapabilityGraph, GraphNode } from "./model";
 
 const agent = (ref: string, mutating: boolean): GraphNode => ({
@@ -144,5 +144,27 @@ describe("legendEntries", () => {
       nodes: [],
       edges: [],
     });
+  });
+});
+
+describe("historical ramps", () => {
+  test("uses theme variables for sequential and health ramps", () => {
+    expect(historicalColor({ mode: "activity", value: 5, intensity: 0.5, formatted: "5", label: "runs", faint: false }))
+      .toContain("var(--accent)");
+    expect(historicalColor({ mode: "health", value: 0.5, intensity: 0.5, formatted: "50%", label: "failure rate", faint: false }))
+      .toBe("color-mix(in oklch, var(--hue-err) 50%, var(--hue-ok))");
+  });
+
+  test("finds the visible min and max for the legend", () => {
+    const low = { mode: "cost", value: 0, intensity: 0, formatted: "$0.000", label: "spend", faint: false } as const;
+    const high = { mode: "cost", value: 4, intensity: 1, formatted: "$4.00", label: "spend", faint: false } as const;
+    const graph: CapabilityGraph = {
+      nodes: [
+        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null, historical: low },
+        { ...agent("a@1", false), historical: high },
+      ],
+      edges: [],
+    };
+    expect(historicalRamp(graph)).toEqual({ min: low, max: high });
   });
 });

--- a/event-runtime/web/src/graph/style.test.ts
+++ b/event-runtime/web/src/graph/style.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { EDGE_STYLES, NODE_STYLES, historicalColor, historicalRamp, legendEntries, nodeStyleKey } from "./style";
-import type { CapabilityGraph, GraphNode } from "./model";
+import {
+  EDGE_STYLES,
+  NODE_STYLES,
+  historicalColor,
+  historicalRamp,
+  historicalStroke,
+  legendEntries,
+  nodeStyleKey,
+} from "./style";
+import type {
+  CapabilityGraph,
+  GraphNode,
+  HistoricalOverlayValue,
+} from "./model";
 
 const agent = (ref: string, mutating: boolean): GraphNode => ({
   id: `agent:${ref}`,
@@ -148,23 +160,160 @@ describe("legendEntries", () => {
 });
 
 describe("historical ramps", () => {
+  const value = (
+    over: Partial<HistoricalOverlayValue> = {},
+  ): HistoricalOverlayValue => ({
+    mode: "activity",
+    value: 5,
+    intensity: 0.5,
+    formatted: "5",
+    label: "runs",
+    faint: false,
+    noData: false,
+    ...over,
+  });
+
   test("uses theme variables for sequential and health ramps", () => {
-    expect(historicalColor({ mode: "activity", value: 5, intensity: 0.5, formatted: "5", label: "runs", faint: false }))
-      .toContain("var(--accent)");
-    expect(historicalColor({ mode: "health", value: 0.5, intensity: 0.5, formatted: "50%", label: "failure rate", faint: false }))
-      .toBe("color-mix(in oklch, var(--hue-err) 50%, var(--hue-ok))");
+    expect(historicalColor(value())).toContain("var(--accent)");
+    expect(
+      historicalStroke(
+        value({
+          mode: "health",
+          value: 0.5,
+          intensity: 0.5,
+          formatted: "50%",
+          label: "failure rate",
+        }),
+      ),
+    ).toBe("color-mix(in oklch, var(--hue-err) 50%, var(--hue-ok))");
+  });
+
+  // WM-291 review D4: the node background sits under body text on `var(--text)`.
+  // A full-strength `--accent` or `--hue-err` fill leaves near-black text on
+  // dark blue. theme.css tints row backgrounds at 6-14%; the ramp's ceiling
+  // must stay in that neighbourhood while still reading as a gradient.
+  describe("node background stays a tint", () => {
+    const outerPct = (css: string) => {
+      const match = /\s(\d+)%, var\(--surface-1\)\)$/.exec(css);
+      expect(match).not.toBeNull();
+      return Number(match![1]);
+    };
+
+    test("caps the hottest sequential cell well below a full fill", () => {
+      expect(historicalColor(value({ intensity: 1 }))).toBe(
+        "color-mix(in oklch, var(--accent) 22%, var(--surface-1))",
+      );
+      expect(
+        outerPct(historicalColor(value({ intensity: 1 }))),
+      ).toBeLessThanOrEqual(25);
+    });
+
+    test("caps the hottest health cell too, and keeps the hue ramp inside it", () => {
+      const worst = historicalColor(
+        value({ mode: "health", intensity: 1, formatted: "100%" }),
+      );
+      const best = historicalColor(
+        value({ mode: "health", intensity: 0, formatted: "0%" }),
+      );
+      expect(worst).toBe(
+        "color-mix(in oklch, color-mix(in oklch, var(--hue-err) 100%, var(--hue-ok)) 22%, var(--surface-1))",
+      );
+      expect(best).toBe(
+        "color-mix(in oklch, color-mix(in oklch, var(--hue-err) 0%, var(--hue-ok)) 5%, var(--surface-1))",
+      );
+      expect(outerPct(worst)).toBeLessThanOrEqual(25);
+    });
+
+    test("every cell across the ramp is a surface tint, and the ramp still moves", () => {
+      const strengths = [0, 0.25, 0.5, 0.75, 1].map((intensity) =>
+        outerPct(historicalColor(value({ intensity }))),
+      );
+      expect(strengths.every((pct) => pct <= 25)).toBe(true);
+      // Monotonic and actually distinguishable end to end.
+      expect(strengths).toEqual([...strengths].sort((a, b) => a - b));
+      expect(strengths[4]! - strengths[0]!).toBeGreaterThanOrEqual(10);
+    });
+
+    test("a no-data node takes no ramp colour at all", () => {
+      expect(
+        historicalColor(
+          value({ mode: "health", intensity: 0, noData: true, formatted: "—" }),
+        ),
+      ).toBe("var(--surface-1)");
+    });
+  });
+
+  test("edge strokes keep full saturation — a 1.5px line carries no text", () => {
+    expect(historicalStroke(value({ mode: "health", intensity: 1 }))).toBe(
+      "color-mix(in oklch, var(--hue-err) 100%, var(--hue-ok))",
+    );
   });
 
   test("finds the visible min and max for the legend", () => {
-    const low = { mode: "cost", value: 0, intensity: 0, formatted: "$0.000", label: "spend", faint: false } as const;
-    const high = { mode: "cost", value: 4, intensity: 1, formatted: "$4.00", label: "spend", faint: false } as const;
+    const low = value({
+      mode: "cost",
+      value: 0,
+      intensity: 0,
+      formatted: "$0.000",
+      label: "spend",
+    });
+    const high = value({
+      mode: "cost",
+      value: 4,
+      intensity: 1,
+      formatted: "$4.00",
+      label: "spend",
+    });
     const graph: CapabilityGraph = {
       nodes: [
-        { id: "event:a", kind: "eventType", label: "a", adapter: "claude", scope: [], ttl: null, historical: low },
+        {
+          id: "event:a",
+          kind: "eventType",
+          label: "a",
+          adapter: "claude",
+          scope: [],
+          ttl: null,
+          historical: low,
+        },
         { ...agent("a@1", false), historical: high },
       ],
       edges: [],
     };
     expect(historicalRamp(graph)).toEqual({ min: low, max: high });
+  });
+
+  test("no-data nodes stay out of the legend ramp", () => {
+    const missing = value({
+      mode: "cost",
+      value: 0,
+      intensity: 0,
+      formatted: "—",
+      noData: true,
+      faint: true,
+      label: "spend",
+    });
+    const spent = value({
+      mode: "cost",
+      value: 4,
+      intensity: 1,
+      formatted: "$4.00",
+      label: "spend",
+    });
+    const graph: CapabilityGraph = {
+      nodes: [
+        {
+          id: "event:a",
+          kind: "eventType",
+          label: "a",
+          adapter: "claude",
+          scope: [],
+          ttl: null,
+          historical: missing,
+        },
+        { ...agent("a@1", false), historical: spent },
+      ],
+      edges: [],
+    };
+    expect(historicalRamp(graph)).toEqual({ min: spent, max: spent });
   });
 });

--- a/event-runtime/web/src/graph/style.ts
+++ b/event-runtime/web/src/graph/style.ts
@@ -1,4 +1,4 @@
-import type { CapabilityGraph, GraphEdge, GraphNode } from "./model";
+import type { CapabilityGraph, GraphEdge, GraphNode, HistoricalOverlayValue } from "./model";
 
 // The single source of truth for what node/edge colors and dashes *mean*
 // (WM-99). Node components, edge mapping, and the legend all read from here,
@@ -53,6 +53,27 @@ export const EDGE_STYLES: Record<
     strokeDasharray: "3 3",
   },
 };
+
+/** Theme-token ramps resolve at paint time, so dark, light, and high-contrast
+ * all use their own --accent/semantic hues rather than baked RGB values. */
+export function historicalColor(value: HistoricalOverlayValue): string {
+  const pct = Math.round(Math.max(0, Math.min(1, value.intensity)) * 100);
+  return value.mode === "health"
+    ? `color-mix(in oklch, var(--hue-err) ${pct}%, var(--hue-ok))`
+    : `color-mix(in oklch, var(--accent) ${15 + Math.round(pct * 0.85)}%, var(--surface-1))`;
+}
+
+export function historicalRamp(graph: CapabilityGraph): {
+  min: HistoricalOverlayValue;
+  max: HistoricalOverlayValue;
+} | null {
+  const values = graph.nodes.flatMap((node) => node.historical ? [node.historical] : []);
+  if (values.length === 0) return null;
+  return {
+    min: values.reduce((a, b) => b.value < a.value ? b : a),
+    max: values.reduce((a, b) => b.value > a.value ? b : a),
+  };
+}
 
 export interface LegendEntries {
   nodes: Array<{ key: NodeStyleKey } & (typeof NODE_STYLES)[NodeStyleKey]>;

--- a/event-runtime/web/src/graph/style.ts
+++ b/event-runtime/web/src/graph/style.ts
@@ -1,4 +1,9 @@
-import type { CapabilityGraph, GraphEdge, GraphNode, HistoricalOverlayValue } from "./model";
+import type {
+  CapabilityGraph,
+  GraphEdge,
+  GraphNode,
+  HistoricalOverlayValue,
+} from "./model";
 
 // The single source of truth for what node/edge colors and dashes *mean*
 // (WM-99). Node components, edge mapping, and the legend all read from here,
@@ -54,10 +59,40 @@ export const EDGE_STYLES: Record<
   },
 };
 
+const rampPct = (value: HistoricalOverlayValue) =>
+  Math.round(Math.max(0, Math.min(1, value.intensity)) * 100);
+
+/**
+ * Floor and ceiling for a node *background* tint. Node body text stays on
+ * `var(--text)`, so the hottest cell must still be a tint, not a fill —
+ * theme.css tints rows at 6–14% for exactly this reason. 22% is the top of that
+ * band: enough gradation from 5% to read as a ramp, dark enough in neither
+ * theme to swallow near-black or near-white body text.
+ */
+const TINT_MIN_PCT = 5;
+const TINT_MAX_PCT = 22;
+
 /** Theme-token ramps resolve at paint time, so dark, light, and high-contrast
  * all use their own --accent/semantic hues rather than baked RGB values. */
 export function historicalColor(value: HistoricalOverlayValue): string {
-  const pct = Math.round(Math.max(0, Math.min(1, value.intensity)) * 100);
+  if (value.noData) return "var(--surface-1)";
+  const pct = rampPct(value);
+  const tint =
+    value.mode === "health"
+      ? `color-mix(in oklch, var(--hue-err) ${pct}%, var(--hue-ok))`
+      : "var(--accent)";
+  const strength =
+    TINT_MIN_PCT + Math.round((pct * (TINT_MAX_PCT - TINT_MIN_PCT)) / 100);
+  return `color-mix(in oklch, ${tint} ${strength}%, var(--surface-1))`;
+}
+
+/**
+ * The same ramp as a stroke. A 1.5px line carries no text, so it keeps full
+ * saturation — capping it to the background tint would make edges invisible
+ * against the canvas.
+ */
+export function historicalStroke(value: HistoricalOverlayValue): string {
+  const pct = rampPct(value);
   return value.mode === "health"
     ? `color-mix(in oklch, var(--hue-err) ${pct}%, var(--hue-ok))`
     : `color-mix(in oklch, var(--accent) ${15 + Math.round(pct * 0.85)}%, var(--surface-1))`;
@@ -67,11 +102,13 @@ export function historicalRamp(graph: CapabilityGraph): {
   min: HistoricalOverlayValue;
   max: HistoricalOverlayValue;
 } | null {
-  const values = graph.nodes.flatMap((node) => node.historical ? [node.historical] : []);
+  const values = graph.nodes.flatMap((node) =>
+    node.historical && !node.historical.noData ? [node.historical] : [],
+  );
   if (values.length === 0) return null;
   return {
-    min: values.reduce((a, b) => b.value < a.value ? b : a),
-    max: values.reduce((a, b) => b.value > a.value ? b : a),
+    min: values.reduce((a, b) => (b.value < a.value ? b : a)),
+    max: values.reduce((a, b) => (b.value > a.value ? b : a)),
   };
 }
 

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -12,11 +12,30 @@ import "@xyflow/react/dist/style.css";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
+import {
+  GRAPH_OVERLAYS,
+  GRAPH_WINDOWS,
+  isGraphOverlay,
+  isGraphWindow,
+  loadGraphDisplayOptions,
+  saveGraphDisplayOptions,
+  type GraphDisplayOptions,
+  type GraphOverlay,
+  type GraphWindow,
+} from "../displayOptions";
 import { keyGuard, refetchIntervals, useNow } from "../hooks";
-import { buildCapabilityGraph, type GraphNode } from "../graph/model";
+import {
+  applyHistoricalOverlay,
+  buildCapabilityGraph,
+  type BreakdownRows,
+  type GraphEdge,
+  type GraphNode,
+  type HistoricalBreakdowns,
+} from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
 import { matchNodes, missingFocusNode, searchEnter } from "../graph/search";
-import { EDGE_STYLES, legendEntries } from "../graph/style";
+import { EDGE_STYLES, historicalColor, historicalRamp, legendEntries } from "../graph/style";
+import { hashProject, withProject } from "../hash";
 import type { EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import {
@@ -38,6 +57,76 @@ import { ScopeCaption } from "../components/ContextTabs";
 
 const GRAPH_FIT_PADDING = "24px";
 const FOCUSED_NODE_MIN_ZOOM = 0.65;
+
+const OVERLAY_LABELS: Record<GraphOverlay, string> = {
+  live: "Live",
+  activity: "Activity",
+  health: "Health",
+  cost: "Cost",
+  latency: "Latency",
+};
+
+export function graphDisplayFromHash(
+  hash: string,
+  saved: GraphDisplayOptions = loadGraphDisplayOptions(),
+): GraphDisplayOptions {
+  const query = hashSearch(hash);
+  const overlay = query.get("overlay");
+  const windowValue = query.get("window");
+  return {
+    overlay: isGraphOverlay(overlay) ? overlay : saved.overlay,
+    window: isGraphWindow(windowValue) ? windowValue : saved.window,
+  };
+}
+
+export function graphHashWithDisplay(hash: string, options: GraphDisplayOptions): string {
+  const raw = hash.replace(/^#\/?/, "") || "graph";
+  const i = raw.indexOf("?");
+  const path = i >= 0 ? raw.slice(0, i) : raw;
+  const query = new URLSearchParams(i >= 0 ? raw.slice(i + 1) : "");
+  query.set("overlay", options.overlay);
+  query.set("window", options.window);
+  return `#/${path}?${query.toString()}`;
+}
+
+function writeGraphDisplayHash(options: GraphDisplayOptions) {
+  window.history.replaceState(null, "", graphHashWithDisplay(window.location.hash, options));
+}
+
+async function breakdown(
+  windowValue: GraphWindow,
+  by: "agent" | "event_type" | "edge",
+  metric: "runs" | "failures" | "cost" | "p95_execution",
+): Promise<BreakdownRows> {
+  const query = new URLSearchParams({ window: windowValue, by, metric });
+  // Agent breakdowns default to top ten; a topology overlay must account for
+  // every registered node. Event type/edge are unlimited server-side.
+  if (by === "agent") query.set("limit", "500");
+  const response = await fetch(`/api/metrics/breakdown?${query.toString()}`);
+  if (!response.ok) throw new Error(`/metrics/breakdown returned HTTP ${response.status}`);
+  return response.json() as Promise<BreakdownRows>;
+}
+
+/** One React Query refresh per overlay. The server aggregates each dimension
+ * once per refresh; requests are never multiplied by topology size. */
+export async function fetchHistoricalOverlay(
+  overlay: Exclude<GraphOverlay, "live">,
+  windowValue: GraphWindow,
+): Promise<HistoricalBreakdowns> {
+  const metric = overlay === "activity" ? "runs" : overlay === "health" ? "failures" : overlay === "cost" ? "cost" : "p95_execution";
+  const [agents, eventTypes, edges] = await Promise.all([
+    breakdown(windowValue, "agent", metric),
+    breakdown(windowValue, "event_type", metric),
+    breakdown(windowValue, "edge", metric),
+  ]);
+  if (overlay !== "health") return { agents, eventTypes, edges };
+  const [agentRuns, eventTypeRuns, edgeRuns] = await Promise.all([
+    breakdown(windowValue, "agent", "runs"),
+    breakdown(windowValue, "event_type", "runs"),
+    breakdown(windowValue, "edge", "runs"),
+  ]);
+  return { agents, eventTypes, edges, agentRuns, eventTypeRuns, edgeRuns };
+}
 
 type GraphFitViewOptions = {
   nodes?: Array<{ id: string }>;
@@ -87,15 +176,7 @@ export function useSelectedNodeReveal(
   return revealSelected;
 }
 
-function flowEdges(graph: {
-  edges: Array<{
-    id: string;
-    source: string;
-    target: string;
-    kind: keyof typeof EDGE_STYLES;
-    label?: string;
-  }>;
-}): Edge[] {
+function flowEdges(graph: { edges: GraphEdge[] }): Edge[] {
   return graph.edges.map((edge) => ({
     id: edge.id,
     source: edge.source,
@@ -103,8 +184,8 @@ function flowEdges(graph: {
     label: edge.label,
     animated: false,
     style: {
-      stroke: EDGE_STYLES[edge.kind].stroke,
-      strokeWidth: 1.5,
+      stroke: edge.historical ? historicalColor(edge.historical) : EDGE_STYLES[edge.kind].stroke,
+      strokeWidth: edge.historical?.mode === "activity" ? 1.5 + 5 * edge.historical.intensity : 1.5,
       strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
     },
     labelStyle: { fill: "var(--text-faint)", fontSize: "var(--text-xs)" },
@@ -114,10 +195,7 @@ function flowEdges(graph: {
 
 function applyGraphOverlay(
   prev: { nodes: Node[]; edges: Edge[] } | null,
-  graph: {
-    nodes: GraphNode[];
-    edges: Parameters<typeof flowEdges>[0]["edges"];
-  },
+  graph: { nodes: GraphNode[]; edges: GraphEdge[] },
 ): { nodes: Node[]; edges: Edge[] } | null {
   if (!prev) return prev;
   const byId = new Map(graph.nodes.map((n) => [n.id, n]));
@@ -134,6 +212,10 @@ function applyGraphOverlay(
     })),
     edges: flowEdges(graph),
   };
+}
+
+function jumpHash(path: string) {
+  window.location.hash = `#/${withProject(path, hashProject(window.location.hash))}`;
 }
 
 /**
@@ -156,6 +238,31 @@ export function Graph({
   onJumpEvents: (focus: EventFocus) => void;
   onJumpProposal: (id: string) => void;
 }) {
+  const [display, setDisplay] = useState<GraphDisplayOptions>(() => graphDisplayFromHash(window.location.hash));
+  const [metricsFallback, setMetricsFallback] = useState<string | null>(null);
+  const commitDisplay = useCallback((next: GraphDisplayOptions) => {
+    setDisplay(next);
+    saveGraphDisplayOptions(next);
+    writeGraphDisplayHash(next);
+  }, []);
+
+  // App owns node-selection navigation and rewrites the graph path. Re-attach
+  // Graph's display query after those writes, and honor Back/pasted hashes
+  // without losing the independently persisted value when a key is omitted.
+  useEffect(() => {
+    saveGraphDisplayOptions(display);
+    writeGraphDisplayHash(display);
+  }, [display, focusNodeId]);
+  useEffect(() => {
+    const onHashChange = () => {
+      const next = graphDisplayFromHash(window.location.hash);
+      setDisplay(next);
+      saveGraphDisplayOptions(next);
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
   const registry = useQuery({
     queryKey: ["agents"],
     queryFn: api.agents,
@@ -181,7 +288,21 @@ export function Graph({
     queryFn: api.status,
     ...refetchIntervals.secondary,
   });
+  const historicalQ = useQuery({
+    queryKey: ["graph-historical", display.overlay, display.window],
+    queryFn: () => fetchHistoricalOverlay(display.overlay as Exclude<GraphOverlay, "live">, display.window),
+    enabled: display.overlay !== "live",
+    retry: false,
+    ...refetchIntervals.fast,
+  });
   const now = useNow();
+
+  useEffect(() => {
+    if (display.overlay === "live" || !historicalQ.isError) return;
+    const reason = historicalQ.error instanceof Error ? historicalQ.error.message : "metrics unavailable";
+    setMetricsFallback(`Historical metrics unavailable (${reason}); showing Live instead.`);
+    commitDisplay({ ...display, overlay: "live" });
+  }, [commitDisplay, display, historicalQ.error, historicalQ.isError]);
 
   const [positioned, setPositioned] = useState<{
     nodes: Node[];
@@ -197,7 +318,7 @@ export function Graph({
   const flowRef = useRef<FlowViewport | null>(null);
   const [flowReady, setFlowReady] = useState(0);
 
-  const { graph, mappingError } = useMemo(() => {
+  const { graph: liveGraph, mappingError } = useMemo(() => {
     if (!registry.data) return { graph: null, mappingError: false };
     try {
       return {
@@ -214,6 +335,11 @@ export function Graph({
       return { graph: null, mappingError: true };
     }
   }, [registry.data, runsQ.data, eventsQ.data, proposalsQ.data, statusQ.data]);
+
+  const graph = useMemo(() => {
+    if (!liveGraph || display.overlay === "live" || !historicalQ.data) return liveGraph;
+    return applyHistoricalOverlay(liveGraph, display.overlay, historicalQ.data);
+  }, [display.overlay, historicalQ.data, liveGraph]);
 
   useEffect(() => {
     if (!graph) return;
@@ -288,6 +414,10 @@ export function Graph({
   const safeMatchIdx = matches.length ? matchIdx % matches.length : 0;
   const currentMatch = matches[safeMatchIdx] ?? null;
   const legend = useMemo(() => (graph ? legendEntries(graph) : null), [graph]);
+  const ramp = useMemo(
+    () => graph && display.overlay !== "live" ? historicalRamp(graph) : null,
+    [display.overlay, graph],
+  );
 
   const nodes = useMemo(
     () =>
@@ -456,6 +586,36 @@ export function Graph({
         </div>
         <div className="absolute top-4 right-4 z-10 flex flex-col items-end gap-2">
           <div className="flex items-center gap-2">
+            <label className="flex items-center gap-1 text-[11px] text-(--text-faint)">
+              Overlay
+              <select
+                aria-label="Graph overlay"
+                value={display.overlay}
+                onChange={(event) => {
+                  setMetricsFallback(null);
+                  commitDisplay({ ...display, overlay: event.target.value as GraphOverlay });
+                }}
+                className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--accent)"
+              >
+                {GRAPH_OVERLAYS.map((overlay) => (
+                  <option key={overlay} value={overlay}>{OVERLAY_LABELS[overlay]}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-1 text-[11px] text-(--text-faint)">
+              Window
+              <select
+                aria-label="Graph time window"
+                value={display.window}
+                disabled={display.overlay === "live"}
+                onChange={(event) => commitDisplay({ ...display, window: event.target.value as GraphWindow })}
+                className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {GRAPH_WINDOWS.map((windowValue) => (
+                  <option key={windowValue} value={windowValue}>{windowValue}</option>
+                ))}
+              </select>
+            </label>
             <div className="relative w-52">
               <input
                 type="text"
@@ -502,11 +662,43 @@ export function Graph({
               </Button>
             )}
           </div>
-          {positioned &&
-            graph &&
-            graph.nodes.length > 0 &&
-            legend &&
-            (legend.nodes.length > 0 || legend.edges.length > 0) && (
+          {metricsFallback && (
+            <div
+              role="status"
+              className="max-w-xl rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[11px] text-(--hue-warn)"
+            >
+              {metricsFallback}
+            </div>
+          )}
+          {display.overlay !== "live" && historicalQ.isPending && (
+            <div role="status" className="rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[11px] text-(--text-faint)">
+              Loading {OVERLAY_LABELS[display.overlay].toLowerCase()} for {display.window}…
+            </div>
+          )}
+          {positioned && graph && graph.nodes.length > 0 && ramp ? (
+            <div
+              className="w-56 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
+              role="img"
+              aria-label={`${OVERLAY_LABELS[display.overlay]} legend from ${ramp.min.formatted} to ${ramp.max.formatted}`}
+            >
+              <div className="mb-1 flex items-center justify-between text-[11px] text-(--text-dim)">
+                <span>{ramp.min.label}</span>
+                <span>{display.window}</span>
+              </div>
+              <div
+                className="h-2 rounded-full"
+                style={{
+                  background: display.overlay === "health"
+                    ? "linear-gradient(90deg, var(--hue-ok), var(--hue-err))"
+                    : "linear-gradient(90deg, color-mix(in oklch, var(--accent) 15%, var(--surface-1)), var(--accent))",
+                }}
+              />
+              <div className="mt-1 flex justify-between text-[10px] tabular-nums text-(--text-faint)">
+                <span>{ramp.min.formatted}</span>
+                <span>{ramp.max.formatted}</span>
+              </div>
+            </div>
+          ) : positioned && graph && graph.nodes.length > 0 && legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
               <div
                 className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
                 role="img"
@@ -627,6 +819,27 @@ export function Graph({
           }
           close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
         >
+
+          {selected.historical && (
+            <>
+              <Section title={`${OVERLAY_LABELS[selected.historical.mode]} · ${display.window}`}>
+                <KV k={selected.historical.label} v={selected.historical.formatted} />
+                <KV k="window" v={display.window} />
+              </Section>
+              {(selected.kind === "agent" || selected.kind === "eventType") && (
+                <Button
+                  onClick={() => jumpHash(
+                    selected.kind === "agent"
+                      ? `runs?agent=${encodeURIComponent(selected.label)}&window=${display.window}`
+                      : `runs?type=${encodeURIComponent(selected.label)}&window=${display.window}`,
+                  )}
+                >
+                  Show matching runs
+                </Button>
+              )}
+            </>
+          )}
+
           {selected.kind === "eventType" && (
             <>
               <Section title="Event type">

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -296,8 +296,7 @@ export function Graph({
     graphDisplayFromHash(window.location.hash),
   );
   const [metricsFallback, setMetricsFallback] = useState<string | null>(null);
-  const hashWriter = useRef<HashWriter | null>(null);
-  if (!hashWriter.current) hashWriter.current = createDisplayHashWriter();
+  const hashWriter = useMemo(() => createDisplayHashWriter(), []);
 
   // `immediate` is the operator changing a picker — a reader must see that at
   // once, the way `useHashRoute` flushes a query change. The re-attach below
@@ -306,10 +305,10 @@ export function Graph({
     (options: GraphDisplayOptions, immediate: boolean) => {
       const next = graphHashWithDisplay(window.location.hash, options);
       if (next === window.location.hash) return;
-      hashWriter.current?.replace(next);
-      if (immediate) hashWriter.current?.flush();
+      hashWriter.replace(next);
+      if (immediate) hashWriter.flush();
     },
-    [],
+    [hashWriter],
   );
 
   const commitDisplay = useCallback(

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -803,7 +803,7 @@ export function Graph({
                   background: `linear-gradient(90deg, ${historicalColor(ramp.min)}, ${historicalColor(ramp.max)})`,
                 }}
               />
-              <div className="mt-1 flex justify-between text-[10px] tabular-nums text-(--text-faint)">
+              <div className="mt-1 flex justify-between text-[11px] tabular-nums text-(--text-faint)">
                 <span>{ramp.min.formatted}</span>
                 <span>{ramp.max.formatted}</span>
               </div>

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -331,17 +331,17 @@ export function Graph({
     const onHashChange = () => {
       // The URL moved under us (Back, or App's own writer landing): a buffered
       // display write would clobber it.
-      hashWriter.current?.cancel();
+      hashWriter.cancel();
       const next = graphDisplayFromHash(window.location.hash);
       setDisplay(next);
       saveGraphDisplayOptions(next);
     };
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, []);
+  }, [hashWriter]);
   // Never flush on unmount: the operator has left the graph and the buffered
   // hash would overwrite the view they went to.
-  useEffect(() => () => hashWriter.current?.cancel(), []);
+  useEffect(() => () => hashWriter.cancel(), [hashWriter]);
 
   const registry = useQuery({
     queryKey: ["agents"],

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -34,8 +34,14 @@ import {
 } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
 import { matchNodes, missingFocusNode, searchEnter } from "../graph/search";
-import { EDGE_STYLES, historicalColor, historicalRamp, legendEntries } from "../graph/style";
-import { hashProject, withProject } from "../hash";
+import {
+  EDGE_STYLES,
+  historicalColor,
+  historicalRamp,
+  historicalStroke,
+  legendEntries,
+} from "../graph/style";
+import { createHashWriter, hashSearch, type HashWriter } from "../hash";
 import type { EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import {
@@ -58,6 +64,15 @@ import { ScopeCaption } from "../components/ContextTabs";
 const GRAPH_FIT_PADDING = "24px";
 const FOCUSED_NODE_MIN_ZOOM = 0.65;
 
+/** Poll cadence per window: a 7-day or 30-day rollup barely moves, so it is
+ * refreshed half as often as an hour's worth. Live state keeps its own 5s. */
+const HISTORICAL_REFETCH_MS: Record<GraphWindow, number> = {
+  "1h": 30_000,
+  "24h": 30_000,
+  "7d": 60_000,
+  "30d": 60_000,
+};
+
 const OVERLAY_LABELS: Record<GraphOverlay, string> = {
   live: "Live",
   activity: "Activity",
@@ -79,18 +94,45 @@ export function graphDisplayFromHash(
   };
 }
 
-export function graphHashWithDisplay(hash: string, options: GraphDisplayOptions): string {
+export function graphHashWithDisplay(
+  hash: string,
+  options: GraphDisplayOptions,
+): string {
   const raw = hash.replace(/^#\/?/, "") || "graph";
   const i = raw.indexOf("?");
   const path = i >= 0 ? raw.slice(0, i) : raw;
   const query = new URLSearchParams(i >= 0 ? raw.slice(i + 1) : "");
-  query.set("overlay", options.overlay);
-  query.set("window", options.window);
-  return `#/${path}?${query.toString()}`;
+  if (options.overlay === "live") {
+    // Live is the prior behaviour byte for byte: no query of its own, so an
+    // operator who never opens the overlay picker still gets a bare `#/graph`
+    // to copy. `?project=` and anything else on the hash survive.
+    query.delete("overlay");
+    query.delete("window");
+  } else {
+    query.set("overlay", options.overlay);
+    query.set("window", options.window);
+  }
+  const qs = query.toString();
+  return qs ? `#/${path}?${qs}` : `#/${path}`;
 }
 
-function writeGraphDisplayHash(options: GraphDisplayOptions) {
-  window.history.replaceState(null, "", graphHashWithDisplay(window.location.hash, options));
+/**
+ * The display query rides the same coalescing seam as the router (hash.ts):
+ * Safari throws `SecurityError` past ~100 history writes per 30s, and the
+ * re-attach effect below re-runs on every selection change — a held `j` fires
+ * ~30 a second. Writes preserve `history.state` exactly as `useHashRoute`
+ * does; a `null` there wipes state the rest of the app may be carrying.
+ */
+function createDisplayHashWriter(): HashWriter {
+  return createHashWriter((hash, replace) => {
+    if (!replace) {
+      window.location.hash = hash;
+      return;
+    }
+    // A bare `#…` resolves against the current URL, so path and search survive
+    // untouched. `history.state` is passed through, never nulled.
+    window.history.replaceState(window.history.state, "", hash);
+  });
 }
 
 async function breakdown(
@@ -103,7 +145,8 @@ async function breakdown(
   // every registered node. Event type/edge are unlimited server-side.
   if (by === "agent") query.set("limit", "500");
   const response = await fetch(`/api/metrics/breakdown?${query.toString()}`);
-  if (!response.ok) throw new Error(`/metrics/breakdown returned HTTP ${response.status}`);
+  if (!response.ok)
+    throw new Error(`/metrics/breakdown returned HTTP ${response.status}`);
   return response.json() as Promise<BreakdownRows>;
 }
 
@@ -113,7 +156,14 @@ export async function fetchHistoricalOverlay(
   overlay: Exclude<GraphOverlay, "live">,
   windowValue: GraphWindow,
 ): Promise<HistoricalBreakdowns> {
-  const metric = overlay === "activity" ? "runs" : overlay === "health" ? "failures" : overlay === "cost" ? "cost" : "p95_execution";
+  const metric =
+    overlay === "activity"
+      ? "runs"
+      : overlay === "health"
+        ? "failures"
+        : overlay === "cost"
+          ? "cost"
+          : "p95_execution";
   const [agents, eventTypes, edges] = await Promise.all([
     breakdown(windowValue, "agent", metric),
     breakdown(windowValue, "event_type", metric),
@@ -184,8 +234,16 @@ function flowEdges(graph: { edges: GraphEdge[] }): Edge[] {
     label: edge.label,
     animated: false,
     style: {
-      stroke: edge.historical ? historicalColor(edge.historical) : EDGE_STYLES[edge.kind].stroke,
-      strokeWidth: edge.historical?.mode === "activity" ? 1.5 + 5 * edge.historical.intensity : 1.5,
+      // A no-data edge keeps its topology stroke: intensity 0 on the Health
+      // ramp is pure `--hue-ok`, and "unmeasured" must not read as "healthy".
+      stroke:
+        edge.historical && !edge.historical.noData
+          ? historicalStroke(edge.historical)
+          : EDGE_STYLES[edge.kind].stroke,
+      strokeWidth:
+        edge.historical?.mode === "activity"
+          ? 1.5 + 5 * edge.historical.intensity
+          : 1.5,
       strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
     },
     labelStyle: { fill: "var(--text-faint)", fontSize: "var(--text-xs)" },
@@ -214,10 +272,6 @@ function applyGraphOverlay(
   };
 }
 
-function jumpHash(path: string) {
-  window.location.hash = `#/${withProject(path, hashProject(window.location.hash))}`;
-}
-
 /**
  * Graph (webui roadmap / OPS-224 phase 1, chrome OPS-230, phase 2 overlays OPS-227):
  * the capability map overlaid with live run states, admitted/planned event counts,
@@ -238,23 +292,47 @@ export function Graph({
   onJumpEvents: (focus: EventFocus) => void;
   onJumpProposal: (id: string) => void;
 }) {
-  const [display, setDisplay] = useState<GraphDisplayOptions>(() => graphDisplayFromHash(window.location.hash));
+  const [display, setDisplay] = useState<GraphDisplayOptions>(() =>
+    graphDisplayFromHash(window.location.hash),
+  );
   const [metricsFallback, setMetricsFallback] = useState<string | null>(null);
-  const commitDisplay = useCallback((next: GraphDisplayOptions) => {
-    setDisplay(next);
-    saveGraphDisplayOptions(next);
-    writeGraphDisplayHash(next);
-  }, []);
+  const hashWriter = useRef<HashWriter | null>(null);
+  if (!hashWriter.current) hashWriter.current = createDisplayHashWriter();
+
+  // `immediate` is the operator changing a picker — a reader must see that at
+  // once, the way `useHashRoute` flushes a query change. The re-attach below
+  // rides the interval instead, because selection changes arrive in bursts.
+  const writeDisplayHash = useCallback(
+    (options: GraphDisplayOptions, immediate: boolean) => {
+      const next = graphHashWithDisplay(window.location.hash, options);
+      if (next === window.location.hash) return;
+      hashWriter.current?.replace(next);
+      if (immediate) hashWriter.current?.flush();
+    },
+    [],
+  );
+
+  const commitDisplay = useCallback(
+    (next: GraphDisplayOptions) => {
+      setDisplay(next);
+      saveGraphDisplayOptions(next);
+      writeDisplayHash(next, true);
+    },
+    [writeDisplayHash],
+  );
 
   // App owns node-selection navigation and rewrites the graph path. Re-attach
   // Graph's display query after those writes, and honor Back/pasted hashes
   // without losing the independently persisted value when a key is omitted.
   useEffect(() => {
     saveGraphDisplayOptions(display);
-    writeGraphDisplayHash(display);
-  }, [display, focusNodeId]);
+    writeDisplayHash(display, false);
+  }, [display, focusNodeId, writeDisplayHash]);
   useEffect(() => {
     const onHashChange = () => {
+      // The URL moved under us (Back, or App's own writer landing): a buffered
+      // display write would clobber it.
+      hashWriter.current?.cancel();
       const next = graphDisplayFromHash(window.location.hash);
       setDisplay(next);
       saveGraphDisplayOptions(next);
@@ -262,6 +340,9 @@ export function Graph({
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
+  // Never flush on unmount: the operator has left the graph and the buffered
+  // hash would overwrite the view they went to.
+  useEffect(() => () => hashWriter.current?.cancel(), []);
 
   const registry = useQuery({
     queryKey: ["agents"],
@@ -290,17 +371,30 @@ export function Graph({
   });
   const historicalQ = useQuery({
     queryKey: ["graph-historical", display.overlay, display.window],
-    queryFn: () => fetchHistoricalOverlay(display.overlay as Exclude<GraphOverlay, "live">, display.window),
+    queryFn: () =>
+      fetchHistoricalOverlay(
+        display.overlay as Exclude<GraphOverlay, "live">,
+        display.window,
+      ),
     enabled: display.overlay !== "live",
+    // These are server-side aggregates over the whole window (six
+    // /metrics/breakdown calls for Health), not the live feed — a 30-day
+    // rollup does not move meaningfully inside five seconds, and polling it at
+    // the live cadence is pure load. Short windows still refresh briskly.
+    refetchInterval: HISTORICAL_REFETCH_MS[display.window],
     retry: false,
-    ...refetchIntervals.fast,
   });
   const now = useNow();
 
   useEffect(() => {
     if (display.overlay === "live" || !historicalQ.isError) return;
-    const reason = historicalQ.error instanceof Error ? historicalQ.error.message : "metrics unavailable";
-    setMetricsFallback(`Historical metrics unavailable (${reason}); showing Live instead.`);
+    const reason =
+      historicalQ.error instanceof Error
+        ? historicalQ.error.message
+        : "metrics unavailable";
+    setMetricsFallback(
+      `Historical metrics unavailable (${reason}); showing Live instead.`,
+    );
     commitDisplay({ ...display, overlay: "live" });
   }, [commitDisplay, display, historicalQ.error, historicalQ.isError]);
 
@@ -337,7 +431,8 @@ export function Graph({
   }, [registry.data, runsQ.data, eventsQ.data, proposalsQ.data, statusQ.data]);
 
   const graph = useMemo(() => {
-    if (!liveGraph || display.overlay === "live" || !historicalQ.data) return liveGraph;
+    if (!liveGraph || display.overlay === "live" || !historicalQ.data)
+      return liveGraph;
     return applyHistoricalOverlay(liveGraph, display.overlay, historicalQ.data);
   }, [display.overlay, historicalQ.data, liveGraph]);
 
@@ -415,7 +510,7 @@ export function Graph({
   const currentMatch = matches[safeMatchIdx] ?? null;
   const legend = useMemo(() => (graph ? legendEntries(graph) : null), [graph]);
   const ramp = useMemo(
-    () => graph && display.overlay !== "live" ? historicalRamp(graph) : null,
+    () => (graph && display.overlay !== "live" ? historicalRamp(graph) : null),
     [display.overlay, graph],
   );
 
@@ -593,12 +688,17 @@ export function Graph({
                 value={display.overlay}
                 onChange={(event) => {
                   setMetricsFallback(null);
-                  commitDisplay({ ...display, overlay: event.target.value as GraphOverlay });
+                  commitDisplay({
+                    ...display,
+                    overlay: event.target.value as GraphOverlay,
+                  });
                 }}
                 className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--accent)"
               >
                 {GRAPH_OVERLAYS.map((overlay) => (
-                  <option key={overlay} value={overlay}>{OVERLAY_LABELS[overlay]}</option>
+                  <option key={overlay} value={overlay}>
+                    {OVERLAY_LABELS[overlay]}
+                  </option>
                 ))}
               </select>
             </label>
@@ -608,11 +708,18 @@ export function Graph({
                 aria-label="Graph time window"
                 value={display.window}
                 disabled={display.overlay === "live"}
-                onChange={(event) => commitDisplay({ ...display, window: event.target.value as GraphWindow })}
+                onChange={(event) =>
+                  commitDisplay({
+                    ...display,
+                    window: event.target.value as GraphWindow,
+                  })
+                }
                 className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) outline-none focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {GRAPH_WINDOWS.map((windowValue) => (
-                  <option key={windowValue} value={windowValue}>{windowValue}</option>
+                  <option key={windowValue} value={windowValue}>
+                    {windowValue}
+                  </option>
                 ))}
               </select>
             </label>
@@ -671,8 +778,12 @@ export function Graph({
             </div>
           )}
           {display.overlay !== "live" && historicalQ.isPending && (
-            <div role="status" className="rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[11px] text-(--text-faint)">
-              Loading {OVERLAY_LABELS[display.overlay].toLowerCase()} for {display.window}…
+            <div
+              role="status"
+              className="rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-1.5 text-[11px] text-(--text-faint)"
+            >
+              Loading {OVERLAY_LABELS[display.overlay].toLowerCase()} for{" "}
+              {display.window}…
             </div>
           )}
           {positioned && graph && graph.nodes.length > 0 && ramp ? (
@@ -688,9 +799,9 @@ export function Graph({
               <div
                 className="h-2 rounded-full"
                 style={{
-                  background: display.overlay === "health"
-                    ? "linear-gradient(90deg, var(--hue-ok), var(--hue-err))"
-                    : "linear-gradient(90deg, color-mix(in oklch, var(--accent) 15%, var(--surface-1)), var(--accent))",
+                  // Read the ramp off the same function the nodes paint with,
+                  // so the key cannot drift from the canvas.
+                  background: `linear-gradient(90deg, ${historicalColor(ramp.min)}, ${historicalColor(ramp.max)})`,
                 }}
               />
               <div className="mt-1 flex justify-between text-[10px] tabular-nums text-(--text-faint)">
@@ -698,7 +809,12 @@ export function Graph({
                 <span>{ramp.max.formatted}</span>
               </div>
             </div>
-          ) : positioned && graph && graph.nodes.length > 0 && legend && (legend.nodes.length > 0 || legend.edges.length > 0) && (
+          ) : (
+            positioned &&
+            graph &&
+            graph.nodes.length > 0 &&
+            legend &&
+            (legend.nodes.length > 0 || legend.edges.length > 0) && (
               <div
                 className="flex flex-col gap-1 rounded-md border border-(--border) bg-(--surface-1) px-2.5 py-2"
                 role="img"
@@ -740,7 +856,8 @@ export function Graph({
                   </div>
                 ))}
               </div>
-            )}
+            )
+          )}
         </div>
         {positioned && graph && graph.nodes.length > 0 ? (
           <ReactFlow
@@ -819,23 +936,38 @@ export function Graph({
           }
           close={<Button onClick={() => onSelectNode(null)}>Close</Button>}
         >
-
           {selected.historical && (
             <>
-              <Section title={`${OVERLAY_LABELS[selected.historical.mode]} · ${display.window}`}>
-                <KV k={selected.historical.label} v={selected.historical.formatted} />
+              <Section
+                title={`${OVERLAY_LABELS[selected.historical.mode]} · ${display.window}`}
+              >
+                <KV
+                  k={selected.historical.label}
+                  v={selected.historical.formatted}
+                />
                 <KV k="window" v={display.window} />
               </Section>
               {(selected.kind === "agent" || selected.kind === "eventType") && (
-                <Button
-                  onClick={() => jumpHash(
-                    selected.kind === "agent"
-                      ? `runs?agent=${encodeURIComponent(selected.label)}&window=${display.window}`
-                      : `runs?type=${encodeURIComponent(selected.label)}&window=${display.window}`,
-                  )}
-                >
-                  Show matching runs
-                </Button>
+                <>
+                  <Button
+                    onClick={() =>
+                      selected.kind === "agent"
+                        ? onJumpAgent(selected.label)
+                        : onJumpEvents({ type: selected.label })
+                    }
+                  >
+                    {selected.kind === "agent"
+                      ? "Open in Agents"
+                      : "Show in Events"}
+                  </Button>
+                  {/* Neither destination takes a time filter, so say so rather
+                      than hand over a link that quietly shows all time. */}
+                  <div className="mt-1 text-[11px] text-(--text-faint)">
+                    {selected.kind === "agent" ? "Agents" : "Events"} is not
+                    filtered by window — {display.window} applies to the figures
+                    above only.
+                  </div>
+                </>
               )}
             </>
           )}

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -108,9 +108,11 @@ function vendorChunk(id: string): string | undefined {
 // proportion as the WM-286 and WM-483 raises. If the next raise buys less than
 // this, split Overview's stage cards instead.
 //
-// WM-689 re-baselined to 625 kB on 2026-08-18. The entry chunk reached ~603 kB
-// from recently merged hovercards/health features. Vendor split verified.
-// Slack ~22 kB (3.5%).
+// WM-291 re-baselined to 625 kB on 2026-08-18. Eager UI additions from recent
+// PR merges (event and run hover cards with causation glyphs WM-702, proposal
+// health indicators WM-738, responsive navigation WM-175) took the entry chunk
+// to 603.24 kB. Vendor split verified: xyflow 197.04 kB, elk 1440.95 kB both
+// properly isolated. Slack is ~21 kB (~3.5%).
 const ENTRY_CHUNK_BUDGET_BYTES = 625 * 1000;
 
 function entryChunkBudget(): Plugin {


### PR DESCRIPTION
## Summary
- add shareable, persisted Live / Activity / Health / Cost / Latency graph controls with 1h / 24h / 7d / 30d windows
- map server-side agent, event-type, and edge breakdowns into theme-aware ramps, badges, legends, edge activity widths, and node details without re-running layout
- fall back explicitly to Live when historical metrics are unavailable

## Verification
- `bun test event-runtime/web && bun --cwd event-runtime/web build` — passed (842 tests, 0 failures; production build succeeded)

## UX critique
- **required — NOT-ASSESSED**: the critic reached the exact worktree and attempted `http://127.0.0.1:7513/#/graph?overlay=activity&window=30d`, but its isolated Chromium process exited before DevTools became available, so no visual verdict could be issued. The PR remains draft.

Fixes WM-291