### PR TITLE
feat(merge-scan): route operational conditions to FIX, not ESCALATE (WM-679)

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -35,7 +35,7 @@
   },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:0c60e0346e1c58fe32a7eb86d4b8cd812d59a79174baff0b571142f0ce40a327",
+    "agents/merge-fix.md": "sha256:3f2a4733d1bf5dffc8a7d0ba9874a4a01b389592f434cc317f3f867e4e4fb12d",
     "schemas/merge-fix.input.json": "sha256:71a8c16d52dfc908972bf3f9ca6d942c93ab6b0213588298a1cd2715e265aa6c",
     "schemas/merge-fix.output.json": "sha256:0aa6ba59514abbb6609ef53c124f627c7e5ab09eca655696c99aa4e38e34ce46"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -6,23 +6,38 @@ isolated worktree for the ticket. This is not a general implementation run.
 1. Read the ticket and all comments. Re-read the PR head/base and required
    checks. Refuse if head SHA, base SHA, ticket, branch, finding hash, or PR
    identity moved; stale evidence requires a fresh independent scan.
-2. Confirm the finding is mechanical, round is 1 or 2, the change is wholly
-   within the supplied Owned Paths and the ticket's live Owned Paths, and no
+2. Confirm the finding is mechanical, round is 1 or 2, and no
    security/product/policy judgment is involved. Otherwise move the ticket to
    Blocked, notify when policy requires, and output BLOCKED without editing.
+   Owned Paths bound the *correction*, not the *rebase* (WM-679):
+   - `rebase_onto_base` / `rerun_ci_at_head`: rebase the head branch onto the
+     current base. Resolve conflicts faithfully to both sides, reading the
+     surrounding code; the files git reports as conflicting are in scope for
+     the resolution regardless of the ticket's Owned Paths, because a rebase
+     touches what the base touched. Never `git stash` or `--autostash`. If a
+     hunk is genuinely ambiguous — two real behaviours, no way to keep both —
+     that is the one case to BLOCK with the hunk named. Then re-run
+     verification and push with `--force-with-lease`.
+   - A finding that names an Owned Paths deviation (an expectation outside the
+     ticket's paths that the PR's own change invalidated): make that one
+     correction, and record the deviation on the ticket in your comment.
+   - Any other change outside the supplied Owned Paths and the ticket's live
+     Owned Paths: BLOCK.
 3. Move the ticket from In Review to In Progress. Check out the existing PR
    head branch at the pinned SHA. Make only the smallest correction, add or
-   update a falsifiable regression test, and run the ticket's exact
-   Verification Command. Never weaken or skip it.
+   update a falsifiable regression test where the finding is a code change (a
+   pure rebase adds none), and run the ticket's exact Verification Command.
+   Never weaken or skip it.
 4. Commit with the ticket ID, push the same head branch, and add a PR comment
    exactly `factory-merge-fix round=<round> finding=<findingHash> old=<oldSha>
 new=<newSha>`. Do not merge, approve, mark Done, or delete anything.
 5. Return UPDATED with the new 40-hex head SHA. Completion chains to a wholly
    new merge-scan run. You are forbidden to declare your own update mergeable.
 
