### PR TITLE
feat(dispatch-gate): owned_paths_collision policy — advisory mode records overlap instead of refusing (WM-677)

### DIFF
--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -24,6 +24,20 @@ chain_auto_approval:
 merge:
   max_fix_rounds: 2
 
+dispatch:
+  # Owned Paths collision handling at dispatch (WM-677).
+  #   strict   — any overlap with an in-flight ticket refuses dispatch. Fail-closed
+  #              default when this key is absent.
+  #   advisory — the overlap is recorded on the proposal/run as evidence and
+  #              dispatch proceeds; only an IDENTICAL concrete file claim, or a
+  #              `**` claim on either side, still refuses (owned_paths_conflict_hard).
+  # Operator decision 2026-08-18: textual overlap is what rebase and merge-fix
+  # already resolve — six overlapping PRs rebased clean that day — and refusing
+  # it at dispatch was starving the pool (2 running workers from 9 attempts).
+  # Merging stays serialized (max_concurrent_merges below), which is where real
+  # conflicts are caught.
+  owned_paths_collision: advisory
+
 concurrency:
   # Per-repo admission ceiling. Actual execution remains bounded by worker
   # availability, ticket claims, and Owned Paths collision checks.

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -149,6 +149,28 @@ parseable `Owned Paths` owns everything (dispatchable, but alone), and
 ambiguous glob overlap errs toward collision — a false positive serializes
 two tickets, a false negative puts two agents in one file.
 
+**Collision mode (WM-677).** `config/policy.yaml` `dispatch.owned_paths_collision`
+selects what a collision *does*:
+
+| mode | on overlap | still refuses |
+| --- | --- | --- |
+| `strict` (default when absent) | refuse, `owned_paths_overlap` | — |
+| `advisory` | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | identical concrete file on both sides, or `**` on either side → `owned_paths_conflict_hard` |
+
+Advisory exists because the strict oracle refuses far more than it protects:
+tickets scope themselves with qualified claims (`views/*.tsx (formatter
+call-sites only)`) that the glob algebra cannot see, and shared-prefix
+wildcards collide by construction. On 2026-08-18 nine dispatch attempts
+became two running workers under strict, while six textually-overlapping PRs
+rebased onto develop clean the same day. Textual overlap is a rebase job and
+`merge-fix` already does it; the pool should not idle waiting for it. What
+advisory keeps hard is the case a rebase genuinely cannot fix — two agents
+handed the *same file* — and the `**` sentinel, whose whole meaning is
+"alone". Merging remains serialized (`concurrency.max_concurrent_merges`),
+which is where real conflicts are caught. Both the planner and the worker's
+execute-time re-check read the same setting, so operator approval and worker
+claim cannot disagree.
+
 **Rejected: a second overlap implementation inside the runtime.** The
 existing parser has already bitten once — architecture.md §2.3's CLNT-616,
 where a correctly specced ticket parsed as empty and dispatch refused it —

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -15,6 +15,8 @@ import path from "node:path";
 import {
   effectiveOwnedPaths,
   globToRegExp,
+  hardPathConflicts,
+  pathOverlaps,
   pathsCollide,
   parseOwnedPaths,
   readPinManifestRequirements,
@@ -219,6 +221,27 @@ function policyMaxInFlight(root = reposRoot()) {
     return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : DEFAULT_MAX_IN_FLIGHT;
   } catch {
     return DEFAULT_MAX_IN_FLIGHT;
+  }
+}
+
+/**
+ * Owned Paths collision mode (WM-677). `strict` refuses dispatch on any overlap
+ * with an in-flight ticket — the historical behavior, and the fail-closed
+ * default when the key is absent or malformed. `advisory` records the overlap
+ * on the proposal as evidence and dispatches anyway, refusing only the narrow
+ * hard-conflict set (identical concrete file, or `**`): textual overlap is what
+ * rebase and merge-fix already resolve, and refusing it at dispatch was
+ * starving the pool for conflicts that mostly never materialized.
+ */
+export const DEFAULT_OWNED_PATHS_COLLISION = "strict";
+export function policyOwnedPathsCollision(root = reposRoot()) {
+  const file = path.join(root, "config", "policy.yaml");
+  if (!existsSync(file)) return DEFAULT_OWNED_PATHS_COLLISION;
+  try {
+    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch?.owned_paths_collision;
+    return value === "advisory" ? "advisory" : DEFAULT_OWNED_PATHS_COLLISION;
+  } catch {
+    return DEFAULT_OWNED_PATHS_COLLISION;
   }
 }
 
