### PR TITLE
fix(event-runtime-web): unify empty and time formatting (WM-559)

### DIFF
--- a/event-runtime/web/src/components/ApprovalRisk.test.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.test.tsx
@@ -116,7 +116,7 @@ describe("ApprovalSafetyCard (WM-505)", () => {
     expect(text).toContain("Risk");
     expect(text).toContain("gh:write");
     expect(text).toContain("linear:read");
-    expect(text).toContain("900s");
+    expect(text).toContain("15m");
     expect(text).toContain("max 2 att");
     expect(text).toContain("github");
   });
@@ -153,7 +153,7 @@ describe("ApprovalRiskDetails (WM-505)", () => {
     );
     const text = r.container.textContent ?? "";
     expect(text).toContain("gh:write");
-    expect(text).toContain("900s");
+    expect(text).toContain("15m");
     expect(text).toContain("Mutating");
     expect(text).toContain("immutable RunSpec");
   });

--- a/event-runtime/web/src/components/ApprovalRisk.tsx
+++ b/event-runtime/web/src/components/ApprovalRisk.tsx
@@ -12,6 +12,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, type ReactNode } from "react";
 import { api } from "../api";
+import { EMPTY, formatDuration } from "../format";
 import type { AgentDef, Proposal } from "../types";
 import { Countdown, Disclosure, JsonBlock, KV } from "./ui";
 
@@ -46,7 +47,7 @@ export function computeApprovalRisk(p: Proposal, ag?: AgentDef): ApprovalRisk | 
   const inp = (typeof spec.input === "object" && spec.input ? spec.input : {}) as Record<string, unknown>;
   const repo = p.repos.length ? p.repos.join(", ") : String(inp.repo || inp.repository || "unscoped");
   const branch = String(inp.branch || inp.targetBranch || inp.base || "default");
-  const issue = String(inp.issueId || inp.issue || inp.ticket || p.eventId || "—");
+  const issue = String(inp.issueId || inp.issue || inp.ticket || p.eventId || EMPTY);
   const host = spec.placement
     ? Object.entries(spec.placement).map(([k, v]) => `${k}=${v}`).join(", ")
     : ag?.hosts?.length