-If the branch cannot be reconstructed safely, verification fails, a path is
-out of scope, or any evidence is uncertain, preserve the worktree/branch,
-block the ticket with one answerable reason, and return BLOCKED.
+If the branch cannot be reconstructed safely, verification fails, a change
+beyond the finding is out of scope, or any evidence is uncertain, preserve
+the worktree/branch, block the ticket with one answerable reason, and return
+BLOCKED.
 
 ## Result contract
 

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -25,7 +25,7 @@
   },
   "mutating": false,
   "pins": {
-    "agents/merge-scan.md": "sha256:904a4f571dc93629fb39c51f2bcd1bab3bac34a866dc37bad644c0a90d668537",
+    "agents/merge-scan.md": "sha256:d31d1cfe43cbacc628819fa60580415d5be814999cf07e90f0244a00c030944e",
     "schemas/merge-scan.input.json": "sha256:a1d63f0f667856195ca0cba6a7030b4f4ad0a3cb6a97284d48212934f3dff0f0",
     "schemas/merge-scan.output.json": "sha256:84791d0fcfe80716ffda27b1432cb8be7a003d1c7c967d4dc9445ae182b236a2"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -80,21 +80,41 @@ cancelled, stale-SHA, wrong-workflow, API-error, or otherwise ambiguous
 evidence fails closed. Never substitute all currently visible checks for
 either authoritative set; that recreates the early auxiliary-check race.
 
-ESCALATE auth/authz, money movement, credentials/secrets, destructive
-migrations, production infrastructure, CLNT security behavior, any
-`escalate_paths` match, product ambiguity, missing/uncertain evidence,
-`main`/`master`, or the configured deploy branch. Notify-worthy ambiguity is
-not a mechanical fix. Existing draft/escalated holds stay held and are
-summarized.
+ESCALATE is for conditions a human must decide, and nothing else: auth/authz,
+money movement, credentials/secrets, destructive migrations, production
+infrastructure, CLNT security behavior, any `escalate_paths` match, product
+ambiguity in the diff itself, `main`/`master`, the configured deploy branch,
+and a fix whose next round would exceed `merge.max_fix_rounds`. Existing
+draft/escalated holds stay held and are summarized.
 
-A FIX may auto-dispatch only when it is mechanical, wholly inside the ticket's
-Owned Paths, and its next round is at most `merge.max_fix_rounds` (2). Read PR
-comments for `factory-merge-fix round=<n> finding=<hash>` markers. Set the next
-round and SHA-256 hash of the exact finding. Exhausted, outside-scope,
-security, or ambiguous findings are ESCALATE, never FIX.
+Operational conditions are FIX, never ESCALATE (WM-679). They are mechanical
+and merge-fix already performs them; the round counter bounds them:
 
-Fail closed if GitHub, Linear, config, mergeability, base SHA, or checks are
-uncertain. Populate `escalate`, `fix`, and `plan` independently per PR: an
+- CONFLICTING, or behind base → FIX, finding `rebase_onto_base`.
+- Green only on an old SHA, or no run at `headRefOid` → FIX, finding
+  `rerun_ci_at_head` (rebase first if behind, then a fresh run). The evidence
+  is not uncertain; it is old.
+- A red check on a test the PR does not touch, where the same test is also red
+  on the base branch at the merge-base SHA → this is base red, not the PR. Do
+  not escalate the PR. Emit one `CI RED` item for the base (once per base SHA,
+  not per PR) and hold the PR as FIX pending base green, finding
+  `base_red:<test>`.
+- A red test outside the PR's Owned Paths that the PR's own change caused (an
+  expectation its refactor invalidated) → FIX, with the Owned Paths deviation
+  named in the finding so merge-fix updates the expectation and records the
+  deviation on the ticket. Being outside scope alone is not a reason to stop.
+
+A FIX may auto-dispatch only when it is mechanical and its next round is at
+most `merge.max_fix_rounds` (2). Read PR comments for
+`factory-merge-fix round=<n> finding=<hash>` markers. Set the next round and
+SHA-256 hash of the exact finding. Exhausted rounds, security findings, and
+genuine product ambiguity are ESCALATE.
+
+Fail closed only on what truly cannot be evidenced — GitHub or Linear API
+errors, malformed config, an unresolvable base SHA — and record those as
+`noopReason` for the next tick, not as a per-PR human escalation.
+
+Populate `escalate`, `fix`, and `plan` independently per PR: an
 escalated or held PR appears in `escalate` but suppresses only itself, never an
 eligible fix or safe merge for another PR. Include every eligible mechanical
 fix in `fix`, and put exactly one deterministic safe candidate (lowest PR

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -104,7 +104,10 @@ describe("registry", () => {
     // Regenerated 2026-08-18: #559 (WM-662, merge agents cursor→pi/terra) landed
     // between #479's review and its merge, changing event-types.json and two
     // agent defs — registry inputs. Reason in PR body per the rule above.
-    const expected = "sha256:b2a2887bf5869f236339199447c91acd8dd617fcb5c85c095c1f85e1d6b1ea9b";
+    // Regenerated 2026-08-18 (WM-679): merge-scan.md / merge-fix.md re-prompted so
+    // operational conditions route to FIX instead of ESCALATE; both are registry
+    // inputs. Reason in PR body per the rule above.
+    const expected = "sha256:677ed34e1e04aa29437594922a2fd9ebca419c68a8a4c794dac78b2435897aeb";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Fixes WM-679. Operator direction (2026-08-18): the merge loop should merge more broadly and escalate less. Escalation is for policy and security; the scan was using it as the catch-all for anything it would not fix itself.

## Evidence

The 06:00Z scan reviewed nine PRs against develop@b718425: **4 ESCALATE, 0 MERGE, 0 FIX**. Every escalation reason was operational: #563 CONFLICTING + a red test outside Owned Paths; #562 red on the registry digest test **that was trunk-red on the base** (fixed in #564 minutes earlier); #528/#494 CONFLICTING. One `merge-fix` round each; all four sat as inbox escalations.

## Change

**`agents/merge-scan.md`** — ESCALATE narrowed to the human-required set (auth/authz, money, secrets, destructive migrations, prod infra, CLNT security, `escalate_paths`, deploy branch, product ambiguity *in the diff*, rounds exhausted). Operational conditions become **FIX** with named findings:

| condition | finding |
|---|---|
| CONFLICTING / behind base | `rebase_onto_base` |
| green only on old SHA / no run at head | `rerun_ci_at_head` |
| red test the PR does not touch, also red on base at merge-base | `base_red:<test>` — one `CI RED` item per base SHA, PR held as FIX pending base green |
| red test outside Owned Paths that the PR itself caused | FIX with the deviation named, so merge-fix records it |

API/config uncertainty → `noopReason` for the next tick, not a per-PR escalation.

**`agents/merge-fix.md`** — Owned Paths bound the *correction*, not the *rebase*: git's conflicting files are in scope for resolution (a rebase touches what the base touched; genuinely ambiguous hunks still BLOCK with the hunk named); a deviation-naming finding may make that one correction and must record it on the ticket; anything else out of scope still BLOCKs.

Both defs re-pinned via `update-pins`.

## Handoff
- Verification: `bun test` → **2419 pass, 0 fail**; `bun build/emit.mjs --check` → 0; `update-pins` → current.
- **Owned Paths deviation, named:** `event-runtime/lib/registry.test.mjs` digest constant regenerated — agent defs are registry inputs, and the test's own contract asks for the new value plus a reason in the PR body. This is that reason.
- No dedicated merge doc section exists in `docs/` to update; the agent prompts are the spec. AC 6 not applicable as written.
- UX critique: skipped — no user-facing surface.
- **Restart required** after merge — agent definitions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz