### PR TITLE
ui(web): normalize the type scale

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -1196,7 +1196,7 @@ export function GoPrefixHint({
                   >
                     <span className="mono text-(--text-dim)">{n.go}</span>{" "}
                     {n.label}{" "}
-                    <span className="rounded px-1 text-[10px] text-(--text-faint) ring-1 ring-inset ring-(--border)">
+                    <span className="rounded px-1 text-xs text-(--text-faint) ring-1 ring-inset ring-(--border)">
                       current
                     </span>
                   </span>

--- a/event-runtime/web/src/components/AgentHoverCard.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.tsx
@@ -124,14 +124,14 @@ export function AgentHoverCard({
                   {agent?.ref ?? agentRef}
                 </span>
                 {agent?.version !== undefined && (
-                  <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim)">
+                  <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-xs text-(--text-dim)">
                     v{agent.version}
                   </span>
                 )}
               </div>
               {agent?.promptFile && (
                 <div
-                  className="mt-0.5 mono text-[10px] text-(--text-faint) truncate"
+                  className="mt-0.5 mono text-xs text-(--text-faint) truncate"
                   title={agent.promptFile}
                 >
                   {agent.promptFile}
@@ -190,21 +190,21 @@ export function AgentHoverCard({
 
               {agent.eventTypes && agent.eventTypes.length > 0 && (
                 <div className="mt-2 pt-2 border-t border-(--border)">
-                  <div className="text-(--text-faint) text-[10px] mb-1 uppercase tracking-wide">
+                  <div className="text-(--text-faint) text-xs mb-1 uppercase tracking-wide">
                     Subscribed Events ({agent.eventTypes.length})
                   </div>
                   <div className="flex flex-wrap gap-1">
                     {agent.eventTypes.slice(0, 3).map((et) => (
                       <span
                         key={et.type}
-                        className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim) truncate max-w-[200px]"
+                        className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-xs text-(--text-dim) truncate max-w-[200px]"
                         title={et.type}
                       >
                         {et.type}
                       </span>
                     ))}
                     {agent.eventTypes.length > 3 && (
-                      <span className="mono text-[10px] text-(--text-faint) self-center">
+                      <span className="mono text-xs text-(--text-faint) self-center">
                         +{agent.eventTypes.length - 3} more
                       </span>
                     )}

--- a/event-runtime/web/src/components/ApprovalRisk.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.tsx
@@ -226,7 +226,7 @@ export function ApprovalSafetyCard({
               risk.caps.map((c) => (
                 <span
                   key={c}
-                  className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-[11.5px] text-(--text-dim)"
+                  className="rounded bg-(--surface-2) px-1.5 py-0.5 mono text-sm text-(--text-dim)"
                 >
                   {c}
                 </span>

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -23,7 +23,14 @@ import {
   type TableRow,
 } from "../lib/artifactView";
 import type { ArtifactTone, ArtifactView as ArtifactViewDoc } from "../types";
-import { DisclosureChevron, JsonBlock, JumpLink, StateBadge, Th } from "./ui";
+import {
+  DisclosureChevron,
+  JsonBlock,
+  JumpLink,
+  StateBadge,
+  Table,
+  Th,
+} from "./ui";
 
 // ---------------------------------------------------------------------------
 // Raw toggle persistence
@@ -189,7 +196,7 @@ function Value({
               {f.value.map((v, i) => (
                 <li
                   key={i}
-                  className="mono break-all py-px text-[11.5px] text-(--text-dim)"
+                  className="mono break-all py-px text-sm text-(--text-dim)"
                 >
                   {String(v)}
                 </li>
@@ -264,7 +271,7 @@ function ExpandedRow({
         colSpan={colSpan}
         className="border-b border-(--border) bg-(--surface-1) px-3 py-2 whitespace-normal"
       >
-        <div className="grid grid-cols-[minmax(0,10rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 text-[11.5px]">
+        <div className="grid grid-cols-[minmax(0,10rem)_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 text-sm">
           {row.expand.map((cell) => (
             <Fragment key={cell.key}>
               <span className="truncate text-(--text-faint)" title={cell.key}>
@@ -392,14 +399,14 @@ function GroupRow({
               boxShadow: `0 0 0 3px color-mix(in oklch, ${hue} 18%, transparent)`,
             }}
           />
-          <span className="text-[11.5px] font-medium text-(--text)">
+          <span className="text-sm font-medium text-(--text)">
             {group.label}
           </span>
           <span className="tabular-nums text-[11px] text-(--text-faint)">
             {group.rows.length}
           </span>
           {collapsed && (
-            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">
+            <span className="ml-auto pr-1 text-xs text-(--text-faint)">
               collapsed
             </span>
           )}
@@ -442,9 +449,9 @@ function TableSection({
         <div className="text-[12px] text-(--text-faint)">None.</div>
       ) : (
         <div className="overflow-x-auto rounded-md border border-(--border)">
-          <table className="w-full border-separate border-spacing-0 text-[12px]">
+          <Table className="w-full border-separate border-spacing-0">
             <thead>
-              <tr className="text-left text-[11px] text-(--text-faint)">
+              <tr className="text-left">
                 {s.hasExpand && <Th label="" />}
                 {s.columns.map((c) => (
                   <Th key={c} label={c} />
@@ -484,7 +491,7 @@ function TableSection({
                 />
               )}
             </tbody>
-          </table>
+          </Table>
         </div>
       )}
     </section>
@@ -588,7 +595,7 @@ function SectionBlock({
           <SectionHeading label={s.label} />
           <pre
             data-language={s.language}
-            className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap"
+            className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap"
           >
             {s.text}
           </pre>

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -376,7 +376,7 @@ export function ContextTabs({
           {goArmed && (
             <span
               aria-hidden="true"
-              className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-[10px] font-semibold text-(--accent)"
+              className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-xs font-semibold text-(--accent)"
             >
               0
             </span>
@@ -414,7 +414,7 @@ export function ContextTabs({
                 {goArmed && idx < 9 && (
                   <span
                     aria-hidden="true"
-                    className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-[10px] font-semibold text-(--accent)"
+                    className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-xs font-semibold text-(--accent)"
                   >
                     {idx + 1}
                   </span>
@@ -461,7 +461,7 @@ export function ContextTabs({
                   onFocus={() => setTabStopId(tabKey)}
                   title={`Run ${runId}`}
                 >
-                  <span className="opacity-70 text-[10px]" aria-hidden="true">
+                  <span className="opacity-70 text-xs" aria-hidden="true">
                     ▶
                   </span>
                   <span className="mono max-w-32 truncate">{runId}</span>
@@ -512,7 +512,7 @@ export function ContextTabs({
           {goArmed && (
             <span
               aria-hidden="true"
-              className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-[10px] font-semibold text-(--accent)"
+              className="mono ml-0.5 rounded bg-(--surface-2) px-1 text-xs font-semibold text-(--accent)"
             >
               i
             </span>

--- a/event-runtime/web/src/components/CustomCell.tsx
+++ b/event-runtime/web/src/components/CustomCell.tsx
@@ -53,11 +53,11 @@ export function CustomCell({ row, path }: { row: unknown; path: string }) {
 
   return (
     <td
-      className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11.5px] text-(--text-dim)"
+      className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
       title={title}
     >
       {isComplex ? (
-        <span className="mono rounded bg-(--surface-2) px-1 py-0.5 text-[10.5px] text-(--text-faint)">
+        <span className="mono rounded bg-(--surface-2) px-1 py-0.5 text-xs text-(--text-faint)">
           {text}
         </span>
       ) : typeof value === "boolean" ? (

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -356,7 +356,7 @@ export function DecisionCard({
                 boxShadow: chosen ? `inset 3px 0 ${hue}` : undefined,
               }}
             >
-              <span className="mono mt-0.5 text-[10px] text-(--text-faint)">
+              <span className="mono mt-0.5 text-xs text-(--text-faint)">
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1">
@@ -375,7 +375,7 @@ export function DecisionCard({
                   </span>
                 </span>
                 {option.id === currentRequest.recommended && (
-                  <span className="ml-2 rounded bg-(--surface-3) px-1.5 py-0.5 text-[10px] text-(--accent)">
+                  <span className="ml-2 rounded bg-(--surface-3) px-1.5 py-0.5 text-xs text-(--accent)">
                     suggested
                   </span>
                 )}

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -165,7 +165,7 @@ function ListboxSelect({
         className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-left text-[12px] text-(--text) outline-none hover:border-(--border-strong) focus:border-(--accent) disabled:cursor-not-allowed disabled:opacity-40"
       >
         <span className="truncate">{selected?.label}</span>
-        <span aria-hidden className="shrink-0 text-[9px] text-(--text-faint)">
+        <span aria-hidden className="shrink-0 text-xs text-(--text-faint)">
           ▼
         </span>
       </PrimitiveButton>
@@ -444,7 +444,7 @@ function DiscoveredFieldSuggestInput({
         >
           {indexedGroups.map((group) => (
             <li key={group.root} role="presentation">
-              <div className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+              <div className="px-2 pt-1.5 pb-0.5 text-xs font-medium tracking-wide text-(--text-faint) uppercase">
                 {group.root}
               </div>
               <ul role="group" aria-label={`${group.root} fields`}>
@@ -467,7 +467,7 @@ function DiscoveredFieldSuggestInput({
                     }`}
                   >
                     <div className="mono truncate">{field.path}</div>
-                    <div className="flex items-center justify-between gap-2 text-[10px] text-(--text-faint)">
+                    <div className="flex items-center justify-between gap-2 text-xs text-(--text-faint)">
                       <span className="truncate">{field.sampleValue}</span>
                       <span className="shrink-0">
                         {field.occurrenceCount}{" "}
@@ -483,7 +483,7 @@ function DiscoveredFieldSuggestInput({
       )}
 
       {showNotSeenHint && (
-        <div role="status" className="mt-1 text-[10px] text-(--text-faint)">
+        <div role="status" className="mt-1 text-xs text-(--text-faint)">
           not seen in loaded items; the column will show — until a row has it
         </div>
       )}
@@ -614,7 +614,7 @@ export function DisplayOptions<T>({
         Display
         <span
           aria-hidden="true"
-          className="mono ml-1 text-(--text-faint) text-[10px]"
+          className="mono ml-1 text-(--text-faint) text-xs"
         >
           v
         </span>
@@ -723,7 +723,7 @@ export function DisplayOptions<T>({
                       onClick={() =>
                         onChange((s) => ({ ...s, sortDir: direction }))
                       }
-                      className={`cursor-pointer rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+                      className={`cursor-pointer rounded px-1.5 py-0.5 text-xs transition-colors ${
                         pressed
                           ? "bg-(--surface-2) text-(--text) shadow-sm"
                           : "text-(--text-faint) hover:text-(--text-dim)"

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -113,7 +113,7 @@ export class ErrorBoundary extends Component<Props, State> {
           role="alert"
           className="max-w-lg border-l-2 border-(--hue-warn) pl-4"
         >
-          <h1 className="display text-lg font-semibold">{title}</h1>
+          <h1 className="display text-h1 font-semibold">{title}</h1>
           <p className="mt-2 text-sm text-(--text-dim)">{detail}</p>
           {!reloading && (
             <PrimitiveButton

--- a/event-runtime/web/src/components/EventHoverCard.tsx
+++ b/event-runtime/web/src/components/EventHoverCard.tsx
@@ -146,7 +146,7 @@ export function CausationGlyphs({
     </>
   );
   const className =
-    "inline-flex shrink-0 items-center gap-1 text-[10px] text-(--text-faint)";
+    "inline-flex shrink-0 items-center gap-1 text-xs text-(--text-faint)";
 
   if (!href) {
     return (
@@ -304,7 +304,7 @@ export function EventHoverCard({
               >
                 {event.type}
               </div>
-              <div className="mono mt-0.5 truncate text-[10px] text-(--text-faint)">
+              <div className="mono mt-0.5 truncate text-xs text-(--text-faint)">
                 {event.source} · {event.eventId}
               </div>
             </div>
@@ -363,7 +363,7 @@ export function EventHoverCard({
 
             {summary.entries.length > 0 && (
               <div className="mt-2 border-t border-(--border) pt-2">
-                <div className="mb-1 text-[10px] uppercase tracking-wide text-(--text-faint)">
+                <div className="mb-1 text-xs uppercase tracking-wide text-(--text-faint)">
                   Payload
                 </div>
                 <div className="space-y-1">
@@ -378,7 +378,7 @@ export function EventHoverCard({
                     </div>
                   ))}
                   {hidden > 0 && (
-                    <div className="text-[10px] text-(--text-faint)">
+                    <div className="text-xs text-(--text-faint)">
                       +{hidden} more
                     </div>
                   )}

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1109,7 +1109,7 @@ export function InjectDialog({
               placeholder="JSON…"
               className={`${inputCls} resize-y leading-relaxed`}
             />
-            <div className="mt-0.5 flex items-center gap-1.5 text-[10px]">
+            <div className="mt-0.5 flex items-center gap-1.5 text-xs">
               <span
                 className="size-1.5 rounded-full"
                 style={{
@@ -1177,7 +1177,7 @@ export function InjectDialog({
             {f.name}
           </label>
           {f.required && (
-            <span className="text-[10px] text-(--text-faint)">required</span>
+            <span className="text-xs text-(--text-faint)">required</span>
           )}
           <span className="flex-1" />
           {f.kind === "string" && isAtField(f.name) && (
@@ -1185,7 +1185,7 @@ export function InjectDialog({
               bare
               type="button"
               onClick={() => setField(f.name, new Date().toISOString())}
-              className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
+              className="rounded border border-(--border) px-1.5 py-0.5 text-xs text-(--text-dim) hover:bg-(--surface-2)"
               title="Write the current time as an ISO timestamp"
             >
               Now
@@ -1196,7 +1196,7 @@ export function InjectDialog({
               bare
               type="button"
               onClick={() => setField(f.name, triggerId(Date.now()))}
-              className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
+              className="rounded border border-(--border) px-1.5 py-0.5 text-xs text-(--text-dim) hover:bg-(--surface-2)"
               title="Generate a fresh web-trigger id"
             >
               Generate
@@ -1204,7 +1204,7 @@ export function InjectDialog({
           )}
         </div>
         {f.description && (
-          <div className="mb-1 text-[10px] text-(--text-faint)">
+          <div className="mb-1 text-xs text-(--text-faint)">
             {f.description}
           </div>
         )}
@@ -1300,7 +1300,7 @@ export function InjectDialog({
 
             {filteredRecent.length > 0 && (
               <div className="pt-1 pb-1">
-                <div className="px-1 text-[10px] font-semibold uppercase tracking-wider text-(--text-faint)">
+                <div className="px-1 text-xs font-semibold uppercase tracking-wider text-(--text-faint)">
                   Recent
                 </div>
                 <div className="mt-1 space-y-1">
@@ -1339,14 +1339,14 @@ export function InjectDialog({
             {groupedTemplates.length > 0 && (
               <div className={filteredRecent.length > 0 ? "pt-1" : ""}>
                 {filteredRecent.length > 0 && (
-                  <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-(--text-faint)">
+                  <div className="px-1 pb-1 text-xs font-semibold uppercase tracking-wider text-(--text-faint)">
                     Templates
                   </div>
                 )}
                 <div className="space-y-2">
                   {groupedTemplates.map((group) => (
                     <div key={group.domain} data-template-domain={group.domain}>
-                      <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-(--text-faint)">
+                      <div className="px-1 pb-1 text-xs font-semibold uppercase tracking-wider text-(--text-faint)">
                         {group.domain}
                       </div>
                       <div className="space-y-1">

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -374,7 +374,7 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
             </div>
           )}
           {content !== null && (
-            <pre className="mono max-h-64 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap">
+            <pre className="mono max-h-64 overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap">
               {content}
             </pre>
           )}
@@ -961,7 +961,7 @@ export function RunDetailBlocks({
                   <span className="flex w-[100px] shrink-0 items-center gap-1">
                     {jumped && (
                       <span
-                        className="shrink-0 text-[10px] text-(--text-faint)"
+                        className="shrink-0 text-xs text-(--text-faint)"
                         title={`from ${e.from_state ?? "·"}`}
                       >
                         {e.from_state ?? "·"}→
@@ -971,12 +971,12 @@ export function RunDetailBlocks({
                   </span>
                   {/* WM-145: wrap the reason; title includes it, not actor alone. */}
                   <span
-                    className="min-w-0 flex-1 break-words whitespace-pre-wrap text-[11.5px] leading-relaxed text-(--text-faint)"
+                    className="min-w-0 flex-1 break-words whitespace-pre-wrap text-sm leading-relaxed text-(--text-faint)"
                     title={e.reason ? `${e.actor} · ${e.reason}` : e.actor}
                   >
                     <ActorRef
                       actor={e.actor}
-                      className="text-[11.5px]"
+                      className="text-sm"
                       title={e.reason ? `${e.actor} · ${e.reason}` : e.actor}
                     />
                     {e.reason ? ` · ${e.reason}` : ""}

--- a/event-runtime/web/src/components/RunHoverCard.tsx
+++ b/event-runtime/web/src/components/RunHoverCard.tsx
@@ -164,7 +164,7 @@ export function RunHoverCard({
               >
                 {shortId(run.runId)}
               </div>
-              <div className="mt-0.5 truncate text-[10px] text-(--text-faint)">
+              <div className="mt-0.5 truncate text-xs text-(--text-faint)">
                 <span className="mono rounded bg-(--surface-2) px-1.5 py-0.5 text-(--text-dim)">
                   {run.agent}
                 </span>{" "}

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -229,7 +229,7 @@ export function MarkdownView({
             </TraceIconButton>
           </div>
         )}
-        <pre className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-[11.5px] leading-relaxed whitespace-pre-wrap text-(--text-dim)">
+        <pre className="mono overflow-auto rounded-md border border-(--border) bg-(--surface-0) p-2.5 text-sm leading-relaxed whitespace-pre-wrap text-(--text-dim)">
           {text}
         </pre>
       </div>
@@ -500,7 +500,7 @@ function TimingWaterfall({
       : `${durationMs}ms`;
   return (
     <div
-      className="flex items-center gap-1.5 mono text-[10px] text-(--text-faint)"
+      className="flex items-center gap-1.5 mono text-xs text-(--text-faint)"
       title={`Execution time: ${durLabel}`}
     >
       <div className="h-1.5 w-12 overflow-hidden rounded-full bg-(--surface-2)">
@@ -657,7 +657,7 @@ function TraceBody({
         >
           {originatingCall?.input !== undefined && (
             <div className="mb-2">
-              <div className="mb-1 text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+              <div className="mb-1 text-xs font-medium tracking-wide text-(--text-faint) uppercase">
                 Originating call · {originatingCall.name ?? "unknown tool"}
               </div>
               <JsonBlock value={originatingCall.input} />
@@ -1180,7 +1180,7 @@ export function RunTrace({
               <span>{followLive ? "Follow live" : "Follow live (paused)"}</span>
               <span
                 aria-hidden="true"
-                className="mono ml-0.5 text-(--text-faint) text-[10px]"
+                className="mono ml-0.5 text-(--text-faint) text-xs"
               >
                 l
               </span>
@@ -1247,7 +1247,7 @@ export function RunTrace({
                 )}
                 <span
                   aria-hidden="true"
-                  className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                  className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                 >
                   {idx + 1}
                 </span>
@@ -1267,7 +1267,7 @@ export function RunTrace({
               >
                 <ArrowDownIcon aria-hidden="true" className="size-3" />
                 <span>next error</span>
-                <span className="mono text-[10px] opacity-75">
+                <span className="mono text-xs opacity-75">
                   {activeErrorIdx === null
                     ? 0
                     : (activeErrorIdx % counts.errors) + 1}
@@ -1275,7 +1275,7 @@ export function RunTrace({
                 </span>
                 <span
                   aria-hidden="true"
-                  className="mono ml-0.5 opacity-75 text-[10px]"
+                  className="mono ml-0.5 opacity-75 text-xs"
                 >
                   .
                 </span>
@@ -1299,14 +1299,14 @@ export function RunTrace({
               {!search && (
                 <kbd
                   aria-hidden="true"
-                  className="mono text-[9px] text-(--text-faint) border border-(--border) rounded px-1 bg-(--surface-1)"
+                  className="mono text-xs text-(--text-faint) border border-(--border) rounded px-1 bg-(--surface-1)"
                 >
                   /
                 </kbd>
               )}
               {search && (
                 <>
-                  <span className="mono text-[10px] text-(--text-faint)">
+                  <span className="mono text-xs text-(--text-faint)">
                     {searchMatches.length
                       ? `${(activeMatch % searchMatches.length) + 1}/${searchMatches.length}`
                       : "0"}
@@ -1369,7 +1369,7 @@ export function RunTrace({
               <span>{expandAll ? "Collapse details" : "Expand details"}</span>
               <span
                 aria-hidden="true"
-                className="mono text-[10px] text-(--text-faint)"
+                className="mono text-xs text-(--text-faint)"
               >
                 e
               </span>
@@ -1466,7 +1466,7 @@ export function RunTrace({
                 </span>
                 <span
                   aria-hidden="true"
-                  className="mono ml-0.5 text-white/75 text-[10px]"
+                  className="mono ml-0.5 text-white/75 text-xs"
                 >
                   G
                 </span>

--- a/event-runtime/web/src/components/SpecDiff.tsx
+++ b/event-runtime/web/src/components/SpecDiff.tsx
@@ -167,7 +167,7 @@ export function SpecDiff({
         ))}
       </div>
       {linesBelow > 0 && (
-        <div className="pointer-events-none sticky bottom-0 -mt-10 flex h-10 items-end justify-center bg-linear-to-t from-(--surface-3) to-transparent px-3 pb-2 text-center text-[10px] text-(--text-faint)">
+        <div className="pointer-events-none sticky bottom-0 -mt-10 flex h-10 items-end justify-center bg-linear-to-t from-(--surface-3) to-transparent px-3 pb-2 text-center text-xs text-(--text-faint)">
           {`${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`}
         </div>
       )}

--- a/event-runtime/web/src/components/TicketDecisions.tsx
+++ b/event-runtime/web/src/components/TicketDecisions.tsx
@@ -293,7 +293,7 @@ export function TicketDecisions({
               {decisions.map((d, i) => (
                 <li
                   key={`${d.proposalId ?? ""}:${d.runId ?? ""}:${d.event?.eventId ?? ""}:${i}`}
-                  className="py-1 text-[11.5px]"
+                  className="py-1 text-sm"
                 >
                   <div className="flex items-baseline gap-2">
                     <span

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   forwardRef,
   type ButtonHTMLAttributes,
+  type ComponentProps,
   type ReactNode,
   useContext,
   useEffect,
@@ -555,7 +556,7 @@ export function FilterInput<T = unknown, C = unknown>({
         {!value && (
           <kbd
             aria-hidden
-            className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-(--border) px-1 font-sans text-[10px] text-(--text-faint)"
+            className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 rounded border border-(--border) px-1 font-sans text-xs text-(--text-faint)"
           >
             /
           </kbd>
@@ -600,7 +601,7 @@ export function FilterInput<T = unknown, C = unknown>({
                     {s.label}
                   </span>
                 </span>
-                <span className="mono shrink-0 truncate text-[10px] text-(--text-faint)">
+                <span className="mono shrink-0 truncate text-xs text-(--text-faint)">
                   {s.kind === "facet" ? "facet" : s.field || s.description}
                 </span>
               </li>
@@ -717,7 +718,7 @@ export function PaneHeader({
       )}
       {/* Row 3: Utility Row (copy/share quiet text line) */}
       {utility != null && (
-        <div className="mt-2 flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
+        <div className="mt-2 flex flex-wrap items-center gap-x-2 text-xs text-(--text-faint)">
           {utility}
         </div>
       )}
@@ -725,7 +726,17 @@ export function PaneHeader({
   );
 }
 
-/** Pinned header chrome; the spec and payload scroll underneath (WM-209). */
+/** The shared data-table type contract: caption headers, body copy, mono data. */
+export function Table({ className = "", ...props }: ComponentProps<"table">) {
+  return (
+    <table
+      {...props}
+      className={`text-sm [&_thead]:text-xs [&_thead]:uppercase [&_thead]:text-(--text-faint) [&_td.mono]:text-sm ${className}`}
+    />
+  );
+}
+
+/** Pinned title, verb, and utility rows; the spec and payload scroll underneath (WM-209). */
 export function DetailPane({
   widthClass,
   title,
@@ -904,7 +915,7 @@ export function Th({
             {label}
             <span
               aria-hidden
-              className={`text-[9px] transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
+              className={`text-xs transition-opacity ${dir ? "opacity-100" : "opacity-0 group-hover/th:opacity-50"}`}
             >
               {(dir ?? naturalDir ?? "asc") === "desc" ? "↓" : "↑"}
             </span>
@@ -995,7 +1006,7 @@ export function GroupHeaderRow({
             />
           )}
           <span
-            className={`font-medium ${sub ? "text-[11.5px] text-(--text-dim)" : "text-[12px] text-(--text)"}`}
+            className={`font-medium ${sub ? "text-sm text-(--text-dim)" : "text-sm text-(--text)"}`}
           >
             {section.label}
           </span>
@@ -1003,7 +1014,7 @@ export function GroupHeaderRow({
             {section.count}
           </span>
           {collapsed && section.count > 0 && (
-            <span className="ml-auto pr-1 text-[10px] text-(--text-faint)">
+            <span className="ml-auto pr-1 text-xs text-(--text-faint)">
               collapsed
             </span>
           )}
@@ -1397,7 +1408,7 @@ export function StatCard({
         {label}
       </div>
       <div
-        className={`display font-semibold tabular-nums ${compact ? "mt-0.5 text-lg" : "mt-1 text-xl"}`}
+        className={`display font-semibold tabular-nums ${compact ? "mt-0.5 text-h1" : "mt-1 text-h1"}`}
       >
         <span data-stat-value style={hue ? { color: hue } : undefined}>
           {value}
@@ -1405,11 +1416,7 @@ export function StatCard({
         {suffix}
       </div>
       {caption != null && (
-        <div
-          className={`${compact ? "text-[10px]" : "text-[11px]"} mt-0.5 text-(--text-faint)`}
-        >
-          {caption}
-        </div>
+        <div className="mt-0.5 text-xs text-(--text-faint)">{caption}</div>
       )}
     </div>
   );
@@ -1430,7 +1437,7 @@ export function StatTile({
     <>
       <div className="text-[11px] text-(--text-faint)">{label}</div>
       <div
-        className="display text-xl tabular-nums"
+        className="display text-h1 tabular-nums"
         style={hue ? { color: hue } : undefined}
       >
         {value}
@@ -1727,7 +1734,7 @@ export function JsonBlock({ value }: { value: unknown }) {
         bare
         type="button"
         onClick={copy}
-        className="absolute top-2 right-2 rounded border border-(--border) bg-(--surface-1) px-2 py-0.5 text-[10px] font-medium text-(--text-dim) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--surface-2) hover:text-(--text)"
+        className="absolute top-2 right-2 rounded border border-(--border) bg-(--surface-1) px-2 py-0.5 text-xs font-medium text-(--text-dim) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--surface-2) hover:text-(--text)"
       >
         {copied ? "Copied!" : "Copy"}
       </Button>
@@ -2326,7 +2333,7 @@ export function Tabs({
           aria-disabled={t.disabled || undefined}
           title={t.title}
           onClick={() => onSelect(t.id)}
-          className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+          className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
             active === t.id
               ? "bg-(--surface-3) text-(--text)"
               : t.disabled

--- a/event-runtime/web/src/graph/chainNodes.tsx
+++ b/event-runtime/web/src/graph/chainNodes.tsx
@@ -48,7 +48,7 @@ export function ChainEventNode({ data, selected }: NodeProps) {
       )}
       <div className="flex items-center justify-between gap-1">
         <span
-          className="text-[10px] tracking-wide uppercase"
+          className="text-xs tracking-wide uppercase"
           style={{ color: accent }}
         >
           {node.root ? "origin event" : "event"} · {e.source}
@@ -88,7 +88,7 @@ export function ChainRunNode({ data, selected }: NodeProps) {
       )}
       <div className="flex items-center justify-between gap-1">
         <span
-          className="text-[10px] tracking-wide uppercase"
+          className="text-xs tracking-wide uppercase"
           style={{ color: accent }}
         >
           run{r.adapter ? ` · ${r.adapter}` : ""}

--- a/event-runtime/web/src/graph/nodes.tsx
+++ b/event-runtime/web/src/graph/nodes.tsx
@@ -108,7 +108,7 @@ export function Line({
 }) {
   return (
     <div
-      className="mono truncate text-[11.5px]"
+      className="mono truncate text-sm"
       style={{ color: dim ? "var(--text-faint)" : "var(--text-dim)" }}
     >
       {children}
@@ -133,7 +133,7 @@ export function EventTypeNode({ data, selected }: NodeProps) {
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
         <span
-          className="text-[10px] tracking-wide uppercase"
+          className="text-xs tracking-wide uppercase"
           style={{ color: NODE_STYLES.eventType.accent }}
         >
           event type
@@ -199,7 +199,7 @@ export function AgentNode({ data, selected }: NodeProps) {
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-2">
         <span
-          className="text-[10px] tracking-wide uppercase"
+          className="text-xs tracking-wide uppercase"
           style={{ color: accent }}
         >
           {node.execution === "model"
@@ -262,7 +262,7 @@ export function TerminalNode({ data, selected }: NodeProps) {
     >
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div
-        className="text-[10px] tracking-wide uppercase"
+        className="text-xs tracking-wide uppercase"
         style={{ color: "var(--text-faint)" }}
       >
         terminal
@@ -289,7 +289,7 @@ export function ProposalNode({ data, selected }: NodeProps) {
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <div className="flex items-center justify-between gap-1">
         <span
-          className="text-[10px] tracking-wide uppercase font-semibold"
+          className="text-xs tracking-wide uppercase font-semibold"
           style={{ color: NODE_STYLES.proposal.accent }}
         >
           proposal

--- a/event-runtime/web/src/theme.css
+++ b/event-runtime/web/src/theme.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
 @import "@fontsource-variable/inter/opsz.css";
 
+/* The complete product type scale (webui spec §5.4). Keep component markup
+   semantic so a size change remains a token edit rather than a view sweep. */
+@theme {
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-h1: 18px;
+}
+
 /*
  * Three color tokens drive text, borders, and state hues (webui spec §5.1,
  * after Linear's redesign). Dark is the default. Light additionally declares
@@ -64,7 +73,7 @@ body {
   background: var(--surface-0);
   color: var(--text);
   font-family: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-optical-sizing: auto;
   -webkit-font-smoothing: antialiased;
 }
@@ -81,7 +90,7 @@ body {
 
   .mono {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
-    font-size: 11.5px;
+    font-size: var(--text-sm);
   }
 
   /* Table banding is intentionally a semantic surface rather than a separate
@@ -108,7 +117,7 @@ body {
 
   [cmdk-group-heading] {
     padding: 8px 12px 2px;
-    font-size: 11px;
+    font-size: var(--text-xs);
     color: var(--text-faint);
   }
 }

--- a/event-runtime/web/src/theme.test.ts
+++ b/event-runtime/web/src/theme.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, test } from "bun:test";
 import fs from "fs";
 import path from "path";
 
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(target);
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [target] : [];
+  });
+}
+
 export interface OklchColor {
   l: number;
   c: number;
@@ -313,5 +321,33 @@ describe("Theme contrast & accessibility (OPS-447, OPS-338)", () => {
     expect(css).toMatch(
       /\.row-selected\s*\{[^}]*var\(--hue-accent\)\s+1[2-6]%,\s*transparent[^}]*inset\s+2px\s+0\s+0\s+var\(--hue-accent\)/s,
     );
+  });
+
+  test("type scale exposes four semantic tokens and source has no undersized/off-scale literals (WM-557)", () => {
+    const css = fs.readFileSync(path.resolve(__dirname, "theme.css"), "utf-8");
+    expect(css).toMatch(/--text-xs:\s*11px;/);
+    expect(css).toMatch(/--text-sm:\s*12px;/);
+    expect(css).toMatch(/--text-base:\s*13px;/);
+    expect(css).toMatch(/--text-h1:\s*18px;/);
+
+    const offenders = sourceFiles(__dirname).flatMap((file) => {
+      const source = fs.readFileSync(file, "utf-8");
+      const utilityOffenders =
+        source
+          .match(/text-\[\d+(?:\.\d+)?px\]/g)
+          ?.filter((literal) => {
+            const size = Number(literal.match(/[\d.]+/)?.[0]);
+            return size < 11 || size === 11.5;
+          })
+          .map((literal) => `${path.relative(__dirname, file)}: ${literal}`) ??
+        [];
+      const inlineOffenders = [
+        ...source.matchAll(/fontSize\s*:\s*["']?(\d+(?:\.\d+)?)/g),
+      ]
+        .filter((match) => Number(match[1]) < 11)
+        .map((match) => `${path.relative(__dirname, file)}: ${match[0]}`);
+      return [...utilityOffenders, ...inlineOffenders];
+    });
+    expect(offenders).toEqual([]);
   });
 });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -35,6 +35,7 @@ import {
   ListPane,
   ModelCell,
   Section,
+  Table,
   Th,
   copyText,
   copyLink,
@@ -349,7 +350,7 @@ export function Agents({
         <ListPane
           chrome={
             <>
-              <h1 className="display mb-4 text-lg font-semibold">Agents</h1>
+              <h1 className="display mb-4 text-h1 font-semibold">Agents</h1>
               <ScopeCaption
                 context={context}
                 surface="registry"
@@ -388,7 +389,7 @@ export function Agents({
                       </span>
                       <span
                         aria-hidden="true"
-                        className="mono ml-1 text-[10px] text-(--text-faint) opacity-70"
+                        className="mono ml-1 text-xs text-(--text-faint) opacity-70"
                       >
                         {index + 1}
                       </span>
@@ -414,9 +415,9 @@ export function Agents({
             </>
           }
         >
-          <table className="w-full border-separate border-spacing-0">
+          <Table className="w-full border-separate border-spacing-0">
             <thead>
-              <tr className="text-left text-[11px] text-(--text-faint)">
+              <tr className="text-left">
                 {cols.map((c) => {
                   const sort = AGENTS_DISPLAY.sorts.find(
                     (s) => s.column === c.key,
@@ -630,7 +631,7 @@ export function Agents({
                 />
               )}
             </tbody>
-          </table>
+          </Table>
 
           <div className="mt-6">
             <Section title="Shared contracts">

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -12,6 +12,7 @@ import {
   ListEmpty,
   ListPane,
   StatCard,
+  Table,
   Th,
   copyText,
   shortId,
@@ -443,7 +444,7 @@ export function Artifacts({
           <>
             <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
               <div>
-                <h1 className="display text-lg font-semibold">Artifacts</h1>
+                <h1 className="display text-h1 font-semibold">Artifacts</h1>
                 <p className="mt-1 text-[12px] text-(--text-faint)">
                   Physical files in the content-addressed store. Project context
                   does not narrow this factory-wide inventory.
@@ -549,16 +550,14 @@ export function Artifacts({
           </>
         }
       >
-        <table
+        <Table
           role="grid"
           aria-label="Artifacts inventory"
-          className="w-full border-separate border-spacing-0 text-[12px]"
+          className="w-full border-separate border-spacing-0"
         >
           <thead role="rowgroup">
-            <tr
-              role="row"
-              className="text-left text-[11px] text-(--text-faint)"
-            >
+            <tr role="row" className="text-left">
+
               {columns.map((column) => {
                 const sort = ARTIFACTS_DISPLAY.sorts.find(
                   (field) => field.column === column.key,
@@ -753,7 +752,7 @@ export function Artifacts({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
 
       {selectedSha && (
@@ -993,7 +992,7 @@ export function Artifacts({
                   These bytes cannot be previewed as text. Download the file to
                   open it in a local viewer.
                 </p>
-                <dl className="mono mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-[11.5px]">
+                <dl className="mono mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-sm">
                   <dt className="text-(--text-faint)">File</dt>
                   <dd className="break-all">{selectedName}</dd>
                   <dt className="text-(--text-faint)">Size</dt>
@@ -1030,7 +1029,7 @@ export function Artifacts({
                     <div
                       role="region"
                       aria-label="Artifact content"
-                      className="mono max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-[11.5px] leading-relaxed"
+                      className="mono max-h-[60vh] overflow-auto rounded-md border border-(--border) bg-(--surface-0) py-2 text-sm leading-relaxed"
                     >
                       {previewLines.map((line, index) => (
                         <div

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -557,7 +557,6 @@ export function Artifacts({
         >
           <thead role="rowgroup">
             <tr role="row" className="text-left">
-
               {columns.map((column) => {
                 const sort = ARTIFACTS_DISPLAY.sorts.find(
                   (field) => field.column === column.key,

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -501,7 +501,7 @@ export function Chain({
                 : "absolute top-4 left-5 z-10 max-w-[60%]"
             }
           >
-            <h1 className="display text-lg font-semibold">Chain</h1>
+            <h1 className="display text-h1 font-semibold">Chain</h1>
             <div
               className="mono truncate text-[11px] text-(--text-faint)"
               title={correlationId}
@@ -1061,7 +1061,7 @@ function ChainTimelineList({
                 >
                   {time}
                 </span>
-                <span className="mono w-[52px] shrink-0 pt-0.5 text-right text-[10px] tabular-nums text-(--text-faint)">
+                <span className="mono w-[52px] shrink-0 pt-0.5 text-right text-xs tabular-nums text-(--text-faint)">
                   {row.kind === "next" ? "" : formatDelta(row.deltaMs)}
                 </span>
                 <span
@@ -1084,7 +1084,7 @@ function ChainTimelineList({
                       dot={false}
                     />
                   </span>
-                  <span className="min-w-0 flex-1 break-words text-[11.5px] leading-relaxed text-(--text-dim)">
+                  <span className="min-w-0 flex-1 break-words text-sm leading-relaxed text-(--text-dim)">
                     {row.actor && (
                       <span className="mono text-(--text)">{row.actor}</span>
                     )}

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -397,7 +397,7 @@ export function Chains({
                     {chain.origin.type}
                   </div>
                   <div
-                    className="mono truncate text-[10px] text-(--text-faint)"
+                    className="mono truncate text-xs text-(--text-faint)"
                     title={chain.origin.source}
                   >
                     {chain.origin.source}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -75,6 +75,7 @@ import {
   GroupHeaderRow,
   Section,
   StateBadge,
+  Table,
   TableWindowFooter,
   Th,
   VerbError,
@@ -938,7 +939,7 @@ export function Events({
       <ListPane
         chrome={
           <>
-            <h1 className="display mb-4 text-lg font-semibold">Events</h1>
+            <h1 className="display mb-4 text-h1 font-semibold">Events</h1>
             {context.kind === "inflight" && (
               <ScopeCaption context={context} surface="fleet" />
             )}
@@ -979,7 +980,7 @@ export function Events({
                     )}
                     <span
                       aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                     >
                       {idx + 1}
                     </span>
@@ -1112,9 +1113,9 @@ export function Events({
           </>
         }
       >
-        <table className="w-full table-fixed border-separate border-spacing-0">
+        <Table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+            <tr className="text-left">
               {listCols.map((c) => {
                 const sort = displayConfig.sorts.find(
                   (s) => s.column === c.key,
@@ -1334,7 +1335,7 @@ export function Events({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
 
       {sel && (

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -107,7 +107,7 @@ function flowEdges(graph: {
       strokeWidth: 1.5,
       strokeDasharray: EDGE_STYLES[edge.kind].strokeDasharray,
     },
-    labelStyle: { fill: "var(--text-faint)", fontSize: 10 },
+    labelStyle: { fill: "var(--text-faint)", fontSize: "var(--text-xs)" },
     labelBgStyle: { fill: "var(--surface-0)" },
   }));
 }
@@ -433,7 +433,7 @@ export function Graph({
     <div className="flex h-full min-w-0">
       <div className="relative min-w-0 flex-1">
         <div className="absolute top-4 left-5 z-10 rounded-md bg-(--surface-0)/85 px-2.5 py-2 backdrop-blur-sm">
-          <h1 className="display text-lg font-semibold">Graph</h1>
+          <h1 className="display text-h1 font-semibold">Graph</h1>
           <div className="text-[11px] text-(--text-faint)">
             what this runtime can do — registered routes and recommendation
             edges

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -46,6 +46,7 @@ import {
   ListPane,
   Section,
   StateBadge,
+  Table,
   Th,
   VerbError,
   notify,
@@ -737,7 +738,7 @@ export function Inbox({
         <ListPane
           chrome={
             <>
-              <h1 className="display mb-4 text-lg font-semibold">Inbox</h1>
+              <h1 className="display mb-4 text-h1 font-semibold">Inbox</h1>
               <div className="mb-3 flex flex-wrap items-center gap-2">
                 <div
                   className="flex min-w-0 flex-1 flex-wrap gap-1"
@@ -767,7 +768,7 @@ export function Inbox({
                       )}
                       <span
                         aria-hidden="true"
-                        className="mono ml-1 text-[10px] text-(--text-faint) opacity-70"
+                        className="mono ml-1 text-xs text-(--text-faint) opacity-70"
                       >
                         {idx + 1}
                       </span>
@@ -819,9 +820,9 @@ export function Inbox({
               Nothing waiting on you.
             </div>
           ) : (
-            <table className="w-full border-separate border-spacing-0">
+            <Table className="w-full border-separate border-spacing-0">
               <thead>
-                <tr className="text-left text-[11px] text-(--text-faint)">
+                <tr className="text-left">
                   {selectionEnabled && (
                     <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
                       <input
@@ -1022,7 +1023,7 @@ export function Inbox({
                   />
                 )}
               </tbody>
-            </table>
+            </Table>
           )}
         </ListPane>
       </div>
@@ -1253,7 +1254,7 @@ export function Inbox({
           >
             {bulkAcking ? "Acking…" : "Ack"}
             <span
-              className="mono ml-1 text-[10px] text-(--text-faint)"
+              className="mono ml-1 text-xs text-(--text-faint)"
               aria-hidden="true"
             >
               A
@@ -1267,7 +1268,7 @@ export function Inbox({
           >
             Resolve…
             <span
-              className="mono ml-1 text-[10px] text-(--text-faint)"
+              className="mono ml-1 text-xs text-(--text-faint)"
               aria-hidden="true"
             >
               X
@@ -1357,7 +1358,7 @@ function RefChips({
 }) {
   const r = item.refs;
   const chip =
-    "inline-block max-w-20 truncate rounded border border-(--border) bg-(--surface-1) px-1 align-bottom text-[10px]";
+    "inline-block max-w-20 truncate rounded border border-(--border) bg-(--surface-1) px-1 align-bottom text-xs";
   const chips: { key: string; description: string; node: React.ReactNode }[] =
     [];
   if (r.runId)

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -70,7 +70,7 @@ export function SectionTitle({
       >
         <span
           aria-hidden="true"
-          className={`text-[9px] text-(--text-faint) transition-transform ${collapsed ? "" : "rotate-90"}`}
+          className={`text-xs text-(--text-faint) transition-transform ${collapsed ? "" : "rotate-90"}`}
         >
           ▶
         </span>
@@ -201,7 +201,7 @@ export function StatLegendItem({
         {value}
       </span>
       {factoryWide && (
-        <span className="text-[10px] text-(--text-faint)">(all)</span>
+        <span className="text-xs text-(--text-faint)">(all)</span>
       )}
     </PrimitiveButton>
   );
@@ -238,7 +238,7 @@ export function StageCard({
             {meta && <span>{meta}</span>}
             {headline != null && (
               <span
-                className="display text-xl font-semibold tabular-nums"
+                className="display text-h1 font-semibold tabular-nums"
                 style={headlineHue ? { color: headlineHue } : undefined}
               >
                 {headline}
@@ -617,7 +617,7 @@ function CategoryPill({ kind }: { kind: AnomalyKind }) {
     configuration: "configuration",
   };
   return (
-    <span className="shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-(--text-dim)">
+    <span className="shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-xs font-medium tracking-wide text-(--text-dim)">
       {labels[kind]}
     </span>
   );
@@ -1237,7 +1237,7 @@ export function Overview({
   return (
     <div className="h-full min-w-0 overflow-auto p-5">
       <div className="mb-4 flex items-baseline justify-between gap-3">
-        <h1 className="display text-lg font-semibold">Overview</h1>
+        <h1 className="display text-h1 font-semibold">Overview</h1>
       </div>
       <OverviewScopeNotice context={context} />
 
@@ -1697,7 +1697,7 @@ export function Overview({
                   className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-(--border) bg-(--surface-1) px-3 py-1.5 text-left hover:bg-(--surface-2)"
                 >
                   <span
-                    className="display text-xl tabular-nums"
+                    className="display text-h1 tabular-nums"
                     style={
                       s.inbox.open > 0
                         ? { color: "var(--hue-warn)" }

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -35,6 +35,7 @@ import {
   ListEmpty,
   ListPane,
   Section,
+  Table,
   Th,
   VerbError,
   copyLink,
@@ -478,7 +479,7 @@ export function Projects({
       <ListPane
         chrome={
           <>
-            <h1 className="display mb-4 text-lg font-semibold">Projects</h1>
+            <h1 className="display mb-4 text-h1 font-semibold">Projects</h1>
             <ScopeCaption
               context={context}
               surface="registry"
@@ -533,7 +534,7 @@ export function Projects({
                     </span>
                     <span
                       aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                     >
                       {idx + 1}
                     </span>
@@ -550,12 +551,12 @@ export function Projects({
           </>
         }
       >
-        <table
+        <Table
           aria-label="Projects table"
           className="w-full min-w-[760px] border-separate border-spacing-0"
         >
           <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+            <tr className="text-left">
               {PROJECTS_SORT.columns.map((column) => {
                 const field = PROJECTS_SORT.sorts.find(
                   (candidate) => candidate.column === column.key,
@@ -619,11 +620,11 @@ export function Projects({
                       {r.reportOnly ? "Report Only" : "Dispatchable"}
                     </span>
                   </td>
-                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
+                  <td className="mono border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
                     {r.base}
                     {r.deployBranch ? ` → ${r.deployBranch}` : ""}
                   </td>
-                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-faint)">
+                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-xs text-(--text-faint)">
                     {worktreeScripts(r) || (
                       <span className="text-(--text-faint)">—</span>
                     )}
@@ -641,7 +642,7 @@ export function Projects({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
 
       {sel && (
@@ -670,7 +671,7 @@ export function Projects({
                 GitHub
                 <span
                   aria-hidden="true"
-                  className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                  className="mono ml-1.5 text-(--text-faint) text-xs opacity-70"
                 >
                   g h
                 </span>
@@ -712,7 +713,7 @@ export function Projects({
                   Triage Scan
                   <span
                     aria-hidden="true"
-                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                    className="mono ml-1.5 text-(--text-faint) text-xs opacity-70"
                   >
                     d t
                   </span>
@@ -731,7 +732,7 @@ export function Projects({
                   Status Report
                   <span
                     aria-hidden="true"
-                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                    className="mono ml-1.5 text-(--text-faint) text-xs opacity-70"
                   >
                     d s
                   </span>
@@ -750,7 +751,7 @@ export function Projects({
                   Janitor Scan
                   <span
                     aria-hidden="true"
-                    className="mono ml-1.5 text-(--text-faint) text-[10px] opacity-70"
+                    className="mono ml-1.5 text-(--text-faint) text-xs opacity-70"
                   >
                     d j
                   </span>

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -63,6 +63,7 @@ import {
   PROPOSAL_STATUS_HUES,
   GroupHeaderRow,
   Section,
+  Table,
   TableWindowFooter,
   StateBadge,
   Th,
@@ -1031,7 +1032,7 @@ export function Proposals({
         <ListPane
           chrome={
             <>
-              <h1 className="display mb-4 text-lg font-semibold">Proposals</h1>
+              <h1 className="display mb-4 text-h1 font-semibold">Proposals</h1>
               {context.kind === "inflight" && (
                 <ScopeCaption context={context} surface="fleet" />
               )}
@@ -1084,7 +1085,7 @@ export function Proposals({
                         )}
                         <span
                           aria-hidden="true"
-                          className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                          className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                         >
                           {idx + 1}
                         </span>
@@ -1133,9 +1134,9 @@ export function Proposals({
             </>
           }
         >
-          <table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
+          <Table className="w-full table-fixed border-separate border-spacing-0 max-sm:[&_th:nth-child(n+4)]:hidden max-sm:[&_td:nth-child(n+4)]:hidden">
             <thead>
-              <tr className="text-left text-[11px] text-(--text-faint)">
+              <tr className="text-left">
                 {tab === "open" && (
                   <th className="sticky top-0 z-10 h-7 w-8 bg-(--surface-0) px-3 shadow-[inset_0_-1px_0_var(--border)]">
                     <input
@@ -1384,7 +1385,7 @@ export function Proposals({
                 />
               )}
             </tbody>
-          </table>
+          </Table>
         </ListPane>
       </div>
 
@@ -1766,7 +1767,7 @@ export function Proposals({
               ? "Approving…"
               : `Approve selected (${approvableSelected.length})`}
             <span
-              className="mono ml-1 text-[10px] text-(--text-faint)"
+              className="mono ml-1 text-xs text-(--text-faint)"
               aria-hidden="true"
             >
               A
@@ -1784,7 +1785,7 @@ export function Proposals({
           >
             Reject selected ({selectedIds.size})
             <span
-              className="mono ml-1 text-[10px] text-(--text-faint)"
+              className="mono ml-1 text-xs text-(--text-faint)"
               aria-hidden="true"
             >
               X

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -356,7 +356,7 @@ export function RunFull({
                   <span>← Runs</span>
                   <span
                     aria-hidden="true"
-                    className="mono ml-1 text-(--text-faint) text-[10px]"
+                    className="mono ml-1 text-(--text-faint) text-xs"
                   >
                     Esc
                   </span>
@@ -495,7 +495,7 @@ export function RunFull({
               <span>Open in tab</span>
               <span
                 aria-hidden="true"
-                className="mono ml-1 text-(--text-faint) text-[10px]"
+                className="mono ml-1 text-(--text-faint) text-xs"
               >
                 p
               </span>
@@ -630,7 +630,7 @@ export function RunFull({
                                   {e.type}
                                 </span>
                                 <span
-                                  className="mono shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase"
+                                  className="mono shrink-0 rounded px-1.5 py-0.5 text-xs font-medium tracking-wide uppercase"
                                   style={{
                                     background:
                                       e.status === "planned" ||

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -75,6 +75,7 @@ import {
   StateBadge,
   STATE_HUES,
   GroupHeaderRow,
+  Table,
   TableWindowFooter,
   Th,
   VerbError,
@@ -1061,7 +1062,7 @@ export function Runs({
       <ListPane
         chrome={
           <>
-            <h1 className="display mb-4 text-lg font-semibold">Runs</h1>
+            <h1 className="display mb-4 text-h1 font-semibold">Runs</h1>
 
             {/* `flex-wrap`: the token chips are a full-width item, so they take
             their own line under the tabs and the box instead of squeezing them. */}
@@ -1098,7 +1099,7 @@ export function Runs({
                       )}
                       <span
                         aria-hidden="true"
-                        className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                        className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                       >
                         {idx + 1}
                       </span>
@@ -1126,9 +1127,9 @@ export function Runs({
           </>
         }
       >
-        <table className="w-full table-fixed border-separate border-spacing-0">
+        <Table className="w-full table-fixed border-separate border-spacing-0">
           <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+            <tr className="text-left">
               {listCols.map((c) => {
                 const sort = displayConfig.sorts.find(
                   (s) => s.column === c.key,
@@ -1363,7 +1364,7 @@ export function Runs({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
 
       {sel && (

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -27,6 +27,7 @@ import {
   ListEmpty,
   ListPane,
   Section,
+  Table,
   Th,
   VerbError,
   copyLink,
@@ -454,7 +455,7 @@ export function Schedules({
       <ListPane
         chrome={
           <>
-            <h1 className="display mb-4 text-lg font-semibold">Schedules</h1>
+            <h1 className="display mb-4 text-h1 font-semibold">Schedules</h1>
             <ScopeCaption
               context={context}
               surface="registry"
@@ -521,9 +522,9 @@ export function Schedules({
           role="tabpanel"
           aria-labelledby={`schedule-tab-${tab}`}
         >
-          <table className="w-full border-separate border-spacing-0">
+          <Table className="w-full border-separate border-spacing-0">
             <thead>
-              <tr className="text-left text-[11px] text-(--text-faint)">
+              <tr className="text-left">
                 {SCHEDULES_SORT.columns.map((column) => {
                   const field = SCHEDULES_SORT.sorts.find(
                     (candidate) => candidate.column === column.key,
@@ -691,7 +692,7 @@ export function Schedules({
                 />
               )}
             </tbody>
-          </table>
+          </Table>
           <div className="px-3 py-2 text-[11px] text-(--text-faint)">
             Enable or disable schedules in{" "}
             <code className="mono">event-runtime/schedules.json</code> (or via

--- a/event-runtime/web/src/views/Settings.tsx
+++ b/event-runtime/web/src/views/Settings.tsx
@@ -46,7 +46,7 @@ function ReloadChip({ reload }: { reload: ConfigReload }) {
     <span
       tabIndex={0}
       aria-label={`${reload}. ${RELOAD_HELP[reload]}`}
-      className="mono shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-[10px] text-(--text-dim)"
+      className="mono shrink-0 rounded border border-(--border) bg-(--surface-2) px-1.5 py-0.5 text-xs text-(--text-dim)"
       title={RELOAD_HELP[reload]}
     >
       {reload}
@@ -82,14 +82,14 @@ function SettingsRow({
           {value}
         </pre>
         {entry.note && (
-          <div className="mt-1 text-[10px] text-(--text-faint)">
+          <div className="mt-1 text-xs text-(--text-faint)">
             {entry.note}
           </div>
         )}
       </div>
       <div className="flex items-start gap-1.5 md:justify-end">
         <span
-          className="mono shrink-0 rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-faint)"
+          className="mono shrink-0 rounded border border-(--border) px-1.5 py-0.5 text-xs text-(--text-faint)"
           title={section.source.file}
         >
           {sourceName(section.source.file)}
@@ -213,7 +213,7 @@ export function Settings({
                   className={`flex min-w-max items-center justify-between gap-3 rounded px-2.5 py-1.5 text-left text-[12px] md:min-w-0 ${selected?.id === section.id ? "bg-(--surface-3) font-medium text-(--text)" : "text-(--text-dim) hover:bg-(--surface-2)"}`}
                 >
                   <span>{section.title}</span>
-                  <span className="mono text-[10px] text-(--text-faint)">
+                  <span className="mono text-xs text-(--text-faint)">
                     {section.entries.length}
                   </span>
                 </button>
@@ -239,7 +239,7 @@ export function Settings({
                     >
                       {section.title}
                     </h2>
-                    <span className="mono text-[10px] text-(--text-faint)">
+                    <span className="mono text-xs text-(--text-faint)">
                       {section.source.file}
                     </span>
                   </div>

--- a/event-runtime/web/src/views/Settings.tsx
+++ b/event-runtime/web/src/views/Settings.tsx
@@ -82,9 +82,7 @@ function SettingsRow({
           {value}
         </pre>
         {entry.note && (
-          <div className="mt-1 text-xs text-(--text-faint)">
-            {entry.note}
-          </div>
+          <div className="mt-1 text-xs text-(--text-faint)">{entry.note}</div>
         )}
       </div>
       <div className="flex items-start gap-1.5 md:justify-end">

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -51,7 +51,7 @@ async function fetchTicketJourney(
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-24 rounded-md border border-(--border) bg-(--surface-0) px-3 py-2">
-      <div className="text-[10px] font-medium tracking-wide text-(--text-faint) uppercase">
+      <div className="text-xs font-medium tracking-wide text-(--text-faint) uppercase">
         {label}
       </div>
       <div className="mt-0.5 tabular-nums text-[13px] font-medium text-(--text)">
@@ -122,13 +122,13 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
           </div>
         </SourceLink>
         {item.detail && (
-          <div className="mt-0.5 break-words text-[11.5px] text-(--text-faint)">
+          <div className="mt-0.5 break-words text-sm text-(--text-faint)">
             {item.detail}
           </div>
         )}
       </div>
       <time
-        className="mono shrink-0 text-[10px] text-(--text-faint)"
+        className="mono shrink-0 text-xs text-(--text-faint)"
         dateTime={item.at}
         title={item.at}
       >
@@ -143,7 +143,7 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
 
   return (
     <li className="flex items-start gap-3" data-kind={item.kind}>
-      <div className="mono w-16 shrink-0 pt-0.5 text-right text-[10px] tabular-nums text-(--text-faint)">
+      <div className="mono w-16 shrink-0 pt-0.5 text-right text-xs tabular-nums text-(--text-faint)">
         {item.durationMs == null ? "" : `+${formatDuration(item.durationMs)}`}
       </div>
       {item.children?.length ? (
@@ -215,7 +215,7 @@ function TicketPicker({
   };
   return (
     <div className="mx-auto max-w-lg p-8">
-      <h1 className="display text-xl font-semibold">Ticket journey</h1>
+      <h1 className="display text-h1 font-semibold">Ticket journey</h1>
       <p className="mt-2 text-[13px] text-(--text-dim)">
         Enter a Linear ticket id to see its decisions, attempts, PR, CI, and
         merge history on one timeline.
@@ -283,7 +283,7 @@ function JourneyLayout({
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
-                <h1 className="display mono text-lg font-semibold text-(--text)">
+                <h1 className="display mono text-h1 font-semibold text-(--text)">
                   {heading}
                 </h1>
                 {state && <StateBadge state={state} />}

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -49,6 +49,7 @@ import {
   Section,
   StateBadge,
   StatCard,
+  Table,
   Th,
   copyLink,
   copyText,
@@ -758,7 +759,7 @@ export function Workers({
       <ListPane
         chrome={
           <>
-            <h1 className="display mb-4 text-lg font-semibold">Workers</h1>
+            <h1 className="display mb-4 text-h1 font-semibold">Workers</h1>
             <ScopeCaption context={context} surface="fleet" />
             {query.isSuccess && <CapacityBand capacity={capacity} />}
             <div className="mb-3 flex flex-wrap items-center gap-2">
@@ -815,7 +816,7 @@ export function Workers({
                     )}
                     <span
                       aria-hidden="true"
-                      className="mono ml-1 text-(--text-faint) text-[10px] opacity-70"
+                      className="mono ml-1 text-(--text-faint) text-xs opacity-70"
                     >
                       {idx + 1}
                     </span>
@@ -860,9 +861,9 @@ export function Workers({
           </>
         }
       >
-        <table className="w-full border-separate border-spacing-0">
+        <Table className="w-full border-separate border-spacing-0">
           <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+            <tr className="text-left">
               {cols.map((c) => {
                 const sort = WORKERS_DISPLAY.sorts.find(
                   (s) => s.column === c.key,
@@ -1111,7 +1112,7 @@ export function Workers({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
 
       {sel && (


### PR DESCRIPTION
## Summary
- define the four-step 11/12/13/18px semantic type scale
- normalize undersized captions, keyboard hints, mono copy, and view headings
- centralize table typography and add source-scan regression coverage

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (843 tests)

UX critique: required — NOT-ASSESSED (isolated Chromium exited before DevTools became available; Runs and Events could not be driven)

Fixes WM-557