@@ -158,7 +159,7 @@ export function ApprovalSafetyCard({
         <div>
           <div className="text-[11px] uppercase text-(--text-faint)">Budget</div>
           <div className="mono text-(--text-dim)">
-            {risk.timeoutSeconds}s · max {risk.maxAttempts} att
+            {formatDuration(risk.timeoutSeconds)} · max {risk.maxAttempts} att
           </div>
         </div>
         <div>
@@ -208,7 +209,7 @@ export function ApprovalRiskDetails({ proposal, agent }: { proposal: Proposal; a
         <KV k="agent" v={proposal.spec.agent} />
         <KV k="adapter" v={proposal.spec.adapter} />
         <KV k="capabilities" v={proposal.spec.capabilities.join(", ") || "none"} />
-        <KV k="timeout" v={`${proposal.spec.timeoutSeconds}s`} />
+        <KV k="timeout" v={formatDuration(proposal.spec.timeoutSeconds)} />
         <KV k="attempts" v={String(proposal.spec.maxAttempts)} />
         <KV k="ttl" v={<Countdown createdAt={proposal.created_at} ttlSeconds={proposal.ttl_seconds} />} />
       </div>

--- a/event-runtime/web/src/components/RunDetailBlocks.test.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.test.tsx
@@ -241,7 +241,9 @@ describe("model surfacing (WM-221)", () => {
     const r = renderBlocks(modelDetail({}));
     expect(r.getByText("not declared")).toBeTruthy();
     expect(r.getByText("default (CLI)")).toBeTruthy();
-    expect(r.getByText("not recorded")).toBeTruthy();
+    const observed = r.getByText("n/a");
+    expect(observed).toBeTruthy();
+    expect(observed.getAttribute("title")).toBe("observed model not recorded");
   });
 
   test("an exact-id override with no tier reads as `override`", () => {

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -2,13 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Suspense, lazy, useState, type ReactNode } from "react";
 import { api, artifactUrl } from "../api";
 import { hashPath, hashProject, withProject } from "../hash";
-import { dur } from "../heartbeat";
+import { NOT_APPLICABLE, formatBytes, formatDuration, formatRelative } from "../format";
 import { humanizeReason } from "../reasons";
 import type { AdmittedEvent, ArtifactRef, Attempt, LifecycleEvent, RunDetail, RunSpec, RunState } from "../types";
 import {
-  Ago,
   Disclosure,
-  humanSize,
   JsonBlock,
   JumpLink,
   KV,
@@ -101,7 +99,7 @@ const budgetHue = (c: Clock, timeoutSeconds: number): string | undefined => {
  * claiming the run is TIMED_OUT, which is the state badge's call on the next poll.
  */
 export function BudgetClock({ c, timeoutSeconds }: { c: Clock; timeoutSeconds: number }) {
-  const budget = `${timeoutSeconds}s budget`;
+  const budget = `${formatDuration(timeoutSeconds)} budget`;
   if (c.kind === "off")
     return (
       <span className="text-(--text-faint)" title={`${budget}, not started`}>
@@ -116,8 +114,8 @@ export function BudgetClock({ c, timeoutSeconds }: { c: Clock; timeoutSeconds: n
       </span>
     );
   return (
-    <span style={{ color: hue }} title={`timeout in ${dur(c.leftMs)}`}>
-      timeout in {dur(c.leftMs)}
+    <span style={{ color: hue }} title={`timeout in ${formatDuration(c.leftMs / 1000)}`}>
+      timeout in {formatDuration(c.leftMs / 1000)}
     </span>
   );
 }
@@ -131,8 +129,8 @@ export function LeaseClock({ c, urgent }: { c: Clock; urgent: boolean }) {
       </span>
     );
   return (
-    <span style={urgent ? { color: "var(--hue-warn)" } : undefined} title={`reaped in ${dur(c.leftMs)}`}>
-      reaped in {dur(c.leftMs)}
+    <span style={urgent ? { color: "var(--hue-warn)" } : undefined} title={`reaped in ${formatDuration(c.leftMs / 1000)}`}>
+      reaped in {formatDuration(c.leftMs / 1000)}
     </span>
   );
 }
@@ -277,7 +275,7 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
           </span>
         </span>
         <span className="flex shrink-0 items-baseline gap-3">
-          <span className="tabular-nums text-(--text-faint)">{humanSize(a.sizeBytes)}</span>
+          <span className="tabular-nums text-(--text-faint)">{formatBytes(a.sizeBytes)}</span>
           {textFriendly && (
             <button
               type="button"
@@ -342,7 +340,7 @@ const DEFAULT_MODEL_TEXT = "default (CLI)";
  *   the CLI chose → `default (CLI)`; `model (observed)` is what it chose
  */
 export const pinnedModelText = (adapter: string, model: string | null | undefined): string => {
-  if (!MODEL_ADAPTERS.has(adapter)) return "n/a";
+  if (!MODEL_ADAPTERS.has(adapter)) return NOT_APPLICABLE;
   return model == null || model === DEFAULT_MODEL ? DEFAULT_MODEL_TEXT : model;
 };
 
@@ -352,7 +350,7 @@ export const pinnedModelText = (adapter: string, model: string | null | undefine
  */
 export const modelTierText = (spec: Pick<RunSpec, "adapter" | "modelTier" | "model">): string => {
   if (spec.modelTier) return spec.modelTier;
-  if (!MODEL_ADAPTERS.has(spec.adapter)) return "n/a";
+  if (!MODEL_ADAPTERS.has(spec.adapter)) return NOT_APPLICABLE;
   return spec.model ? "override" : "not declared";
 };
 
@@ -385,14 +383,14 @@ function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null 
         k="model"
         v={
           <span
-            className="text-(--text-dim)"
+            className="text-(--text-faint)"
             title={
               spec.modelTier
                 ? `Declared model_tier "${spec.modelTier}", but the ${spec.adapter} adapter runs a fixed argv, not a model.`
                 : `The ${spec.adapter} adapter runs a fixed argv, not a model.`
             }
           >
-            n/a
+            {NOT_APPLICABLE}
           </span>
         }
       />
@@ -439,8 +437,8 @@ function ModelRows({ spec, observed }: { spec: RunSpec; observed: string | null 
           observed ? (
             <ModelCell model={observed} className="text-(--text-dim)" />
           ) : (
-            <span className="text-(--text-faint)" title="No model id in this run's transcript — it may predate the capture, or none was stored.">
-              not recorded
+            <span className="text-(--text-faint)" title="observed model not recorded">
+              {NOT_APPLICABLE}
             </span>
           )
         }
@@ -681,8 +679,8 @@ export function RunDetailBlocks({
             }
           />
         )}
-        <KV k="created" v={<Ago iso={d.run.created_at} now={now} />} />
-        <KV k="updated" v={<Ago iso={d.run.updated_at} now={now} />} />
+        <KV k="created" v={<span title={d.run.created_at}>{formatRelative(d.run.created_at, now)}</span>} />
+        <KV k="updated" v={<span title={d.run.updated_at}>{formatRelative(d.run.updated_at, now)}</span>} />
         <KV k="placement" v={d.run.spec.placement ? JSON.stringify(d.run.spec.placement) : "any worker"} />
         <Disclosure label="internals — ids, hashes, paths">
           <KV k="run" v={d.run.runId} />
@@ -720,7 +718,7 @@ export function RunDetailBlocks({
                 attempt #{current.attempt}{" "}
                 {current.started_at ? (
                   <>
-                    started <Ago iso={current.started_at} now={now} className="text-(--text-dim)" />
+                    started <span className="text-(--text-dim)" title={current.started_at}>{formatRelative(current.started_at, now)}</span>
                   </>
                 ) : (
                   "not started"
@@ -845,7 +843,7 @@ export function RunDetailBlocks({
                   <>
                     <span>started</span>
                     <span className="min-w-0 truncate">
-                      <Ago iso={a.started_at} now={now} />
+                      <span title={a.started_at}>{formatRelative(a.started_at, now)}</span>
                     </span>
                   </>
                 )}
@@ -853,7 +851,7 @@ export function RunDetailBlocks({
                   <>
                     <span>finished</span>
                     <span className="min-w-0 truncate">
-                      <Ago iso={a.finished_at} now={now} />
+                      <span title={a.finished_at}>{formatRelative(a.finished_at, now)}</span>
                     </span>
                   </>
                 )}

--- a/event-runtime/web/src/format.test.ts
+++ b/event-runtime/web/src/format.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { EMPTY, formatBytes, formatDuration, formatRelative } from "./format";
+
+describe("formatDuration", () => {
+  test.each([
+    [59, "59s"],
+    [60, "1m"],
+    [3_599, "59m 59s"],
+    [3_600, "1h"],
+    [4_200, "1h 10m"],
+    [86_400, "1d"],
+    [604_800, "7d"],
+  ])("formats %i seconds", (seconds, expected) => {
+    expect(formatDuration(seconds)).toBe(expected);
+  });
+
+  test("uses the shared empty placeholder", () => {
+    expect(formatDuration(null)).toBe(EMPTY);
+  });
+});
+
+describe("formatBytes", () => {
+  test.each([
+    [1_023, "1023 B"],
+    [1024 ** 2, "1.0 MB"],
+    [1024 ** 3, "1.0 GB"],
+  ])("formats %i bytes", (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
+  });
+});
+
+describe("formatRelative", () => {
+  const now = Date.parse("2026-01-02T00:00:00.000Z");
+
+  test.each([
+    ["2026-01-01T23:59:01.000Z", "59s ago"],
+    ["2026-01-01T23:59:00.000Z", "1m ago"],
+    ["2026-01-01T23:00:00.000Z", "1h ago"],
+    ["2026-01-01T00:00:00.000Z", "1d ago"],
+  ])("formats %s", (timestamp, expected) => {
+    expect(formatRelative(timestamp, now)).toBe(expected);
+  });
+
+  test("uses the shared empty placeholder", () => {
+    expect(formatRelative(undefined, now)).toBe(EMPTY);
+  });
+});

--- a/event-runtime/web/src/format.ts
+++ b/event-runtime/web/src/format.ts
@@ -1,0 +1,52 @@
+/** The single placeholder for an absent value in a table cell or key/value row. */
+export const EMPTY = "—";
+
+/** A semantic empty: the value does not apply to the adapter rather than being unknown. */
+export const NOT_APPLICABLE = "n/a";
+
+/** Compact whole-second durations, from seconds through days. */
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds)) return EMPTY;
+
+  let remaining = Math.max(0, Math.floor(seconds));
+  const units = [
+    [86_400, "d"],
+    [3_600, "h"],
+    [60, "m"],
+    [1, "s"],
+  ] as const;
+  const parts: string[] = [];
+
+  for (const [size, suffix] of units) {
+    const value = Math.floor(remaining / size);
+    if (value > 0 || (size === 1 && parts.length === 0)) parts.push(`${value}${suffix}`);
+    remaining %= size;
+  }
+
+  return parts.join(" ");
+}
+
+/** Binary byte units with the same one-decimal precision at every scaled size. */
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return EMPTY;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+/** Compact relative time for timestamps in the past. */
+export function formatRelative(
+  timestamp: string | number | Date | null | undefined,
+  now = Date.now(),
+): string {
+  if (timestamp == null) return EMPTY;
+  const at = timestamp instanceof Date ? timestamp.getTime() : new Date(timestamp).getTime();
+  if (Number.isNaN(at)) return EMPTY;
+
+  const seconds = Math.max(0, Math.floor((now - at) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+}

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -35,11 +35,8 @@ import {
   copyLink,
 } from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
-import {
-  AgentMutationBadge,
-  EMPTY_VALUE,
-  formatDurationSeconds,
-} from "../components/AgentHoverCard";
+import { AgentMutationBadge } from "../components/AgentHoverCard";
+import { EMPTY, NOT_APPLICABLE, formatDuration } from "../format";
 import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
 
@@ -62,7 +59,7 @@ const MODEL_ADAPTERS = new Set(["claude", "pi"]);
  * so "sort by tier" and "group by tier" cannot disagree. `override` is not a
  * tier but reads as one here: it is what a definition says instead of a tier.
  */
-const TIER_ORDER = ["strong", "standard", "light", "override", EMPTY_VALUE] as const;
+const TIER_ORDER = ["strong", "standard", "light", "override", EMPTY] as const;
 
 const AGENT_TABS = ["ALL", "MUTATING", "READ_ONLY"] as const;
 type AgentTab = (typeof AGENT_TABS)[number];
@@ -89,7 +86,7 @@ const uniq = (values: string[]) => [...new Set(values)];
  * to an empty cell.
  */
 export const routeModel = (r: AgentEventRoute): string =>
-  r.resolvedModel ?? (MODEL_ADAPTERS.has(r.adapter) ? "default" : "n/a");
+  r.resolvedModel ?? (MODEL_ADAPTERS.has(r.adapter) ? "default" : NOT_APPLICABLE);
 
 /**
  * Row-level roll-ups. An agent is one row but can be routed by several event
@@ -98,11 +95,11 @@ export const routeModel = (r: AgentEventRoute): string =>
  * truth; picking one adapter to show would be a lie the table cannot flag.
  */
 export const adapterText = (a: AgentDef): string =>
-  uniq(a.eventTypes.map((r) => r.adapter)).join(", ") || EMPTY_VALUE;
+  uniq(a.eventTypes.map((r) => r.adapter)).join(", ") || EMPTY;
 
 /** Declared intent. An exact-id override answers for a definition that names no tier. */
 export const tierText = (a: AgentDef): string =>
-  a.modelTier ?? (a.model ? "override" : EMPTY_VALUE);
+  a.modelTier ?? (a.model ? "override" : EMPTY);
 
 /** Sort key for the Tier column: TIER_ORDER's position, unknowns last. */
 const tierRank = (a: AgentDef): number => {
@@ -116,7 +113,7 @@ const tierRank = (a: AgentDef): number => {
  * declaration, so the fact is not lost.
  */
 export const modelText = (a: AgentDef): string =>
-  uniq(a.eventTypes.map(routeModel)).join(", ") || EMPTY_VALUE;
+  uniq(a.eventTypes.map(routeModel)).join(", ") || EMPTY;
 
 /** Grouping/ordering/columns for the registry table (OPS-493/OPS-492). */
 const AGENTS_DISPLAY: DisplayConfig<AgentDef> = {
@@ -402,7 +399,10 @@ export function Agents({
                   )}
                   {show.has("model") && (
                     <td className="max-w-56 border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      <ModelCell model={modelText(a)} className="text-(--text-dim)" />
+                      <ModelCell
+                        model={modelText(a)}
+                        className={modelText(a) === NOT_APPLICABLE ? "text-(--text-faint)" : "text-(--text-dim)"}
+                      />
                     </td>
                   )}
                   {show.has("mutating") && (
@@ -418,13 +418,13 @@ export function Agents({
                   {show.has("timeout") && (
                     <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
                       <span title={a.limits.timeout_seconds != null ? `${a.limits.timeout_seconds}s` : undefined}>
-                        {formatDurationSeconds(a.limits.timeout_seconds)}
+                        {formatDuration(a.limits.timeout_seconds)}
                       </span>
                     </td>
                   )}
                   {show.has("attempts") && (
                     <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim) whitespace-nowrap">
-                      {a.limits.attempts ?? EMPTY_VALUE}
+                      {a.limits.attempts ?? EMPTY}
                     </td>
                   )}
                   {cols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (
@@ -528,14 +528,14 @@ export function Agents({
               />
               <KV k="capabilities" v={caps(sel)} />
               <KV k="adapter" v={adapterText(sel)} />
-              <KV k="hosts" v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : EMPTY_VALUE} />
-              <KV k="command" v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : EMPTY_VALUE} />
+              <KV k="hosts" v={sel.hosts && sel.hosts.length > 0 ? sel.hosts.join(", ") : EMPTY} />
+              <KV k="command" v={sel.command && sel.command.length > 0 ? sel.command.join(" ") : EMPTY} />
               <KV
                 k="action registry"
                 v={
                   sel.actionRegistry && Object.keys(sel.actionRegistry).length > 0
                     ? Object.keys(sel.actionRegistry).join(", ")
-                    : EMPTY_VALUE
+                    : EMPTY
                 }
               />
             </KVGroup>
@@ -543,14 +543,14 @@ export function Agents({
                 route actually resolves to is per adapter, and lives on the
                 Event routing lines below — the same split `cli.mjs agents` prints. */}
             <KVGroup title="Model">
-              <KV k="model tier" v={sel.modelTier ?? EMPTY_VALUE} />
+              <KV k="model tier" v={sel.modelTier ?? EMPTY} />
               <KV
                 k="model override"
                 v={
                   sel.model ? (
                     <span title="Exact model id — resolved verbatim, whatever the tier says.">{sel.model}</span>
                   ) : (
-                    EMPTY_VALUE
+                    EMPTY
                   )
                 }
               />
@@ -560,11 +560,11 @@ export function Agents({
                 k="timeout"
                 v={
                   <span title={sel.limits.timeout_seconds != null ? `${sel.limits.timeout_seconds}s` : undefined}>
-                    {formatDurationSeconds(sel.limits.timeout_seconds)}
+                    {formatDuration(sel.limits.timeout_seconds)}
                   </span>
                 }
               />
-              <KV k="attempts" v={String(sel.limits.attempts ?? EMPTY_VALUE)} />
+              <KV k="attempts" v={String(sel.limits.attempts ?? EMPTY)} />
             </KVGroup>
           </Section>
 

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -644,7 +644,12 @@ export function Agents({
                         {routeModel(r)}
                       </span>{" "}
                       · idempotency {r.idempotencyScope}
-                      {r.proposalTtlSeconds != null ? ` · proposal TTL ${r.proposalTtlSeconds}s` : ""}
+                      {r.proposalTtlSeconds != null ? (
+                        <>
+                          {" · proposal TTL "}
+                          <span title={`${r.proposalTtlSeconds}s`}>{formatDuration(r.proposalTtlSeconds)}</span>
+                        </>
+                      ) : ""}
                     </div>
                   </a>
                 ))}

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -5,7 +5,6 @@ import { ArtifactPanel, loadArtifactRaw } from "../components/ArtifactView";
 import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import {
-  Ago,
   Button,
   DetailPane,
   FilterInput,
@@ -24,8 +23,9 @@ import {
   visibleColumns,
   type DisplayConfig,
 } from "../displayOptions";
+import { EMPTY, formatBytes, formatRelative } from "../format";
 import { refetchIntervals, useDisplayOptions, useNow } from "../hooks";
-import { formatBytes, viewApplies } from "../lib/artifactView";
+import { viewApplies } from "../lib/artifactView";
 import type { AdmittedEvent, AgentDef, ArtifactInventoryItem, StatusView } from "../types";
 
 export { formatBytes };
@@ -329,7 +329,7 @@ export function Artifacts({
             </div>
             {summary.at && (
               <span className="text-[11px] text-(--text-faint)" title={summary.at}>
-                measured <Ago iso={summary.at} now={now} />
+                measured {formatRelative(summary.at, now)}
               </span>
             )}
           </div>
@@ -462,7 +462,7 @@ export function Artifacts({
                         {artifactKinds.map((kind) => <KindBadge key={kind} kind={kind} />)}
                       </div>
                     ) : (
-                      <span className="text-(--text-faint)">—</span>
+                      <span className="text-(--text-faint)">{EMPTY}</span>
                     )}
                   </td>
                 )}
@@ -473,7 +473,7 @@ export function Artifacts({
                 )}
                 {shown.has("age") && (
                   <td className="whitespace-nowrap border-b border-(--border) px-3 py-1.5" title={new Date(artifact.mtime).toLocaleString()}>
-                    <Ago iso={artifact.mtime} now={now} />
+                    <span title={artifact.mtime}>{formatRelative(artifact.mtime, now)}</span>
                   </td>
                 )}
                 {shown.has("references") && (
@@ -491,7 +491,7 @@ export function Artifacts({
                         ))}
                       </div>
                     ) : (
-                      <span className="text-(--text-faint)">—</span>
+                      <span className="text-(--text-faint)">{EMPTY}</span>
                     )}
                   </td>
                 )}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -6,21 +6,19 @@ import { keyGuard, refetchIntervals, useNow, useRequeuePoll } from "../hooks";
 import type { JournalEntry, EventFocus, Proposal, RunState, StatusView } from "../types";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
+import { EMPTY, formatBytes, formatRelative } from "../format";
 import type { WorkerHealthFilter } from "./Workers";
 import {
-  Ago,
   Button,
   Disclosure,
   Dialog,
   EVENT_STATUS_HUES,
   STATE_HUES,
-  humanSize,
   JsonBlock,
   JumpLink,
   StateBadge,
   StateIcon,
   VerbError,
-  ago,
   copyText,
   notify,
   shortId,
@@ -491,7 +489,7 @@ export function buildAnomalyRows(
   for (const w of anomalies.stalledWorkers) {
     rows.push({
       kind: "worker",
-      text: `stalled worker ${w.workerId} still holds run ${w.runId} (host ${w.host}, last seen ${now ? ago(w.lastSeen, now) : "recently"})`,
+      text: `stalled worker ${w.workerId} still holds run ${w.runId} (host ${w.host}, last seen ${now ? formatRelative(w.lastSeen, now) : "recently"})`,
       links: [
         { label: "View worker", go: () => callbacks.onNavigate("workers") },
         { label: "View run", go: () => callbacks.onJumpRun(w.runId) },
@@ -602,7 +600,7 @@ function RecentOutcomesStrip({
                   : o.to === "TIMED_OUT"
                     ? "var(--hue-warn)"
                     : "var(--text-faint)";
-            const label = `${o.runId} · ${o.to} · ${ago(o.at, now)}`;
+            const label = `${o.runId} · ${o.to} · ${formatRelative(o.at, now)}`;
             return (
               <button
                 key={o.seq}
@@ -1118,28 +1116,30 @@ export function Overview({
                               {shortId(a.proposalId)}
                             </button>
                             <span className="text-(--text-faint)">·</span>
-                            <span>agent: {a.proposal?.agent ?? "—"}</span>
+                            <span>agent: {a.proposal?.agent ?? EMPTY}</span>
                             <span className="text-(--text-faint)">·</span>
                             <span>
-                              {a.proposal?.decision ?? "—"}
+                              {a.proposal?.decision ?? EMPTY}
                               {a.proposal?.reason ? ` — ${a.proposal.reason}` : ""}
                             </span>
                             <span className="text-(--text-faint)">·</span>
                             <span className="text-(--text-faint)">
-                              origin {a.proposal?.eventSource ?? "—"}/
+                              origin {a.proposal?.eventSource ?? EMPTY}/
                               {a.proposal?.eventId ? (
                                 <span className="mono" title={a.proposal.eventId}>
                                   {shortId(a.proposal.eventId)}
                                 </span>
                               ) : (
-                                "—"
+                                EMPTY
                               )}
                             </span>
                             <span className="text-(--text-faint)">·</span>
                             {a.proposal?.created_at ? (
-                              <Ago iso={a.proposal.created_at} now={now} className="mono text-(--text-faint)" />
+                              <span className="mono text-(--text-faint)" title={a.proposal.created_at}>
+                                {formatRelative(a.proposal.created_at, now)}
+                              </span>
                             ) : (
-                              <span className="text-(--text-faint)">age —</span>
+                              <span className="text-(--text-faint)">age {EMPTY}</span>
                             )}
                           </div>
                         ) : primaryLink ? (
@@ -1264,7 +1264,7 @@ export function Overview({
           </div>
           <div className="flex items-center gap-2 text-[11px] text-(--text-faint)">
             <span>
-              as of <Ago iso={new Date(status.dataUpdatedAt || now).toISOString()} now={now} />
+              as of {formatRelative(new Date(status.dataUpdatedAt || now), now)}
             </span>
             <span>·</span>
             <span>{feedsUnscoped ? "scope: factory-wide" : "scope: all repos"}</span>
@@ -1564,7 +1564,7 @@ export function Overview({
               className="mb-0"
               meta={
                 <span className="mono">
-                  {s.artifacts.files} files · {humanSize(s.artifacts.bytes)}
+                  {s.artifacts.files} files · {formatBytes(s.artifacts.bytes)}
                   {s.artifacts.orphans > 0 ? ` · ${s.artifacts.orphans} orphans` : ""}
                   {factoryWide ? " · factory-wide" : ""}
                 </span>
@@ -1597,7 +1597,9 @@ export function Overview({
                 const row = formatActivityGroup(group);
                 return (
                   <div key={group.seq} className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-(--border) py-1.5 last:border-0">
-                    <Ago iso={group.at} now={now} className="mono shrink-0 text-(--text-faint)" />
+                    <span className="mono shrink-0 text-(--text-faint)" title={group.at}>
+                      {formatRelative(group.at, now)}
+                    </span>
                     <span className="text-(--text-faint)">·</span>
                     <JumpLink onClick={() => onJumpRun(group.runId)} title={group.runId} className="shrink-0">
                       {shortId(group.runId)}
@@ -1677,7 +1679,9 @@ export function Overview({
                           )}
                         </div>
                         {o.published_at ? (
-                          <Ago iso={o.published_at} now={now} className="mono shrink-0 text-(--text-faint)" />
+                          <span className="mono shrink-0 text-(--text-faint)" title={o.published_at}>
+                            {formatRelative(o.published_at, now)}
+                          </span>
                         ) : (
                           <span className="shrink-0 text-[11px] text-(--hue-warn)">
                             unpublished

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -36,8 +36,8 @@ import { matchesInFlight, matchesRepo } from "../context";
 import { RUN_FACETS, matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import { decideRevealFilters, formatRevealNotification } from "../reveal";
 import type { Proposal, RunListItem, RunState } from "../types";
+import { EMPTY, formatRelative } from "../format";
 import {
-  Ago,
   Button,
   CopyActions,
   Dialog,
@@ -827,7 +827,7 @@ export function Runs({
                       className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"
                       title={r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : undefined}
                     >
-                      {r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : ""}
+                      {r.reasonCode && r.reasonCode.toLowerCase() !== "ok" ? r.reasonCode : EMPTY}
                     </td>
                   )}
                   {show.has("origin") && (
@@ -843,13 +843,13 @@ export function Runs({
                           {shortId(r.eventId)}
                         </JumpLink>
                       ) : (
-                        (r.eventId ? shortId(r.eventId) : "-")
+                        (r.eventId ? shortId(r.eventId) : EMPTY)
                       )}
                     </td>
                   )}
                   {show.has("updated") && (
                     <td className="max-w-24 whitespace-nowrap border-b border-(--border) px-3 py-1.5 text-(--text-faint)">
-                      <Ago iso={r.updated_at} now={now} />
+                      <span title={r.updated_at}>{formatRelative(r.updated_at, now)}</span>
                     </td>
                   )}
                   {listCols.filter((c) => c.isCustom || c.key.startsWith("custom:")).map((c) => (

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -12,9 +12,9 @@ import {
 import { setContextActions } from "../palette";
 import type { AdmittedEvent, AgentDef } from "../types";
 import type { OperatorContext } from "../context";
+import { EMPTY, formatDuration, formatRelative } from "../format";
 import { ScopeCaption } from "../components/ContextTabs";
 import {
-  Ago,
   Button,
   CopyActions,
   Countdown,
@@ -63,7 +63,7 @@ const SCHEDULE_TABS: readonly ScheduleTab[] = ["all", "enabled", "disabled"];
 export function compareSchedules(a: ScheduleItem, b: ScheduleItem): number {
   if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
   // Disabled schedules are not due, even if the API retains a historical
-  // nextDue value; the table renders "-" for them, so name is their tie-break.
+  // nextDue value; the table renders the shared empty value for them, so name is their tie-break.
   const parsedADue = a.enabled && a.nextDue ? Date.parse(a.nextDue) : Number.POSITIVE_INFINITY;
   const parsedBDue = b.enabled && b.nextDue ? Date.parse(b.nextDue) : Number.POSITIVE_INFINITY;
   const aDue = Number.isNaN(parsedADue) ? Number.POSITIVE_INFINITY : parsedADue;
@@ -483,13 +483,13 @@ export function Schedules({
                     {s.catchUp}
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
-                    {s.lastSlot ? <Ago iso={s.lastSlot} now={now} /> : <span className="text-(--text-faint)">never</span>}
+                    {s.lastSlot ? <span title={s.lastSlot}>{formatRelative(s.lastSlot, now)}</span> : <span className="text-(--text-faint)">never</span>}
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-[11px] text-(--text-dim)">
                     {!s.enabled ? (
-                      <span className="text-(--text-faint)">-</span>
+                      <span className="text-(--text-faint)">{EMPTY}</span>
                     ) : s.error ? (
-                      <span className="text-(--hue-err)">-</span>
+                      <span className="text-(--hue-err)">{EMPTY}</span>
                     ) : s.nextDue && s.cadenceSeconds ? (
                       <Countdown
                         createdAt={
@@ -498,7 +498,7 @@ export function Schedules({
                         ttlSeconds={s.cadenceSeconds}
                       />
                     ) : (
-                      "-"
+                      EMPTY
                     )}
                   </td>
                   <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
@@ -632,7 +632,9 @@ export function Schedules({
                   <span>
                     <span className="mono">{sel.every}</span>
                     {sel.cadenceSeconds && (
-                      <span className="ml-2 text-(--text-faint)">({sel.cadenceSeconds}s)</span>
+                      <span className="ml-2 text-(--text-faint)" title={`${sel.cadenceSeconds}s`}>
+                        ({formatDuration(sel.cadenceSeconds)})
+                      </span>
                     )}
                   </span>
                 }
@@ -696,7 +698,7 @@ export function Schedules({
                 v={
                   sel.lastSlot ? (
                     <span>
-                      <Ago iso={sel.lastSlot} now={now} />{" "}
+                      <span title={sel.lastSlot}>{formatRelative(sel.lastSlot, now)}</span>{" "}
                       <span className="mono text-[11px] text-(--text-faint)">({sel.lastSlot})</span>
                     </span>
                   ) : (
@@ -709,7 +711,7 @@ export function Schedules({
                 v={
                   sel.lastCompletedSlot ? (
                     <span>
-                      <Ago iso={sel.lastCompletedSlot} now={now} />{" "}
+                      <span title={sel.lastCompletedSlot}>{formatRelative(sel.lastCompletedSlot, now)}</span>{" "}
                       <span className="mono text-[11px] text-(--text-faint)">
                         ({sel.lastCompletedSlot})
                       </span>
@@ -736,7 +738,7 @@ export function Schedules({
                       <span className="mono text-[11px] text-(--text-faint)">({sel.nextDue})</span>
                     </span>
                   ) : (
-                    "-"
+                    EMPTY
                   )
                 }
               />
@@ -773,7 +775,7 @@ export function Schedules({
                             )}
                           </div>
                           <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-(--text-dim)">
-                            <Ago iso={e.occurredAt} now={now} />
+                            <span title={e.occurredAt}>{formatRelative(e.occurredAt, now)}</span>
                             <span>·</span>
                             <span>source: {e.source}</span>
                             {typeof payload.skippedSlots === "number" && payload.skippedSlots > 0 && (

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -20,16 +20,15 @@ import type { RunListItem, Worker, WorkerCapacity } from "../types";
 import type { OperatorContext } from "../context";
 import { pinnedModelText } from "../components/RunDetailBlocks";
 import {
-  dur,
   heartbeatHue,
   heartbeatOf,
   HEARTBEAT_STALE_MS,
   isOverdue,
   type Heartbeat,
 } from "../heartbeat";
+import { EMPTY, formatDuration, formatRelative } from "../format";
 import { ScopeCaption } from "../components/ContextTabs";
 import {
-  Ago,
   Button,
   CopyActions,
   DetailPane,
@@ -159,14 +158,14 @@ export interface EnrichedWorker extends Worker {
 
 export function enrichWorker(w: Worker, runMap: Map<string, RunListItem>): EnrichedWorker {
   const r = w.currentRun ? (runMap.get(w.currentRun) ?? null) : null;
-  const activeAgent = r?.agent ?? "-";
+  const activeAgent = r?.agent ?? EMPTY;
   const repos = r?.repos?.length ? r.repos.join(", ") : "";
   const ticketMatch = r?.eventId?.match(/\b([A-Z]{2,10}-\d+|PR-\d+)\b/)?.[0] ?? "";
   const activeTarget =
     repos && ticketMatch && !repos.includes(ticketMatch)
       ? `${repos} · ${ticketMatch}`
-      : repos || ticketMatch || (r?.eventId ? shortId(r.eventId) : "-");
-  const activeModel = r ? pinnedModelText(r.adapter, r.model) : "-";
+      : repos || ticketMatch || (r?.eventId ? shortId(r.eventId) : EMPTY);
+  const activeModel = r ? pinnedModelText(r.adapter, r.model) : EMPTY;
   return {
     ...w,
     activeAgent,
@@ -230,7 +229,7 @@ const WORKERS_DISPLAY: DisplayConfig<EnrichedWorker> = {
  * a second before the runtime does.
  */
 function StaleClock({ hb, className }: { hb: Heartbeat; className?: string }) {
-  const windowLabel = `${HEARTBEAT_STALE_MS / 1000}s`;
+  const windowLabel = formatDuration(HEARTBEAT_STALE_MS / 1000);
   if (hb.kind === "none")
     return (
       <span
@@ -246,9 +245,9 @@ function StaleClock({ hb, className }: { hb: Heartbeat; className?: string }) {
       <span
         className={className}
         style={{ color: hue }}
-        title={`No check-in for ${dur(hb.overdueMs)} longer than the ${windowLabel} window allows.`}
+        title={`No check-in for ${formatDuration(hb.overdueMs / 1000)} longer than the ${windowLabel} window allows.`}
       >
-        stale for {dur(hb.overdueMs)}
+        stale for {formatDuration(hb.overdueMs / 1000)}
       </span>
     );
   if (isOverdue(hb))
@@ -265,9 +264,9 @@ function StaleClock({ hb, className }: { hb: Heartbeat; className?: string }) {
     <span
       className={className}
       style={{ color: hue }}
-      title={`Goes stale unless this worker checks in within ${dur(hb.remainingMs)} (${windowLabel} window).`}
+      title={`Goes stale unless this worker checks in within ${formatDuration(hb.remainingMs / 1000)} (${windowLabel} window).`}
     >
-      stale in {dur(hb.remainingMs)}
+      stale in {formatDuration(hb.remainingMs / 1000)}
     </span>
   );
 }
@@ -278,7 +277,7 @@ function HeartbeatCell({ w, now }: { w: Worker; now: number }) {
   return (
     <>
       <span style={{ color: heartbeatHue(hb) }}>
-        <Ago iso={w.lastSeen} now={now} />
+        <span title={w.lastSeen}>{formatRelative(w.lastSeen, now)}</span>
       </span>
       <span className="px-1.5">·</span>
       <StaleClock hb={hb} className="text-[11px]" />
@@ -303,7 +302,7 @@ function HeartbeatMeter({ hb }: { hb: Heartbeat }) {
 const labelText = (labels: Record<string, string>) =>
   Object.entries(labels)
     .map(([k, v]) => `${k}=${v}`)
-    .join(", ") || "-";
+    .join(", ") || EMPTY;
 
 /** Runs already own `#/runs/:id`; the fleet is a way in, not a second router. */
 const openRun = (runId: string) => {
@@ -740,24 +739,24 @@ export function Workers({
                   {show.has("agent") && (
                     <td
                       className="max-w-36 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
-                      title={w.activeAgent !== "-" ? w.activeAgent : undefined}
+                      title={w.activeAgent !== EMPTY ? w.activeAgent : undefined}
                     >
-                      {w.activeAgent !== "-" ? (
+                      {w.activeAgent !== EMPTY ? (
                         <span className="mono font-medium text-(--text)">{w.activeAgent}</span>
                       ) : (
-                        <span className="text-(--text-faint)">-</span>
+                        <span className="text-(--text-faint)">{EMPTY}</span>
                       )}
                     </td>
                   )}
                   {show.has("target") && (
                     <td
                       className="max-w-44 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)"
-                      title={w.activeTarget !== "-" ? w.activeTarget : undefined}
+                      title={w.activeTarget !== EMPTY ? w.activeTarget : undefined}
                     >
-                      {w.activeTarget !== "-" ? (
+                      {w.activeTarget !== EMPTY ? (
                         <span>{w.activeTarget}</span>
                       ) : (
-                        <span className="text-(--text-faint)">-</span>
+                        <span className="text-(--text-faint)">{EMPTY}</span>
                       )}
                     </td>
                   )}
@@ -773,7 +772,7 @@ export function Workers({
                           {shortId(w.currentRun)}
                         </JumpLink>
                       ) : (
-                        "-"
+                        EMPTY
                       )}
                     </td>
                   )}
@@ -784,7 +783,7 @@ export function Workers({
                     >
                       {w.adapters.length > 0
                         ? `${w.adapters.length} adapter${w.adapters.length === 1 ? "" : "s"}`
-                        : "-"}
+                        : EMPTY}
                     </td>
                   )}
                   {show.has("labels") && (
@@ -797,7 +796,7 @@ export function Workers({
                       className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap tabular-nums text-(--text-faint)"
                       title={`Started ${w.startedAt}`}
                     >
-                      <Ago iso={w.startedAt} now={now} />
+                      <span title={w.startedAt}>{formatRelative(w.startedAt, now)}</span>
                     </td>
                   )}
                   {show.has("heartbeat") && (
@@ -899,7 +898,7 @@ export function Workers({
                 background: "color-mix(in oklch, var(--hue-err) 10%, transparent)",
               }}
             >
-              Heartbeat went stale {dur(selHeartbeat.overdueMs)} ago — this process is gone, whatever it last reported
+              Heartbeat went stale {formatDuration(selHeartbeat.overdueMs / 1000)} ago — this process is gone, whatever it last reported
               {sel.currentRun ? ` (it still holds ${sel.currentRun}; the run is reclaimed when its lease expires)` : ""}.
             </div>
           )}
@@ -917,7 +916,7 @@ export function Workers({
               {sel.runItem?.agent && (
                 <KV k="agent" v={<span className="mono font-medium">{sel.runItem.agent}</span>} />
               )}
-              {sel.activeTarget !== "-" && <KV k="target" v={sel.activeTarget} />}
+              {sel.activeTarget !== EMPTY && <KV k="target" v={sel.activeTarget} />}
               {sel.runItem && (
                 <KV
                   k="model"
@@ -933,14 +932,14 @@ export function Workers({
             <div className="rounded-md border border-(--border) px-3 py-2 tabular-nums">
               <div className="flex items-baseline justify-between gap-4">
                 <span className="text-(--text-faint)">
-                  last check-in <Ago iso={sel.lastSeen} now={now} className="text-(--text-dim)" />
+                  last check-in <span className="text-(--text-dim)" title={sel.lastSeen}>{formatRelative(sel.lastSeen, now)}</span>
                 </span>
                 <StaleClock hb={selHeartbeat} />
               </div>
               <HeartbeatMeter hb={selHeartbeat} />
               {selHeartbeat.kind !== "none" && (
                 <div className="mt-2 text-[11px] text-(--text-faint)">
-                  A worker that has not checked in for {HEARTBEAT_STALE_MS / 1000}s is treated as gone, whatever its
+                  A worker that has not checked in for {formatDuration(HEARTBEAT_STALE_MS / 1000)} is treated as gone, whatever its
                   last reported state was.
                 </div>
               )}
@@ -968,12 +967,12 @@ export function Workers({
                     {shortId(sel.currentRun)}
                   </JumpLink>
                 ) : (
-                  "-"
+                  EMPTY
                 )
               }
             />
-            <KV k="startedAt" v={<Ago iso={sel.startedAt} now={now} />} />
-            {sel.stoppedAt && <KV k="stoppedAt" v={<Ago iso={sel.stoppedAt} now={now} />} />}
+            <KV k="startedAt" v={<span title={sel.startedAt}>{formatRelative(sel.startedAt, now)}</span>} />
+            {sel.stoppedAt && <KV k="stoppedAt" v={<span title={sel.stoppedAt}>{formatRelative(sel.stoppedAt, now)}</span>} />}
           </Section>
 
           <Section title="Adapters" card={false}>


### PR DESCRIPTION
## Summary
- add shared empty-value, duration, byte-size, and relative-time formatters
- use canonical formatting across Agents, Schedules, Artifacts, Overview, Runs, Workers, run details, and approval risk
- cover formatter boundaries and canonical rendered strings

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (855 tests, 0 failures)

UX critique: skipped — copy/formatting-only consistency change to existing read-only displays; no flow or interaction change

Fixes WM-559