### PR TITLE
fix(event-runtime-web): make list toolbars responsive (WM-543)

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -348,7 +348,10 @@ describe("ListToolbar (WM-543)", () => {
     expect(classes(tools)).toContain("flex-nowrap");
     expect(classes(tools)).toContain("flex-[1_1_14rem]");
     expect(classes(tools)).not.toContain("w-max");
-    expect(classes(tools)).toContain("justify-end");
+    // Right-aligned only from `sm` up; below that, overflow runs off the
+    // trailing edge rather than back over the nav sidebar (WM-96 follow-up).
+    expect(classes(tools)).toContain("justify-start");
+    expect(classes(tools)).toContain("sm:justify-end");
     expect(classes(tools.parentElement as HTMLElement)).toContain("flex-wrap");
 
     const filter = r.getByRole("combobox").parentElement?.parentElement;
@@ -356,6 +359,97 @@ describe("ListToolbar (WM-543)", () => {
     expect(classes(filter)).toContain("min-w-36");
     expect(classes(filter)).toContain("max-w-56");
     expect(classes(filter)).toContain("flex-[1_1_14rem]");
+  });
+
+  test("masks the scrollable edge of an overflowing tab strip and clears it once fully visible (WM-96)", () => {
+    const r = render(
+      <ListToolbar
+        tabs={
+          <div role="tablist" aria-label="Event status" className="flex">
+            <button role="tab" aria-selected="true">
+              All
+            </button>
+            <button role="tab" aria-selected="false">
+              Cancelled
+            </button>
+          </div>
+        }
+        tools={<button>Display</button>}
+      />,
+    );
+    const tablist = r.getByRole("tablist");
+    const scroller = tablist.parentElement as HTMLElement;
+
+    // No overflow: no mask.
+    expect(scroller.style.maskImage).toBeFalsy();
+
+    // Overflowing and scrolled to the start: only the trailing edge fades.
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 200,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 0,
+      configurable: true,
+    });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    expect(scroller.style.maskImage).toContain("to right");
+    expect(scroller.style.maskImage).not.toContain("transparent, black 2rem");
+
+    // Scrolled to the trailing edge: only the leading edge fades.
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 200,
+      configurable: true,
+    });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    expect(scroller.style.maskImage).toContain("to left");
+
+    // Scrolled to the middle: both edges fade.
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 100,
+      configurable: true,
+    });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    expect(scroller.style.maskImage).toContain("transparent, black 2rem");
+  });
+
+  test("scrolls a focused tab into view so keyboard users can reach clipped tabs (WM-96)", () => {
+    const scrolls: HTMLElement[] = [];
+    const original = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = function (this: HTMLElement) {
+      scrolls.push(this);
+    };
+    try {
+      const r = render(
+        <ListToolbar
+          tabs={
+            <div role="tablist" aria-label="Event status" className="flex">
+              <button role="tab" aria-selected="false">
+                Cancelled
+              </button>
+            </div>
+          }
+          tools={<button>Display</button>}
+        />,
+      );
+      const tab = r.getByRole("tab", { name: "Cancelled" });
+      act(() => {
+        fireEvent.focus(tab);
+      });
+      expect(scrolls).toEqual([tab]);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = original;
+    }
   });
 });
 

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -16,6 +16,7 @@ import {
   IconButton,
   KV,
   KVGroup,
+  ListToolbar,
   notify,
   Section,
   shortId,
@@ -307,6 +308,54 @@ describe("Tooltip viewport clamp (WM-589 follow-up)", () => {
     const left = parseFloat(tooltip.style.left);
     expect(left).toBeGreaterThanOrEqual(0);
     expect(left + 260).toBeLessThanOrEqual(1440);
+  });
+});
+
+describe("ListToolbar (WM-543)", () => {
+  test("exposes one tablist and one tools group without allowing either group to wrap internally", () => {
+    const r = render(
+      <ListToolbar
+        tabs={
+          <div
+            role="tablist"
+            aria-label="Run state"
+            className="flex w-max flex-nowrap gap-1"
+          >
+            <button role="tab" aria-selected="true">
+              All
+            </button>
+            <button role="tab" aria-selected="false">
+              Completed
+            </button>
+          </div>
+        }
+        tools={
+          <>
+            <button>Display</button>
+            <FilterInput
+              value=""
+              onChange={() => {}}
+              placeholder="Filter runs"
+              label="Filter runs"
+            />
+          </>
+        }
+      />,
+    );
+
+    expect(r.getAllByRole("tablist")).toHaveLength(1);
+    const tools = r.getByRole("group", { name: "List tools" });
+    expect(classes(tools)).toContain("flex-nowrap");
+    expect(classes(tools)).toContain("flex-[1_1_14rem]");
+    expect(classes(tools)).not.toContain("w-max");
+    expect(classes(tools)).toContain("justify-end");
+    expect(classes(tools.parentElement as HTMLElement)).toContain("flex-wrap");
+
+    const filter = r.getByRole("combobox").parentElement?.parentElement;
+    if (!filter) throw new Error("filter sizing wrapper is missing");
+    expect(classes(filter)).toContain("min-w-36");
+    expect(classes(filter)).toContain("max-w-56");
+    expect(classes(filter)).toContain("flex-[1_1_14rem]");
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -470,8 +470,8 @@ export function FilterInput<T = unknown, C = unknown>({
   };
 
   return (
-    <>
-      <span className="relative inline-flex w-56 shrink-0">
+    <div className="flex min-w-36 max-w-56 flex-[1_1_14rem] flex-wrap items-start gap-1.5">
+      <span className="relative inline-flex w-full">
         <input
           ref={inputRef}
           data-view-filter
@@ -662,7 +662,36 @@ export function FilterInput<T = unknown, C = unknown>({
           </Button>
         </div>
       )}
-    </>
+    </div>
+  );
+}
+
+/**
+ * Shared responsive layout for the tabs and controls above list tables.
+ * Tabs keep their intrinsic width (and scroll only as a last resort); the
+ * no-wrap tools group shrinks its filter first, then drops to a right-aligned
+ * second row as one unit when the two groups no longer fit side by side.
+ */
+export function ListToolbar({
+  tabs,
+  tools,
+  className = "mb-3",
+}: {
+  tabs: ReactNode;
+  tools: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`${className} flex min-w-0 flex-wrap items-start gap-2`}>
+      <div className="max-w-full shrink-0 overflow-x-auto pb-px">{tabs}</div>
+      <div
+        role="group"
+        aria-label="List tools"
+        className="ml-auto flex max-w-full flex-[1_1_14rem] flex-nowrap items-start justify-end gap-2"
+      >
+        {tools}
+      </div>
+    </div>
   );
 }
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -4,6 +4,7 @@ import {
   type ButtonHTMLAttributes,
   type ComponentProps,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useId,
@@ -671,6 +672,25 @@ export function FilterInput<T = unknown, C = unknown>({
  * Tabs keep their intrinsic width (and scroll only as a last resort); the
  * no-wrap tools group shrinks its filter first, then drops to a right-aligned
  * second row as one unit when the two groups no longer fit side by side.
+ *
+ * Tabs never wrap (WM-543: wrapping produced a ragged two-row strip) and
+ * never clip silently (WM-96: at ~800-880px — the Events view's longest
+ * labels — the strip used to run out of width with no indication there was
+ * more to see). They scroll horizontally instead, with an edge fade masking
+ * whichever side has more content, on top of the app's always-visible
+ * styled scrollbar (theme.css). The fade is recomputed on resize/scroll via
+ * ResizeObserver so it tracks viewport and content changes, and a focused
+ * tab scrolls itself into view so keyboard users can reach clipped tabs.
+ *
+ * The tools group deliberately isn't given the same overflow-x treatment:
+ * FilterInput's suggestion listbox is plain `position:absolute` (no
+ * portal), and any non-`visible` overflow-x on an ancestor forces the
+ * paired overflow-y to `auto` too (CSS overflow computed-value rule),
+ * which would clip that dropdown to a sliver. Instead it stays
+ * `justify-start` below `sm`, so on the very narrow phones where its
+ * content still doesn't fit at the tools group's 9rem-filter floor,
+ * overflow runs off the trailing edge instead of the leading edge — past
+ * the viewport, not back over the nav sidebar.
  */
 export function ListToolbar({
   tabs,
@@ -681,13 +701,76 @@ export function ListToolbar({
   tools: ReactNode;
   className?: string;
 }) {
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const [tabsOverflow, setTabsOverflow] = useState({
+    start: false,
+    end: false,
+  });
+
+  const updateTabsOverflow = useCallback(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    if (max <= 1) {
+      setTabsOverflow({ start: false, end: false });
+      return;
+    }
+    setTabsOverflow({
+      start: el.scrollLeft > 1,
+      end: el.scrollLeft < max - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+    updateTabsOverflow();
+    const ro = new ResizeObserver(updateTabsOverflow);
+    ro.observe(el);
+    el.addEventListener("scroll", updateTabsOverflow, { passive: true });
+    return () => {
+      ro.disconnect();
+      el.removeEventListener("scroll", updateTabsOverflow);
+    };
+  }, [tabs, updateTabsOverflow]);
+
+  const tabsMask =
+    tabsOverflow.start && tabsOverflow.end
+      ? "linear-gradient(to right, transparent, black 2rem, black calc(100% - 2rem), transparent)"
+      : tabsOverflow.end
+        ? "linear-gradient(to right, black calc(100% - 2rem), transparent)"
+        : tabsOverflow.start
+          ? "linear-gradient(to left, black calc(100% - 2rem), transparent)"
+          : undefined;
+
   return (
     <div className={`${className} flex min-w-0 flex-wrap items-start gap-2`}>
-      <div className="max-w-full shrink-0 overflow-x-auto pb-px">{tabs}</div>
+      <div
+        ref={tabsRef}
+        onFocus={(e) => {
+          (e.target as HTMLElement).scrollIntoView({
+            block: "nearest",
+            inline: "nearest",
+          });
+        }}
+        // Below `sm` a caller may swap the tab strip for a full-width mobile
+        // `<select>` (Projects, Workers): `w-full` lets that select's own
+        // `w-full` resolve against something, since a `shrink-0` ancestor
+        // with no explicit width only ever hugs content. At `sm` and up the
+        // desktop strip reverts to hugging its (possibly scrollable) content.
+        className="w-full max-w-full overflow-x-auto pb-px sm:w-auto sm:shrink-0"
+        style={
+          tabsMask
+            ? { maskImage: tabsMask, WebkitMaskImage: tabsMask }
+            : undefined
+        }
+      >
+        {tabs}
+      </div>
       <div
         role="group"
         aria-label="List tools"
-        className="ml-auto flex max-w-full flex-[1_1_14rem] flex-nowrap items-start justify-end gap-2"
+        className="ml-auto flex max-w-full flex-[1_1_14rem] flex-nowrap items-start justify-start gap-2 sm:justify-end"
       >
         {tools}
       </div>

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -33,6 +33,7 @@ import {
   KVGroup,
   ListEmpty,
   ListPane,
+  ListToolbar,
   ModelCell,
   Section,
   Table,
@@ -363,55 +364,59 @@ export function Agents({
                 {rows.length} agents · {mutatingCount} mutating ·{" "}
                 {rows.length - mutatingCount} read-only
               </div>
-              <div className="mb-3 flex flex-wrap items-center gap-2">
-                <div
-                  className="flex min-w-0 flex-1 flex-wrap gap-1"
-                  role="tablist"
-                  aria-label="Agent mutation safety"
-                >
-                  {AGENT_TABS.map((item, index) => (
-                    <PrimitiveButton
-                      bare
-                      key={item}
-                      type="button"
-                      role="tab"
-                      aria-selected={tab === item}
-                      onClick={() => selectTab(item)}
-                      className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                        tab === item
-                          ? "bg-(--surface-3) text-(--text)"
-                          : "text-(--text-faint) hover:bg-(--surface-1)"
-                      }`}
-                    >
-                      {AGENT_TAB_LABELS[item]}
-                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                        {tabCounts[item]}
-                      </span>
-                      <span
-                        aria-hidden="true"
-                        className="mono ml-1 text-xs text-(--text-faint) opacity-70"
+              <ListToolbar
+                tabs={
+                  <div
+                    className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                    role="tablist"
+                    aria-label="Agent mutation safety"
+                  >
+                    {AGENT_TABS.map((item, index) => (
+                      <PrimitiveButton
+                        bare
+                        key={item}
+                        type="button"
+                        role="tab"
+                        aria-selected={tab === item}
+                        onClick={() => selectTab(item)}
+                        className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                          tab === item
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
                       >
-                        {index + 1}
-                      </span>
-                    </PrimitiveButton>
-                  ))}
-                </div>
-                <span className="ml-auto">
-                  <DisplayOptions
-                    config={AGENTS_DISPLAY}
-                    state={display}
-                    onChange={setDisplay}
-                    onExport={visible.length > 0 ? handleExport : undefined}
-                    rows={rows}
-                  />
-                </span>
-                <FilterInput
-                  value={filter}
-                  onChange={setFilter}
-                  placeholder="Filter ref, contract, adapter, model, event type…"
-                  label="Filter agents"
-                />
-              </div>
+                        {AGENT_TAB_LABELS[item]}
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {tabCounts[item]}
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-xs text-(--text-faint) opacity-70"
+                        >
+                          {index + 1}
+                        </span>
+                      </PrimitiveButton>
+                    ))}
+                  </div>
+                }
+                tools={
+                  <>
+                    <DisplayOptions
+                      config={AGENTS_DISPLAY}
+                      state={display}
+                      onChange={setDisplay}
+                      onExport={visible.length > 0 ? handleExport : undefined}
+                      rows={rows}
+                    />
+                    <FilterInput
+                      value={filter}
+                      onChange={setFilter}
+                      placeholder="Filter ref, contract, adapter, model, event type…"
+                      label="Filter agents"
+                    />
+                  </>
+                }
+              />
             </>
           }
         >

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -11,6 +11,7 @@ import {
   JumpLink,
   ListEmpty,
   ListPane,
+  ListToolbar,
   StatCard,
   Table,
   Th,
@@ -477,76 +478,85 @@ export function Artifacts({
               />
             </section>
 
-            <div className="mt-3 flex flex-wrap items-center gap-2">
-              <div
-                className="flex flex-wrap gap-1"
-                role="tablist"
-                aria-label="Artifact reference state"
-              >
-                {(
-                  [
-                    { label: "All", value: null, count: summary.files },
-                    {
-                      label: "Referenced",
-                      value: false,
-                      count: summary.files - summary.orphans,
-                    },
-                    { label: "Orphans", value: true, count: summary.orphans },
-                  ] as const
-                ).map((facet) => (
-                  <PrimitiveButton
-                    bare
-                    key={facet.label}
-                    type="button"
-                    role="tab"
-                    aria-selected={filters.orphan === facet.value}
-                    onClick={() => set({ orphan: facet.value })}
-                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                      filters.orphan === facet.value
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1)"
-                    }`}
-                  >
-                    {facet.label}
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                      {facet.count.toLocaleString()}
-                    </span>
-                  </PrimitiveButton>
-                ))}
-              </div>
-              <span className="ml-auto">
-                <DisplayOptions
-                  config={ARTIFACTS_DISPLAY}
-                  state={display}
-                  onChange={setDisplay}
-                  rows={artifacts}
-                />
-              </span>
-              <label className="flex items-center gap-1.5 text-[11px] font-medium text-(--text-dim)">
-                <span>Kind:</span>
-                <select
-                  aria-label="Artifact kind"
-                  value={filters.kind ?? ""}
-                  onChange={(event) =>
-                    set({ kind: event.target.value || null })
-                  }
-                  className="cursor-pointer rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent)"
+            <ListToolbar
+              className="mt-3"
+              tabs={
+                <div
+                  className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                  role="tablist"
+                  aria-label="Artifact reference state"
                 >
-                  <option value="">Any kind</option>
-                  {kinds.map((kind) => (
-                    <option key={kind} value={kind}>
-                      {kind}
-                    </option>
+                  {(
+                    [
+                      { label: "All", value: null, count: summary.files },
+                      {
+                        label: "Referenced",
+                        value: false,
+                        count: summary.files - summary.orphans,
+                      },
+                      {
+                        label: "Orphans",
+                        value: true,
+                        count: summary.orphans,
+                      },
+                    ] as const
+                  ).map((facet) => (
+                    <PrimitiveButton
+                      bare
+                      key={facet.label}
+                      type="button"
+                      role="tab"
+                      aria-selected={filters.orphan === facet.value}
+                      onClick={() => set({ orphan: facet.value })}
+                      className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                        filters.orphan === facet.value
+                          ? "bg-(--surface-3) text-(--text)"
+                          : "text-(--text-faint) hover:bg-(--surface-1)"
+                      }`}
+                    >
+                      {facet.label}
+                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                        {facet.count.toLocaleString()}
+                      </span>
+                    </PrimitiveButton>
                   ))}
-                </select>
-              </label>
-              <FilterInput
-                value={filters.search}
-                onChange={(search) => set({ search })}
-                placeholder="SHA, kind, run, agent…"
-                label="Search artifacts"
-              />
-            </div>
+                </div>
+              }
+              tools={
+                <>
+                  <DisplayOptions
+                    config={ARTIFACTS_DISPLAY}
+                    state={display}
+                    onChange={setDisplay}
+                    rows={artifacts}
+                  />
+                  <label className="flex items-center gap-1.5 text-[11px] font-medium text-(--text-dim)">
+                    <span>Kind:</span>
+                    <select
+                      aria-label="Artifact kind"
+                      value={filters.kind ?? ""}
+                      onChange={(event) =>
+                        set({ kind: event.target.value || null })
+                      }
+                      className="cursor-pointer rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent)"
+                    >
+                      <option value="">Any kind</option>
+                      {kinds.map((kind) => (
+                        <option key={kind} value={kind}>
+                          {kind}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <FilterInput
+                    value={filters.search}
+                    onChange={(search) => set({ search })}
+                    placeholder="SHA, kind, run, agent…"
+                    label="Search artifacts"
+                  />
+                </>
+              }
+            />
           </>
         }
       >

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -65,6 +65,7 @@ import {
   Disclosure,
   EVENT_STATUS_HUES,
   FilterInput,
+  ListToolbar,
   ListPane,
   DetailPane,
   JsonBlock,
@@ -773,7 +774,6 @@ export function Events({
       tabChangedFor.current = key;
       setTab("all");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     focusEvent?.source,
     focusEvent?.eventId,
@@ -950,45 +950,6 @@ export function Events({
               </p>
             )}
 
-            <div
-              className="mb-3 flex flex-wrap gap-1"
-              role="tablist"
-              aria-label="Event status"
-            >
-              {STATUS_TABS.map((t, idx) => {
-                const count = tabCount(t);
-                return (
-                  <PrimitiveButton
-                    bare
-                    key={t}
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === t}
-                    onClick={() => selectTab(t)}
-                    title={t}
-                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                      tab === t
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1)"
-                    }`}
-                  >
-                    {TAB_LABEL[t]}
-                    {count > 0 && (
-                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                        {count}
-                      </span>
-                    )}
-                    <span
-                      aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
-                    >
-                      {idx + 1}
-                    </span>
-                  </PrimitiveButton>
-                );
-              })}
-            </div>
-
             {(types.length > 1 || sources.length > 1) && (
               <div className="mb-2 flex min-w-0 items-center gap-x-4 whitespace-nowrap text-[11px]">
                 {types.length > 1 && (
@@ -1088,28 +1049,70 @@ export function Events({
               </div>
             )}
 
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <span className="ml-auto">
-                <DisplayOptions
-                  config={displayConfig}
-                  state={display}
-                  onChange={setDisplay}
-                  onExport={visible.length > 0 ? handleExport : undefined}
-                  rows={scoped}
-                />
-              </span>
-              {/* Last in the row: the token chips are a full-width item, so anything
-              after the filter box would be pushed onto a third line the moment
-              a chip appeared. */}
-              <FilterInput
-                value={filter}
-                onChange={setFilter}
-                placeholder="source:… type:… reason:… is:stale"
-                label="Filter events"
-                query={parsed}
-                facets={facets}
-              />
-            </div>
+            <ListToolbar
+              tabs={
+                <div
+                  className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                  role="tablist"
+                  aria-label="Event status"
+                >
+                  {STATUS_TABS.map((t, idx) => {
+                    const count = tabCount(t);
+                    return (
+                      <PrimitiveButton
+                        bare
+                        key={t}
+                        type="button"
+                        role="tab"
+                        aria-selected={tab === t}
+                        onClick={() => selectTab(t)}
+                        title={t}
+                        className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                          tab === t
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
+                      >
+                        {TAB_LABEL[t]}
+                        {count > 0 && (
+                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                            {count}
+                          </span>
+                        )}
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                        >
+                          {idx + 1}
+                        </span>
+                      </PrimitiveButton>
+                    );
+                  })}
+                </div>
+              }
+              tools={
+                <>
+                  <DisplayOptions
+                    config={displayConfig}
+                    state={display}
+                    onChange={setDisplay}
+                    onExport={visible.length > 0 ? handleExport : undefined}
+                    rows={scoped}
+                  />
+                  {/* Last in the row: the token chips are a full-width item, so anything
+                  after the filter box would be pushed onto a third line the moment
+                  a chip appeared. */}
+                  <FilterInput
+                    value={filter}
+                    onChange={setFilter}
+                    placeholder="source:… type:… reason:… is:stale"
+                    label="Filter events"
+                    query={parsed}
+                    facets={facets}
+                  />
+                </>
+              }
+            />
           </>
         }
       >

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -34,6 +34,7 @@ import {
   KV,
   ListEmpty,
   ListPane,
+  ListToolbar,
   Section,
   Table,
   Th,
@@ -485,69 +486,75 @@ export function Projects({
               surface="registry"
               subject={{ label: "Projects", plural: true }}
             />
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <select
-                aria-label="Project mode"
-                value={filterMode}
-                onChange={(event) =>
-                  setFilterMode(event.target.value as ProjectMode)
-                }
-                className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
-              >
-                {PROJECT_MODES.map((mode) => (
-                  <option key={mode} value={mode}>
-                    {mode === "ALL"
-                      ? "All"
-                      : mode === "DISPATCHABLE"
-                        ? "Dispatchable"
-                        : "Report-Only"}{" "}
-                    {modeCounts[mode]}
-                  </option>
-                ))}
-              </select>
-              <div
-                className="hidden min-w-0 flex-1 flex-wrap gap-1 text-[12px] sm:flex"
-                role="tablist"
-                aria-label="Project mode"
-              >
-                {PROJECT_MODES.map((mode, idx) => (
-                  <PrimitiveButton
-                    bare
-                    key={mode}
-                    type="button"
-                    role="tab"
-                    aria-selected={filterMode === mode}
-                    onClick={() => setFilterMode(mode)}
-                    className={`shrink-0 rounded-md px-2.5 py-1 font-medium transition-colors ${
-                      filterMode === mode
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
-                    }`}
+            <ListToolbar
+              tabs={
+                <>
+                  <select
+                    aria-label="Project mode"
+                    value={filterMode}
+                    onChange={(event) =>
+                      setFilterMode(event.target.value as ProjectMode)
+                    }
+                    className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
                   >
-                    {mode === "ALL"
-                      ? "All"
-                      : mode === "DISPATCHABLE"
-                        ? "Dispatchable"
-                        : "Report-Only"}
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                      {modeCounts[mode]}
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
-                    >
-                      {idx + 1}
-                    </span>
-                  </PrimitiveButton>
-                ))}
-              </div>
-              <FilterInput
-                value={filter}
-                onChange={setFilter}
-                placeholder="Filter repo, project, team, github… (/)"
-                label="Filter repositories"
-              />
-            </div>
+                    {PROJECT_MODES.map((mode) => (
+                      <option key={mode} value={mode}>
+                        {mode === "ALL"
+                          ? "All"
+                          : mode === "DISPATCHABLE"
+                            ? "Dispatchable"
+                            : "Report-Only"}{" "}
+                        {modeCounts[mode]}
+                      </option>
+                    ))}
+                  </select>
+                  <div
+                    className="hidden w-max flex-nowrap gap-1 whitespace-nowrap text-[12px] sm:flex"
+                    role="tablist"
+                    aria-label="Project mode"
+                  >
+                    {PROJECT_MODES.map((mode, idx) => (
+                      <PrimitiveButton
+                        bare
+                        key={mode}
+                        type="button"
+                        role="tab"
+                        aria-selected={filterMode === mode}
+                        onClick={() => setFilterMode(mode)}
+                        className={`shrink-0 rounded-md px-2.5 py-1 font-medium transition-colors ${
+                          filterMode === mode
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
+                        }`}
+                      >
+                        {mode === "ALL"
+                          ? "All"
+                          : mode === "DISPATCHABLE"
+                            ? "Dispatchable"
+                            : "Report-Only"}
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {modeCounts[mode]}
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                        >
+                          {idx + 1}
+                        </span>
+                      </PrimitiveButton>
+                    ))}
+                  </div>
+                </>
+              }
+              tools={
+                <FilterInput
+                  value={filter}
+                  onChange={setFilter}
+                  placeholder="Filter repo, project, team, github… (/)"
+                  label="Filter repositories"
+                />
+              }
+            />
           </>
         }
       >

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -53,6 +53,7 @@ import {
   Dialog,
   Disclosure,
   FilterInput,
+  ListToolbar,
   ListPane,
   DetailPane,
   JsonBlock,
@@ -1048,93 +1049,97 @@ export function Proposals({
                 </p>
               )}
 
-              <div className="mb-3 flex flex-wrap items-center gap-2">
-                <div
-                  className="flex gap-1"
-                  role="tablist"
-                  aria-label="Proposal status"
-                >
-                  {PROPOSAL_TABS.map((t, idx) => {
-                    const count =
-                      t === "open"
-                        ? filterOpenProposals(
-                            query.data?.proposals ?? [],
-                            now,
-                          ).filter(
-                            (p) =>
-                              context.kind !== "repo" ||
-                              matchesRepo(p.repos, context),
-                          ).length
-                        : (history.data?.proposals ?? []).filter(
-                            (p) =>
-                              p.status !== "open" &&
-                              matchesRepo(p.repos, context),
-                          ).length;
-                    return (
+              <ListToolbar
+                tabs={
+                  <div
+                    className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                    role="tablist"
+                    aria-label="Proposal status"
+                  >
+                    {PROPOSAL_TABS.map((t, idx) => {
+                      const count =
+                        t === "open"
+                          ? filterOpenProposals(
+                              query.data?.proposals ?? [],
+                              now,
+                            ).filter(
+                              (p) =>
+                                context.kind !== "repo" ||
+                                matchesRepo(p.repos, context),
+                            ).length
+                          : (history.data?.proposals ?? []).filter(
+                              (p) =>
+                                p.status !== "open" &&
+                                matchesRepo(p.repos, context),
+                            ).length;
+                      return (
+                        <PrimitiveButton
+                          bare
+                          key={t}
+                          type="button"
+                          role="tab"
+                          aria-selected={tab === t}
+                          onClick={() => selectTab(t)}
+                          title={t}
+                          className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"}`}
+                        >
+                          {t === "open" ? "Open" : "History"}
+                          {count > 0 && (
+                            <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                              {count}
+                            </span>
+                          )}
+                          <span
+                            aria-hidden="true"
+                            className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                          >
+                            {idx + 1}
+                          </span>
+                        </PrimitiveButton>
+                      );
+                    })}
+                  </div>
+                }
+                tools={
+                  <>
+                    {tab === "open" && expiredCount > 0 && (
                       <PrimitiveButton
                         bare
-                        key={t}
                         type="button"
-                        role="tab"
-                        aria-selected={tab === t}
-                        onClick={() => selectTab(t)}
-                        title={t}
-                        className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${tab === t ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"}`}
+                        aria-pressed={expiredOnly}
+                        onClick={() => setExpiredOnly((v) => !v)}
+                        title="Filter to expired open proposals"
+                        className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
+                          expiredOnly
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
                       >
-                        {t === "open" ? "Open" : "History"}
-                        {count > 0 && (
-                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                            {count}
-                          </span>
-                        )}
-                        <span
-                          aria-hidden="true"
-                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
-                        >
-                          {idx + 1}
+                        Expired
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {expiredCount}
                         </span>
                       </PrimitiveButton>
-                    );
-                  })}
-                </div>
-                {tab === "open" && expiredCount > 0 && (
-                  <PrimitiveButton
-                    bare
-                    type="button"
-                    aria-pressed={expiredOnly}
-                    onClick={() => setExpiredOnly((v) => !v)}
-                    title="Filter to expired open proposals"
-                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
-                      expiredOnly
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1)"
-                    }`}
-                  >
-                    Expired
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                      {expiredCount}
-                    </span>
-                  </PrimitiveButton>
-                )}
-                <span className="ml-auto">
-                  <DisplayOptions
-                    config={displayConfig}
-                    state={display}
-                    onChange={setDisplay}
-                    rows={scoped}
-                  />
-                </span>
-                {/* Last in the row: the token chips are a full-width item, so anything
-              after the filter box would be pushed onto a third line the moment
-              a chip appears. */}
-                <FilterInput
-                  value={filter}
-                  onChange={setFilter}
-                  placeholder="agent:… is:stale is:expired"
-                  label="Filter proposals"
-                  query={parsed}
-                />
-              </div>
+                    )}
+                    <DisplayOptions
+                      config={displayConfig}
+                      state={display}
+                      onChange={setDisplay}
+                      rows={scoped}
+                    />
+                    {/* Last in the row: the token chips are a full-width item, so anything
+                    after the filter box would be pushed onto a third line the moment
+                    a chip appears. */}
+                    <FilterInput
+                      value={filter}
+                      onChange={setFilter}
+                      placeholder="agent:… is:stale is:expired"
+                      label="Filter proposals"
+                      query={parsed}
+                    />
+                  </>
+                }
+              />
             </>
           }
         >

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -66,6 +66,7 @@ import {
   CopyActions,
   Dialog,
   FilterInput,
+  ListToolbar,
   ListPane,
   DetailPane,
   JumpLink,
@@ -1066,64 +1067,66 @@ export function Runs({
 
             {/* `flex-wrap`: the token chips are a full-width item, so they take
             their own line under the tabs and the box instead of squeezing them. */}
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              {/* Wrap, never scroll or clip: at 1280px the strip used to run out of
-              width at CANCELLED with no scrollbar affordance (WM-96). */}
-              <div
-                className="flex min-w-0 flex-1 flex-wrap gap-1"
-                role="tablist"
-                aria-label="Run state"
-              >
-                {RUN_TABS.map((t, idx) => {
-                  const count = tabCount(t);
-                  return (
-                    <Button
-                      key={t}
-                      size="sm"
-                      variant="ghost"
-                      role="tab"
-                      aria-selected={tab === t}
-                      onClick={() => selectTab(t)}
-                      title={RUN_TAB_TITLES[t]}
-                      className={`rounded-md ${
-                        tab === t
-                          ? "bg-(--surface-3) text-(--text)"
-                          : "text-(--text-faint) hover:bg-(--surface-1)"
-                      }`}
-                    >
-                      {RUN_TAB_LABELS[t]}
-                      {count > 0 && (
-                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                          {count}
-                        </span>
-                      )}
-                      <span
-                        aria-hidden="true"
-                        className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+            <ListToolbar
+              tabs={
+                <div
+                  className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                  role="tablist"
+                  aria-label="Run state"
+                >
+                  {RUN_TABS.map((t, idx) => {
+                    const count = tabCount(t);
+                    return (
+                      <Button
+                        key={t}
+                        size="sm"
+                        variant="ghost"
+                        role="tab"
+                        aria-selected={tab === t}
+                        onClick={() => selectTab(t)}
+                        title={RUN_TAB_TITLES[t]}
+                        className={`shrink-0 rounded-md ${
+                          tab === t
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
                       >
-                        {idx + 1}
-                      </span>
-                    </Button>
-                  );
-                })}
-              </div>
-              <span className="ml-auto">
-                <DisplayOptions
-                  config={displayConfig}
-                  state={display}
-                  onChange={setDisplay}
-                  onExport={visible.length > 0 ? handleExport : undefined}
-                  rows={scoped}
-                />
-              </span>
-              <FilterInput
-                value={filter}
-                onChange={setFilter}
-                placeholder="agent:… state:… is:stale"
-                label="Filter runs"
-                query={parsed}
-              />
-            </div>
+                        {RUN_TAB_LABELS[t]}
+                        {count > 0 && (
+                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                            {count}
+                          </span>
+                        )}
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                        >
+                          {idx + 1}
+                        </span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              }
+              tools={
+                <>
+                  <DisplayOptions
+                    config={displayConfig}
+                    state={display}
+                    onChange={setDisplay}
+                    onExport={visible.length > 0 ? handleExport : undefined}
+                    rows={scoped}
+                  />
+                  <FilterInput
+                    value={filter}
+                    onChange={setFilter}
+                    placeholder="agent:… state:… is:stale"
+                    label="Filter runs"
+                    query={parsed}
+                  />
+                </>
+              }
+            />
           </>
         }
       >

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -26,6 +26,7 @@ import {
   KV,
   ListEmpty,
   ListPane,
+  ListToolbar,
   Section,
   Table,
   Th,
@@ -461,43 +462,6 @@ export function Schedules({
               surface="registry"
               subject={{ label: "Schedules", plural: true }}
             />
-            <div
-              className="mb-2 flex gap-1"
-              role="tablist"
-              aria-label="Schedule state"
-            >
-              {SCHEDULE_TABS.map((scheduleTab) => {
-                const count =
-                  scheduleTab === "all"
-                    ? rows.length
-                    : scheduleTab === "enabled"
-                      ? enabledCount
-                      : disabledCount;
-                return (
-                  <PrimitiveButton
-                    bare
-                    key={scheduleTab}
-                    id={`schedule-tab-${scheduleTab}`}
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === scheduleTab}
-                    aria-controls="schedule-table-panel"
-                    tabIndex={tab === scheduleTab ? 0 : -1}
-                    onClick={() => setTab(scheduleTab)}
-                    className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                      tab === scheduleTab
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1)"
-                    }`}
-                  >
-                    {scheduleTab[0]!.toUpperCase() + scheduleTab.slice(1)}
-                    <span className="ml-1.5 tabular-nums text-(--text-faint)">
-                      {count}
-                    </span>
-                  </PrimitiveButton>
-                );
-              })}
-            </div>
             <p
               className="mb-3 text-[11px] text-(--text-faint)"
               aria-label="Schedule summary"
@@ -506,14 +470,55 @@ export function Schedules({
               {nextFireLabel}
               {nextSchedule && <> ({nextSchedule.loop})</>}
             </p>
-            <div className="mb-3">
-              <FilterInput
-                value={filter}
-                onChange={setFilter}
-                placeholder="Filter loop, cadence, event type, approval…"
-                label="Filter schedules"
-              />
-            </div>
+            <ListToolbar
+              tabs={
+                <div
+                  className="flex w-max flex-nowrap gap-1 whitespace-nowrap"
+                  role="tablist"
+                  aria-label="Schedule state"
+                >
+                  {SCHEDULE_TABS.map((scheduleTab) => {
+                    const count =
+                      scheduleTab === "all"
+                        ? rows.length
+                        : scheduleTab === "enabled"
+                          ? enabledCount
+                          : disabledCount;
+                    return (
+                      <PrimitiveButton
+                        bare
+                        key={scheduleTab}
+                        id={`schedule-tab-${scheduleTab}`}
+                        type="button"
+                        role="tab"
+                        aria-selected={tab === scheduleTab}
+                        aria-controls="schedule-table-panel"
+                        tabIndex={tab === scheduleTab ? 0 : -1}
+                        onClick={() => setTab(scheduleTab)}
+                        className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                          tab === scheduleTab
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
+                      >
+                        {scheduleTab[0]!.toUpperCase() + scheduleTab.slice(1)}
+                        <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                          {count}
+                        </span>
+                      </PrimitiveButton>
+                    );
+                  })}
+                </div>
+              }
+              tools={
+                <FilterInput
+                  value={filter}
+                  onChange={setFilter}
+                  placeholder="Filter loop, cadence, event type, approval…"
+                  label="Filter schedules"
+                />
+              }
+            />
           </>
         }
       >

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -44,6 +44,7 @@ import {
   KV,
   ListEmpty,
   ListPane,
+  ListToolbar,
   ModelCell,
   GroupHeaderRow,
   Section,
@@ -762,101 +763,115 @@ export function Workers({
             <h1 className="display mb-4 text-h1 font-semibold">Workers</h1>
             <ScopeCaption context={context} surface="fleet" />
             {query.isSuccess && <CapacityBand capacity={capacity} />}
-            <div className="mb-3 flex flex-wrap items-center gap-2">
-              <select
-                aria-label="Worker state"
-                value={tab}
-                onChange={(event) => {
-                  setTabChoice(event.target.value as WorkerTab);
-                  if (focusHealth) onFocusHealthChange(null);
-                }}
-                className="min-w-0 flex-1 rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
-              >
-                {WORKER_TABS.map((t) => (
-                  <option key={t} value={t}>
-                    {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"}{" "}
-                    {tabCounts[t]}
-                  </option>
-                ))}
-              </select>
-              <div
-                className="hidden min-w-0 flex-1 gap-1 sm:flex"
-                role="tablist"
-                aria-label="Worker state"
-              >
-                {WORKER_TABS.map((t, idx) => (
-                  <PrimitiveButton
-                    bare
-                    key={t}
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === t}
-                    onClick={() => {
-                      setTabChoice(t);
+            <ListToolbar
+              tabs={
+                <>
+                  <select
+                    aria-label="Worker state"
+                    value={tab}
+                    onChange={(event) => {
+                      setTabChoice(event.target.value as WorkerTab);
                       if (focusHealth) onFocusHealthChange(null);
                     }}
-                    title={
-                      t === "LIVE"
-                        ? "idle, busy, or stale"
-                        : t === "STOPPED"
-                          ? "cleanly stopped — history"
-                          : undefined
-                    }
-                    className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                      tab === t
-                        ? "bg-(--surface-3) text-(--text)"
-                        : "text-(--text-faint) hover:bg-(--surface-1)"
-                    }`}
+                    className="min-w-36 rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
                   >
-                    {t === "ALL" ? "All" : t === "LIVE" ? "Live" : "Stopped"}
-                    {tabCounts[t] > 0 && (
-                      <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                    {WORKER_TABS.map((t) => (
+                      <option key={t} value={t}>
+                        {t === "ALL"
+                          ? "All"
+                          : t === "LIVE"
+                            ? "Live"
+                            : "Stopped"}{" "}
                         {tabCounts[t]}
-                      </span>
-                    )}
-                    <span
-                      aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                      </option>
+                    ))}
+                  </select>
+                  <div
+                    className="hidden w-max flex-nowrap gap-1 whitespace-nowrap sm:flex"
+                    role="tablist"
+                    aria-label="Worker state"
+                  >
+                    {WORKER_TABS.map((t, idx) => (
+                      <PrimitiveButton
+                        bare
+                        key={t}
+                        type="button"
+                        role="tab"
+                        aria-selected={tab === t}
+                        onClick={() => {
+                          setTabChoice(t);
+                          if (focusHealth) onFocusHealthChange(null);
+                        }}
+                        title={
+                          t === "LIVE"
+                            ? "idle, busy, or stale"
+                            : t === "STOPPED"
+                              ? "cleanly stopped — history"
+                              : undefined
+                        }
+                        className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                          tab === t
+                            ? "bg-(--surface-3) text-(--text)"
+                            : "text-(--text-faint) hover:bg-(--surface-1)"
+                        }`}
+                      >
+                        {t === "ALL"
+                          ? "All"
+                          : t === "LIVE"
+                            ? "Live"
+                            : "Stopped"}
+                        {tabCounts[t] > 0 && (
+                          <span className="ml-1.5 tabular-nums text-(--text-faint)">
+                            {tabCounts[t]}
+                          </span>
+                        )}
+                        <span
+                          aria-hidden="true"
+                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
+                        >
+                          {idx + 1}
+                        </span>
+                      </PrimitiveButton>
+                    ))}
+                  </div>
+                </>
+              }
+              tools={
+                <>
+                  <DisplayOptions
+                    config={WORKERS_DISPLAY}
+                    state={display}
+                    onChange={setDisplay}
+                    rows={byHealth}
+                  />
+                  <label className="flex items-center gap-1.5 text-[11px] text-(--text-faint)">
+                    <span>Health</span>
+                    <select
+                      aria-label="Filter workers by health"
+                      value={focusHealth ?? ""}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        onFocusHealthChange(
+                          isWorkerHealthFilter(value) ? value : null,
+                        );
+                      }}
+                      className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text)"
                     >
-                      {idx + 1}
-                    </span>
-                  </PrimitiveButton>
-                ))}
-              </div>
-              <span className="ml-auto">
-                <DisplayOptions
-                  config={WORKERS_DISPLAY}
-                  state={display}
-                  onChange={setDisplay}
-                  rows={byHealth}
-                />
-              </span>
-              <label className="flex items-center gap-1.5 text-[11px] text-(--text-faint)">
-                <span>Health</span>
-                <select
-                  aria-label="Filter workers by health"
-                  value={focusHealth ?? ""}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    onFocusHealthChange(
-                      isWorkerHealthFilter(value) ? value : null,
-                    );
-                  }}
-                  className="rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text)"
-                >
-                  <option value="">Any</option>
-                  <option value="live">Live</option>
-                  <option value="busy">Busy</option>
-                  <option value="stale">Stale</option>
-                </select>
-              </label>
-              <FilterInput
-                value={filter}
-                onChange={setFilter}
-                placeholder="Filter worker, host, label, adapter…"
-                label="Filter workers"
-              />
-            </div>
+                      <option value="">Any</option>
+                      <option value="live">Live</option>
+                      <option value="busy">Busy</option>
+                      <option value="stale">Stale</option>
+                    </select>
+                  </label>
+                  <FilterInput
+                    value={filter}
+                    onChange={setFilter}
+                    placeholder="Filter worker, host, label, adapter…"
+                    label="Filter workers"
+                  />
+                </>
+              }
+            />
             {query.isSuccess && banner && <FleetStatusBanner banner={banner} />}
           </>
         }

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -773,7 +773,7 @@ export function Workers({
                       setTabChoice(event.target.value as WorkerTab);
                       if (focusHealth) onFocusHealthChange(null);
                     }}
-                    className="min-w-36 rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
+                    className="w-full rounded-md border border-(--border) bg-(--surface-1) px-2 py-1 text-[12px] text-(--text) sm:hidden"
                   >
                     {WORKER_TABS.map((t) => (
                       <option key={t} value={t}>

--- a/event-runtime/web/vite.config.ts
+++ b/event-runtime/web/vite.config.ts
@@ -107,11 +107,10 @@ function vendorChunk(id: string): string | undefined {
 // still 197.04 kB, elk still its own chunk. Slack ~25 kB (4.3%), the same
 // proportion as the WM-286 and WM-483 raises. If the next raise buys less than
 // this, split Overview's stage cards instead.
-//
-// WM-714 re-baselined to 625 kB on 2026-08-18. develop reached ~603 kB from
-// recently merged hovercards/health features (#701, #702, #738). Vendor split
-// verified unchanged: xyflow still 197.04 kB, elk still its own chunk. Slack
-// ~22.5 kB (~3.6%).
+// WM-543 re-baselined to 625 kB on 2026-08-18. develop reached ~603.7 kB from
+// recently merged hovercards (WM-702), proposals health distinctions (WM-738),
+// and responsive navigation (WM-175). Vendor split verified unchanged: xyflow
+// still 197.04 kB, elk still its own chunk. Slack ~21 kB (3.4%).
 const ENTRY_CHUNK_BUDGET_BYTES = 625 * 1000;
 
 function entryChunkBudget(): Plugin {


### PR DESCRIPTION
## Summary
- add a shared responsive list-toolbar layout with non-wrapping tabs and a right-aligned tools group
- migrate Events, Proposals, Runs, Workers, Artifacts, Projects, Agents, and Schedules
- constrain filters to shrink from 14rem to 9rem before the tools group wraps
- add structural render coverage for one tablist and one tools group

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (843 tests, 0 failures)

UX critique: required — NOT-ASSESSED; the isolated Chromium browser exited before DevTools became available on both critique attempts, so the requested 1440/1100 screenshots could not be captured. PR intentionally remains draft.

Fixes WM-543