@@ -487,11 +510,32 @@ export function worktreeDispatchAutoEligibility(payload, {
 
   const inFlight = fetchInFlight(repo);
   evidence.inFlight = inFlight.filter((issue) => String(issue.identifier) !== String(payload?.ticket)).map(evidenceInFlight);
-  if (pathsCollide(evidence.ticket.ownedPaths, evidence.inFlight.flatMap((issue) => issue.ownedPaths))) {
+  const collisionMode = policyOwnedPathsCollision();
+  evidence.checks.owned_paths_collision_mode = collisionMode;
+  const inFlightPaths = evidence.inFlight.flatMap((issue) => issue.ownedPaths);
+  if (pathsCollide(evidence.ticket.ownedPaths, inFlightPaths)) {
     evidence.checks.owned_paths_disjoint = false;
-    return refusal("owned_paths_overlap", evidence);
+    if (collisionMode !== "advisory") return refusal("owned_paths_overlap", evidence);
+    // Advisory: name every overlapping claim and who holds it, so the proposal
+    // and `inspect` show what this run may have to rebase across, then only
+    // refuse the pairs that cannot be reconciled by a rebase.
+    evidence.ownedPathsOverlap = evidence.inFlight.flatMap((issue) =>
+      pathOverlaps(evidence.ticket.ownedPaths, issue.ownedPaths).map(({ a, b }) => ({
+        ticket: issue.id, path: a, inFlightPath: b,
+      })),
+    );
+    const hard = evidence.inFlight.flatMap((issue) =>
+      hardPathConflicts(evidence.ticket.ownedPaths, issue.ownedPaths).map(({ a, b }) => ({
+        ticket: issue.id, path: a, inFlightPath: b,
+      })),
+    );
+    if (hard.length) {
+      evidence.ownedPathsHardConflicts = hard;
+      return refusal("owned_paths_conflict_hard", evidence);
+    }
+  } else {
+    evidence.checks.owned_paths_disjoint = true;
   }
-  evidence.checks.owned_paths_disjoint = true;
   try {
     evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
   } catch (err) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2135,6 +2135,63 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     expect(sum5.reasonCode).toBe("ticket_claim_lost");
   });
 
+  // WM-677: under `dispatch.owned_paths_collision: advisory` a textual overlap
+  // is evidence, not a refusal — the run is claimed and executes. Only the
+  // narrow hard-conflict set (identical concrete file, or `**`) still refuses.
+  // The worker consumes the same gate as the planner, so this is the
+  // execute-time half of the contract; the fixture policy.yaml is `{}` for
+  // every other test here, which is why they still see strict.
+  test("advisory owned-paths mode dispatches across overlap and refuses only hard conflicts (WM-677)", async () => {
+    const db = openDb(":memory:");
+    const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-advisory-"));
+    const policyPath = path.join(factoryRoot, "config", "policy.yaml");
+    const priorPolicy = readFileSync(policyPath, "utf8");
+    writeFileSync(policyPath, "dispatch:\n  owned_paths_collision: advisory\n");
+    try {
+      // Containment overlap (src/api/** vs src/api/routes.ts): strict refuses this
+      // exact pair in the test above; advisory lets it run.
+      const specA = queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-707" } }));
+      const sumA = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-707", { description: "## Owned Paths\n- src/api/**\n" }),
+          fetchInFlight: () => [{ identifier: "WM-800", description: "## Owned Paths\n- src/api/routes.ts\n" }],
+          countLeases: () => 0,
+        },
+      }));
+      expect(sumA.terminalState).not.toBe("REFUSED");
+      expect(sumA.reasonCode).not.toBe("owned_paths_overlap");
+
+      // Identical concrete file on both sides: still a hard conflict.
+      queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-708" } }));
+      const sumB = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-708", { description: "## Owned Paths\n- src/api/routes.ts\n" }),
+          fetchInFlight: () => [{ identifier: "WM-801", description: "## Owned Paths\n- src/api/routes.ts\n" }],
+          countLeases: () => 0,
+        },
+      }));
+      expect(sumB.terminalState).toBe("REFUSED");
+      expect(sumB.reasonCode).toBe("owned_paths_conflict_hard");
+
+      // A `**` claim on the in-flight side: still a hard conflict.
+      queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-709" } }));
+      const sumC = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
+        dispatch: {
+          locksDir: lockDir,
+          fetchTicket: () => readyDispatchTicket("WM-709", { description: "## Owned Paths\n- docs/readme.md\n" }),
+          fetchInFlight: () => [{ identifier: "WM-802", description: "## Owned Paths\n- **\n" }],
+          countLeases: () => 0,
+        },
+      }));
+      expect(sumC.terminalState).toBe("REFUSED");
+      expect(sumC.reasonCode).toBe("owned_paths_conflict_hard");
+    } finally {
+      writeFileSync(policyPath, priorPolicy);
+    }
+  });
+
   test("lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)", async () => {
     const db = openDb(":memory:");
     const lockDir = mkdtempSync(path.join(os.tmpdir(), "evrt-claim-retry-locks-"));

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -178,6 +178,36 @@ export function pathsCollide(setA = [], setB = []) {
   return setA.some((a) => setB.some((b) => globsOverlap(a, b)));
 }
 
+/**
+ * Every overlapping pair between two Owned Paths sets, for advisory evidence.
+ * Same predicate as pathsCollide, but returns the pairs instead of a boolean so
+ * a proposal can name what it overlaps with rather than just refusing.
+ */
+export function pathOverlaps(setA = [], setB = []) {
+  const out = [];
+  for (const a of setA) for (const b of setB) if (globsOverlap(a, b)) out.push({ a, b });
+  return out;
+}
+
+/**
+ * The narrow set of overlaps that still refuse dispatch under advisory mode
+ * (WM-677): two claims that are the SAME concrete file, or a `**` claim on
+ * either side. Everything else — shared directory prefixes, qualified globs,
+ * wildcards that merely could reach the same file — is textual overlap that
+ * git resolves at rebase far more often than not, so it is recorded on the
+ * proposal and dispatch proceeds.
+ */
+export function hardPathConflicts(setA = [], setB = []) {
+  const isConcrete = (g) => !/[*?{]/.test(g);
+  const norm = (g) => String(g ?? "").trim().replace(/^\.\//, "").replace(/\/$/, "");
+  return pathOverlaps(setA, setB).filter(({ a, b }) => {
+    const na = norm(a);
+    const nb = norm(b);
+    if (na === "**" || nb === "**") return true;
+    return isConcrete(na) && isConcrete(nb) && na === nb;
+  });
+}
+
 function walkFiles(rootDir, baseDir = rootDir, out = []) {
   for (const dirent of readdirSync(rootDir, { withFileTypes: true })) {
     const nextPath = path.join(rootDir, dirent.name);

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -12,6 +12,8 @@ import { test, expect } from "bun:test";
 const expectEqual = (a, b, msg) => expect(a, msg).toEqual(b);
 const expectTrue = (v, msg) => expect(v, msg).toBeTruthy();
 import {
+  hardPathConflicts,
+  pathOverlaps,
   parseOwnedPaths,
   effectiveOwnedPaths,
   globsOverlap,
@@ -270,4 +272,30 @@ test("supports level 4 numbered headers (#### 4. Owned Paths)", () => {
 
 - \`event-runtime/cli.mjs\``;
   expectEqual(parseOwnedPaths(desc), ["event-runtime/cli.mjs"]);
+});
+
+// WM-677: advisory mode needs the overlap as pairs (to record it) and a narrow
+// hard-conflict predicate (to still refuse). These pin the boundary between
+// "textual overlap a rebase resolves" and "the same file, or everything".
+test("pathOverlaps returns every overlapping pair, in order", () => {
+  expectEqual(
+    pathOverlaps(["src/api/**", "docs/a.md"], ["src/api/routes.ts", "docs/a.md", "lib/x.mjs"]),
+    [
+      { a: "src/api/**", b: "src/api/routes.ts" },
+      { a: "docs/a.md", b: "docs/a.md" },
+    ],
+  );
+  expectEqual(pathOverlaps(["a.md"], ["b.md"]), []);
+});
+
+test("hardPathConflicts: identical concrete file, or ** on either side — nothing else", () => {
+  // Containment and shared-prefix overlaps are NOT hard.
+  expectEqual(hardPathConflicts(["src/api/**"], ["src/api/routes.ts"]), []);
+  expectEqual(hardPathConflicts(["src/**/*.test.mjs"], ["src/lib/registry.test.mjs"]), []);
+  expectEqual(hardPathConflicts(["views/*.tsx"], ["views/*.tsx"]), []); // same glob, still a rebase job
+  // The same concrete file IS hard.
+  expectEqual(hardPathConflicts(["docs/a.md"], ["docs/a.md"]), [{ a: "docs/a.md", b: "docs/a.md" }]);
+  // `**` on either side is hard against anything it reaches.
+  expectTrue(hardPathConflicts(["**"], ["docs/a.md"]).length === 1);
+  expectTrue(hardPathConflicts(["docs/a.md"], ["**"]).length === 1);
 });


### PR DESCRIPTION
Fixes WM-677. Operator direction (2026-08-18): Owned Paths overlap should be *visible* at dispatch but must not hard-stop it — most of the time it is not a real conflict, including at merge.

## What

New `config/policy.yaml` key `dispatch.owned_paths_collision`:

| mode | on overlap | still refuses |
| --- | --- | --- |
| `strict` (**default when absent**) | refuse, `owned_paths_overlap` — today's behaviour | — |
| `advisory` | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | identical concrete file on both sides, or `**` on either side → `owned_paths_conflict_hard` |

**Sets the live policy to `advisory`.**

`orchestrator/owned-paths.mjs` gains `pathOverlaps` (the pairs, for evidence) and `hardPathConflicts` (the narrow predicate) alongside the unchanged `pathsCollide`. The planner and the worker's execute-time re-check both consume `worktreeDispatchAutoEligibility`, so they read the same setting — operator approval and worker claim cannot disagree.

## Why

Over 05:00–06:20Z today, **nine dispatch attempts became two running workers** under strict — refused at plan time or by the worker's re-check. The same day, **six textually-overlapping PRs rebased onto develop clean** (#479, #503, #504, #552, #558, #560). The oracle refuses far more than it protects: tickets scope themselves with qualified claims (`views/*.tsx (formatter call-sites only)`) the glob algebra cannot see, and shared-prefix wildcards collide by construction. Textual overlap is a rebase job that `merge-fix` already does. What advisory keeps hard is the case a rebase genuinely cannot fix — two agents in the *same file* — and the `**` sentinel whose whole meaning is "alone". Merging stays serialized (`max_concurrent_merges: 1`), which is where real conflicts are caught.

## Handoff
- Verification: `bun test` → **2419 pass, 0 fail**; `bun build/emit.mjs --check` → exit 0.
- Tests: `owned-paths.test.mjs` +2 (pairs; hard-conflict boundary — containment/same-glob/shared-prefix are NOT hard, identical file and `**` ARE); `worker.test.mjs` +1 asserting the execute-time half under advisory (containment overlap runs; identical file and `**` refuse `owned_paths_conflict_hard`). **The pre-existing strict refusal test passes unchanged** because the fixture policy is `{}` → strict; that is the fail-closed default demonstrated.
- Not vacuous: the advisory test writes the policy key and restores it in `finally`.
- UX critique: skipped — no user-facing surface.
- Files: 6, all within Owned Paths (`planner.mjs`, `worker.test.mjs`, `owned-paths.mjs` + test, `policy.yaml`, `docs/event-runtime-dispatch.md`). `worker.mjs` was declared but needed no change — it already shares the gate.
- Risk: this is a deliberate loosening of the fail-closed posture in ORCHESTRATOR.md §1, made on explicit operator instruction. Reverting is one line in `policy.yaml`. Two agents editing the same *lines* of a shared file will now surface at rebase rather than dispatch; `merge-fix` handles that today.
- Restart required after merge: `config/**` changed → full `bin/live-stack.sh down && up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz