### PR TITLE
Fix Graph proposal navigation coordination (WM-165)

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -12,7 +12,8 @@ import {
 import { App } from "./App";
 import { goPrefix } from "./goSequence";
 import { NAV } from "./nav";
-import type { StatusView } from "./types";
+import { createProposalFixture } from "./test-render";
+import type { Proposal, StatusView } from "./types";
 
 const ENV = { name: "dev", home: "/tmp/factory", adapter: null };
 
@@ -43,6 +44,7 @@ let currentStatus = STATUS;
 // /api/health answers; "error" is a runtime that answered with a failure.
 let healthMode: "ok" | "pending" | "error" = "ok";
 let healthCalls = 0;
+let currentProposals: Proposal[] = [];
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {
@@ -72,6 +74,7 @@ beforeEach(() => {
   currentStatus = STATUS;
   healthMode = "ok";
   healthCalls = 0;
+  currentProposals = [];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.includes("/api/health")) {
@@ -96,6 +99,8 @@ beforeEach(() => {
       });
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
+    if (url.includes("/api/proposals"))
+      return jsonResponse({ proposals: currentProposals });
     if (url.includes("/api/runs?ticket=")) {
       const ticket =
         new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
@@ -189,6 +194,29 @@ describe("sidebar navigation accessibility", () => {
         n.key === "events" ? "page" : null,
       );
     }
+  });
+});
+
+describe("Graph proposal navigation (WM-165)", () => {
+  test("Open in Proposals routes through App to the selected proposal", async () => {
+    currentProposals = [
+      createProposalFixture({
+        id: "prop_graph",
+        agent: "doctor@1",
+        spec: null,
+        repos: [],
+      }),
+    ];
+    window.location.hash = "#/graph/proposal:prop_graph";
+    const utils = renderApp();
+
+    const open = await utils.findByRole("button", {
+      name: "Open in Proposals",
+    });
+    fireEvent.click(open);
+
+    expect(window.location.hash).toBe("#/proposals/prop_graph");
+    await utils.findByRole("heading", { name: "Proposals" });
   });
 });
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -850,6 +850,7 @@ export function App() {
                   onSelectNode={(id) => navigate(hashPath("graph", id))}
                   onJumpAgent={jumpToAgent}
                   onJumpEvents={jumpToEvents}
+                  onJumpProposal={jumpToProposal}
                 />
               </Suspense>
             ) : view === "agents" ? (

--- a/event-runtime/web/src/graph/nodes.test.tsx
+++ b/event-runtime/web/src/graph/nodes.test.tsx
@@ -384,6 +384,7 @@ function renderGraph(props: Partial<Parameters<typeof Graph>[0]> = {}) {
       onSelectNode={() => {}}
       onJumpAgent={() => {}}
       onJumpEvents={() => {}}
+      onJumpProposal={() => {}}
       {...props}
     />,
   );
@@ -541,11 +542,12 @@ describe("Graph view inspect loop", () => {
     expect(fitView).toHaveBeenCalledTimes(1);
   });
 
-  test("selected proposal node shows Open in Proposals jumping via hashPath", async () => {
+  test("selected proposal node delegates Open in Proposals to onJumpProposal", async () => {
     const proposal = createProposalFixture({
       id: "prop_abc",
       agent: "doctor@1",
     });
+    const onJumpProposal = mock((_id: string) => {});
     await withApi(
       {
         agents: async () => graphAgents(),
@@ -553,13 +555,15 @@ describe("Graph view inspect loop", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { getByRole } = renderGraph({ focusNodeId: "proposal:prop_abc" });
+        const { getByRole } = renderGraph({
+          focusNodeId: "proposal:prop_abc",
+          onJumpProposal,
+        });
         const btn = await waitFor(() =>
           getByRole("button", { name: "Open in Proposals" }),
         );
-        window.location.hash = "#/graph/proposal:prop_abc";
         fireEvent.click(btn);
-        expect(window.location.hash).toBe("#/proposals/prop_abc");
+        expect(onJumpProposal).toHaveBeenCalledWith("prop_abc");
       },
     );
   });

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -17,7 +17,6 @@ import { buildCapabilityGraph, type GraphNode } from "../graph/model";
 import { nodeTypes } from "../graph/nodes";
 import { matchNodes, missingFocusNode, searchEnter } from "../graph/search";
 import { EDGE_STYLES, legendEntries } from "../graph/style";
-import { hashPath, hashProject, withProject } from "../hash";
 import type { EventFocus } from "../types";
 import type { OperatorContext } from "../context";
 import {
@@ -137,10 +136,6 @@ function applyGraphOverlay(
   };
 }
 
-function jumpHash(path: string) {
-  window.location.hash = `#/${withProject(path, hashProject(window.location.hash))}`;
-}
-
 /**
  * Graph (webui roadmap / OPS-224 phase 1, chrome OPS-230, phase 2 overlays OPS-227):
  * the capability map overlaid with live run states, admitted/planned event counts,
@@ -152,12 +147,14 @@ export function Graph({
   onSelectNode,
   onJumpAgent,
   onJumpEvents,
+  onJumpProposal,
 }: {
   context: OperatorContext;
   focusNodeId: string | null;
   onSelectNode: (id: string | null) => void;
   onJumpAgent: (ref: string) => void;
   onJumpEvents: (focus: EventFocus) => void;
+  onJumpProposal: (id: string) => void;
 }) {
   const registry = useQuery({
     queryKey: ["agents"],
@@ -416,7 +413,6 @@ export function Graph({
       minZoom: zoom,
       maxZoom: zoom,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentMatch, flowReady]);
 
   const emptyCopy = registry.isPending
@@ -736,11 +732,7 @@ export function Graph({
                   Open in Agents
                 </Button>
               )}
-              <Button
-                onClick={() =>
-                  jumpHash(hashPath("proposals", selected.proposalId))
-                }
-              >
+              <Button onClick={() => onJumpProposal(selected.proposalId)}>
                 Open in Proposals
               </Button>
             </>


### PR DESCRIPTION
## Summary
- delegate Graph proposal navigation to App's existing `jumpToProposal` callback
- preserve HashWriter coordination and `rejumpEpoch` updates for graph-to-proposal jumps
- cover component delegation and app-level Graph → Proposals navigation

## Verification
- `cd event-runtime/web && bun test` — 843 pass, 0 fail
- regression test observed failing against the pre-fix `Graph.tsx`

UX critique: required — NOT-ASSESSED because isolated Chromium failed to launch; attempted `http://127.0.0.1:7709/#/graph`.

Fixes WM-165
