### PR TITLE
fix(registry): regenerate zero-pack digest baseline — trunk red since #479 landed over #559

### DIFF
--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -101,7 +101,10 @@ describe("registry", () => {
     // The serializer omits only WM-470's new pack provenance and normalizes
     // the absolute prompt path. Changing this digest requires an explicit
     // reason in the PR body: it is the mechanical zero-pack compatibility gate.
-    const expected = "sha256:65fd52598a910dc92f9657eeddce3cd1af10695b8f24fceece24ed1f4b33f580";
+    // Regenerated 2026-08-18: #559 (WM-662, merge agents cursor→pi/terra) landed
+    // between #479's review and its merge, changing event-types.json and two
+    // agent defs — registry inputs. Reason in PR body per the rule above.
+    const expected = "sha256:b2a2887bf5869f236339199447c91acd8dd617fcb5c85c095c1f85e1d6b1ea9b";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Trunk is red: `registry.test.mjs › zero-pack merged-view digest matches the develop baseline` fails on develop, and every dispatch since ~05:53Z dies at the repo verify gate (`contract_violation: repo_verify_failed`, e.g. WM-654 run_3513fdc5).

## Why

The digest constant was pinned against develop `1d95d0e` when #479 (WM-470) was reviewed. #559 (WM-662, merge-scan/merge-fix cursor→pi/terra) merged in between, changing `event-types.json` and two agent defs — registry inputs. #479 then merged onto the moved develop and its own gate went red.

The test's comment sets the rule: *"Regenerate on develop… Changing this digest requires an explicit reason in the PR body."* This is that reason. Received value taken directly from the failing assertion on develop `b9eb37a`.

Not a real registry incompatibility — the change is the intended one from #559.

## Handoff
- Verification: `bun test event-runtime/lib/registry.test.mjs` → 30 pass, 0 fail.
- Files: 1 (`event-runtime/lib/registry.test.mjs`, one constant + comment).
- Follow-up worth its own ticket: this gate will go red every time a registry-input PR lands between another PR's review and merge; that is a merge-serialization concern, not a bug in either PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz