### PR TITLE
fix(dispatch-gate): advisory hard-conflict is ** only — same file is not same lines (WM-677)

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -155,7 +155,7 @@ selects what a collision *does*:
 | mode | on overlap | still refuses |
 | --- | --- | --- |
 | `strict` (default when absent) | refuse, `owned_paths_overlap` | — |
-| `advisory` | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | identical concrete file on both sides, or `**` on either side → `owned_paths_conflict_hard` |
+| `advisory` | record on the proposal as `evidence.ownedPathsOverlap` (`{ticket, path, inFlightPath}` per pair) and dispatch | `**` on either side → `owned_paths_conflict_hard` |
 
 Advisory exists because the strict oracle refuses far more than it protects:
 tickets scope themselves with qualified claims (`views/*.tsx (formatter
@@ -164,9 +164,11 @@ wildcards collide by construction. On 2026-08-18 nine dispatch attempts
 became two running workers under strict, while six textually-overlapping PRs
 rebased onto develop clean the same day. Textual overlap is a rebase job and
 `merge-fix` already does it; the pool should not idle waiting for it. What
-advisory keeps hard is the case a rebase genuinely cannot fix — two agents
-handed the *same file* — and the `**` sentinel, whose whole meaning is
-"alone". Merging remains serialized (`concurrency.max_concurrent_merges`),
+advisory keeps hard is only the `**` sentinel, whose whole meaning is
+"alone". Two tickets naming the *same file* is not hard: same file is not
+same lines — tickets qualify claims (`App.tsx (interval constants only)`) for
+exactly this — and an identical-file rule tried first refused four tickets in
+one batch on `App.tsx`/`hooks.ts`/`api.mjs`. Merging remains serialized (`concurrency.max_concurrent_merges`),
 which is where real conflicts are caught. Both the planner and the worker's
 execute-time re-check read the same setting, so operator approval and worker
 claim cannot disagree.

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2162,7 +2162,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       expect(sumA.terminalState).not.toBe("REFUSED");
       expect(sumA.reasonCode).not.toBe("owned_paths_overlap");
 
-      // Identical concrete file on both sides: still a hard conflict.
+      // Identical concrete file on both sides: same file is not same lines —
+      // advisory lets it run too (evidence carries the pair).
       queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-708" } }));
       const sumB = await runOnce(db, registry, { fake: dispatchFakeAdapter }, opts({
         dispatch: {
@@ -2172,8 +2173,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
           countLeases: () => 0,
         },
       }));
-      expect(sumB.terminalState).toBe("REFUSED");
-      expect(sumB.reasonCode).toBe("owned_paths_conflict_hard");
+      expect(sumB.terminalState).not.toBe("REFUSED");
+      expect(sumB.reasonCode).not.toBe("owned_paths_conflict_hard");
 
       // A `**` claim on the in-flight side: still a hard conflict.
       queueRun(db, makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-709" } }));

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -190,22 +190,21 @@ export function pathOverlaps(setA = [], setB = []) {
 }
 
 /**
- * The narrow set of overlaps that still refuse dispatch under advisory mode
- * (WM-677): two claims that are the SAME concrete file, or a `**` claim on
- * either side. Everything else — shared directory prefixes, qualified globs,
- * wildcards that merely could reach the same file — is textual overlap that
- * git resolves at rebase far more often than not, so it is recorded on the
- * proposal and dispatch proceeds.
+ * The set of overlaps that still refuse dispatch under advisory mode (WM-677):
+ * a `**` claim on either side, and nothing else. `**` is the fail-closed
+ * sentinel for "this ticket's scope is unknown, it must run alone" — the one
+ * claim a rebase cannot reason about. Everything else, including two tickets
+ * naming the SAME concrete file, is textual overlap: same file is not same
+ * lines (tickets qualify claims like `App.tsx (interval constants only)` for
+ * exactly this), and rebase/merge-fix resolve it far more often than not. So
+ * it is recorded on the proposal and dispatch proceeds. The identical-file
+ * rule was tried first and refused App.tsx/hooks.ts/api.mjs across four
+ * tickets in one batch on 2026-08-18 — precisely the starvation advisory mode
+ * exists to end.
  */
 export function hardPathConflicts(setA = [], setB = []) {
-  const isConcrete = (g) => !/[*?{]/.test(g);
   const norm = (g) => String(g ?? "").trim().replace(/^\.\//, "").replace(/\/$/, "");
-  return pathOverlaps(setA, setB).filter(({ a, b }) => {
-    const na = norm(a);
-    const nb = norm(b);
-    if (na === "**" || nb === "**") return true;
-    return isConcrete(na) && isConcrete(nb) && na === nb;
-  });
+  return pathOverlaps(setA, setB).filter(({ a, b }) => norm(a) === "**" || norm(b) === "**");
 }
 
 function walkFiles(rootDir, baseDir = rootDir, out = []) {

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -288,13 +288,13 @@ test("pathOverlaps returns every overlapping pair, in order", () => {
   expectEqual(pathOverlaps(["a.md"], ["b.md"]), []);
 });
 
-test("hardPathConflicts: identical concrete file, or ** on either side — nothing else", () => {
-  // Containment and shared-prefix overlaps are NOT hard.
+test("hardPathConflicts: ** on either side — nothing else", () => {
+  // Containment, shared-prefix, same-glob, and even the SAME concrete file are
+  // NOT hard: same file is not same lines, and a rebase resolves it.
   expectEqual(hardPathConflicts(["src/api/**"], ["src/api/routes.ts"]), []);
   expectEqual(hardPathConflicts(["src/**/*.test.mjs"], ["src/lib/registry.test.mjs"]), []);
-  expectEqual(hardPathConflicts(["views/*.tsx"], ["views/*.tsx"]), []); // same glob, still a rebase job
-  // The same concrete file IS hard.
-  expectEqual(hardPathConflicts(["docs/a.md"], ["docs/a.md"]), [{ a: "docs/a.md", b: "docs/a.md" }]);
+  expectEqual(hardPathConflicts(["views/*.tsx"], ["views/*.tsx"]), []);
+  expectEqual(hardPathConflicts(["docs/a.md"], ["docs/a.md"]), []);
   // `**` on either side is hard against anything it reaches.
   expectTrue(hardPathConflicts(["**"], ["docs/a.md"]).length === 1);
   expectTrue(hardPathConflicts(["docs/a.md"], ["**"]).length === 1);


### PR DESCRIPTION
Follow-up to #565. The first cut of advisory mode still refused when both sides named the same concrete file. In its first live batch that refused **four tickets** (WM-165, WM-247, WM-266, WM-477) on `App.tsx` / `hooks.ts` / `api.mjs` against WM-586 — whose claim is literally `App.tsx (interval constants only)`, the qualifier that says "not the same lines". That is precisely the starvation advisory mode exists to end.

Narrows the hard set to the `**` sentinel alone: it is the fail-closed marker for "scope unknown, must run alone", the one claim a rebase cannot reason about. Everything else — same file included — is recorded on the proposal and dispatches; rebase and merge-fix resolve it.

## Handoff
- Verification: `bun test orchestrator/owned-paths.test.mjs event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs` → 163 pass, 0 fail.
- Tests updated: identical-file case flipped from "refuses" to "runs" in both the helper unit test and the worker execute-time test; `**` case unchanged and still refuses.
- Files: 4 (`owned-paths.mjs` + test, `worker.test.mjs`, `docs/event-runtime-dispatch.md`).
- Restart required after merge (`orchestrator/**` is loaded by the planner in `serve`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz