### PR TITLE
fix(tests): reap spawned runtime processes

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -26,6 +26,56 @@ WEB_PORT="${FACTORY_EVENT_WEB_PORT:-7382}"
 mkdir -p "$RUN_DIR" "$HOME_DIR"
 REPO="$(repo_root)"
 
+elapsed_seconds() {
+  local elapsed="${1//[[:space:]]/}" days=0 rest hours=0 minutes=0 seconds=0
+  rest="$elapsed"
+  if [[ "$rest" == *-* ]]; then
+    days="${rest%%-*}"
+    rest="${rest#*-}"
+  fi
+  local parts=()
+  IFS=: read -r -a parts <<<"$rest"
+  case "${#parts[@]}" in
+    2) minutes="${parts[0]}"; seconds="${parts[1]}" ;;
+    3) hours="${parts[0]}"; minutes="${parts[1]}"; seconds="${parts[2]}" ;;
+    *) return 1 ;;
+  esac
+  printf '%s\n' $((10#$days * 86400 + 10#$hours * 3600 + 10#$minutes * 60 + 10#$seconds))
+}
+
+cleanup_stale_fake_runtimes() {
+  local max_age_minutes="${FACTORY_FAKE_RUNTIME_MAX_AGE_MINUTES:-30}"
+  [[ "$max_age_minutes" =~ ^[0-9]+$ ]] || {
+    warn "ignoring invalid FACTORY_FAKE_RUNTIME_MAX_AGE_MINUTES=$max_age_minutes"
+    return 0
+  }
+
+  local pid pgid elapsed command age_seconds process_with_env seen_groups=" "
+  local current_pgid
+  current_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+  while read -r pid pgid elapsed command; do
+    [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
+    [[ "$pgid" =~ ^[0-9]+$ ]] || continue
+    [[ -z "$current_pgid" || "$pgid" != "$current_pgid" ]] || continue
+    [[ "$command" =~ event-runtime/cli\.mjs[[:space:]]+(serve|work)([[:space:]]|$) ]] || continue
+    [[ " $command " == *" --adapter-override fake "* ]] || continue
+    if [[ "$command" != *"factory-test-"* ]]; then
+      process_with_env="$(ps eww -p "$pid" -o command= 2>/dev/null || true)"
+      [[ "$process_with_env" =~ FACTORY_TEST_TRACKED_PROCESS=[^[:space:]]+ ]] || continue
+    fi
+    age_seconds="$(elapsed_seconds "$elapsed")" || continue
+    (( age_seconds >= max_age_minutes * 60 )) || continue
+    [[ "$seen_groups" == *" $pgid "* ]] && continue
+    seen_groups+="$pgid "
+
+    warn "killing stale fake-adapter test runtime pid $pid (age $elapsed): $command"
+    # The explicit test-owner marker prevents --fake live/staging stacks from
+    # being mistaken for test debris. Marked runtimes are detached group
+    # leaders, so a group kill also removes wrappers and grandchildren.
+    kill -KILL -- "-$pgid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  done < <(ps -axo pid=,pgid=,etime=,command=)
+}
+
 case "$ACTION" in
   up)
     ADAPTER_FLAG=()
@@ -371,6 +421,7 @@ case "$ACTION" in
     await_daemon "$RUN_DIR/worker.pid" "worker"
     await_daemon "$RUN_DIR/serve.pid" "event runtime"
     rm -f "$RUN_DIR"/*.pid "$RUN_DIR"/*.drain "$RUN_DIR"/*.id
+    cleanup_stale_fake_runtimes
     info "done — live factory stack is down (durable state preserved at $HOME_DIR)"
     ;;
 

--- a/event-runtime/cli/process-cleanup.test.mjs
+++ b/event-runtime/cli/process-cleanup.test.mjs
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  cleanupTrackedProcesses,
+  processOwnerWatchdogSource,
+  spawnTracked,
+  trackProcessGroupForPid,
+} from "../lib/test-helpers-process.mjs";
+
+const EVENT_RUNTIME = fileURLToPath(new URL("..", import.meta.url));
+const LIVE_STACK = fileURLToPath(
+  new URL("../../bin/live-stack.sh", import.meta.url),
+);
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+async function waitForFile(file, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return readFileSync(file, "utf8").trim();
+    } catch {}
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out waiting for ${file}`);
+}
+
+async function waitForExit(pid, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`pid ${pid} did not exit`);
+}
+
+function testFiles(root) {
+  const found = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) found.push(...testFiles(target));
+    else if (entry.name.endsWith(".test.mjs")) found.push(target);
+  }
+  return found;
+}
+
+describe("tracked test processes (WM-654)", () => {
+  test("refuses to register the test runner's own process group", () => {
+    expect(() => trackProcessGroupForPid(process.pid)).toThrow(
+      "refusing to track the test runner process group",
+    );
+  });
+
+  test("spawn failures report error without throwing before listeners attach", async () => {
+    const child = spawnTracked("factory-wm654-command-does-not-exist", [], {
+      stdio: "ignore",
+    });
+    const error = await new Promise((resolve) => child.once("error", resolve));
+    expect(error.code).toBe("ENOENT");
+  });
+
+  test("detached fixtures self-destruct when their test owner disappears", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-owner-watch-"));
+    const script = path.join(dir, "fixture.mjs");
+    writeFileSync(
+      script,
+      `${processOwnerWatchdogSource(2_147_483_646)}\nsetInterval(() => {}, 10_000);\n`,
+      "utf8",
+    );
+    const child = spawnTracked("bun", [script], { stdio: "ignore" });
+    const result = await new Promise((resolve) =>
+      child.once("exit", (code, signal) => resolve({ code, signal })),
+    );
+    expect(result).toEqual({ code: null, signal: "SIGKILL" });
+  });
+
+  test("cleanup kills a spawned wrapper and its long-lived grandchild", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tracked-group-"));
+    const pidFile = path.join(dir, "grandchild.pid");
+    const child = spawnTracked(
+      "bash",
+      ["-c", `sleep 60 & printf '%s\\n' "$!" > ${JSON.stringify(pidFile)}; wait`],
+      { stdio: "ignore" },
+    );
+    const grandchildPid = Number(await waitForFile(pidFile));
+    expect(processExists(child.pid)).toBe(true);
+    expect(processExists(grandchildPid)).toBe(true);
+
+    await cleanupTrackedProcesses();
+
+    await waitForExit(child.pid);
+    await waitForExit(grandchildPid);
+  });
+
+  test("live-stack down warns and kills old fake-adapter test runtimes", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-stale-fake-"));
+    const fakeCli = path.join(dir, "event-runtime", "cli.mjs");
+    mkdirSync(path.dirname(fakeCli), { recursive: true });
+    writeFileSync(fakeCli, "setInterval(() => {}, 10_000);\n", "utf8");
+    const child = spawnTracked(
+      "bun",
+      [fakeCli, "serve", "--adapter-override", "fake"],
+      { stdio: "ignore" },
+    );
+
+    const result = spawnSync("bash", [LIVE_STACK, "down"], {
+      cwd: path.dirname(EVENT_RUNTIME),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FACTORY_EVENT_HOME: path.join(dir, "home"),
+        FACTORY_RUN_DIR: path.join(dir, "run"),
+        FACTORY_FAKE_RUNTIME_MAX_AGE_MINUTES: "0",
+      },
+    });
+
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      `killing stale fake-adapter test runtime pid ${child.pid}`,
+    );
+    expect(result.status).toBe(0);
+    await waitForExit(child.pid);
+  });
+
+  test("live-stack down leaves unmarked fake-adapter runtimes alone", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-unmarked-fake-"));
+    const fakeCli = path.join(dir, "event-runtime", "cli.mjs");
+    mkdirSync(path.dirname(fakeCli), { recursive: true });
+    writeFileSync(fakeCli, "setInterval(() => {}, 10_000);\n", "utf8");
+    const args = [fakeCli, "serve", "--adapter-override", "fake"];
+    const child = spawn("bun", args, {
+      detached: process.platform !== "win32",
+      stdio: "ignore",
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => key !== "FACTORY_TEST_TRACKED_PROCESS"),
+      ),
+    });
+    try {
+      const result = spawnSync("bash", [LIVE_STACK, "down"], {
+        cwd: path.dirname(EVENT_RUNTIME),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FACTORY_EVENT_HOME: path.join(dir, "home"),
+          FACTORY_RUN_DIR: path.join(dir, "run"),
+          FACTORY_FAKE_RUNTIME_MAX_AGE_MINUTES: "0",
+        },
+      });
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).not.toContain(
+        `fake-adapter test runtime pid ${child.pid}`,
+      );
+      expect(processExists(child.pid)).toBe(true);
+    } finally {
+      if (process.platform === "win32") child.kill("SIGKILL");
+      else process.kill(-child.pid, "SIGKILL");
+      await waitForExit(child.pid);
+    }
+  });
+
+  test("event-runtime tests never spawn cli.mjs serve/work without spawnTracked", () => {
+    const offenders = [];
+    const directSpawn = new RegExp("\\bspawn\\s*\\(", "g");
+    for (const file of testFiles(EVENT_RUNTIME)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(directSpawn)) {
+        const call = source.slice(match.index, match.index + 800);
+        const closesAt = call.indexOf(");");
+        const invocation = closesAt >= 0 ? call.slice(0, closesAt) : call;
+        if (
+          /(?:\bCLI\b|cli\.mjs)/.test(invocation) &&
+          /["'](?:serve|work)["']/.test(invocation)
+        ) {
+          offenders.push(path.relative(EVENT_RUNTIME, file));
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -23,6 +23,7 @@ import {
   runCli,
   runNotifierDeliveryCase,
   seedRun,
+  spawnTracked,
   spawnSupervisor,
   spawnWorker,
   waitFor,
@@ -32,7 +33,7 @@ describe("serve command", () => {
   test("serve --watch re-execs under bun --watch and binds", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-watch-"));
     const port = String(59000 + (process.pid % 800));
-    const child = spawn("bun", [CLI, "serve", "--watch", "--port", port], {
+    const child = spawnTracked("bun", [CLI, "serve", "--watch", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -58,7 +59,7 @@ describe("serve command", () => {
   test("serve binds the control API, starts the loop, and answers /health", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-serve-"));
     const port = String(59800 + (process.pid % 100));
-    const child = spawn("bun", [CLI, "serve", "--port", port], {
+    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -89,7 +90,7 @@ describe("serve command", () => {
   test("serve --adapter-override pi is accepted at the serve call site (OPS-517)", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-serve-pi-"));
     const port = String(59800 + (process.pid % 150));
-    const child = spawn(
+    const child = spawnTracked(
       "bun",
       [CLI, "serve", "--adapter-override", "pi", "--port", port],
       {

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -23,6 +23,7 @@ import {
   runCli,
   runNotifierDeliveryCase,
   seedRun,
+  spawnTracked,
   spawnSupervisor,
   spawnWorker,
   throwawayRunDir,
@@ -116,7 +117,7 @@ describe("status and doctor commands", () => {
   test("doctor against a healthy live serve outputs anomalies none and exits 0", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-doc-healthy-"));
     const port = String(59700 + (process.pid % 100));
-    const child = spawn("bun", [CLI, "serve", "--port", port], {
+    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env: {
         ...process.env,
         FACTORY_EVENT_HOME: home,
@@ -178,7 +179,7 @@ describe("status and doctor commands", () => {
     );
     db.close();
 
-    const child = spawn("bun", [CLI, "serve", "--port", port], {
+    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -1,5 +1,5 @@
 import { expect } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -13,6 +13,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
+export {
+  cleanupTrackedProcesses,
+  processOwnerWatchdogSource,
+  spawnTracked,
+  trackMarkedFakeRuntimeGroups,
+  trackProcess,
+  trackProcessGroupForPid,
+  trackProcessGroupsMatching,
+} from "../lib/test-helpers-process.mjs";
+import { spawnTracked, trackProcess } from "../lib/test-helpers-process.mjs";
 
 export const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
 
@@ -80,21 +90,22 @@ export function writeGatedNotifier(dir, { exitCode = 0 } = {}) {
   const outFile = path.join(dir, "pushes.txt");
   const startedFile = path.join(dir, "notifier-started");
   const releaseFile = path.join(dir, "notifier-release");
+  const pidFile = path.join(dir, "notifier.pid");
   const stub = path.join(dir, "notify-stub.sh");
   // The child advertises that it is pending, then waits for the test's explicit
   // release condition. A visible message alone is deliberately insufficient.
   writeFileSync(
     stub,
-    `#!/bin/sh\nprintf '%s\\n' "$1" >> ${outFile}\n: > ${startedFile}\nwhile [ ! -f ${releaseFile} ]; do sleep 0.01; done\nexit ${exitCode}\n`,
+    `#!/bin/sh\nprintf '%s\\n' "$$" > ${pidFile}\nprintf '%s\\n' "$1" >> ${outFile}\n: > ${startedFile}\nwhile [ ! -f ${releaseFile} ]; do sleep 0.01; done\nexit ${exitCode}\n`,
   );
   spawnSync("chmod", ["+x", stub]);
-  return { outFile, startedFile, releaseFile, stub };
+  return { outFile, pidFile, startedFile, releaseFile, stub };
 }
 
 export async function assertHealthyLiveServe() {
   const home = mkdtempSync(path.join(os.tmpdir(), "evrt-doc-healthy-"));
   const port = String(59700 + (process.pid % 100));
-  const child = spawn("bun", [CLI, "serve", "--port", port], {
+  const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
     env: {
       ...process.env,
       FACTORY_EVENT_HOME: home,
@@ -141,7 +152,7 @@ export async function runNotifierDeliveryCase({
   const { tick } = await import("../cli.mjs");
   const { loadRegistry } = await import("../lib/registry.mjs");
   const dir = mkdtempSync(path.join(os.tmpdir(), "evrt-tick-notify-"));
-  const { outFile, startedFile, releaseFile, stub } = writeGatedNotifier(dir);
+  const { outFile, pidFile, startedFile, releaseFile, stub } = writeGatedNotifier(dir);
   const db = openDb(path.join(dir, "runtime.db"));
   const at = new Date().toISOString();
   db.query(
@@ -171,6 +182,7 @@ export async function runNotifierDeliveryCase({
     });
     deliveryStarted = true;
     await awaitFile(startedFile, "notifier start");
+    trackProcess(Number(readFileSync(pidFile, "utf8").trim()), { group: false });
     if (failWhilePending)
       throw new Error(
         "intentional assertion failure while notifier delivery is pending",
@@ -240,7 +252,7 @@ export function editStampRoot(root, body) {
 
 /** Spawn a worker, collecting stdout+stderr into one buffer. */
 export function spawnWorker(args, env) {
-  const child = spawn("bun", [CLI, "work", ...args], {
+  const child = spawnTracked("bun", [CLI, "work", ...args], {
     env: { ...process.env, ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -304,7 +316,7 @@ export async function seedRun(home, { runId, input = {}, timeoutSeconds = 5 }) {
 }
 
 export function spawnSupervisor(args, env) {
-  const child = spawn("bun", [CLI, "supervise", ...args], {
+  const child = spawnTracked("bun", [CLI, "supervise", ...args], {
     env: { ...process.env, ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -24,6 +24,7 @@ import {
   runCli,
   runNotifierDeliveryCase,
   seedRun,
+  spawnTracked,
   spawnSupervisor,
   spawnWorker,
   waitFor,
@@ -200,7 +201,7 @@ describe("work command", () => {
     });
     db.close();
 
-    const child = spawn("bun", [CLI, "work", "--adapter-override", "fake"], {
+    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "fake"], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -240,7 +241,7 @@ describe("work command", () => {
 
   test("work --adapter-override pi is accepted at the work call site (OPS-517)", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-pi-"));
-    const child = spawn("bun", [CLI, "work", "--adapter-override", "pi"], {
+    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "pi"], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -462,7 +463,7 @@ describe("work command", () => {
 
   test("work --adapter-override cursor is accepted at the work call site (WM-440)", async () => {
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-work-cursor-"));
-    const child = spawn("bun", [CLI, "work", "--adapter-override", "cursor"], {
+    const child = spawnTracked("bun", [CLI, "work", "--adapter-override", "cursor"], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -1,10 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { validate } from "../lib/schema.mjs";
+import { spawnTracked } from "../lib/test-helpers-process.mjs";
 
 const CLI = fileURLToPath(new URL("../cli.mjs", import.meta.url));
 const SEED = fileURLToPath(new URL("./seed.mjs", import.meta.url));
@@ -118,10 +119,10 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     port = String(probe.port);
     probe.stop(true);
 
-    serveChild = spawn("bun", [CLI, "serve", "--adapter-override", "fake", "--port", port], {
+    serveChild = spawnTracked("bun", [CLI, "serve", "--adapter-override", "fake", "--port", port], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
-    });
+    }, { scope: "suite" });
 
     // Wait for health
     let up = false;
@@ -138,10 +139,10 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
     }
     expect(up).toBe(true);
 
-    workerChild = spawn("bun", [CLI, "work", "--adapter-override", "fake", "--port", port, "--poll-ms", "40"], {
+    workerChild = spawnTracked("bun", [CLI, "work", "--adapter-override", "fake", "--port", port, "--poll-ms", "40"], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
-    });
+    }, { scope: "suite" });
 
     // Health only proves the control API is listening. Seed drives approvals
     // immediately, so wait for the separate worker process to register first.

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -20,6 +20,7 @@ import {
   WRITE_TOOLS,
 } from "./claude.mjs";
 import { SandboxUnsupportedError } from "./sandboxed.mjs";
+import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
 
 describe("sandbox decision (WM-313): deferred, so refused — never ignored", () => {
   const sandboxedDef = (promptPath) => ({
@@ -383,6 +384,8 @@ describe("execute conformance (OPS-427, docs/event-runtime.md §6)", () => {
   const stubScript = `#!/usr/bin/env bun
 import { writeFileSync } from "node:fs";
 
+${processOwnerWatchdogSource()}
+
 if (process.env.FACTORY_TEST_RECORD_FILE) {
   writeFileSync(
     process.env.FACTORY_TEST_RECORD_FILE,
@@ -554,7 +557,11 @@ if (behavior === "emit_denial_then_recovery") {
 
   async function waitForGrandchildPid(pidFile) {
     for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      if (existsSync(pidFile)) {
+        const pid = Number(readFileSync(pidFile, "utf8"));
+        trackProcessGroupForPid(pid);
+        return pid;
+      }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     throw new Error("stub did not report its grandchild PID");

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -18,6 +18,7 @@ import {
   safeChildEnvironment,
   toolNameFromKey,
 } from "./cursor.mjs";
+import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed Cursor refusal shapes yet)", () => {
   test("nothing matches — empty until a Cursor-authored shape is observed", () => {
@@ -256,6 +257,8 @@ describe("execute conformance (WM-440, docs/event-runtime.md §6)", () => {
   const stubScript = `#!/usr/bin/env bun
 import { writeFileSync } from "node:fs";
 
+${processOwnerWatchdogSource()}
+
 if (process.env.FACTORY_TEST_RECORD_FILE) {
   writeFileSync(
     process.env.FACTORY_TEST_RECORD_FILE,
@@ -362,7 +365,11 @@ if (behavior === "emit_error_tool_result") {
 
   async function waitForGrandchildPid(pidFile) {
     for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      if (existsSync(pidFile)) {
+        const pid = Number(readFileSync(pidFile, "utf8"));
+        trackProcessGroupForPid(pid);
+        return pid;
+      }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     throw new Error("stub did not report its grandchild PID");

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "./pi.mjs";
 import { preflight, SandboxUnavailableError } from "../sandbox/gondolin.mjs";
 import { SANDBOX_CONSOLE_FILE } from "./sandboxed.mjs";
+import { processOwnerWatchdogSource, trackProcessGroupForPid } from "../test-helpers-process.mjs";
 
 describe("isHarnessDenial (WM-127, no confirmed pi refusal shapes yet)", () => {
   test("nothing matches — pi enforces read-only by tool non-exposure, not runtime denial", () => {
@@ -372,6 +373,8 @@ describe("execute conformance (OPS-296, docs/event-runtime.md §6)", () => {
   const stubScript = `#!/usr/bin/env bun
 import { writeFileSync } from "node:fs";
 
+${processOwnerWatchdogSource()}
+
 let stdin = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => { stdin += chunk; });
@@ -492,7 +495,11 @@ process.stdin.on("end", () => {
 
   async function waitForGrandchildPid(pidFile) {
     for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) return Number(readFileSync(pidFile, "utf8"));
+      if (existsSync(pidFile)) {
+        const pid = Number(readFileSync(pidFile, "utf8"));
+        trackProcessGroupForPid(pid);
+        return pid;
+      }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     throw new Error("stub did not report its grandchild PID");

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
+import { spawnTracked } from "./test-helpers-process.mjs";
 import {
   GH_SECRET,
   PV,
@@ -485,11 +486,10 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
   });
 
   test("serve with invalid non-numeric FACTORY_EVENT_PORT fails loudly", async () => {
-    const { spawn } = await import("node:child_process");
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-port-err-"));
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
 
-    const child = spawn("bun", [CLI, "serve"], {
+    const child = spawnTracked("bun", [CLI, "serve"], {
       env: {
         ...process.env,
         FACTORY_EVENT_HOME: home,
@@ -508,7 +508,6 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
   });
 
   test("serve startup banner warns when FACTORY_EVENT_SECRET is unset", async () => {
-    const { spawn } = await import("node:child_process");
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-banner-"));
     const port = String(59600 + (process.pid % 200));
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
@@ -516,7 +515,7 @@ describe("missing FACTORY_EVENT_SECRET and FACTORY_GITHUB_WEBHOOK_SECRET visibil
     const env = { ...process.env, FACTORY_EVENT_HOME: home };
     delete env.FACTORY_EVENT_SECRET;
 
-    const child = spawn("bun", [CLI, "serve", "--port", port], {
+    const child = spawnTracked("bun", [CLI, "serve", "--port", port], {
       env,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -36,6 +36,7 @@ import {
 } from "./api-test-helpers.mjs";
 import { cpSync } from "node:fs";
 import { emitDueTicks } from "./schedules.mjs";
+import { spawnTracked } from "./test-helpers-process.mjs";
 
 describe("schedule trigger metadata (WM-259)", () => {
   test("run and trigger return the unchanged next scheduled tick", async () => {
@@ -250,13 +251,12 @@ describe("serve PID lock (OPS-458)", () => {
   });
 
   test("concurrent duplicate serve on same home fails second instance and releasing first allows next", async () => {
-    const { spawn } = await import("node:child_process");
     const home = mkdtempSync(path.join(os.tmpdir(), "evrt-lock-cli-"));
     const port1 = String(59500 + (process.pid % 200));
     const port2 = String(59700 + (process.pid % 200));
     const CLI = path.resolve(import.meta.dir, "../cli.mjs");
 
-    const serve1 = spawn("bun", [CLI, "serve", "--port", port1], {
+    const serve1 = spawnTracked("bun", [CLI, "serve", "--port", port1], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -276,7 +276,7 @@ describe("serve PID lock (OPS-458)", () => {
     expect(out1).toContain("control API on");
 
     // Second serve targeting same home should fail immediately
-    const serve2 = spawn("bun", [CLI, "serve", "--port", port2], {
+    const serve2 = spawnTracked("bun", [CLI, "serve", "--port", port2], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -298,7 +298,7 @@ describe("serve PID lock (OPS-458)", () => {
     await new Promise((resolve) => serve1.on("exit", resolve));
 
     // Now a third serve should succeed
-    const serve3 = spawn("bun", [CLI, "serve", "--port", port2], {
+    const serve3 = spawnTracked("bun", [CLI, "serve", "--port", port2], {
       env: { ...process.env, FACTORY_EVENT_HOME: home },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -1,0 +1,214 @@
+import { afterAll, afterEach } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+
+const tracked = new Map();
+let handlingSignal = false;
+const defaultTestMarker = `spawn-tracked-${process.pid}`;
+
+function processGroupForPid(pid) {
+  if (process.platform === "win32") return null;
+  const result = spawnSync("ps", ["-o", "pgid=", "-p", String(pid)], {
+    encoding: "utf8",
+  });
+  const pgid = Number(result.stdout.trim());
+  return result.status === 0 && Number.isInteger(pgid) && pgid > 0 ? pgid : null;
+}
+
+const testRunnerPgid = processGroupForPid(process.pid);
+
+function keyFor({ pid, group }) {
+  return `${group ? "group" : "pid"}:${pid}`;
+}
+
+function signalTracked(entry, signal) {
+  try {
+    if (entry.group && process.platform !== "win32") {
+      process.kill(-entry.pid, signal);
+    } else {
+      process.kill(entry.pid, signal);
+    }
+    return true;
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+    return false;
+  }
+}
+
+function isAlive(entry) {
+  try {
+    if (entry.group && process.platform !== "win32") {
+      process.kill(-entry.pid, 0);
+    } else {
+      process.kill(entry.pid, 0);
+    }
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+/**
+ * Register an already-running test process (or detached process group).
+ * Adapter tests use this after a fixture reports a PID owned by the adapter's
+ * detached group; notifier fixtures use group:false because they have no
+ * descendants and share the test runner's process group.
+ */
+export function trackProcess(pid, { group = true, scope = "test" } = {}) {
+  if (!Number.isInteger(Number(pid)) || Number(pid) <= 0) {
+    throw new Error(`cannot track invalid test process pid ${pid}`);
+  }
+  const entry = { pid: Number(pid), group, scope };
+  if (entry.group && testRunnerPgid !== null && entry.pid === testRunnerPgid) {
+    throw new Error(`refusing to track the test runner process group ${testRunnerPgid}`);
+  }
+  tracked.set(keyFor(entry), entry);
+  return entry;
+}
+
+/** Find and register the detached process group containing pid. */
+export function trackProcessGroupForPid(pid, options = {}) {
+  if (process.platform === "win32") return trackProcess(pid, { ...options, group: false });
+  const pgid = processGroupForPid(pid);
+  if (pgid === null) {
+    throw new Error(`could not resolve process group for test pid ${pid}`);
+  }
+  return trackProcess(pgid, { ...options, group: true });
+}
+
+/** Register every process group whose current command contains fragment. */
+export function trackProcessGroupsMatching(fragment, options = {}) {
+  if (!fragment) throw new Error("process-group command fragment is required");
+  const result = spawnSync("ps", ["-axo", "pid=,pgid=,command="], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) throw new Error("could not inspect test process groups");
+  for (const line of result.stdout.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match || !match[3].includes(fragment)) continue;
+    const pgid = Number(match[2]);
+    if (pgid > 0 && pgid !== testRunnerPgid) {
+      trackProcess(pgid, { ...options, group: process.platform !== "win32" });
+    }
+  }
+}
+
+/** Register fake-runtime groups carrying one exact test-owner marker. */
+export function trackMarkedFakeRuntimeGroups(marker, options = {}) {
+  if (!marker) throw new Error("test process marker is required");
+  const result = spawnSync("ps", ["-axo", "pid=,pgid=,command="], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) throw new Error("could not inspect marked test process groups");
+  for (const line of result.stdout.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match) continue;
+    const [, pid, pgid, command] = match;
+    if (!/event-runtime\/cli\.mjs\s+(serve|work)(\s|$)/.test(command)) continue;
+    if (!/(^|\s)--adapter-override\s+fake(\s|$)/.test(command)) continue;
+    if (!command.includes(`factory-test-${marker}`)) {
+      const withEnv = spawnSync("ps", ["eww", "-p", pid, "-o", "command="], {
+        encoding: "utf8",
+      }).stdout;
+      if (!withEnv.includes(`FACTORY_TEST_TRACKED_PROCESS=${marker}`)) continue;
+    }
+    const group = Number(pgid);
+    if (group > 0 && group !== testRunnerPgid) trackProcess(group, options);
+  }
+}
+
+/**
+ * Source embedded in detached adapter/wrapper fixtures. A SIGKILLed Bun test
+ * process cannot run hooks, so each detached fixture also watches its original
+ * owner and destroys its own process group if that owner disappears.
+ */
+export function processOwnerWatchdogSource(ownerPid = process.pid) {
+  if (!Number.isInteger(Number(ownerPid)) || Number(ownerPid) <= 0) {
+    throw new Error(`cannot watch invalid test owner pid ${ownerPid}`);
+  }
+  return [
+    `const __factoryTestOwnerPid = ${Number(ownerPid)};`,
+    "const __factoryTestOwnerWatch = setInterval(() => {",
+    "  try { process.kill(__factoryTestOwnerPid, 0); } catch {",
+    "    try { process.kill(-process.pid, \"SIGKILL\"); } catch { process.exit(1); }",
+    "  }",
+    "}, 100);",
+    "__factoryTestOwnerWatch.unref?.();",
+  ].join("\n");
+}
+
+/**
+ * Spawn a test-owned child in a new process group and register it immediately.
+ * child.kill() is intentionally upgraded to signal the whole group, preserving
+ * existing test cleanup while making wrappers and grandchildren impossible to
+ * orphan.
+ */
+export function spawnTracked(command, args = [], options = {}, tracking = {}) {
+  const marker = options.env?.FACTORY_TEST_TRACKED_PROCESS ?? defaultTestMarker;
+  const childEnv = options.env
+    ? { ...options.env, FACTORY_TEST_TRACKED_PROCESS: marker }
+    : { ...process.env, FACTORY_TEST_TRACKED_PROCESS: marker };
+  const child = spawn(command, args, {
+    ...options,
+    argv0: options.argv0 ?? `factory-test-${marker}`,
+    env: childEnv,
+    detached: process.platform !== "win32",
+  });
+  let entry = null;
+  child.once("error", () => {
+    if (entry) tracked.delete(keyFor(entry));
+  });
+  if (!child.pid) return child;
+  entry = trackProcess(child.pid, {
+    group: process.platform !== "win32",
+    scope: tracking.scope ?? "test",
+  });
+  const originalKill = child.kill.bind(child);
+  child.kill = (signal = "SIGTERM") => {
+    if (process.platform === "win32") return originalKill(signal);
+    return signalTracked(entry, signal);
+  };
+  child.once("exit", () => {
+    // A wrapper can exit before its descendants. Sweep the group once more
+    // before forgetting it; ESRCH is the normal clean-exit case.
+    signalTracked(entry, "SIGKILL");
+    tracked.delete(keyFor(entry));
+  });
+  return child;
+}
+
+export async function cleanupTrackedProcesses({ scope = "all", graceMs = 250 } = {}) {
+  const entries = [...tracked.values()].filter((entry) => scope === "all" || entry.scope === scope);
+  for (const entry of entries) signalTracked(entry, "SIGTERM");
+
+  if (graceMs > 0 && entries.some(isAlive)) {
+    await new Promise((resolve) => setTimeout(resolve, graceMs));
+  }
+
+  for (const entry of entries) {
+    if (isAlive(entry)) signalTracked(entry, "SIGKILL");
+    tracked.delete(keyFor(entry));
+  }
+}
+
+function cleanupTrackedProcessesSync() {
+  for (const entry of tracked.values()) signalTracked(entry, "SIGKILL");
+  tracked.clear();
+}
+
+afterEach(() => cleanupTrackedProcesses({ scope: "test" }));
+afterAll(() => cleanupTrackedProcesses({ scope: "all" }));
+process.once("exit", cleanupTrackedProcessesSync);
+
+// Bun may terminate a timed-out test file with a signal, which does not emit
+// "exit" by itself. Re-raise after the synchronous group sweep so the original
+// signal semantics and exit status are preserved.
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  const handler = () => {
+    if (handlingSignal) return;
+    handlingSignal = true;
+    cleanupTrackedProcessesSync();
+    process.off(signal, handler);
+    process.kill(process.pid, signal);
+  };
+  process.on(signal, handler);
+}

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { buildClaudeArgv, execute as executeClaude } from "./adapters/claude.mjs";
@@ -24,6 +24,7 @@ import {
   repositoryStatus, resolveLinearApiKey, retryRun, runLinearCli, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
+import { cleanupTrackedProcesses, processOwnerWatchdogSource, trackMarkedFakeRuntimeGroups, trackProcess, trackProcessGroupsMatching } from "./test-helpers-process.mjs";
 
 const registry = loadRegistry();
 const adapters = { fake };
@@ -2550,12 +2551,14 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     );
 
     const testPortBase = 18400 + Math.floor(Math.random() * 1000) * 2;
+    const testProcessMarker = `wm334-${process.pid}-${ticket}`;
 
     const bunStubLines = [
       "#!/usr/bin/env node",
       "const fs = require(\"fs\");",
       "const path = require(\"path\");",
       "const { spawn } = require(\"child_process\");",
+      ...processOwnerWatchdogSource().split("\n"),
       `const stateDir = process.env.WM334_LINEAR_STATE_DIR || ${JSON.stringify(linearStateDir)}`,
       `const realBun = process.env.WM334_REAL_BUN || ${JSON.stringify(realBun)}`,
       "const args = process.argv.slice(2);",
@@ -2615,7 +2618,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       "}",
       "const child = spawn(realBun, args, {",
       "  stdio: \"inherit\",",
-      "  env: process.env,",
+      `  argv0: ${JSON.stringify(`factory-test-${testProcessMarker}`)},`,
+      `  env: { ...process.env, FACTORY_TEST_TRACKED_PROCESS: ${JSON.stringify(testProcessMarker)} },`,
       "});",
       "process.on(\"SIGTERM\", () => child.kill(\"SIGTERM\"));",
       "process.on(\"SIGINT\", () => child.kill(\"SIGINT\"));",
@@ -2666,6 +2670,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       WM334_LINEAR_STATE_DIR: process.env.WM334_LINEAR_STATE_DIR,
       WM334_REAL_BUN: process.env.WM334_REAL_BUN,
       WM334_BUN_LOG: process.env.WM334_BUN_LOG,
+      FACTORY_TEST_TRACKED_PROCESS: process.env.FACTORY_TEST_TRACKED_PROCESS,
     };
     try {
       process.env.FACTORY_REPOS_ROOT = tmpRoot;
@@ -2678,6 +2683,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       process.env.WM334_LINEAR_STATE_DIR = linearStateDir;
       process.env.WM334_REAL_BUN = realBun;
       process.env.WM334_BUN_LOG = path.join(tmpRoot, 'bun-calls.log');
+      process.env.FACTORY_TEST_TRACKED_PROCESS = testProcessMarker;
 
       const db = openDb(":memory:");
       const lockDir = mkdtempSync(path.join(os.tmpdir(), "wm334-real-locks-"));
@@ -2728,18 +2734,30 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           input: { repo: repoName, ticket },
           workspace: { type: "worktree", checkoutDir: "repo", retainOnFailure: false },
         }));
-        return runOnce(db, registry, { fake: observedAdapter }, opts({
-          workspacesRoot: mkdtempSync(path.join(os.tmpdir(), `${repoName}-run-`)),
-          dispatch: {
-            locksDir: lockDir,
-            leasesDir: leaseDir,
-            fetchTicket: () => readyDispatchTicket(ticket),
-            fetchInFlight: () => [],
-            countLeases: () => 0,
-            claimTicket: () => ({ ok: true }),
-            blockBaselineTicket: blockTicket,
-          },
-        }));
+        try {
+          return await runOnce(db, registry, { fake: observedAdapter }, opts({
+            workspacesRoot: mkdtempSync(path.join(os.tmpdir(), `${repoName}-run-`)),
+            dispatch: {
+              locksDir: lockDir,
+              leasesDir: leaseDir,
+              fetchTicket: () => readyDispatchTicket(ticket),
+              fetchInFlight: () => [],
+              countLeases: () => 0,
+              claimTicket: () => ({ ok: true }),
+              blockBaselineTicket: blockTicket,
+            },
+          }));
+        } finally {
+          trackProcessGroupsMatching(tmpRoot);
+          trackMarkedFakeRuntimeGroups(testProcessMarker);
+          const runDir = path.join(worktreeRoot, ticket, ".factory", "run");
+          if (existsSync(runDir)) {
+            for (const name of readdirSync(runDir).filter((entry) => entry.endsWith(".pid"))) {
+              const pid = Number(readFileSync(path.join(runDir, name), "utf8").trim());
+              if (Number.isInteger(pid) && pid > 0) trackProcess(pid);
+            }
+          }
+        }
       };
 
       const first = await run();
@@ -2771,6 +2789,9 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       });
       expect(comments[0].body).toContain(`<!-- ${marker} -->`);
     } finally {
+      trackProcessGroupsMatching(tmpRoot);
+      trackMarkedFakeRuntimeGroups(testProcessMarker);
+      await cleanupTrackedProcesses();
       if (detachedBaseBranch) {
         spawnSync("git", ["-C", repoRoot, "update-ref", "-d", `refs/remotes/origin/${detachedBaseBranch}`]);
       }


### PR DESCRIPTION
## Summary
- add process-group-aware `spawnTracked()` cleanup with test hooks, signal handling, and owner watchdogs
- migrate CLI serve/work test processes and adapter fixtures to tracked cleanup
- make `live-stack down` reap only marked stale fake-adapter test runtimes while preserving legitimate fake stacks
- cover group cleanup, owner loss, false-positive protection, spawn errors, and direct CLI spawn regressions

## Verification
- `bun test event-runtime/lib/adapters event-runtime/cli && pgrep -fc 'adapter-override fake' ; test $? -eq 1` — pass (246 tests, 5 VM-only skips; pgrep 0)\n- `bun test event-runtime/lib/worker.test.mjs -t 'worktree-up handles an actual baseline-red repo verification'` — pass\n- `bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-intake.test.mjs event-runtime/demo/seed.test.mjs` — pass (29 tests)\n\nUX critique: skipped — test/process infrastructure only; no user-facing flow\n\nFixes WM-654