### PR TITLE
fix(adapters-pi): add codex tool names so read-only agents can write result.json (WM-665)

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -107,7 +107,34 @@ const TEXT_PREVIEW_CHARS = 4000;
 // tool removal. Containment for mutating: false is therefore the ephemeral or
 // pinned workspace as cwd — audited, not enforced, per §14 until stage 2's
 // native capability enforcement (OPS-515).
-export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write", "bash"];
+//   exec_command / apply_patch
+//          the third occurrence (WM-665), and the reason both name families are
+//          listed. Tool names are PER PROVIDER, not per pi version. On
+//          openai-codex models (sol/terra/luna — what `pi.*` resolves to in
+//          config/policy.yaml) there is no `read`, `write` or `bash` at all:
+//          the shell is `exec_command` and file writing is `apply_patch`.
+//          `grep`/`find`/`ls` do exist, so exactly those three survived the
+//          allowlist and the failure looked like a weak model rather than a
+//          config bug. pi drops an unrecognized name silently — no error, no
+//          warning — so a mutating: false agent kept its contract obligation
+//          and lost the only tool that could satisfy it, then failed closed
+//          with "this session exposes no shell or file-write tool"
+//          (run_b66e2338 merge-scan@2, run_06cfd301 work-scan@1, pi 0.84.2).
+// Both families are kept: an unrecognized name is inert, so listing them
+// together is what makes one allowlist correct across providers.
+// `apply_patch` conflates write and edit, so a mutating: false agent on codex
+// does get an edit-capable tool. That is deliberate and consistent with the
+// paragraph below: containment is the workspace, not the tool list.
+export const READ_ONLY_TOOLS = [
+  "read",
+  "grep",
+  "find",
+  "ls",
+  "write",
+  "bash",
+  "exec_command",
+  "apply_patch",
+];
 
 // The mutating counterpart, and the reason it exists (WM-336): until now
 // `--tools` was passed ONLY for `mutating: false`, so a mutating agent ran on
@@ -133,7 +160,19 @@ export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls", "write", "bash"];
 // agent. `subagent` is deliberately included: dispatch delegates focused work —
 // notably the UX critique (WM-335) — and the alternative is one context doing
 // everything, which is what long-run degradation looks like.
-export const MUTATING_TOOLS = ["read", "grep", "find", "ls", "write", "bash", "edit", "subagent"];
+export const MUTATING_TOOLS = [
+  "read",
+  "grep",
+  "find",
+  "ls",
+  "write",
+  "bash",
+  "edit",
+  "subagent",
+  // Codex-provider equivalents of bash/write+edit — see WM-665 above.
+  "exec_command",
+  "apply_patch",
+];
 
 export class CliNotFoundError extends Error {
   constructor(message) {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -139,11 +139,14 @@ describe("buildPiArgv", () => {
     ]);
   });
 
-  test("mutating: false → --tools read,grep,find,ls,write,bash (pi's own read-only pattern, not -r)", () => {
+  test("mutating: false → pi's own read-only pattern plus the codex names, not -r", () => {
     const argv = buildPiArgv({ def: { mutating: false }, model: null });
     expect(argv).toContain("--tools");
     expect(argv[argv.indexOf("--tools") + 1]).toBe(READ_ONLY_TOOLS.join(","));
-    expect(argv).toEqual(["-p", "--mode", "json", "--tools", "read,grep,find,ls,write,bash"]);
+    expect(argv).toEqual([
+      "-p", "--mode", "json", "--tools",
+      "read,grep,find,ls,write,bash,exec_command,apply_patch",
+    ]);
   });
 
   test("mutating: true → an explicit allowlist, never pi's implicit defaults (WM-336)", () => {
@@ -152,7 +155,24 @@ describe("buildPiArgv", () => {
     // also holds push credentials — was the least constrained agent in the fleet.
     const argv = buildPiArgv({ def: { mutating: true }, model: null });
     expect(argv).toContain("--tools");
-    expect(argv[argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,edit,subagent");
+    expect(argv[argv.indexOf("--tools") + 1]).toBe(
+      "read,grep,find,ls,write,bash,edit,subagent,exec_command,apply_patch",
+    );
+  });
+
+  // WM-665: tool names are per PROVIDER, not per pi version. On openai-codex
+  // models — what every pi.* tier in config/policy.yaml resolves to — there is
+  // no read/write/bash; the shell is exec_command and file writing is
+  // apply_patch. pi drops an unrecognized name silently, so an allowlist
+  // carrying only the other family left agents with grep/find/ls and no way to
+  // write ./result.json, failing contract_violation: missing_result after
+  // exit 0. Both mutability classes must carry a shell and a writer.
+  test("both mutability classes expose a shell and a file writer on codex models (WM-665)", () => {
+    for (const mutating of [false, true]) {
+      const tools = piTools({ mutating });
+      expect(tools).toContain("exec_command");
+      expect(tools).toContain("apply_patch");
+    }
   });
 
   test("mutating: true keeps edit and subagent — the tools that make it a dispatch agent", () => {
@@ -556,7 +576,7 @@ process.stdin.on("end", () => {
     expect(record.argv).toContain("--model");
     expect(record.argv[record.argv.indexOf("--model") + 1]).toBe("openai-codex/gpt-5.6-terra");
     expect(record.argv).toContain("--tools");
-    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash");
+    expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,exec_command,apply_patch");
 
     // 4. .transcript.json artifact capture
     const transcriptPath = path.join(workspaceDir, ".transcript.json");
@@ -868,7 +888,7 @@ describe("sandboxed execution (WM-313)", () => {
     const piArgs = req.command.slice(4);
     expect(piArgs.slice(0, 3)).toEqual(["-p", "--mode", "json"]);
     expect(piArgs[piArgs.indexOf("--model") + 1]).toBe("openai/gpt-5.6-terra");
-    expect(piArgs[piArgs.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash");
+    expect(piArgs[piArgs.indexOf("--tools") + 1]).toBe("read,grep,find,ls,write,bash,exec_command,apply_patch");
     expect(readFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), "utf8")).toBe(`You are a sandboxed test agent.${PROMPT_SUFFIX}`);
 
     // 3. Guest env is built, not inherited: no host key, no push token, no


### PR DESCRIPTION
Fixes WM-665. Unblocks WM-662 (merge-scan on pi) and is the true cause behind WM-663.

## What

Adds `exec_command` and `apply_patch` to both `READ_ONLY_TOOLS` and `MUTATING_TOOLS` in `event-runtime/lib/adapters/pi.mjs`.

## Why

pi tool names are **per provider**, not per pi version. On `openai-codex/*` models — what every `pi.*` tier in `config/policy.yaml` resolves to — there is no `read`, `write`, or `bash`. The shell is `exec_command`; file writing is `apply_patch`. `grep`/`find`/`ls` do exist, so exactly those three survived the allowlist, which made the failure look like a weak model rather than a config bug.

pi drops an unrecognized tool name **silently** — no error, no warning. So a `mutating: false` agent kept its `output_contract` obligation and lost the only tool that could satisfy it.

Two live runs, both exit 0 with no `./result.json`, both `contract_violation: missing_result`:

- `run_b66e2338-c582-4a24-a26f-f0ada6ea74b6` — `merge-scan@2` on pi/terra, whose own output was: *"Unable to create `result.json`: this session exposes no shell or file-write tool. Live GitHub/Linear evidence is therefore unavailable, so the scan must fail closed with `needs_human`."*
- `run_06cfd301-ea61-4854-834e-35bfe65583d3` — `work-scan@1`, tool census over the full transcript `ls: 8, grep: 16, find: 4`, never called write.

The agents reasoned correctly and failed closed. The configuration lied to them.

## Reproduction — outside the factory, pi 0.84.2

Broken (today's allowlist) — no file, exit 1:
```
pi --tools read,grep,find,ls,write,bash --model openai-codex/gpt-5.6-terra \
   -p 'Create result.json containing exactly {"ok":true}. Then reply DONE.'
```

Working (no `--tools`) — writes `{"ok":true}`. Same model, same prompt.

Asking the model to enumerate its tools **under the allowlist** returns only:
```
functions.grep  functions.find  functions.ls  multi_tool_use.parallel
```

With the fix applied — writes the file:
```
pi --tools read,grep,find,ls,write,bash,exec_command,apply_patch --model openai-codex/gpt-5.6-terra ...
```

## Design notes

- **Both name families are kept.** An unrecognized name is inert, so one list stays correct across providers rather than needing a per-provider branch.
- **`apply_patch` conflates write and edit**, so a `mutating: false` agent on codex does gain an edit-capable tool. That is deliberate and consistent with this module's existing stance, quoted in its own comment: *"claude.mjs likewise keeps Bash/Write/Edit for read-only agents and enforces the boundary through workspace confinement instead of tool removal."* Now stated explicitly rather than left implicit.
- This is the **third** time this list has been wrong in the same way — the comment block already records `write` missing (OPS-518) and `bash` missing (WM-301). The list being wrong is cheap; **the silence is the repeat defect.** WM-665 AC 4 tracks failing loudly (or warning) when a requested tool is not granted; not implemented here to keep this PR to the unblocking fix.

## Handoff

- PR: this one
- Verification: `bun test` → **2393 pass, 9 skip, 0 fail** across 172 files; `bun build/emit.mjs --check` → **exit 0**.
- Tests: three existing argv assertions updated (they hardcode the allowlist string deliberately, to catch silent widening), plus a new case asserting both `exec_command` and `apply_patch` are present for **both** mutability classes.
- Not vacuous: the new assertions fail against the pre-fix lists, and the end-to-end behavior was verified against the real `pi` binary, not only in unit tests.
- UX critique: skipped — no user-facing surface; this is adapter tool routing.
- Files: 2 changed (`event-runtime/lib/adapters/pi.mjs`, `event-runtime/lib/adapters/pi.test.mjs`), both within Owned Paths.
- Risks: widens the granted tool surface on codex models to include an edit-capable tool for read-only agents (see design notes). Reverting restores the broken-but-narrower list.

## Rollout

Needs a full stack restart to take effect. Confirm afterwards with a live `merge-scan@2` run producing a schema-valid `result.json` — AC 1 is explicitly a real run, not a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz