### PR TITLE
fix(worktree-up): auto-resume a branch whose unique commits are already on origin (WM-680)

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -598,6 +598,64 @@ exit 99
   }
 }, 15_000);
 
+// WM-680: a unique commit that is already on origin is preserved work (an
+// orphaned/blocked run's WIP the orchestrator pushed), not litter. worktree-up
+// resumes it without --resume so an unattended re-dispatch does not die on
+// worktree_branch_has_commits. The test above keeps the boundary: a unique
+// commit that exists ONLY locally still refuses.
+test("re-dispatch auto-resumes a branch whose unique commits are already on origin (WM-680)", () => {
+  const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-pushed-"));
+  const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-pushed-bin-"));
+  const ticketId = makeTestTicket("PUSHED");
+  const branch = `feat/${ticketId}`;
+  const expectedPath = path.join(tempWtRoot, ticketId);
+  const repo = path.resolve(import.meta.dir, "..");
+
+  try {
+    const firstUp = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    });
+    expect(firstUp.exitCode).toBe(0);
+    writeFileSync(path.join(expectedPath, "wip.txt"), "preserved work\n");
+    expect(Bun.spawnSync({ cmd: ["git", "add", "wip.txt"], cwd: expectedPath }).exitCode).toBe(0);
+    expect(Bun.spawnSync({
+      cmd: ["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "wip: preserved before re-dispatch (WM-680)"],
+      cwd: expectedPath,
+      stdout: "pipe",
+      stderr: "pipe",
+    }).exitCode).toBe(0);
+    const tip = Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath, stdout: "pipe" }).stdout.toString().trim();
+    // Simulate "pushed": stand up the remote-tracking ref at the same SHA.
+    expect(Bun.spawnSync({ cmd: ["git", "update-ref", `refs/remotes/origin/${branch}`, tip], cwd: repo }).exitCode).toBe(0);
+    // Tear the worktree down (branch stays), as an orphaned run leaves it.
+    expect(Bun.spawnSync({ cmd: ["bash", DOWN, ticketId], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } }).exitCode).toBe(0);
+    expect(existsSync(expectedPath)).toBe(false);
+
+    writeFileSync(path.join(mockBin, "gh"), "#!/usr/bin/env bash\nprintf '0\\n'\n", { mode: 0o755 }); // no open PR
+    const secondUp = Bun.spawnSync({
+      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot, PATH: `${mockBin}${path.delimiter}${process.env.PATH}` },
+    });
+    expect(secondUp.stderr.toString()).not.toContain("worktree_branch_has_commits");
+    expect(secondUp.exitCode).toBe(0);
+    expect(existsSync(expectedPath)).toBe(true);
+    // The preserved commit is what the new worktree is on.
+    expect(readFileSync(path.join(expectedPath, "wip.txt"), "utf8")).toBe("preserved work\n");
+    expect(Bun.spawnSync({ cmd: ["git", "rev-parse", "HEAD"], cwd: expectedPath, stdout: "pipe" }).stdout.toString().trim()).toBe(tip);
+  } finally {
+    Bun.spawnSync({ cmd: ["bash", DOWN, ticketId, "--force"], env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot } });
+    rmSync(tempWtRoot, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    Bun.spawnSync({ cmd: ["git", "update-ref", "-d", `refs/remotes/origin/${branch}`], cwd: repo });
+    Bun.spawnSync({ cmd: ["git", "branch", "-D", branch], cwd: repo });
+  }
+});
+
 test("re-dispatch keeps unique-commit refusal ahead of dirty-worktree preservation", () => {
   const tempWtRoot = mkdtempSync(path.join(tmpdir(), "factory-wt-unique-"));
   const mockBin = mkdtempSync(path.join(tmpdir(), "factory-wt-no-pr-bin-"));

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -164,6 +164,22 @@ else
       [[ "$OPEN_PR_COUNT" == "1" ]] && RESUMING=1
     fi
 
+    # WM-680: a branch whose tip is already on origin is preserved work, not
+    # litter — an orphaned or blocked run's WIP that the orchestrator (or the
+    # worker's own preservation) pushed so nothing is lost. Refusing to build
+    # on it forces a human to run --resume by hand for every re-dispatch, and
+    # an unattended loop just loses the slot. Resume it. A branch with unique
+    # commits that exist ONLY locally still refuses below: that is the case
+    # where nobody has vouched for the work by pushing it.
+    if [[ "$RESUMING" -eq 0 && "$UNIQUE_COMMITS" -gt 0 ]]; then
+      if [[ "${FACTORY_WORKTREE_RESUME:-0}" == "1" ]]; then
+        RESUMING=1
+      elif REMOTE_SHA=$(git -C "$REPO" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH") \
+           && [[ "$REMOTE_SHA" == "$BRANCH_SHA" ]]; then
+        RESUMING=1
+      fi
+    fi
+
     if [[ "$RESUMING" -eq 1 ]]; then
       if [[ -d "$WT" ]]; then
         CURRENT_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
@@ -173,7 +189,7 @@ else
       [[ "$CHECKOUT_ONLY" -eq 1 ]] || info "resuming branch $BRANCH as-is"
     else
       if [[ "$UNIQUE_COMMITS" -gt 0 ]]; then
-        die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF — re-run with --resume or remove branch '$BRANCH' explicitly before re-dispatch"
+        die "worktree_branch_has_commits: branch '$BRANCH' has $UNIQUE_COMMITS unique commit(s) beyond $BASE_REF that are not on origin — push them (they are then resumed automatically), re-run with --resume, or remove branch '$BRANCH' explicitly before re-dispatch"
       fi
 
       if [[ -d "$WT" ]]; then


### PR DESCRIPTION
Partial fix for WM-680 (the provisioning half; the reuse-in-place half is left for the ticket).

Re-dispatching a ticket whose earlier run was orphaned or blocked died **six times today** with `worktree_branch_has_commits` — the branch carried the WIP the orchestrator had preserved (committed + pushed, per ORCHESTRATOR.md Loop 4) so nothing was lost, and `worktree-up` refused to build on it unless someone ran `--resume` by hand. The existing auto-resume only fired for an *open PR*; preserved-but-unsubmitted work had no path, so an unattended loop just lost the slot.

**Change:** a branch whose tip is already on `origin` is vouched-for work, not litter — resume it. A branch with unique commits that exist **only locally** still refuses exactly as before (that is the case nobody has vouched for). Also honours `FACTORY_WORKTREE_RESUME=1` as an explicit escape for the dispatcher. Error text now says to push.

## Handoff
- Verification: `bun test bin/worktree-checkout.test.mjs` → 27 pass, 0 fail.
- New test confirmed **failing against the previous script** (`0 pass / 1 fail`) and passing after; the pre-existing local-only refusal test is unchanged and still passes — the boundary is preserved.
- Files: 2 (`bin/worktree-up.sh`, `bin/worktree-checkout.test.mjs`). `bin/worktree-up.sh` is in WM-680's Owned Paths; the test file is its natural pair.
- No restart needed — the script is invoked per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz