### PR TITLE
refactor(event-runtime): de-hardcode agent refs from kernel control flow

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -225,6 +225,9 @@ through the runtime's existing `claude` adapter
 tier-2 workspace from §5. Same registry, same conformance bar, same
 lifecycle, same receipts as every other run — repository mutation is a
 capability and a workspace type, not a parallel execution path.
+Every worktree agent passes the dispatch gate unless its definition declares
+`dispatchGateExempt: true`, which registry validation permits only on a
+`workspace.type: worktree` definition.
 
 **Rejected: a closed command template shelling to `runners/run-agent.sh`.**
 It looks like less work — the runner already spawns ticket-shaped sessions —
@@ -300,6 +303,10 @@ The failure this prevents: earned-automation creep quietly consuming the one
 decision the whole factory routes through a human. Every other gate here may
 someday relax on evidence; this one may not, and the place that says so is a
 validator, not a paragraph.
+
+Command-emitted chain authority is definition data: `chainCommandEdges`
+declares its registered event types, and `chainRepoMustMatchInput: true`
+requires the emitted repository to match the predecessor input.
 
 ---
 

--- a/event-runtime/agents/merge-apply.json
+++ b/event-runtime/agents/merge-apply.json
@@ -5,6 +5,10 @@
   "input_schema": "schemas/merge-apply.input.json",
   "output_schema": "schemas/merge-applied.output.json",
   "output_contract": "factory.merge-applied/v2",
+  "chainCommandEdges": [
+    "factory.merge.requested",
+    "factory.merge-landed"
+  ],
   "itemsField": "plan",
   "itemKey": "ticket",
   "actionRegistry": {

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -6,7 +6,7 @@
   "output_schema": "schemas/merge-fix.output.json",
   "output_contract": "factory.merge-fix-result/v1",
   "model_tier": "standard",
-  "gate": "merge-fix",
+  "dispatchGateExempt": true,
   "workspace": {
     "type": "worktree",
     "checkoutDir": "repo",

--- a/event-runtime/agents/merge-verify.json
+++ b/event-runtime/agents/merge-verify.json
@@ -5,6 +5,10 @@
   "input_schema": "schemas/merge-verify.input.json",
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
+  "chainCommandEdges": [
+    "factory.merge.requested"
+  ],
+  "chainRepoMustMatchInput": true,
   "command": [
     "sh",
     "-c",

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -296,16 +296,19 @@ function dispatchSafe(envelope, approvalPolicy, dispatchEligibility, dispatch) {
   return null;
 }
 
-function mergeBarrierReason(db, candidate, now) {
+function mergeBarrierReason(db, registry, candidate, now) {
+  const applyAgent = registry.eventTypes["factory.merge-apply.requested"]?.agent;
+  const verifyAgent = registry.eventTypes["factory.merge-landed"]?.agent;
+  if (!applyAgent || !verifyAgent) return "merge_barrier_registry_incomplete";
   const inFlight = db
     .query(
       `SELECT run_id, state, spec_json, created_at FROM runs
      WHERE run_id != ?
        AND state IN ('QUEUED','LEASED','RUNNING','VERIFYING')
-       AND json_extract(spec_json, '$.agent') IN ('merge-apply@2','merge-verify@1')
+       AND json_extract(spec_json, '$.agent') IN (?, ?)
      ORDER BY created_at, rowid`,
     )
-    .all(candidate.run_id);
+    .all(candidate.run_id, applyAgent, verifyAgent);
   for (const run of inFlight) {
     let timeoutSeconds;
     try {
@@ -336,22 +339,14 @@ function mergeBarrierReason(db, candidate, now) {
        AND NOT EXISTS (
          SELECT 1 FROM proposals p JOIN runs r ON r.run_id = p.run_id
          WHERE p.event_source = e.source AND p.event_id = e.event_id
-           AND json_extract(r.spec_json, '$.agent') = 'merge-verify@1'
+           AND json_extract(r.spec_json, '$.agent') = ?
            AND r.state = 'COMPLETED'
        )
      LIMIT 1`,
     )
-    .get();
+    .get(verifyAgent);
   return unverified ? `merge_barrier_unverified:${unverified.event_id}` : null;
 }
-
-const REGISTERED_COMMAND_EDGES = {
-  "merge-apply@2": new Set([
-    "factory.merge.requested",
-    "factory.merge-landed",
-  ]),
-  "merge-verify@1": new Set(["factory.merge.requested"]),
-};
 
 function chainContextValue(expr, context) {
   if (typeof expr !== "string" || !expr.startsWith("$.")) return expr;
@@ -488,7 +483,8 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     result,
     envelope,
   );
-  const commandEdge = REGISTERED_COMMAND_EDGES[spec.agent]?.has(envelope.type);
+  const predecessorDef = registry.agents.get(spec.agent);
+  const commandEdge = predecessorDef?.chainCommandEdges?.includes(envelope.type);
   if (
     declaredEdge?.eventType !== envelope.type &&
     !independentEdge &&
@@ -497,32 +493,39 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
     return "chain_edge_not_registered";
 
   // Registered command edges carry immutable identity from their predecessor.
-  // Recheck those pins here instead of trusting event payload text.
-  if (spec.agent === "merge-apply@2") {
+  // Recheck target-required fields that originate in the source input (or its
+  // selected item) instead of trusting event payload text. This preserves the
+  // exact command-edge pins without keying the kernel on a pack agent id.
+  if (commandEdge) {
     const source = spec.input ?? {};
-    const item = source.plan?.[0];
-    if (envelope.type === "factory.merge-landed") {
-      const payload = envelope.payload ?? {};
-      if (
-        payload.repo !== source.repo ||
-        payload.github !== source.github ||
-        payload.base !== source.base ||
-        payload.pr !== item?.pr ||
-        payload.ticket !== item?.ticket ||
-        payload.headSha !== item?.headSha ||
-        payload.headRef !== item?.headRef
-      ) {
+    const sourceRequired = new Set(predecessorDef.inputSchema?.required ?? []);
+    const itemsField = predecessorDef.itemsField;
+    const item =
+      typeof itemsField === "string"
+        ? source[itemsField]?.[0]
+        : undefined;
+    const itemRequired = new Set(
+      typeof itemsField === "string"
+        ? predecessorDef.inputSchema?.properties?.[itemsField]?.items?.required ?? []
+        : [],
+    );
+    const targetAgent = registry.eventTypes[envelope.type]?.agent;
+    const required = registry.agents.get(targetAgent)?.inputSchema?.required ?? [];
+    const payload = envelope.payload ?? {};
+    for (const field of required) {
+      if (sourceRequired.has(field)) {
+        if (payload[field] !== source[field])
+          return "chain_command_edge_payload_mismatch";
+      } else if (itemRequired.has(field) && payload[field] !== item?.[field]) {
         return "chain_command_edge_payload_mismatch";
       }
-    } else if (envelope.payload?.repo !== source.repo) {
+    }
+    if (
+      predecessorDef.chainRepoMustMatchInput === true &&
+      payload.repo !== source.repo
+    ) {
       return "chain_command_edge_payload_mismatch";
     }
-  }
-  if (
-    spec.agent === "merge-verify@1" &&
-    envelope.payload?.repo !== spec.input?.repo
-  ) {
-    return "chain_command_edge_payload_mismatch";
   }
   return null;
 }
@@ -561,7 +564,7 @@ function durableFixRoundReason(db, candidate, input, policy) {
   return null;
 }
 
-function mergeEligibility(db, candidate, envelope, policy, now) {
+function mergeEligibility(db, registry, candidate, envelope, policy, now) {
   if (!MERGE_EVENT_TYPES.has(envelope.type)) return null;
   const input = envelope.payload ?? {};
 
@@ -615,12 +618,12 @@ function mergeEligibility(db, candidate, envelope, policy, now) {
       item.ambiguous !== false
     )
       return "merge_review_not_policy_safe";
-    return mergeBarrierReason(db, candidate, now);
+    return mergeBarrierReason(db, registry, candidate, now);
   }
 
   // merge-landed / merge-verify are allowed only for the exact immutable
   // landing identity; schema validation checks each 40-hex pin.
-  const barrierReason = mergeBarrierReason(db, candidate, now);
+  const barrierReason = mergeBarrierReason(db, registry, candidate, now);
   return barrierReason?.startsWith("merge_barrier_active:")
     ? barrierReason
     : null;
@@ -670,7 +673,7 @@ function eligible(
   );
   if (predecessorReason) return predecessorReason;
 
-  const mergeReason = mergeEligibility(db, candidate, envelope, policy, now);
+  const mergeReason = mergeEligibility(db, registry, candidate, envelope, policy, now);
   if (mergeReason) return mergeReason;
 
   const mapping = getEventType(registry, envelope.type);

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -57,7 +57,7 @@ function seed(
     )
     .find((entry) => entry.edge.eventType === type);
   if (trustedPredecessor && seedPredecessor) {
-    if (!predecessor)
+    if (!predecessor && !predecessorAgent)
       throw new Error(`test fixture has no registered predecessor for ${type}`);
     const parentEventId = `parent-event-${id}`;
     const parentAgent = predecessorAgent ?? predecessor.agent;
@@ -66,10 +66,10 @@ function seed(
     const parentResult = {
       artifact:
         predecessorArtifact ??
-        {
+        (parentRule ? {
           [parentRule.recommendationField]:
             predecessorRecommendation ?? predecessor.recommendation,
-        },
+        } : {}),
     };
     const at = new Date(now).toISOString();
     db.query(
@@ -378,6 +378,74 @@ function autoMerge(db) {
     runtimeGuard: () => null,
   });
 }
+
+describe("declared chain command edge characterization (WM-469)", () => {
+  test.each([
+    ["factory.merge.requested", { repo: "factory" }],
+    [
+      "factory.merge-landed",
+      {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        pr: 469,
+        ticket: "WM-469",
+        headSha: "a".repeat(40),
+        headRef: "feat/WM-469",
+        mergeCommitSha: "c".repeat(40),
+      },
+    ],
+  ])("merge-apply@2 auto-approves its %s command edge", (type, input) => {
+    const db = openDb(":memory:");
+    const predecessorInput = reviewedMergeInput({ pr: 469, ticket: "WM-469" });
+    const candidate = seed(db, {
+      id: `merge-apply-command-${type}`,
+      type,
+      input,
+      predecessorAgent: "merge-apply@2",
+      predecessorInput,
+      predecessorArtifact: { outcome: "applied" },
+    });
+
+    expect(autoMerge(db).approved).toEqual([
+      { proposalId: candidate.id, runId: candidate.runId },
+    ]);
+  });
+
+  test("merge-verify@1 auto-approves factory.merge.requested when repo matches input", () => {
+    const db = openDb(":memory:");
+    const candidate = seed(db, {
+      id: "merge-verify-command-match",
+      type: "factory.merge.requested",
+      input: { repo: "factory" },
+      predecessorAgent: "merge-verify@1",
+      predecessorInput: { repo: "factory" },
+      predecessorArtifact: { outcome: "verified" },
+    });
+
+    expect(autoMerge(db).approved).toEqual([
+      { proposalId: candidate.id, runId: candidate.runId },
+    ]);
+  });
+
+  test("merge-verify@1 repo mismatch remains chain_command_edge_payload_mismatch", () => {
+    const db = openDb(":memory:");
+    const candidate = seed(db, {
+      id: "merge-verify-command-mismatch",
+      type: "factory.merge.requested",
+      input: { repo: "other" },
+      predecessorAgent: "merge-verify@1",
+      predecessorInput: { repo: "factory" },
+      predecessorArtifact: { outcome: "verified" },
+    });
+
+    expect(autoMerge(db).approved).toEqual([]);
+    expect(runState(db, candidate.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toContain(
+      "chain_command_edge_payload_mismatch",
+    );
+  });
+});
 
 describe("chain auto approval (WM-357)", () => {
   test("git-owned policy is an explicit closed allowlist", () => {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -682,7 +682,7 @@ export function worktreeMergeFixEligibility(payload, {
 
 function worktreeGateFor(def) {
   if (def?.workspace?.type !== "worktree") return null;
-  return def.gate ?? "dispatch";
+  return def.dispatchGateExempt === true ? null : "dispatch";
 }
 
 function insertProposal(db, { id, event, runId = null, decision, specJson = null, specHash = null, idempotencyKey = null, status, reason = null, at, ttlSeconds }) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -571,6 +571,53 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  test("merge-fix@1 bypasses the tier-2 dispatch gate while dispatch@1 does not", () => {
+    const mergeFixDb = openDb(":memory:");
+    const mergeFix = admit(mergeFixDb, {
+      type: "factory.merge-fix.requested",
+      eventId: "merge-fix-dispatch-gate-characterization",
+      payload: {
+        repo: "factory",
+        github: "watt-mind/factory",
+        base: "develop",
+        pr: 469,
+        headSha: "a".repeat(40),
+        baseSha: "b".repeat(40),
+        headRef: "feat/WM-469",
+        ticket: "WM-469",
+        finding: "characterization fixture",
+        findingHash: "c".repeat(64),
+        round: 1,
+        mechanical: true,
+        withinOwnedPaths: true,
+        ownedPaths: ["event-runtime/lib/planner.mjs"],
+      },
+    });
+    expect(
+      planEvent(mergeFixDb, registry, mergeFix, {
+        now: NOW,
+        dispatch: {
+          fetchTicket: () => {
+            throw new Error("merge-fix must bypass the dispatch gate");
+          },
+        },
+      }).decision,
+    ).toBe("run");
+
+    const dispatchDb = openDb(":memory:");
+    const dispatch = admit(dispatchDb, {
+      type: "factory.dispatch.requested",
+      eventId: "dispatch-gate-characterization",
+      payload: { repo: "factory", ticket: "WM-469" },
+    });
+    const outcome = planEvent(dispatchDb, registry, dispatch, {
+      now: NOW,
+      dispatch: { fetchTicket: () => null },
+    });
+    expect(outcome.decision).toBe("human_needed");
+    expect(outcome.reason).toBe("ticket_not_found");
+  });
+
   test("merge-fix eligibility expects assigned review tickets and returns merge-fix typed refusals", () => {
     const payload = {
       repo: "factory",
@@ -1184,5 +1231,4 @@ describe("planAdmittedEvents", () => {
     expect(replannedSpec.idempotencyKey).toBe(originalSpec.idempotencyKey);
   });
 });
-
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -554,12 +554,12 @@ describe("planEvent worktree gate (WM-108)", () => {
     payload,
   });
 
-  test("a gate-declared merge-fix agent bypasses dispatch-only planning checks", () => {
+  test("a dispatch-exempt worktree agent bypasses dispatch-only planning checks", () => {
     withReposRoot(`repos:\n  - name: repairable\n    path: /tmp/nowhere\n    base: develop\n`, () => {
       const synthetic = syntheticRegistry();
       synthetic.agents.set("test-worktree@1", {
         ...synthetic.agents.get("test-worktree@1"),
-        gate: "merge-fix",
+        dispatchGateExempt: true,
       });
       const db = openDb(":memory:");
       const ref = admit(db, dispatchEnvelope({ repo: "repairable", ticket: "WM-500" }));
@@ -1231,4 +1231,3 @@ describe("planAdmittedEvents", () => {
     expect(replannedSpec.idempotencyKey).toBe(originalSpec.idempotencyKey);
   });
 });
-

--- a/event-runtime/lib/registry.mjs
+++ b/event-runtime/lib/registry.mjs
@@ -415,6 +415,29 @@ function loadAgentDef(pack, loader, entry, { builtIn = false } = {}) {
   if (def.model !== undefined && (typeof def.model !== "string" || def.model.trim() === "")) {
     throw new RegistryError(`${source}: "model" must be a non-empty string model id — omit the field for tier/default routing (WM-135)`);
   }
+  if (
+    def.chainCommandEdges !== undefined &&
+    (!Array.isArray(def.chainCommandEdges) ||
+      def.chainCommandEdges.length === 0 ||
+      !def.chainCommandEdges.every((type) => typeof type === "string" && type.trim() !== ""))
+  ) {
+    throw new RegistryError(
+      `${source}: "chainCommandEdges" must be a non-empty array of non-empty event type strings`,
+    );
+  }
+  if (def.chainRepoMustMatchInput !== undefined && def.chainRepoMustMatchInput !== true) {
+    throw new RegistryError(`${source}: "chainRepoMustMatchInput" must be true when present`);
+  }
+  if (def.dispatchGateExempt !== undefined) {
+    if (def.dispatchGateExempt !== true) {
+      throw new RegistryError(`${source}: "dispatchGateExempt" must be true when present`);
+    }
+    if (def.workspace?.type !== "worktree") {
+      throw new RegistryError(
+        `${source}: "dispatchGateExempt" is admissible only for workspace.type "worktree"`,
+      );
+    }
+  }
 
   const resources = {};
   const pins = {};
@@ -562,6 +585,19 @@ export function loadRegistry({
       resolveModel(agents.get(agentRef), mapping.adapter, modelTiers);
     } catch (err) {
       throw new RegistryError(`event type ${type}: ${err.message}`);
+    }
+  }
+
+  // Command-emitted chain edges are definition data, but they still target
+  // the one merged event registry. Validate only after every pack's maps have
+  // been merged so namespaced packs can target another loaded pack safely.
+  for (const [agentRef, def] of agents) {
+    for (const eventType of def.chainCommandEdges ?? []) {
+      if (!Object.hasOwn(eventTypes, eventType)) {
+        throw new RegistryError(
+          `${agentSources.get(agentRef)} agent ${agentRef}: chainCommandEdges targets unregistered event type ${eventType}`,
+        );
+      }
     }
   }
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -107,7 +107,9 @@ describe("registry", () => {
     // WM-469 intentionally adds the three declarative kernel-control fields
     // to the affected definitions while preserving their refs and pins
     // (digest regenerated on top of the #559 baseline).
-    const expected = "sha256:0fbb908dd2dbac1184da17106eef92da42f9530c30dac05e205c55ead1312e28";
+    // Regenerated after rebase over #567 (WM-679) + #563 (WM-469): both change
+    // agent definitions, which are registry inputs. Reason in PR body.
+    const expected = "sha256:55929d285a47a1abfadca8df9a0b8dab3ff421bd55ec4b939e77c25ecca92536";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -104,10 +104,10 @@ describe("registry", () => {
     // Regenerated 2026-08-18: #559 (WM-662, merge agents cursor→pi/terra) landed
     // between #479's review and its merge, changing event-types.json and two
     // agent defs — registry inputs. Reason in PR body per the rule above.
-    // Regenerated 2026-08-18 (WM-679): merge-scan.md / merge-fix.md re-prompted so
-    // operational conditions route to FIX instead of ESCALATE; both are registry
-    // inputs. Reason in PR body per the rule above.
-    const expected = "sha256:677ed34e1e04aa29437594922a2fd9ebca419c68a8a4c794dac78b2435897aeb";
+    // WM-469 intentionally adds the three declarative kernel-control fields
+    // to the affected definitions while preserving their refs and pins
+    // (digest regenerated on top of the #559 baseline).
+    const expected = "sha256:0fbb908dd2dbac1184da17106eef92da42f9530c30dac05e205c55ead1312e28";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -364,6 +364,49 @@ describe("registry", () => {
     const raw = JSON.parse(readFileSync(defFile, "utf8"));
     writeFileSync(defFile, JSON.stringify({ ...raw, workspace: { type: "ephemeral" } }));
     expect(() => loadRegistry({ root })).toThrow(/mutating/);
+  });
+
+  test("agent-declared kernel control fields validate fail-closed (WM-469)", () => {
+    const badEdgeRoot = tempRegistry();
+    const applyFile = path.join(badEdgeRoot, "agents", "merge-apply.json");
+    const apply = JSON.parse(readFileSync(applyFile, "utf8"));
+    writeFileSync(
+      applyFile,
+      JSON.stringify({ ...apply, chainCommandEdges: ["factory.not-registered"] }),
+    );
+    expect(() => loadRegistry({ root: badEdgeRoot })).toThrow(
+      /chainCommandEdges targets unregistered event type factory\.not-registered/,
+    );
+
+    const badRepoMatchRoot = tempRegistry();
+    const verifyFile = path.join(badRepoMatchRoot, "agents", "merge-verify.json");
+    const verify = JSON.parse(readFileSync(verifyFile, "utf8"));
+    writeFileSync(
+      verifyFile,
+      JSON.stringify({ ...verify, chainRepoMustMatchInput: false }),
+    );
+    expect(() => loadRegistry({ root: badRepoMatchRoot })).toThrow(
+      /"chainRepoMustMatchInput" must be true when present/,
+    );
+
+    const badExemptionRoot = tempRegistry();
+    const exemptFile = path.join(badExemptionRoot, "agents", "merge-verify.json");
+    const exempt = JSON.parse(readFileSync(exemptFile, "utf8"));
+    writeFileSync(exemptFile, JSON.stringify({ ...exempt, dispatchGateExempt: true }));
+    expect(() => loadRegistry({ root: badExemptionRoot })).toThrow(
+      /"dispatchGateExempt" is admissible only for workspace\.type "worktree"/,
+    );
+  });
+
+  test("every declared chainCommandEdges entry names a merged registered event type", () => {
+    const loaded = loadRegistry();
+    const declared = [...loaded.agents.values()].flatMap((def) =>
+      (def.chainCommandEdges ?? []).map((eventType) => [def.ref, eventType]),
+    );
+    expect(declared.length).toBeGreaterThan(0);
+    for (const [agentRef, eventType] of declared) {
+      expect(loaded.eventTypes[eventType], `${agentRef} -> ${eventType}`).toBeDefined();
+    }
   });
 
   test("schedule payload must be a plain object without reserved tick fields (WM-72)", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1214,7 +1214,13 @@ export async function executeClaimed(db, registry, adapters, claim, {
         return { runId, attempt, terminalState: "REFUSED", reasonCode, receipt: res?.receipt };
       };
 
-      const gate = def?.gate ?? "dispatch";
+      // WM-469 de-hardcoded the merge-fix role from the kernel: the definition
+      // declares `dispatchGateExempt: true` (validated by the registry) instead
+      // of a `gate: "merge-fix"` literal the worker string-matched. Keep the
+      // planner and worker keyed off the SAME declarative field — a legacy
+      // `gate` value is still honoured so an older pinned spec cannot silently
+      // fall through to the dispatch claim gate and refuse with ticket_assigned.
+      const gate = def?.dispatchGateExempt === true ? "merge-fix" : (def?.gate ?? "dispatch");
       if (!["dispatch", "merge-fix"].includes(gate)) {
         releaseClaimLock(lockFile);
         const reasonCode = "worktree_gate_unknown";


### PR DESCRIPTION
## Summary
- characterize the existing merge command-edge and worktree dispatch decisions in a first, independently passing commit
- move command-edge authority, repo matching, and dispatch exemption into validated agent-definition fields
- derive merge barrier participants from the event registry and document the new declarations

The zero-pack registry digest changes intentionally because the three definitions now carry declarative kernel-control metadata; refs and pinned artifacts remain unchanged.

## Verification
- `bun test && bun build/emit.mjs --check && ! grep -n '"merge-apply@2"\\|"merge-verify@1"\\|"merge-fix@1"' event-runtime/lib/auto-approval.mjs event-runtime/lib/planner.mjs && bun event-runtime/cli.mjs update-pins && git diff --quiet -- event-runtime/agents`\n\nUX critique: skipped — backend/runtime architecture refactor with no user-facing surface.\n\nFixes WM-469