### PR TITLE
fix(event-runtime-web): preserve concurrent requeue polls

### DIFF
--- a/event-runtime/web/src/hooks.test.ts
+++ b/event-runtime/web/src/hooks.test.ts
@@ -6,7 +6,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
-import { createElement as h, useState } from "react";
+import { createElement as h, useEffect, useState } from "react";
 import { api } from "./api";
 import {
   modal,
@@ -169,8 +169,13 @@ function ThemeProbe() {
 type PollRequeue = ReturnType<typeof useRequeuePoll>;
 let exposedPollRequeue: PollRequeue | null = null;
 
-function RequeuePollProbe(props: { onJumpProposal: (proposalId: string) => void }) {
-  exposedPollRequeue = useRequeuePoll(props.onJumpProposal);
+function RequeuePollProbe(props: {
+  onJumpProposal: (proposalId: string) => void;
+}) {
+  const pollRequeue = useRequeuePoll(props.onJumpProposal);
+  useEffect(() => {
+    exposedPollRequeue = pollRequeue;
+  }, [pollRequeue]);
   return null;
 }
 
@@ -189,7 +194,9 @@ function requeueProposal(id: string, eventId: string): Proposal {
 describe("useRequeuePoll", () => {
   test("a matched task and source-view unmount do not drop a concurrent task", async () => {
     const originalProposals = api.proposals;
-    const requests: ReturnType<typeof deferred<Awaited<ReturnType<typeof api.proposals>>>>[] = [];
+    const requests: ReturnType<
+      typeof deferred<Awaited<ReturnType<typeof api.proposals>>>
+    >[] = [];
     api.proposals = mock(() => {
       const request = deferred<Awaited<ReturnType<typeof api.proposals>>>();
       requests.push(request);
@@ -197,11 +204,10 @@ describe("useRequeuePoll", () => {
     });
 
     try {
-      let view!: ReturnType<typeof render>;
       const onJumpProposal = mock((proposalId: string) => {
         if (proposalId === "prop_first") view.unmount();
       });
-      view = render(h(RequeuePollProbe, { onJumpProposal }));
+      const view = render(h(RequeuePollProbe, { onJumpProposal }));
       const pollRequeue = exposedPollRequeue!;
 
       const first = pollRequeue("github", "evt_first");
@@ -209,19 +215,22 @@ describe("useRequeuePoll", () => {
       expect(requests).toHaveLength(2);
 
       await act(async () => {
-        requests[0]!.resolve({ proposals: [requeueProposal("prop_first", "evt_first")] });
+        requests[0]!.resolve({
+          proposals: [requeueProposal("prop_first", "evt_first")],
+        });
         await first;
       });
       expect(onJumpProposal).toHaveBeenCalledWith("prop_first");
 
       await act(async () => {
-        requests[1]!.resolve({ proposals: [requeueProposal("prop_second", "evt_second")] });
+        requests[1]!.resolve({
+          proposals: [requeueProposal("prop_second", "evt_second")],
+        });
         await second;
       });
-      expect(onJumpProposal.mock.calls.map(([proposalId]) => proposalId)).toEqual([
-        "prop_first",
-        "prop_second",
-      ]);
+      expect(
+        onJumpProposal.mock.calls.map(([proposalId]) => proposalId),
+      ).toEqual(["prop_first", "prop_second"]);
     } finally {
       api.proposals = originalProposals;
       exposedPollRequeue = null;

--- a/event-runtime/web/src/hooks.test.ts
+++ b/event-runtime/web/src/hooks.test.ts
@@ -1,5 +1,5 @@
 import "./test-dom";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   QueryClient,
   QueryClientProvider,
@@ -13,8 +13,10 @@ import {
   refetchIntervals,
   useHashRoute,
   useListKeys,
+  useRequeuePoll,
   useTheme,
 } from "./hooks";
+import type { Proposal } from "./types";
 
 const originalFetch = globalThis.fetch;
 
@@ -163,6 +165,69 @@ function ThemeProbe() {
   const [theme] = useTheme();
   return h("span", { "data-testid": "theme" }, theme);
 }
+
+type PollRequeue = ReturnType<typeof useRequeuePoll>;
+let exposedPollRequeue: PollRequeue | null = null;
+
+function RequeuePollProbe(props: { onJumpProposal: (proposalId: string) => void }) {
+  exposedPollRequeue = useRequeuePoll(props.onJumpProposal);
+  return null;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function requeueProposal(id: string, eventId: string): Proposal {
+  return { id, eventSource: "github", eventId } as Proposal;
+}
+
+describe("useRequeuePoll", () => {
+  test("a matched task and source-view unmount do not drop a concurrent task", async () => {
+    const originalProposals = api.proposals;
+    const requests: ReturnType<typeof deferred<Awaited<ReturnType<typeof api.proposals>>>>[] = [];
+    api.proposals = mock(() => {
+      const request = deferred<Awaited<ReturnType<typeof api.proposals>>>();
+      requests.push(request);
+      return request.promise;
+    });
+
+    try {
+      let view!: ReturnType<typeof render>;
+      const onJumpProposal = mock((proposalId: string) => {
+        if (proposalId === "prop_first") view.unmount();
+      });
+      view = render(h(RequeuePollProbe, { onJumpProposal }));
+      const pollRequeue = exposedPollRequeue!;
+
+      const first = pollRequeue("github", "evt_first");
+      const second = pollRequeue("github", "evt_second");
+      expect(requests).toHaveLength(2);
+
+      await act(async () => {
+        requests[0]!.resolve({ proposals: [requeueProposal("prop_first", "evt_first")] });
+        await first;
+      });
+      expect(onJumpProposal).toHaveBeenCalledWith("prop_first");
+
+      await act(async () => {
+        requests[1]!.resolve({ proposals: [requeueProposal("prop_second", "evt_second")] });
+        await second;
+      });
+      expect(onJumpProposal.mock.calls.map(([proposalId]) => proposalId)).toEqual([
+        "prop_first",
+        "prop_second",
+      ]);
+    } finally {
+      api.proposals = originalProposals;
+      exposedPollRequeue = null;
+    }
+  });
+});
 
 /** Helper list component driving useListKeys */
 function InteractiveList(props: {

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -439,19 +439,12 @@ export type RequeueTarget = { source: string; eventId: string };
  * - Match found: calls `onJumpProposal(proposal.id)`.
  * - Loop expires without match: shows info toast "Requeued <eventId> — no open proposal appeared".
  * - Error thrown during poll: shows error toast "Requeued <eventId> — could not confirm a proposal appeared".
- * Cancels polling if the component unmounts before completion.
+ * Each invocation owns its full match/timeout/error lifecycle. In particular,
+ * navigating after one match must not cancel concurrent requeue confirmations.
  */
 export function useRequeuePoll(onJumpProposal: (proposalId: string) => void) {
-  const alive = useRef(true);
   const jumpRef = useRef(onJumpProposal);
   jumpRef.current = onJumpProposal;
-
-  useEffect(() => {
-    alive.current = true;
-    return () => {
-      alive.current = false;
-    };
-  }, []);
 
   return useCallback(
     async (
@@ -464,12 +457,12 @@ export function useRequeuePoll(onJumpProposal: (proposalId: string) => void) {
           : targetOrSource;
       const deadline = Date.now() + 8000;
       try {
-        while (alive.current && Date.now() < deadline) {
+        while (Date.now() < deadline) {
           const { proposals } = await api.proposals();
           const match = proposals.find(
             (p) => p.eventSource === source && p.eventId === eventId,
           );
-          if (match && alive.current) {
+          if (match) {
             jumpRef.current(match.id);
             return;
           }
@@ -478,17 +471,13 @@ export function useRequeuePoll(onJumpProposal: (proposalId: string) => void) {
       } catch {
         // The requeue itself landed; only the confirmation poll broke, so say
         // that rather than claiming no proposal appeared.
-        if (alive.current) {
-          notify(
-            `Requeued ${eventId} — could not confirm a proposal appeared`,
-            "err",
-          );
-        }
+        notify(
+          `Requeued ${eventId} — could not confirm a proposal appeared`,
+          "err",
+        );
         return;
       }
-      if (alive.current) {
-        notify(`Requeued ${eventId} — no open proposal appeared`, "info");
-      }
+      notify(`Requeued ${eventId} — no open proposal appeared`, "info");
     },
     [],
   );

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -723,25 +723,28 @@ describe("Overview anomaly deck (WM-95)", () => {
     });
 
     try {
-      let view!: ReturnType<typeof renderOverview>;
       const onJumpProposal = mock((proposalId: string) => {
         if (proposalId === "prop_concurrent_first") view.unmount();
       });
-      view = renderOverview({ kind: "all" }, { onJumpProposal });
+      const view = renderOverview({ kind: "all" }, { onJumpProposal });
 
-      fireEvent.click(await waitFor(() => view.getByRole("button", { name: "Requeue all" })));
+      fireEvent.click(
+        await waitFor(() => view.getByRole("button", { name: "Requeue all" })),
+      );
       fireEvent.click(view.getByRole("button", { name: "Requeue 2 events" }));
       await waitFor(() => expect(api.requeue).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(pollRequests).toHaveLength(2));
 
       await act(async () => {
         pollRequests[0]!.resolve({
-          proposals: [{
-            ...stubProposal,
-            id: "prop_concurrent_first",
-            eventId: eventIds[0]!,
-            eventSource: "github",
-          }],
+          proposals: [
+            {
+              ...stubProposal,
+              id: "prop_concurrent_first",
+              eventId: eventIds[0]!,
+              eventSource: "github",
+            },
+          ],
         });
       });
       await waitFor(() =>
@@ -750,19 +753,20 @@ describe("Overview anomaly deck (WM-95)", () => {
 
       await act(async () => {
         pollRequests[1]!.resolve({
-          proposals: [{
-            ...stubProposal,
-            id: "prop_concurrent_second",
-            eventId: eventIds[1]!,
-            eventSource: "github",
-          }],
+          proposals: [
+            {
+              ...stubProposal,
+              id: "prop_concurrent_second",
+              eventId: eventIds[1]!,
+              eventSource: "github",
+            },
+          ],
         });
       });
       await waitFor(() =>
-        expect(onJumpProposal.mock.calls.map(([proposalId]) => proposalId)).toEqual([
-          "prop_concurrent_first",
-          "prop_concurrent_second",
-        ]),
+        expect(
+          onJumpProposal.mock.calls.map(([proposalId]) => proposalId),
+        ).toEqual(["prop_concurrent_first", "prop_concurrent_second"]),
       );
     } finally {
       api.status = originals.status;

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -45,6 +45,14 @@ function renderWithClient(ui: React.ReactElement) {
 
 const noop = () => {};
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 function baseStatus(
   overrides: Partial<StatusView["anomalies"]> = {},
 ): StatusView {
@@ -676,6 +684,92 @@ describe("Overview anomaly deck (WM-95)", () => {
       api.proposals = originals.proposals;
       api.outbox = originals.outbox;
       api.journal = originals.journal;
+    }
+  });
+
+  test("bulk requeue keeps peer proposal polls alive when the first match navigates away", async () => {
+    const originals = {
+      status: api.status,
+      proposals: api.proposals,
+      outbox: api.outbox,
+      journal: api.journal,
+      requeue: api.requeue,
+    };
+    const eventIds = ["evt_concurrent_first", "evt_concurrent_second"];
+    api.status = async () =>
+      baseStatus({
+        deadLettered: eventIds.map((eventId) => ({
+          source: "github",
+          eventId,
+          lastError: "planner unavailable",
+        })),
+      });
+    api.outbox = async () => ({ outbox: [] });
+    api.journal = async () => ({ entries: [], head: 0 });
+
+    let requeued = 0;
+    api.requeue = mock(async () => {
+      requeued += 1;
+      return { requeued: true };
+    });
+    const pollRequests: ReturnType<
+      typeof deferred<Awaited<ReturnType<typeof api.proposals>>>
+    >[] = [];
+    api.proposals = mock(() => {
+      if (requeued < eventIds.length) return Promise.resolve({ proposals: [] });
+      const request = deferred<Awaited<ReturnType<typeof api.proposals>>>();
+      pollRequests.push(request);
+      return request.promise;
+    });
+
+    try {
+      let view!: ReturnType<typeof renderOverview>;
+      const onJumpProposal = mock((proposalId: string) => {
+        if (proposalId === "prop_concurrent_first") view.unmount();
+      });
+      view = renderOverview({ kind: "all" }, { onJumpProposal });
+
+      fireEvent.click(await waitFor(() => view.getByRole("button", { name: "Requeue all" })));
+      fireEvent.click(view.getByRole("button", { name: "Requeue 2 events" }));
+      await waitFor(() => expect(api.requeue).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(pollRequests).toHaveLength(2));
+
+      await act(async () => {
+        pollRequests[0]!.resolve({
+          proposals: [{
+            ...stubProposal,
+            id: "prop_concurrent_first",
+            eventId: eventIds[0]!,
+            eventSource: "github",
+          }],
+        });
+      });
+      await waitFor(() =>
+        expect(onJumpProposal).toHaveBeenCalledWith("prop_concurrent_first"),
+      );
+
+      await act(async () => {
+        pollRequests[1]!.resolve({
+          proposals: [{
+            ...stubProposal,
+            id: "prop_concurrent_second",
+            eventId: eventIds[1]!,
+            eventSource: "github",
+          }],
+        });
+      });
+      await waitFor(() =>
+        expect(onJumpProposal.mock.calls.map(([proposalId]) => proposalId)).toEqual([
+          "prop_concurrent_first",
+          "prop_concurrent_second",
+        ]),
+      );
+    } finally {
+      api.status = originals.status;
+      api.proposals = originals.proposals;
+      api.outbox = originals.outbox;
+      api.journal = originals.journal;
+      api.requeue = originals.requeue;
     }
   });
 


### PR DESCRIPTION
## Summary
- remove the component-wide alive flag that cancelled every requeue confirmation after the first navigation
- let each poll independently reach proposal match, timeout, or network-error feedback
- add hook and Overview bulk-requeue regression coverage for concurrent polling across unmount

## Verification
- `cd event-runtime/web && bun test src/hooks.test.ts src/hooks.test.tsx src/views/Events.test.tsx src/views/Overview.test.tsx` — 72 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass

UX critique: required — NOT-ASSESSED; worktree and app health passed, but Chromium exited before DevTools became available, so the critic could not drive the flow or collect browser evidence. PR remains draft.

Fixes WM-247