### PR TITLE
feat(event-runtime-web): unify control sizes and tooltips (WM-589)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -41,12 +41,13 @@ import {
   useGoSequences,
   type PaletteAction,
 } from "./components/CommandPalette";
-import { ToastContainer, copyLink, copyText } from "./components/ui";
+import { IconButton, ToastContainer, copyLink, copyText } from "./components/ui";
 import type { ArtifactFilters } from "./views/Artifacts";
 import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";
 import { Runs } from "./views/Runs";
 import { NAV, type NavKey } from "./nav";
+import { Button as PrimitiveButton } from "./components/ui";
 
 type WorkerHealthFilter = "live" | "busy" | "stale";
 const isWorkerHealthFilter = (
@@ -619,7 +620,8 @@ export function App() {
               />
               <span className="display text-[14px] font-semibold">factory</span>
             </div>
-            <button
+            <PrimitiveButton
+              bare
               type="button"
               className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
               title={
@@ -636,13 +638,14 @@ export function App() {
               onClick={() => env?.home && copyText(env.home, "runtime home")}
             >
               {envLabel}
-            </button>
+            </PrimitiveButton>
           </div>
           <div className="flex-1 px-2">
             {NAV.map((n) => {
               const badge = navBadges[n.key];
               return (
-                <button
+                <PrimitiveButton
+                  bare
                   key={n.key}
                   type="button"
                   aria-current={
@@ -671,17 +674,18 @@ export function App() {
                      nodes referenced by labelledby/describedby). */
                     <NavCount id={`nav-badge-${n.key}`} badge={badge} />
                   )}
-                </button>
+                </PrimitiveButton>
               );
             })}
-            <button
+            <PrimitiveButton
+              bare
               type="button"
               onClick={() => setInjectOpen(true)}
               className="mt-2 w-full rounded-md px-2.5 py-1.5 text-left text-[13px] text-(--text-dim) hover:bg-(--surface-2)"
             >
               Inject event…{" "}
               <span className="mono ml-1 text-(--text-faint)">i</span>
-            </button>
+            </PrimitiveButton>
           </div>
         </nav>
 
@@ -711,7 +715,8 @@ export function App() {
                   disabled until <span className="mono">/health</span> responds.
                   This is not an empty factory.
                 </span>
-                <button
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={() => health.refetch()}
                   className="shrink-0 rounded-md border px-2 py-0.5 text-[11px] font-medium"
@@ -722,7 +727,7 @@ export function App() {
                   }}
                 >
                   Retry
-                </button>
+                </PrimitiveButton>
               </div>
             </div>
           )}
@@ -1058,15 +1063,14 @@ export function App() {
             <span className="mono">g</span> go · <span className="mono">?</span>{" "}
             keys
           </div>
-          <button
-            type="button"
+          <IconButton
             onClick={cycleTheme}
-            title={`Theme ${theme} — click for ${nextTheme}`}
             aria-label={`Theme: ${theme}. Switch to ${nextTheme}.`}
-            className="flex cursor-pointer items-center justify-center rounded p-1 text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text) focus-visible:outline focus-visible:outline-1 focus-visible:outline-(--focus-ring) transition-colors"
+            tooltip={`Theme ${theme} — click for ${nextTheme}`}
+            className="text-(--text-faint) focus-visible:outline focus-visible:outline-1 focus-visible:outline-(--focus-ring)"
           >
             <ThemeIcon theme={theme} />
-          </button>
+          </IconButton>
         </div>
       </footer>
 

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -41,7 +41,12 @@ import {
   useGoSequences,
   type PaletteAction,
 } from "./components/CommandPalette";
-import { IconButton, ToastContainer, copyLink, copyText } from "./components/ui";
+import {
+  IconButton,
+  ToastContainer,
+  copyLink,
+  copyText,
+} from "./components/ui";
 import type { ArtifactFilters } from "./views/Artifacts";
 import { Events } from "./views/Events";
 import { Overview } from "./views/Overview";

--- a/event-runtime/web/src/components/AgentHoverCard.tsx
+++ b/event-runtime/web/src/components/AgentHoverCard.tsx
@@ -9,6 +9,7 @@ import { resolveEntity } from "../entities";
 import type { AgentDef } from "../types";
 import { HoverCard } from "./HoverCard";
 import { JumpLink, StateBadge } from "./ui";
+import { Button as PrimitiveButton } from "./ui";
 
 /** Shared empty-value glyph for registry metadata. */
 export const EMPTY_VALUE = "—";
@@ -223,13 +224,14 @@ export function AgentHoverCard({
                 so the card is never a dead end for keyboard or middle-click. */}
           <div className="mt-2.5 pt-2 border-t border-(--border) flex justify-end">
             {onJumpAgent ? (
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={jump(close)}
                 className={FOOTER_LINK_CLASS}
               >
                 Open in Agents <span aria-hidden="true">→</span>
-              </button>
+              </PrimitiveButton>
             ) : (
               entity && (
                 <a

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -1,3 +1,4 @@
+import { Button as PrimitiveButton } from "./ui";
 /**
  * ArtifactView — schema-derived rendering of a run artifact
  * (docs/event-runtime-artifact-views.md §2.4, WM-455).
@@ -56,7 +57,7 @@ export function RawToggle({
   onChange: (raw: boolean) => void;
 }) {
   const opt = (value: boolean, label: string) => (
-    <button
+    <PrimitiveButton bare
       type="button"
       aria-pressed={raw === value}
       onClick={() => onChange(value)}
@@ -67,7 +68,7 @@ export function RawToggle({
       }`}
     >
       {label}
-    </button>
+    </PrimitiveButton>
   );
   return (
     <span
@@ -316,7 +317,7 @@ function Rows({
               {hasExpand && (
                 <td className={`${CELL} w-6 pr-0`}>
                   {expandable && (
-                    <button
+                    <PrimitiveButton bare
                       type="button"
                       aria-expanded={isOpen}
                       aria-label={isOpen ? "Collapse row" : "Expand row"}
@@ -327,7 +328,7 @@ function Rows({
                       className="inline-flex cursor-pointer items-center"
                     >
                       <DisclosureChevron open={isOpen} />
-                    </button>
+                    </PrimitiveButton>
                   )}
                 </td>
               )}
@@ -373,7 +374,7 @@ function GroupRow({
   return (
     <tr>
       <td colSpan={colSpan} className="p-0">
-        <button
+        <PrimitiveButton bare
           type="button"
           aria-expanded={!collapsed}
           onClick={onToggle}
@@ -399,7 +400,7 @@ function GroupRow({
               collapsed
             </span>
           )}
-        </button>
+        </PrimitiveButton>
       </td>
     </tr>
   );

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -57,7 +57,8 @@ export function RawToggle({
   onChange: (raw: boolean) => void;
 }) {
   const opt = (value: boolean, label: string) => (
-    <PrimitiveButton bare
+    <PrimitiveButton
+      bare
       type="button"
       aria-pressed={raw === value}
       onClick={() => onChange(value)}
@@ -317,7 +318,8 @@ function Rows({
               {hasExpand && (
                 <td className={`${CELL} w-6 pr-0`}>
                   {expandable && (
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       type="button"
                       aria-expanded={isOpen}
                       aria-label={isOpen ? "Collapse row" : "Expand row"}
@@ -374,7 +376,8 @@ function GroupRow({
   return (
     <tr>
       <td colSpan={colSpan} className="p-0">
-        <PrimitiveButton bare
+        <PrimitiveButton
+          bare
           type="button"
           aria-expanded={!collapsed}
           onClick={onToggle}

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -123,7 +123,9 @@ describe("ContextTabs", () => {
     const repoAction = r.getByRole("button", { name: "Open a repo tab" });
     expect(toolbar.contains(repoAction)).toBe(false);
     expect(repoAction.textContent).toBe("+");
-    expect(r.getByRole("tooltip", { name: "Open a repo tab (g 1–9)" })).toBeTruthy();
+    expect(
+      r.getByRole("tooltip", { name: "Open a repo tab (g 1–9)" }),
+    ).toBeTruthy();
 
     for (const name of ["Close factory", "Close run_abc"]) {
       const close = r.getByRole("button", { name });

--- a/event-runtime/web/src/components/ContextTabs.test.tsx
+++ b/event-runtime/web/src/components/ContextTabs.test.tsx
@@ -84,7 +84,7 @@ describe("ContextTabs", () => {
     expect(all.className).toContain("focus-visible:ring-2");
   });
 
-  test("groups scope chips on the left, separates In flight, and leaves a labeled Repo action on the right", () => {
+  test("groups scope chips on the left, separates In flight, and leaves a labeled repo icon action on the right", () => {
     const r = render(
       <ContextTabs
         repos={[repo("factory")]}
@@ -122,8 +122,8 @@ describe("ContextTabs", () => {
 
     const repoAction = r.getByRole("button", { name: "Open a repo tab" });
     expect(toolbar.contains(repoAction)).toBe(false);
-    expect(repoAction.textContent).toBe("+Repo");
-    expect(repoAction.getAttribute("title")).toBe("Open a repo tab (g 1–9)");
+    expect(repoAction.textContent).toBe("+");
+    expect(r.getByRole("tooltip", { name: "Open a repo tab (g 1–9)" })).toBeTruthy();
 
     for (const name of ["Close factory", "Close run_abc"]) {
       const close = r.getByRole("button", { name });

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -4,6 +4,8 @@ import { INFLIGHT, toggleInflight } from "../context";
 import { hashProject, withProject } from "../hash";
 import { CONTEXT_TABS_ATTR } from "../hooks";
 import type { RepoItem } from "../types";
+import { IconButton } from "./ui";
+import { Button as PrimitiveButton } from "./ui";
 
 export const PINNED_RUNS_STORAGE_KEY = "factory.pinnedRuns";
 
@@ -355,7 +357,7 @@ export function ContextTabs({
         onKeyDown={handleKeyDown}
         {...{ [CONTEXT_TABS_ATTR]: "" }}
       >
-        <button
+        <PrimitiveButton bare
           type="button"
           data-context-tab="all"
           tabIndex={effectiveTabStop === "all" ? 0 : -1}
@@ -378,7 +380,7 @@ export function ContextTabs({
               0
             </span>
           )}
-        </button>
+        </PrimitiveButton>
         <div
           role="presentation"
           data-context-repos-scroll
@@ -390,7 +392,8 @@ export function ContextTabs({
               role="presentation"
               className={`group ${groupedTabClass(name)}`}
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 data-context-tab={name}
                 tabIndex={effectiveTabStop === name ? 0 : -1}
@@ -415,8 +418,8 @@ export function ContextTabs({
                     {idx + 1}
                   </span>
                 )}
-              </button>
-              <button
+              </PrimitiveButton>
+              <PrimitiveButton bare
                 type="button"
                 tabIndex={-1}
                 aria-label={`Close ${name}`}
@@ -429,7 +432,7 @@ export function ContextTabs({
                 }}
               >
                 ×
-              </button>
+              </PrimitiveButton>
             </div>
           ))}
           {pinnedRuns.map((runId) => {
@@ -441,7 +444,8 @@ export function ContextTabs({
                 role="presentation"
                 className={`group ${groupedTabClass(tabKey)}`}
               >
-                <button
+                <PrimitiveButton
+                  bare
                   type="button"
                   data-context-tab={tabKey}
                   tabIndex={effectiveTabStop === tabKey ? 0 : -1}
@@ -459,8 +463,8 @@ export function ContextTabs({
                     ▶
                   </span>
                   <span className="mono max-w-32 truncate">{runId}</span>
-                </button>
-                <button
+                </PrimitiveButton>
+                <PrimitiveButton bare
                   type="button"
                   tabIndex={-1}
                   aria-label={`Close ${runId}`}
@@ -473,7 +477,7 @@ export function ContextTabs({
                   }}
                 >
                   ×
-                </button>
+                </PrimitiveButton>
               </div>
             );
           })}
@@ -483,7 +487,7 @@ export function ContextTabs({
           data-context-filter-divider
           className="mx-0.5 h-5 w-px shrink-0 bg-(--border)"
         />
-        <button
+        <PrimitiveButton bare
           type="button"
           data-context-tab={INFLIGHT}
           tabIndex={effectiveTabStop === INFLIGHT ? 0 : -1}
@@ -509,26 +513,24 @@ export function ContextTabs({
               i
             </span>
           )}
-        </button>
+        </PrimitiveButton>
       </div>
       <div className="relative flex shrink-0 items-center" ref={pickerRef}>
-        <button
+        <IconButton
           ref={plusRef}
-          type="button"
           aria-expanded={picker}
           aria-haspopup="listbox"
           aria-controls="repo-picker-listbox"
           aria-label="Open a repo tab"
-          title="Open a repo tab (g 1–9)"
-          className="flex h-7 items-center gap-1 rounded-full px-2.5 text-[12px] font-medium text-(--text-dim) outline-none transition-colors hover:bg-(--surface-2) hover:text-(--text) focus-visible:ring-2 focus-visible:ring-(--accent)"
+          tooltip="Open a repo tab (g 1–9)"
+          className="rounded-full text-(--text-dim) outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
           onClick={() => setPicker((open) => !open)}
           onKeyDown={handlePickerTriggerKeyDown}
         >
           <span aria-hidden="true" className="text-[14px] leading-none">
             +
           </span>
-          <span>Repo</span>
-        </button>
+        </IconButton>
         {picker && (
           <div
             ref={listboxRef}
@@ -556,7 +558,7 @@ export function ContextTabs({
               </div>
             ) : (
               available.map((r, i) => (
-                <button
+                <PrimitiveButton bare
                   key={r.name}
                   id={`repo-picker-opt-${i}`}
                   type="button"
@@ -575,7 +577,7 @@ export function ContextTabs({
                   {r.team ? (
                     <span className="ml-2 text-(--text-faint)">{r.team}</span>
                   ) : null}
-                </button>
+                </PrimitiveButton>
               ))
             )}
           </div>

--- a/event-runtime/web/src/components/ContextTabs.tsx
+++ b/event-runtime/web/src/components/ContextTabs.tsx
@@ -357,7 +357,8 @@ export function ContextTabs({
         onKeyDown={handleKeyDown}
         {...{ [CONTEXT_TABS_ATTR]: "" }}
       >
-        <PrimitiveButton bare
+        <PrimitiveButton
+          bare
           type="button"
           data-context-tab="all"
           tabIndex={effectiveTabStop === "all" ? 0 : -1}
@@ -419,7 +420,8 @@ export function ContextTabs({
                   </span>
                 )}
               </PrimitiveButton>
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 type="button"
                 tabIndex={-1}
                 aria-label={`Close ${name}`}
@@ -464,7 +466,8 @@ export function ContextTabs({
                   </span>
                   <span className="mono max-w-32 truncate">{runId}</span>
                 </PrimitiveButton>
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   tabIndex={-1}
                   aria-label={`Close ${runId}`}
@@ -487,7 +490,8 @@ export function ContextTabs({
           data-context-filter-divider
           className="mx-0.5 h-5 w-px shrink-0 bg-(--border)"
         />
-        <PrimitiveButton bare
+        <PrimitiveButton
+          bare
           type="button"
           data-context-tab={INFLIGHT}
           tabIndex={effectiveTabStop === INFLIGHT ? 0 : -1}
@@ -558,7 +562,8 @@ export function ContextTabs({
               </div>
             ) : (
               available.map((r, i) => (
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   key={r.name}
                   id={`repo-picker-opt-${i}`}
                   type="button"

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -144,7 +144,8 @@ function ListboxSelect({
 
   return (
     <div className="relative w-32">
-      <PrimitiveButton bare
+      <PrimitiveButton
+        bare
         ref={triggerRef}
         id={id}
         type="button"
@@ -219,7 +220,8 @@ function Switch({
   label: string;
 }) {
   return (
-    <PrimitiveButton bare
+    <PrimitiveButton
+      bare
       type="button"
       role="switch"
       aria-checked={checked}
@@ -417,7 +419,8 @@ function DiscoveredFieldSuggestInput({
           onKeyDown={onKeyDown}
           className="mono min-w-0 flex-1 rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[11px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--border-strong)"
         />
-        <PrimitiveButton bare
+        <PrimitiveButton
+          bare
           type="button"
           disabled={!value.trim()}
           onMouseDown={(event) => event.preventDefault()}
@@ -594,7 +597,8 @@ export function DisplayOptions<T>({
 
   return (
     <div ref={rootRef} className="relative">
-      <PrimitiveButton bare
+      <PrimitiveButton
+        bare
         ref={triggerRef}
         type="button"
         aria-expanded={open}
@@ -706,7 +710,8 @@ export function DisplayOptions<T>({
                 {(["asc", "desc"] as const).map((direction) => {
                   const pressed = state.sortDir === direction;
                   return (
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       key={direction}
                       type="button"
                       aria-pressed={pressed}
@@ -750,7 +755,8 @@ export function DisplayOptions<T>({
                 {toggleable.map((c) => {
                   const shown = !state.hiddenColumns.includes(c.key);
                   return (
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       key={c.key}
                       type="button"
                       aria-pressed={shown}
@@ -802,7 +808,8 @@ export function DisplayOptions<T>({
                         : "border-(--border) text-(--text-faint)"
                     }`}
                   >
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       type="button"
                       title={shown ? "Hide column" : "Show column"}
                       onClick={() =>
@@ -817,7 +824,8 @@ export function DisplayOptions<T>({
                     >
                       {path}
                     </PrimitiveButton>
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       type="button"
                       aria-label={`Remove column ${path}`}
                       title="Remove column"
@@ -845,7 +853,8 @@ export function DisplayOptions<T>({
           {(onExport || customized) && (
             <div className="mt-3 flex items-center justify-between border-t border-(--border) pt-2">
               {onExport ? (
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={() => {
                     onExport();
@@ -858,7 +867,8 @@ export function DisplayOptions<T>({
                 <span />
               )}
               {customized && (
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={() =>
                     onChange({ ...defaultDisplayState(config), collapsed: [] })

--- a/event-runtime/web/src/components/DisplayOptions.tsx
+++ b/event-runtime/web/src/components/DisplayOptions.tsx
@@ -1,3 +1,4 @@
+import { Button as PrimitiveButton } from "./ui";
 /**
  * The "Display" popover (OPS-493, WM-214) — Linear's view-options panel for the table
  * views: grouping, sub-grouping, ordering, list options, display properties,
@@ -143,7 +144,7 @@ function ListboxSelect({
 
   return (
     <div className="relative w-32">
-      <button
+      <PrimitiveButton bare
         ref={triggerRef}
         id={id}
         type="button"
@@ -166,7 +167,7 @@ function ListboxSelect({
         <span aria-hidden className="shrink-0 text-[9px] text-(--text-faint)">
           ▼
         </span>
-      </button>
+      </PrimitiveButton>
       {open && (
         <ul
           ref={listRef}
@@ -218,7 +219,7 @@ function Switch({
   label: string;
 }) {
   return (
-    <button
+    <PrimitiveButton bare
       type="button"
       role="switch"
       aria-checked={checked}
@@ -235,7 +236,7 @@ function Switch({
         }`}
         style={checked ? { background: "var(--on-accent)" } : undefined}
       />
-    </button>
+    </PrimitiveButton>
   );
 }
 
@@ -416,7 +417,7 @@ function DiscoveredFieldSuggestInput({
           onKeyDown={onKeyDown}
           className="mono min-w-0 flex-1 rounded-md border border-(--border) bg-(--surface-0) px-2 py-1 text-[11px] text-(--text) outline-none placeholder:text-(--text-faint) focus:border-(--border-strong)"
         />
-        <button
+        <PrimitiveButton bare
           type="button"
           disabled={!value.trim()}
           onMouseDown={(event) => event.preventDefault()}
@@ -427,7 +428,7 @@ function DiscoveredFieldSuggestInput({
           className="cursor-pointer rounded-md border border-(--border) bg-(--surface-2) px-2 py-1 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-3) hover:text-(--text) disabled:cursor-not-allowed disabled:opacity-40"
         >
           + Add
-        </button>
+        </PrimitiveButton>
       </div>
 
       {show && (
@@ -593,7 +594,7 @@ export function DisplayOptions<T>({
 
   return (
     <div ref={rootRef} className="relative">
-      <button
+      <PrimitiveButton bare
         ref={triggerRef}
         type="button"
         aria-expanded={open}
@@ -620,7 +621,7 @@ export function DisplayOptions<T>({
             title="Display options customized"
           />
         )}
-      </button>
+      </PrimitiveButton>
 
       {open && (
         <div
@@ -705,7 +706,7 @@ export function DisplayOptions<T>({
                 {(["asc", "desc"] as const).map((direction) => {
                   const pressed = state.sortDir === direction;
                   return (
-                    <button
+                    <PrimitiveButton bare
                       key={direction}
                       type="button"
                       aria-pressed={pressed}
@@ -725,7 +726,7 @@ export function DisplayOptions<T>({
                     >
                       <span aria-hidden>{direction === "asc" ? "↑" : "↓"}</span>{" "}
                       {direction}
-                    </button>
+                    </PrimitiveButton>
                   );
                 })}
               </div>
@@ -749,7 +750,7 @@ export function DisplayOptions<T>({
                 {toggleable.map((c) => {
                   const shown = !state.hiddenColumns.includes(c.key);
                   return (
-                    <button
+                    <PrimitiveButton bare
                       key={c.key}
                       type="button"
                       aria-pressed={shown}
@@ -778,7 +779,7 @@ export function DisplayOptions<T>({
                         </span>
                       )}
                       {c.label}
-                    </button>
+                    </PrimitiveButton>
                   );
                 })}
               </div>
@@ -801,7 +802,7 @@ export function DisplayOptions<T>({
                         : "border-(--border) text-(--text-faint)"
                     }`}
                   >
-                    <button
+                    <PrimitiveButton bare
                       type="button"
                       title={shown ? "Hide column" : "Show column"}
                       onClick={() =>
@@ -815,8 +816,8 @@ export function DisplayOptions<T>({
                       className="cursor-pointer font-medium hover:underline"
                     >
                       {path}
-                    </button>
-                    <button
+                    </PrimitiveButton>
+                    <PrimitiveButton bare
                       type="button"
                       aria-label={`Remove column ${path}`}
                       title="Remove column"
@@ -826,7 +827,7 @@ export function DisplayOptions<T>({
                       className="cursor-pointer text-(--text-faint) hover:text-(--text)"
                     >
                       ×
-                    </button>
+                    </PrimitiveButton>
                   </div>
                 );
               })}
@@ -844,7 +845,7 @@ export function DisplayOptions<T>({
           {(onExport || customized) && (
             <div className="mt-3 flex items-center justify-between border-t border-(--border) pt-2">
               {onExport ? (
-                <button
+                <PrimitiveButton bare
                   type="button"
                   onClick={() => {
                     onExport();
@@ -852,12 +853,12 @@ export function DisplayOptions<T>({
                   className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)"
                 >
                   Export JSON
-                </button>
+                </PrimitiveButton>
               ) : (
                 <span />
               )}
               {customized && (
-                <button
+                <PrimitiveButton bare
                   type="button"
                   onClick={() =>
                     onChange({ ...defaultDisplayState(config), collapsed: [] })
@@ -865,7 +866,7 @@ export function DisplayOptions<T>({
                   className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-2) hover:text-(--text)"
                 >
                   Reset to defaults
-                </button>
+                </PrimitiveButton>
               )}
             </div>
           )}

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button as PrimitiveButton } from "./ui";
 
 export const CHUNK_RELOAD_STORAGE_KEY = "factory.chunkReload";
 const CHUNK_RELOAD_WINDOW_MS = 5 * 60 * 1000;
@@ -115,7 +116,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <h1 className="display text-lg font-semibold">{title}</h1>
           <p className="mt-2 text-sm text-(--text-dim)">{detail}</p>
           {!reloading && (
-            <button
+            <PrimitiveButton bare
               type="button"
               className="mt-4 rounded-md border border-(--border-strong) px-3 py-1.5 text-sm font-medium hover:bg-(--surface-2)"
               onClick={() =>
@@ -123,7 +124,7 @@ export class ErrorBoundary extends Component<Props, State> {
               }
             >
               Reload
-            </button>
+            </PrimitiveButton>
           )}
         </section>
       </main>

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -116,7 +116,8 @@ export class ErrorBoundary extends Component<Props, State> {
           <h1 className="display text-lg font-semibold">{title}</h1>
           <p className="mt-2 text-sm text-(--text-dim)">{detail}</p>
           {!reloading && (
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               className="mt-4 rounded-md border border-(--border-strong) px-3 py-1.5 text-sm font-medium hover:bg-(--surface-2)"
               onClick={() =>

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -1181,7 +1181,8 @@ export function InjectDialog({
           )}
           <span className="flex-1" />
           {f.kind === "string" && isAtField(f.name) && (
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               onClick={() => setField(f.name, new Date().toISOString())}
               className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
@@ -1191,7 +1192,8 @@ export function InjectDialog({
             </PrimitiveButton>
           )}
           {f.kind === "string" && isIdField(f.name) && (
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               onClick={() => setField(f.name, triggerId(Date.now()))}
               className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
@@ -1278,7 +1280,8 @@ export function InjectDialog({
             onKeyDown={onTemplateKeyDown}
           >
             {initialEnvelope && (
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 type="button"
                 {...radioA11y("__given__")}
                 onClick={() => applySelection("__given__")}
@@ -1305,7 +1308,8 @@ export function InjectDialog({
                     const id = `__recent_${r.eventId}__`;
                     const summary = summarizePayload(r.envelope);
                     return (
-                      <PrimitiveButton bare
+                      <PrimitiveButton
+                        bare
                         key={r.eventId || id}
                         type="button"
                         {...radioA11y(id)}
@@ -1349,7 +1353,8 @@ export function InjectDialog({
                         {group.templates.map((t) => {
                           const summary = t.summary || "no params";
                           return (
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               key={t.eventType}
                               type="button"
                               {...radioA11y(t.eventType)}
@@ -1392,7 +1397,8 @@ export function InjectDialog({
                 </div>
               )}
 
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               {...radioA11y(null)}
               onClick={() => applySelection(null)}
@@ -1451,7 +1457,8 @@ export function InjectDialog({
                     {jsonStatus.label}
                   </span>
                 </div>
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={formatJson}
                   className="text-[11px] text-(--text-dim) hover:text-(--accent)"

--- a/event-runtime/web/src/components/InjectDialog.tsx
+++ b/event-runtime/web/src/components/InjectDialog.tsx
@@ -40,6 +40,7 @@ import {
   VerbError,
   notify,
 } from "./ui";
+import { Button as PrimitiveButton } from "./ui";
 
 const REQUIRED = ["schemaVersion", "eventId", "type", "source", "occurredAt"];
 
@@ -1180,24 +1181,24 @@ export function InjectDialog({
           )}
           <span className="flex-1" />
           {f.kind === "string" && isAtField(f.name) && (
-            <button
+            <PrimitiveButton bare
               type="button"
               onClick={() => setField(f.name, new Date().toISOString())}
               className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
               title="Write the current time as an ISO timestamp"
             >
               Now
-            </button>
+            </PrimitiveButton>
           )}
           {f.kind === "string" && isIdField(f.name) && (
-            <button
+            <PrimitiveButton bare
               type="button"
               onClick={() => setField(f.name, triggerId(Date.now()))}
               className="rounded border border-(--border) px-1.5 py-0.5 text-[10px] text-(--text-dim) hover:bg-(--surface-2)"
               title="Generate a fresh web-trigger id"
             >
               Generate
-            </button>
+            </PrimitiveButton>
           )}
         </div>
         {f.description && (
@@ -1277,7 +1278,7 @@ export function InjectDialog({
             onKeyDown={onTemplateKeyDown}
           >
             {initialEnvelope && (
-              <button
+              <PrimitiveButton bare
                 type="button"
                 {...radioA11y("__given__")}
                 onClick={() => applySelection("__given__")}
@@ -1291,7 +1292,7 @@ export function InjectDialog({
                 <div className="text-[11px] text-(--text-faint) truncate">
                   original triggering payload
                 </div>
-              </button>
+              </PrimitiveButton>
             )}
 
             {filteredRecent.length > 0 && (
@@ -1304,7 +1305,7 @@ export function InjectDialog({
                     const id = `__recent_${r.eventId}__`;
                     const summary = summarizePayload(r.envelope);
                     return (
-                      <button
+                      <PrimitiveButton bare
                         key={r.eventId || id}
                         type="button"
                         {...radioA11y(id)}
@@ -1324,7 +1325,7 @@ export function InjectDialog({
                             {summary}
                           </span>
                         </div>
-                      </button>
+                      </PrimitiveButton>
                     );
                   })}
                 </div>
@@ -1348,7 +1349,7 @@ export function InjectDialog({
                         {group.templates.map((t) => {
                           const summary = t.summary || "no params";
                           return (
-                            <button
+                            <PrimitiveButton bare
                               key={t.eventType}
                               type="button"
                               {...radioA11y(t.eventType)}
@@ -1373,7 +1374,7 @@ export function InjectDialog({
                                   {summary}
                                 </span>
                               </div>
-                            </button>
+                            </PrimitiveButton>
                           );
                         })}
                       </div>
@@ -1391,7 +1392,7 @@ export function InjectDialog({
                 </div>
               )}
 
-            <button
+            <PrimitiveButton bare
               type="button"
               {...radioA11y(null)}
               onClick={() => applySelection(null)}
@@ -1405,7 +1406,7 @@ export function InjectDialog({
               <div className="text-[11px] text-(--text-faint)">
                 empty starter envelope
               </div>
-            </button>
+            </PrimitiveButton>
           </div>
         </div>
 
@@ -1450,7 +1451,7 @@ export function InjectDialog({
                     {jsonStatus.label}
                   </span>
                 </div>
-                <button
+                <PrimitiveButton bare
                   type="button"
                   onClick={formatJson}
                   className="text-[11px] text-(--text-dim) hover:text-(--accent)"
@@ -1463,7 +1464,7 @@ export function InjectDialog({
                   >
                     ⌘⇧F
                   </span>
-                </button>
+                </PrimitiveButton>
               </div>
             )}
           </div>

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -251,7 +251,8 @@ export function RunFailureBanner({
           {reason ?? "No reason recorded on the terminal transition."}
         </div>
         {reason && (
-          <PrimitiveButton bare
+          <PrimitiveButton
+            bare
             type="button"
             onClick={() => copyText(reason, "failure reason")}
             className="shrink-0 cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text) hover:underline"
@@ -341,7 +342,8 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
             {formatBytes(a.sizeBytes)}
           </span>
           {textFriendly && (
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               onClick={togglePreview}
               className="text-[12px] text-(--text-dim) hover:text-(--accent)"

--- a/event-runtime/web/src/components/RunDetailBlocks.tsx
+++ b/event-runtime/web/src/components/RunDetailBlocks.tsx
@@ -33,6 +33,7 @@ import {
 } from "./ui";
 import { AgentHoverCard } from "./AgentHoverCard";
 import { attrIcon } from "./attrIcons";
+import { Button as PrimitiveButton } from "./ui";
 
 /**
  * The artifact view renderer (WM-455) is fetched on demand: RunDetailBlocks
@@ -250,13 +251,13 @@ export function RunFailureBanner({
           {reason ?? "No reason recorded on the terminal transition."}
         </div>
         {reason && (
-          <button
+          <PrimitiveButton bare
             type="button"
             onClick={() => copyText(reason, "failure reason")}
             className="shrink-0 cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text) hover:underline"
           >
             Copy reason
-          </button>
+          </PrimitiveButton>
         )}
       </div>
     </div>
@@ -340,13 +341,13 @@ export function ArtifactRow({ a }: { a: ArtifactRef }) {
             {formatBytes(a.sizeBytes)}
           </span>
           {textFriendly && (
-            <button
+            <PrimitiveButton bare
               type="button"
               onClick={togglePreview}
               className="text-[12px] text-(--text-dim) hover:text-(--accent)"
             >
               {open ? "Hide" : "Preview"}
-            </button>
+            </PrimitiveButton>
           )}
           <a
             href={artifactUrl(a.sha256, a.kind)}

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -19,7 +19,8 @@ import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard } from "../hooks";
 import type { RunState, TraceEntry, TracePayload } from "../types";
-import { DisclosureChevron, humanSize, JsonBlock, Section, notify } from "./ui";
+import { DisclosureChevron, humanSize, IconButton, JsonBlock, Section, notify } from "./ui";
+import { Button as PrimitiveButton } from "./ui";
 
 function copyText(text: string, label: string = "text") {
   navigator.clipboard.writeText(text);
@@ -36,15 +37,13 @@ function TraceIconButton({
   children: ReactNode;
 }) {
   return (
-    <button
-      type="button"
+    <IconButton
       aria-label={label}
-      title={label}
       onClick={onClick}
-      className="inline-flex size-6 items-center justify-center rounded text-(--text-faint) transition-colors hover:bg-(--surface-2) hover:text-(--text) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+      className="text-(--text-faint) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
     >
       {children}
-    </button>
+    </IconButton>
   );
 }
 
@@ -1140,7 +1139,7 @@ export function RunTrace({
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         {live ? (
           <div className="flex items-center gap-2">
-            <button
+            <PrimitiveButton bare
               type="button"
               onClick={() => {
                 if (followLive) {
@@ -1177,7 +1176,7 @@ export function RunTrace({
               >
                 l
               </span>
-            </button>
+            </PrimitiveButton>
             {unreadCount > 0 && !followLive ? (
               <span className="text-[11px] font-medium text-(--hue-warn)">
                 {unreadCount} new {unreadCount === 1 ? "event" : "events"}
@@ -1211,7 +1210,7 @@ export function RunTrace({
             aria-label="Trace kind"
           >
             {filterTabs.map((t, idx) => (
-              <button
+              <PrimitiveButton bare
                 key={t.key}
                 type="button"
                 role="tab"
@@ -1243,13 +1242,13 @@ export function RunTrace({
                 >
                   {idx + 1}
                 </span>
-              </button>
+              </PrimitiveButton>
             ))}
           </div>
 
           <div className="flex items-center gap-2">
             {counts.errors > 0 && (
-              <button
+              <PrimitiveButton bare
                 type="button"
                 onClick={handleJumpToError}
                 className={TRACE_QUIET_BUTTON}
@@ -1270,7 +1269,7 @@ export function RunTrace({
                 >
                   .
                 </span>
-              </button>
+              </PrimitiveButton>
             )}
 
             <div className="flex items-center gap-1 rounded border border-(--border) bg-(--surface-0) px-1.5 py-0.5 text-[11px]">
@@ -1304,7 +1303,7 @@ export function RunTrace({
                   </span>
                   {searchMatches.length > 0 && (
                     <>
-                      <button
+                      <PrimitiveButton bare
                         type="button"
                         onClick={() =>
                           setActiveMatch(
@@ -1318,8 +1317,8 @@ export function RunTrace({
                         aria-label="Previous match"
                       >
                         <span aria-hidden="true">↑</span>
-                      </button>
-                      <button
+                      </PrimitiveButton>
+                      <PrimitiveButton bare
                         type="button"
                         onClick={() =>
                           setActiveMatch((m) => (m + 1) % searchMatches.length)
@@ -1329,10 +1328,10 @@ export function RunTrace({
                         aria-label="Next match"
                       >
                         <span aria-hidden="true">↓</span>
-                      </button>
+                      </PrimitiveButton>
                     </>
                   )}
-                  <button
+                  <PrimitiveButton bare
                     type="button"
                     onClick={() => setSearch("")}
                     className="text-(--text-faint) hover:text-(--text)"
@@ -1340,11 +1339,11 @@ export function RunTrace({
                     aria-label="Clear search"
                   >
                     <span aria-hidden="true">×</span>
-                  </button>
+                  </PrimitiveButton>
                 </>
               )}
             </div>
-            <button
+            <PrimitiveButton bare
               type="button"
               onClick={() => {
                 setExpandAll((v) => !v);
@@ -1360,7 +1359,7 @@ export function RunTrace({
               >
                 e
               </span>
-            </button>
+            </PrimitiveButton>
           </div>
         </div>
       )}
@@ -1439,7 +1438,7 @@ export function RunTrace({
 
           {live && !followLive && (
             <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10">
-              <button
+              <PrimitiveButton bare
                 type="button"
                 onClick={jumpToLatest}
                 className="flex items-center gap-1.5 rounded-full bg-(--accent) px-3 py-1 text-[11px] font-medium text-white shadow-lg transition-transform hover:scale-105 active:scale-95"
@@ -1456,7 +1455,7 @@ export function RunTrace({
                 >
                   G
                 </span>
-              </button>
+              </PrimitiveButton>
             </div>
           )}
         </div>
@@ -1468,13 +1467,14 @@ export function RunTrace({
           {onExpand && (
             <>
               {" — "}
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={onExpand}
                 className="text-(--accent) hover:underline"
               >
                 open full view
-              </button>
+              </PrimitiveButton>
             </>
           )}
         </div>

--- a/event-runtime/web/src/components/RunTrace.tsx
+++ b/event-runtime/web/src/components/RunTrace.tsx
@@ -19,7 +19,14 @@ import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import { keyGuard } from "../hooks";
 import type { RunState, TraceEntry, TracePayload } from "../types";
-import { DisclosureChevron, humanSize, IconButton, JsonBlock, Section, notify } from "./ui";
+import {
+  DisclosureChevron,
+  humanSize,
+  IconButton,
+  JsonBlock,
+  Section,
+  notify,
+} from "./ui";
 import { Button as PrimitiveButton } from "./ui";
 
 function copyText(text: string, label: string = "text") {
@@ -1139,7 +1146,8 @@ export function RunTrace({
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         {live ? (
           <div className="flex items-center gap-2">
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               onClick={() => {
                 if (followLive) {
@@ -1210,7 +1218,8 @@ export function RunTrace({
             aria-label="Trace kind"
           >
             {filterTabs.map((t, idx) => (
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 key={t.key}
                 type="button"
                 role="tab"
@@ -1248,7 +1257,8 @@ export function RunTrace({
 
           <div className="flex items-center gap-2">
             {counts.errors > 0 && (
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={handleJumpToError}
                 className={TRACE_QUIET_BUTTON}
@@ -1303,7 +1313,8 @@ export function RunTrace({
                   </span>
                   {searchMatches.length > 0 && (
                     <>
-                      <PrimitiveButton bare
+                      <PrimitiveButton
+                        bare
                         type="button"
                         onClick={() =>
                           setActiveMatch(
@@ -1318,7 +1329,8 @@ export function RunTrace({
                       >
                         <span aria-hidden="true">↑</span>
                       </PrimitiveButton>
-                      <PrimitiveButton bare
+                      <PrimitiveButton
+                        bare
                         type="button"
                         onClick={() =>
                           setActiveMatch((m) => (m + 1) % searchMatches.length)
@@ -1331,7 +1343,8 @@ export function RunTrace({
                       </PrimitiveButton>
                     </>
                   )}
-                  <PrimitiveButton bare
+                  <PrimitiveButton
+                    bare
                     type="button"
                     onClick={() => setSearch("")}
                     className="text-(--text-faint) hover:text-(--text)"
@@ -1343,7 +1356,8 @@ export function RunTrace({
                 </>
               )}
             </div>
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               onClick={() => {
                 setExpandAll((v) => !v);
@@ -1438,7 +1452,8 @@ export function RunTrace({
 
           {live && !followLive && (
             <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10">
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={jumpToLatest}
                 className="flex items-center gap-1.5 rounded-full bg-(--accent) px-3 py-1 text-[11px] font-medium text-white shadow-lg transition-transform hover:scale-105 active:scale-95"

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -131,7 +131,8 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
   return (
     <Dialog title="Keyboard" onClose={onClose}>
       <div className="-mt-9 mb-3 flex justify-end">
-        <PrimitiveButton bare
+        <PrimitiveButton
+          bare
           type="button"
           autoFocus
           ref={(node) => node?.setAttribute("autofocus", "")}

--- a/event-runtime/web/src/components/ShortcutsDialog.tsx
+++ b/event-runtime/web/src/components/ShortcutsDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Dialog } from "./ui";
 import { NAV } from "../nav";
+import { Button as PrimitiveButton } from "./ui";
 
 const CONTEXT_CHORDS: { chord: string; label: string }[] = [
   { chord: "g 0", label: "All context" },
@@ -130,7 +131,7 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
   return (
     <Dialog title="Keyboard" onClose={onClose}>
       <div className="-mt-9 mb-3 flex justify-end">
-        <button
+        <PrimitiveButton bare
           type="button"
           autoFocus
           ref={(node) => node?.setAttribute("autofocus", "")}
@@ -138,7 +139,7 @@ export function ShortcutsDialog({ onClose }: { onClose: () => void }) {
           className="rounded-md border border-(--border-strong) bg-(--surface-2) px-2.5 py-1 text-[12px] font-medium text-(--text) transition-colors hover:bg-(--surface-3) focus-visible:outline-2 focus-visible:outline-(--accent)"
         >
           Close
-        </button>
+        </PrimitiveButton>
       </div>
       <div className="relative">
         <div

--- a/event-runtime/web/src/components/TicketDecisions.tsx
+++ b/event-runtime/web/src/components/TicketDecisions.tsx
@@ -19,6 +19,7 @@ import {
   hashHref,
   ticketIdOf,
 } from "./RunDetailBlocks";
+import { Button as PrimitiveButton } from "./ui";
 
 /**
  * The per-ticket "why isn't this running?" answer (WM-594). Split out of
@@ -232,7 +233,7 @@ export function TicketDecisions({
             onClick={() => setOpen((o) => !o)}
             title={decisionHeadline(latest, now)}
           >
-            <button
+            <PrimitiveButton bare
               type="button"
               aria-expanded={open}
               aria-label={`${open ? "Hide" : "Show"} all ${decisions.length} planner decisions for ${ticket}`}
@@ -244,7 +245,7 @@ export function TicketDecisions({
             >
               <DisclosureChevron open={open} />
               <span className="text-[11px] text-(--text-faint)">last:</span>
-            </button>
+            </PrimitiveButton>
             <StateBadge
               state={latest.outcome}
               hues={OUTCOME_HUES}

--- a/event-runtime/web/src/components/TicketDecisions.tsx
+++ b/event-runtime/web/src/components/TicketDecisions.tsx
@@ -233,7 +233,8 @@ export function TicketDecisions({
             onClick={() => setOpen((o) => !o)}
             title={decisionHeadline(latest, now)}
           >
-            <PrimitiveButton bare
+            <PrimitiveButton
+              bare
               type="button"
               aria-expanded={open}
               aria-label={`${open ? "Hide" : "Show"} all ${decisions.length} planner decisions for ${ticket}`}

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import {
   Button,
   ChipInput,
+  clampTooltipPosition,
   clearToasts,
   CopyActions,
   Countdown,
@@ -21,6 +22,7 @@ import {
   StateBadge,
   SuggestInput,
   ToastContainer,
+  Tooltip,
 } from "./ui";
 import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
 import { modal } from "../hooks";
@@ -76,18 +78,33 @@ describe("control sizing (WM-589)", () => {
   test("Button renders the shared 24, 28, and 32px sizes", () => {
     const r = render(
       <>
-        <Button size="sm"><svg aria-hidden="true" />Small</Button>
-        <Button size="md"><svg aria-hidden="true" />Medium</Button>
-        <Button size="lg"><svg aria-hidden="true" />Large</Button>
+        <Button size="sm">
+          <svg aria-hidden="true" />
+          Small
+        </Button>
+        <Button size="md">
+          <svg aria-hidden="true" />
+          Medium
+        </Button>
+        <Button size="lg">
+          <svg aria-hidden="true" />
+          Large
+        </Button>
       </>,
     );
 
     const small = r.getByRole("button", { name: "Small" });
     const medium = r.getByRole("button", { name: "Medium" });
     const large = r.getByRole("button", { name: "Large" });
-    expect(classes(small)).toEqual(expect.arrayContaining(["h-6", "px-2", "[&>svg]:size-3"]));
-    expect(classes(medium)).toEqual(expect.arrayContaining(["h-7", "px-2.5", "[&>svg]:size-3.5"]));
-    expect(classes(large)).toEqual(expect.arrayContaining(["h-8", "px-3", "[&>svg]:size-4"]));
+    expect(classes(small)).toEqual(
+      expect.arrayContaining(["h-6", "px-2", "[&>svg]:size-3"]),
+    );
+    expect(classes(medium)).toEqual(
+      expect.arrayContaining(["h-7", "px-2.5", "[&>svg]:size-3.5"]),
+    );
+    expect(classes(large)).toEqual(
+      expect.arrayContaining(["h-8", "px-3", "[&>svg]:size-4"]),
+    );
     expect(small.getAttribute("data-control-size")).toBe("sm");
     expect(medium.getAttribute("data-control-size")).toBe("md");
     expect(large.getAttribute("data-control-size")).toBe("lg");
@@ -98,19 +115,138 @@ describe("control sizing (WM-589)", () => {
       render(
         // Runtime protection complements the required TypeScript prop for JS/dynamic callers.
         // @ts-expect-error exercising the runtime guard
-        <IconButton><span aria-hidden="true">×</span></IconButton>,
+        <IconButton>
+          <span aria-hidden="true">×</span>
+        </IconButton>,
       ),
     ).toThrow("IconButton requires a non-empty aria-label");
   });
 
   test("IconButton is a square medium control with a shared tooltip", () => {
     const r = render(
-      <IconButton aria-label="Copy run id"><span aria-hidden="true">#</span></IconButton>,
+      <IconButton aria-label="Copy run id">
+        <span aria-hidden="true">#</span>
+      </IconButton>,
     );
     const button = r.getByRole("button", { name: "Copy run id" });
     expect(classes(button)).toContain("h-7");
     expect(classes(button)).toContain("w-7");
     expect(r.getByRole("tooltip").textContent).toBe("Copy run id");
+  });
+});
+
+describe("Tooltip viewport clamp (WM-589 follow-up)", () => {
+  test("clampTooltipPosition flips above a bottom-pinned trigger instead of opening off-screen", () => {
+    // Footer theme toggle: trigger sits flush with the bottom of the viewport,
+    // so opening downward (the old CSS-only default) put the tooltip entirely
+    // below the visible page.
+    const trigger = { top: 878, left: 700, right: 732, bottom: 900, width: 32 };
+    const tooltip = { width: 140, height: 26 };
+    const viewport = { width: 1440, height: 900 };
+    const pos = clampTooltipPosition(trigger, tooltip, viewport);
+    expect(pos.top).toBeGreaterThanOrEqual(0);
+    expect(pos.top + tooltip.height).toBeLessThanOrEqual(viewport.height);
+    expect(pos.top).toBeLessThan(trigger.top); // flipped above the trigger
+  });
+
+  test("clampTooltipPosition clamps a right-edge trigger's tooltip inside the viewport width", () => {
+    // ContextTabs "+" repo picker: trigger sits top-right, so centering the
+    // tooltip under it (the old CSS-only default) clipped it off the right edge.
+    const trigger = { top: 40, left: 1400, right: 1432, bottom: 68, width: 32 };
+    const tooltip = { width: 220, height: 26 };
+    const viewport = { width: 1440, height: 900 };
+    const pos = clampTooltipPosition(trigger, tooltip, viewport);
+    expect(pos.left).toBeGreaterThanOrEqual(0);
+    expect(pos.left + tooltip.width).toBeLessThanOrEqual(viewport.width);
+  });
+
+  function rect(r: {
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }): DOMRect {
+    return { ...r, x: r.left, y: r.top, toJSON: () => r } as DOMRect;
+  }
+
+  test("Tooltip keeps a bottom-pinned trigger's tooltip on-screen", () => {
+    Object.defineProperty(window, "innerWidth", {
+      value: 1440,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 900,
+      configurable: true,
+    });
+
+    const r = render(
+      <Tooltip label="Switch to dark theme">
+        <button aria-label="Theme">T</button>
+      </Tooltip>,
+    );
+    const trigger = r.getByRole("button", { name: "Theme" })
+      .parentElement as HTMLElement;
+    const tooltip = r.getByRole("tooltip");
+    trigger.getBoundingClientRect = () =>
+      rect({
+        top: 878,
+        left: 700,
+        right: 732,
+        bottom: 900,
+        width: 32,
+        height: 22,
+      });
+    tooltip.getBoundingClientRect = () =>
+      rect({ top: 0, left: 0, right: 140, bottom: 26, width: 140, height: 26 });
+
+    act(() => {
+      fireEvent.mouseEnter(trigger);
+    });
+
+    const top = parseFloat(tooltip.style.top);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top + 26).toBeLessThanOrEqual(900);
+  });
+
+  test("Tooltip keeps a right-edge trigger's tooltip on-screen", () => {
+    Object.defineProperty(window, "innerWidth", {
+      value: 1440,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 900,
+      configurable: true,
+    });
+
+    const r = render(
+      <Tooltip label="Open a repo tab (g 1–9)">
+        <button aria-label="Open repo">+</button>
+      </Tooltip>,
+    );
+    const trigger = r.getByRole("button", { name: "Open repo" })
+      .parentElement as HTMLElement;
+    const tooltip = r.getByRole("tooltip");
+    trigger.getBoundingClientRect = () =>
+      rect({
+        top: 40,
+        left: 1400,
+        right: 1432,
+        bottom: 68,
+        width: 32,
+        height: 28,
+      });
+    tooltip.getBoundingClientRect = () =>
+      rect({ top: 0, left: 0, right: 220, bottom: 26, width: 220, height: 26 });
+
+    act(() => {
+      fireEvent.mouseEnter(trigger);
+    });
+
+    const left = parseFloat(tooltip.style.left);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left + 220).toBeLessThanOrEqual(1440);
   });
 });
 

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -12,6 +12,7 @@ import {
   Dialog,
   FilterInput,
   getValueHue,
+  IconButton,
   KV,
   KVGroup,
   notify,
@@ -71,8 +72,50 @@ describe("shortId (WM-96)", () => {
   });
 });
 
+describe("control sizing (WM-589)", () => {
+  test("Button renders the shared 24, 28, and 32px sizes", () => {
+    const r = render(
+      <>
+        <Button size="sm"><svg aria-hidden="true" />Small</Button>
+        <Button size="md"><svg aria-hidden="true" />Medium</Button>
+        <Button size="lg"><svg aria-hidden="true" />Large</Button>
+      </>,
+    );
+
+    const small = r.getByRole("button", { name: "Small" });
+    const medium = r.getByRole("button", { name: "Medium" });
+    const large = r.getByRole("button", { name: "Large" });
+    expect(classes(small)).toEqual(expect.arrayContaining(["h-6", "px-2", "[&>svg]:size-3"]));
+    expect(classes(medium)).toEqual(expect.arrayContaining(["h-7", "px-2.5", "[&>svg]:size-3.5"]));
+    expect(classes(large)).toEqual(expect.arrayContaining(["h-8", "px-3", "[&>svg]:size-4"]));
+    expect(small.getAttribute("data-control-size")).toBe("sm");
+    expect(medium.getAttribute("data-control-size")).toBe("md");
+    expect(large.getAttribute("data-control-size")).toBe("lg");
+  });
+
+  test("IconButton rejects a missing accessible name", () => {
+    expect(() =>
+      render(
+        // Runtime protection complements the required TypeScript prop for JS/dynamic callers.
+        // @ts-expect-error exercising the runtime guard
+        <IconButton><span aria-hidden="true">×</span></IconButton>,
+      ),
+    ).toThrow("IconButton requires a non-empty aria-label");
+  });
+
+  test("IconButton is a square medium control with a shared tooltip", () => {
+    const r = render(
+      <IconButton aria-label="Copy run id"><span aria-hidden="true">#</span></IconButton>,
+    );
+    const button = r.getByRole("button", { name: "Copy run id" });
+    expect(classes(button)).toContain("h-7");
+    expect(classes(button)).toContain("w-7");
+    expect(r.getByRole("tooltip").textContent).toBe("Copy run id");
+  });
+});
+
 describe("CopyActions (WM-302)", () => {
-  test("renders icon-only actions with accessible labels and shortcut tooltips", () => {
+  test("renders icon-only actions with accessible labels and shared shortcut tooltips", () => {
     const r = render(
       <CopyActions
         id="run_123"
@@ -87,9 +130,11 @@ describe("CopyActions (WM-302)", () => {
       name: "Copy CLI inspect command (c i)",
     });
     const link = r.getByRole("button", { name: "Copy link (c l)" });
-    expect(id.getAttribute("title")).toBe("Copy run id · c");
-    expect(cli.getAttribute("title")).toBe("Copy CLI inspect command · c i");
-    expect(link.getAttribute("title")).toBe("Copy link · c l");
+    expect(r.getAllByRole("tooltip").map((el) => el.textContent)).toEqual([
+      "Copy run id · c",
+      "Copy CLI inspect command · c i",
+      "Copy link · c l",
+    ]);
     expect(id.textContent).toBe("");
     expect(cli.textContent).toBe("");
     expect(link.textContent).toBe("");

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -248,6 +248,66 @@ describe("Tooltip viewport clamp (WM-589 follow-up)", () => {
     expect(left).toBeGreaterThanOrEqual(0);
     expect(left + 220).toBeLessThanOrEqual(1440);
   });
+
+  test("Tooltip recomputes position when its label changes while it stays open", () => {
+    // Regression for a follow-up finding on the theme toggle: the label can
+    // change (and grow) on click without the pointer/focus ever leaving the
+    // button, so the effect must react to the label content too, not just
+    // the open/closed transition.
+    Object.defineProperty(window, "innerWidth", {
+      value: 1440,
+      configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      value: 900,
+      configurable: true,
+    });
+
+    function ToggleLabelHarness() {
+      const [long, setLong] = useState(false);
+      return (
+        <Tooltip label={long ? "A much longer label after the click" : "Short"}>
+          <button aria-label="Toggle" onClick={() => setLong(true)}>
+            T
+          </button>
+        </Tooltip>
+      );
+    }
+
+    const r = render(<ToggleLabelHarness />);
+    const button = r.getByRole("button", { name: "Toggle" });
+    const trigger = button.parentElement as HTMLElement;
+    const tooltip = r.getByRole("tooltip");
+    trigger.getBoundingClientRect = () =>
+      rect({
+        top: 40,
+        left: 1400,
+        right: 1432,
+        bottom: 68,
+        width: 32,
+        height: 28,
+      });
+    tooltip.getBoundingClientRect = () =>
+      rect({ top: 0, left: 0, right: 60, bottom: 26, width: 60, height: 26 });
+
+    act(() => {
+      fireEvent.mouseEnter(trigger);
+    });
+    const shortLeft = parseFloat(tooltip.style.left);
+    expect(shortLeft + 60).toBeLessThanOrEqual(1440);
+
+    // The click grows the label/tooltip without a mouseleave/mouseenter —
+    // pointer stays put, `open` never flips.
+    tooltip.getBoundingClientRect = () =>
+      rect({ top: 0, left: 0, right: 260, bottom: 26, width: 260, height: 26 });
+    act(() => {
+      fireEvent.click(button);
+    });
+
+    const left = parseFloat(tooltip.style.left);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left + 260).toBeLessThanOrEqual(1440);
+  });
 });
 
 describe("CopyActions (WM-302)", () => {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -191,7 +192,8 @@ function CopyActionButton({
     );
   }
   return (
-    <Button bare
+    <Button
+      bare
       type="button"
       title={`${label} · ${chord}`}
       aria-label={`${label} (${chord})`}
@@ -349,7 +351,8 @@ function FilterToken({
   const label = chipLabel(token);
   const help = chipHelp(token, query);
   return (
-    <Button bare
+    <Button
+      bare
       type="button"
       onClick={onRemove}
       title={help}
@@ -646,7 +649,8 @@ export function FilterInput<T = unknown, C = unknown>({
               onRemove={() => rewrite(removeFilterToken(value, token))}
             />
           ))}
-          <Button bare
+          <Button
+            bare
             type="button"
             onClick={() => rewrite("")}
             title="Clear query (Esc)"
@@ -800,7 +804,12 @@ export function ListEmpty({
         )}
         {onClear && filtered && !query.isPending && !query.isError && (
           <div className="mt-3">
-            <Button size="sm" variant="ghost" className="bg-(--surface-3) text-(--text)" onClick={onClear}>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="bg-(--surface-3) text-(--text)"
+              onClick={onClear}
+            >
               Clear filter
             </Button>
           </div>
@@ -856,7 +865,8 @@ export function Th({
         className={`group/th flex h-7 w-full items-center justify-between gap-1 px-3 ${align === "right" ? "justify-end" : ""}`}
       >
         {onSort ? (
-          <Button bare
+          <Button
+            bare
             type="button"
             onClick={onSort}
             onKeyDown={(e) =>
@@ -1405,7 +1415,8 @@ export function StatTile({
     "rounded-md border border-(--border) bg-(--surface-1) px-3 py-2 text-left";
   if (!onClick) return <div className={cls}>{inner}</div>;
   return (
-    <Button bare
+    <Button
+      bare
       type="button"
       onClick={onClick}
       aria-label={`${label}: ${value}`}
@@ -1447,7 +1458,8 @@ export function JumpLink({
     );
   }
   return (
-    <Button bare
+    <Button
+      bare
       type="button"
       className={cls}
       title={title}
@@ -1616,7 +1628,8 @@ function ToastRegion({
       className="flex flex-col gap-2"
     >
       {toasts.map((t) => (
-        <Button bare
+        <Button
+          bare
           key={t.id}
           type="button"
           title="Dismiss"
@@ -1684,7 +1697,8 @@ export function JsonBlock({ value }: { value: unknown }) {
           ),
         )}
       </pre>
-      <Button bare
+      <Button
+        bare
         type="button"
         onClick={copy}
         className="absolute top-2 right-2 rounded border border-(--border) bg-(--surface-1) px-2 py-0.5 text-[10px] font-medium text-(--text-dim) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--surface-2) hover:text-(--text)"
@@ -1898,7 +1912,8 @@ export function KV({
         <span className="truncate">{k}</span>
       </div>
       {copyable ? (
-        <Button bare
+        <Button
+          bare
           type="button"
           // The row truncates long values; the tooltip is the only place the
           // full string is readable without copying (WM-129 critique).
@@ -1958,47 +1973,148 @@ const BUTTON_SIZES: Record<ButtonSize, string> = {
   lg: "h-8 gap-2 px-3 [&>svg]:size-4",
 };
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      children,
+      variant = "default",
+      size = "md",
+      bare = false,
+      className = "",
+      type = "button",
+      ...props
+    },
+    ref,
+  ) {
+    const styles = {
+      default:
+        "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
+      primary:
+        "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
+      danger:
+        "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-(--hue-err)",
+      ghost:
+        "border-transparent bg-transparent text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)",
+    }[variant];
+    return (
+      <button
+        ref={ref}
+        type={type}
+        data-control-size={bare ? undefined : size}
+        className={
+          bare
+            ? className
+            : `inline-flex shrink-0 items-center justify-center rounded-md border text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZES[size]} ${styles} ${className}`
+        }
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+interface TooltipRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+}
+
+export interface TooltipPosition {
+  top: number;
+  left: number;
+}
+
+/**
+ * Clamp/flip a tooltip so it stays fully inside the viewport (WM-589
+ * follow-up). Prefers opening below and centered under the trigger — the
+ * previous CSS-only default — but flips above when there isn't room below
+ * (e.g. a trigger pinned to the bottom edge), and always clamps
+ * horizontally so a right- or left-aligned trigger never clips off-screen.
+ */
+export function clampTooltipPosition(
+  trigger: TooltipRect,
+  tooltip: { width: number; height: number },
+  viewport: { width: number; height: number },
+  margin = 8,
+): TooltipPosition {
+  const gap = 6;
+  let top = trigger.bottom + gap;
+  if (top + tooltip.height + margin > viewport.height) {
+    const above = trigger.top - tooltip.height - gap;
+    top =
+      above >= margin
+        ? above
+        : Math.max(margin, viewport.height - tooltip.height - margin);
+  }
+  const maxLeft = Math.max(margin, viewport.width - tooltip.width - margin);
+  const left = Math.min(
+    Math.max(trigger.left + trigger.width / 2 - tooltip.width / 2, margin),
+    maxLeft,
+  );
+  return { top, left };
+}
+
+/**
+ * A real hover/focus tooltip shared by icon-only controls. Position is
+ * fixed and JS-computed (see `clampTooltipPosition`) rather than pure CSS
+ * placement, so it never opens off-screen for edge-pinned triggers (bottom
+ * status bar, right-aligned toolbar buttons, …).
+ */
+export function Tooltip({
+  label,
   children,
-  variant = "default",
-  size = "md",
-  bare = false,
-  className = "",
-  type = "button",
-  ...props
-}, ref) {
-  const styles = {
-    default:
-      "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
-    primary:
-      "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
-    danger:
-      "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-(--hue-err)",
-    ghost: "border-transparent bg-transparent text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)",
-  }[variant];
+}: {
+  label: ReactNode;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<TooltipPosition | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
+
+  // Kept mounted (opacity-0 while closed) rather than conditionally rendered,
+  // so callers/tests can find the tooltip by role without simulating hover,
+  // and so there is no mount flash the first time it opens.
+  useLayoutEffect(() => {
+    const position = () => {
+      const trigger = triggerRef.current?.getBoundingClientRect();
+      const tooltip = tooltipRef.current?.getBoundingClientRect();
+      if (!trigger || !tooltip) return;
+      setPos(
+        clampTooltipPosition(
+          trigger,
+          { width: tooltip.width, height: tooltip.height },
+          { width: window.innerWidth, height: window.innerHeight },
+        ),
+      );
+    };
+    position();
+    window.addEventListener("resize", position);
+    window.addEventListener("scroll", position, true);
+    return () => {
+      window.removeEventListener("resize", position);
+      window.removeEventListener("scroll", position, true);
+    };
+  }, [open]);
+
   return (
-    <button
-      ref={ref}
-      type={type}
-      data-control-size={bare ? undefined : size}
-      className={bare
-        ? className
-        : `inline-flex shrink-0 items-center justify-center rounded-md border text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZES[size]} ${styles} ${className}`}
-      {...props}
+    <span
+      ref={triggerRef}
+      className="relative inline-flex"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
     >
       {children}
-    </button>
-  );
-});
-
-/** A real hover/focus tooltip shared by icon-only controls. */
-export function Tooltip({ label, children }: { label: ReactNode; children: ReactNode }) {
-  return (
-    <span className="group/tooltip relative inline-flex">
-      {children}
       <span
+        ref={tooltipRef}
         role="tooltip"
-        className="pointer-events-none absolute top-full left-1/2 z-50 mt-1.5 -translate-x-1/2 rounded border border-(--border-strong) bg-(--surface-2) px-2 py-1 text-[11px] font-normal whitespace-nowrap text-(--text) opacity-0 shadow-lg transition-opacity group-hover/tooltip:opacity-100 group-focus-within/tooltip:opacity-100"
+        style={pos ? { top: pos.top, left: pos.left } : undefined}
+        className={`pointer-events-none fixed z-50 rounded border border-(--border-strong) bg-(--surface-2) px-2 py-1 text-[11px] font-normal whitespace-nowrap text-(--text) shadow-lg transition-opacity ${open ? "opacity-100" : "opacity-0"}`}
       >
         {label}
       </span>
@@ -2006,36 +2122,44 @@ export function Tooltip({ label, children }: { label: ReactNode; children: React
   );
 }
 
-export type IconButtonProps = Omit<ButtonProps, "aria-label" | "children" | "size"> & {
+export type IconButtonProps = Omit<
+  ButtonProps,
+  "aria-label" | "children" | "size"
+> & {
   "aria-label": string;
   children: ReactNode;
   tooltip?: ReactNode;
 };
 
 /** Square 28px icon control with a mandatory accessible name and tooltip. */
-export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
-  "aria-label": ariaLabel,
-  tooltip,
-  className = "",
-  variant = "ghost",
-  ...props
-}, ref) {
-  if (!ariaLabel?.trim()) {
-    throw new Error("IconButton requires a non-empty aria-label");
-  }
-  return (
-    <Tooltip label={tooltip ?? ariaLabel}>
-      <Button
-        ref={ref}
-        aria-label={ariaLabel}
-        size="md"
-        variant={variant}
-        className={`w-7 !px-0 ${className}`}
-        {...props}
-      />
-    </Tooltip>
-  );
-});
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton(
+    {
+      "aria-label": ariaLabel,
+      tooltip,
+      className = "",
+      variant = "ghost",
+      ...props
+    },
+    ref,
+  ) {
+    if (!ariaLabel?.trim()) {
+      throw new Error("IconButton requires a non-empty aria-label");
+    }
+    return (
+      <Tooltip label={tooltip ?? ariaLabel}>
+        <Button
+          ref={ref}
+          aria-label={ariaLabel}
+          size="md"
+          variant={variant}
+          className={`w-7 !px-0 ${className}`}
+          {...props}
+        />
+      </Tooltip>
+    );
+  },
+);
 
 const FOCUSABLE =
   "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
@@ -2120,7 +2244,6 @@ export function Dialog({
       modal.depth -= 1;
       window.removeEventListener("keydown", onKey);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- onClose lives in the ref
   }, []);
   return (
     <div
@@ -2163,7 +2286,8 @@ export function Tabs({
       className="inline-flex gap-0.5 rounded-md border border-(--border) bg-(--surface-0) p-0.5"
     >
       {tabs.map((t) => (
-        <Button bare
+        <Button
+          bare
           key={t.id}
           type="button"
           role="tab"
@@ -2411,7 +2535,8 @@ export function ChipInput({
       {values.length > 0 && (
         <div className="mb-1.5 flex flex-wrap gap-1">
           {values.map((v) => (
-            <Button bare
+            <Button
+              bare
               key={v}
               type="button"
               onClick={() => onChange(values.filter((x) => x !== v))}
@@ -2511,7 +2636,8 @@ export function ChipInput({
             </ul>,
             document.body,
           )}
-        <Button bare
+        <Button
+          bare
           type="button"
           onClick={() => add(draft)}
           disabled={!draft.trim()}
@@ -2565,7 +2691,8 @@ export function BulkActionBar({
       {onClear && (
         <>
           <div className="h-4 w-px bg-(--border)" />
-          <Button bare
+          <Button
+            bare
             type="button"
             onClick={onClear}
             className="cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text)"

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -2077,7 +2077,12 @@ export function Tooltip({
 
   // Kept mounted (opacity-0 while closed) rather than conditionally rendered,
   // so callers/tests can find the tooltip by role without simulating hover,
-  // and so there is no mount flash the first time it opens.
+  // and so there is no mount flash the first time it opens. Depends on
+  // `label` too (not just `open`): a tooltip can stay open across a click
+  // that changes its own text (e.g. the theme toggle's label flips on
+  // click without the pointer/focus leaving the button) — without this,
+  // the position goes stale for the new (often wider) label and can clip
+  // off the edge it was just clamped away from.
   useLayoutEffect(() => {
     const position = () => {
       const trigger = triggerRef.current?.getBoundingClientRect();
@@ -2098,7 +2103,7 @@ export function Tooltip({
       window.removeEventListener("resize", position);
       window.removeEventListener("scroll", position, true);
     };
-  }, [open]);
+  }, [open, label]);
 
   return (
     <span

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1,5 +1,7 @@
 import {
   createContext,
+  forwardRef,
+  type ButtonHTMLAttributes,
   type ReactNode,
   useContext,
   useEffect,
@@ -177,8 +179,19 @@ function CopyActionButton({
   quiet = false,
   children,
 }: CopyActionButtonProps) {
+  if (!quiet) {
+    return (
+      <IconButton
+        aria-label={`${label} (${chord})`}
+        tooltip={`${label} · ${chord}`}
+        onClick={onClick}
+      >
+        {children}
+      </IconButton>
+    );
+  }
   return (
-    <button
+    <Button bare
       type="button"
       title={`${label} · ${chord}`}
       aria-label={`${label} (${chord})`}
@@ -190,7 +203,7 @@ function CopyActionButton({
       }
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -336,7 +349,7 @@ function FilterToken({
   const label = chipLabel(token);
   const help = chipHelp(token, query);
   return (
-    <button
+    <Button bare
       type="button"
       onClick={onRemove}
       title={help}
@@ -356,7 +369,7 @@ function FilterToken({
       >
         ×
       </span>
-    </button>
+    </Button>
   );
 }
 
@@ -633,7 +646,7 @@ export function FilterInput<T = unknown, C = unknown>({
               onRemove={() => rewrite(removeFilterToken(value, token))}
             />
           ))}
-          <button
+          <Button bare
             type="button"
             onClick={() => rewrite("")}
             title="Clear query (Esc)"
@@ -641,7 +654,7 @@ export function FilterInput<T = unknown, C = unknown>({
             className="cursor-pointer rounded-md px-1.5 py-0.5 text-[11px] text-(--text-faint) hover:bg-(--surface-1) hover:text-(--text)"
           >
             clear
-          </button>
+          </Button>
         </div>
       )}
     </>
@@ -787,7 +800,9 @@ export function ListEmpty({
         )}
         {onClear && filtered && !query.isPending && !query.isError && (
           <div className="mt-3">
-            <Button onClick={onClear}>Clear filter</Button>
+            <Button size="sm" variant="ghost" className="bg-(--surface-3) text-(--text)" onClick={onClear}>
+              Clear filter
+            </Button>
           </div>
         )}
         {action && !query.isPending && !query.isError && !filtered && (
@@ -841,7 +856,7 @@ export function Th({
         className={`group/th flex h-7 w-full items-center justify-between gap-1 px-3 ${align === "right" ? "justify-end" : ""}`}
       >
         {onSort ? (
-          <button
+          <Button bare
             type="button"
             onClick={onSort}
             onKeyDown={(e) =>
@@ -857,23 +872,21 @@ export function Th({
             >
               {(dir ?? naturalDir ?? "asc") === "desc" ? "↓" : "↑"}
             </span>
-          </button>
+          </Button>
         ) : (
           <span>{label}</span>
         )}
         {onRemove && (
-          <button
-            type="button"
+          <IconButton
             onClick={(e) => {
               e.stopPropagation();
               onRemove();
             }}
-            title={`Remove column ${label}`}
             aria-label={`Remove column ${label}`}
-            className="ml-1 inline-flex size-3.5 cursor-pointer items-center justify-center rounded text-[11px] text-(--text-faint) opacity-0 transition-opacity hover:bg-(--surface-2) hover:text-(--text) group-hover/th:opacity-100"
+            className="ml-1 text-[11px] text-(--text-faint) opacity-0 transition-opacity group-hover/th:opacity-100"
           >
             ×
-          </button>
+          </IconButton>
         )}
       </div>
     </th>
@@ -922,7 +935,8 @@ export function GroupHeaderRow({
         colSpan={colSpan}
         className={`p-0 ${sub ? "" : "sticky top-7 z-[5]"}`}
       >
-        <button
+        <Button
+          bare
           type="button"
           aria-expanded={!collapsed}
           onClick={onToggle}
@@ -957,7 +971,7 @@ export function GroupHeaderRow({
               collapsed
             </span>
           )}
-        </button>
+        </Button>
       </td>
     </tr>
   );
@@ -1391,14 +1405,14 @@ export function StatTile({
     "rounded-md border border-(--border) bg-(--surface-1) px-3 py-2 text-left";
   if (!onClick) return <div className={cls}>{inner}</div>;
   return (
-    <button
+    <Button bare
       type="button"
       onClick={onClick}
       aria-label={`${label}: ${value}`}
       className={`${cls} cursor-pointer hover:bg-(--surface-2)`}
     >
       {inner}
-    </button>
+    </Button>
   );
 }
 
@@ -1433,7 +1447,7 @@ export function JumpLink({
     );
   }
   return (
-    <button
+    <Button bare
       type="button"
       className={cls}
       title={title}
@@ -1443,7 +1457,7 @@ export function JumpLink({
       }}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -1602,7 +1616,7 @@ function ToastRegion({
       className="flex flex-col gap-2"
     >
       {toasts.map((t) => (
-        <button
+        <Button bare
           key={t.id}
           type="button"
           title="Dismiss"
@@ -1629,7 +1643,7 @@ function ToastRegion({
             }}
           />
           <span className="text-(--text) font-medium">{t.message}</span>
-        </button>
+        </Button>
       ))}
     </div>
   );
@@ -1670,13 +1684,13 @@ export function JsonBlock({ value }: { value: unknown }) {
           ),
         )}
       </pre>
-      <button
+      <Button bare
         type="button"
         onClick={copy}
         className="absolute top-2 right-2 rounded border border-(--border) bg-(--surface-1) px-2 py-0.5 text-[10px] font-medium text-(--text-dim) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--surface-2) hover:text-(--text)"
       >
         {copied ? "Copied!" : "Copy"}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -1798,7 +1812,8 @@ export function Section({
     <KVIconsContext.Provider value={icons}>
       <div className="mb-5">
         {collapsible ? (
-          <button
+          <Button
+            bare
             type="button"
             onClick={toggle}
             aria-expanded={!collapsed}
@@ -1806,7 +1821,7 @@ export function Section({
           >
             <DisclosureChevron open={!collapsed} />
             {heading}
-          </button>
+          </Button>
         ) : (
           <div className="mb-1.5">{heading}</div>
         )}
@@ -1883,7 +1898,7 @@ export function KV({
         <span className="truncate">{k}</span>
       </div>
       {copyable ? (
-        <button
+        <Button bare
           type="button"
           // The row truncates long values; the tooltip is the only place the
           // full string is readable without copying (WM-129 critique).
@@ -1892,7 +1907,7 @@ export function KV({
           className={`truncate text-left text-(--text-dim) hover:text-(--accent) ${isMono ? "mono" : ""}`}
         >
           {text}
-        </button>
+        </Button>
       ) : (
         <span
           className={`truncate text-left ${unset ? "text-(--text-faint)" : "text-(--text-dim)"} ${isMono ? "mono" : ""}`}
@@ -1927,19 +1942,31 @@ export function KVGroup({
   );
 }
 
-export function Button({
+export type ButtonSize = "sm" | "md" | "lg";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: ButtonSize;
+  variant?: "default" | "primary" | "danger" | "ghost";
+  /** Preserve a bespoke non-control surface while still routing it through the
+   * shared primitive. Keep this to structural rows and row-inline text verbs. */
+  bare?: boolean;
+};
+
+const BUTTON_SIZES: Record<ButtonSize, string> = {
+  sm: "h-6 gap-1 px-2 [&>svg]:size-3",
+  md: "h-7 gap-1.5 px-2.5 [&>svg]:size-3.5",
+  lg: "h-8 gap-2 px-3 [&>svg]:size-4",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
   children,
-  onClick,
   variant = "default",
-  disabled,
-  autoFocus,
-}: {
-  children: ReactNode;
-  onClick?: () => void;
-  variant?: "default" | "primary" | "danger";
-  disabled?: boolean;
-  autoFocus?: boolean;
-}) {
+  size = "md",
+  bare = false,
+  className = "",
+  type = "button",
+  ...props
+}, ref) {
   const styles = {
     default:
       "border-(--border-strong) bg-(--surface-2) text-(--text) hover:bg-(--surface-3)",
@@ -1947,19 +1974,68 @@ export function Button({
       "border-transparent bg-(--accent) text-(--on-accent) hover:opacity-90",
     danger:
       "border-(--border-strong) bg-(--surface-2) hover:bg-(--surface-3) text-(--hue-err)",
+    ghost: "border-transparent bg-transparent text-(--text-dim) hover:bg-(--surface-2) hover:text-(--text)",
   }[variant];
   return (
     <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      autoFocus={autoFocus}
-      className={`rounded-md border px-2.5 py-1 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${styles}`}
+      ref={ref}
+      type={type}
+      data-control-size={bare ? undefined : size}
+      className={bare
+        ? className
+        : `inline-flex shrink-0 items-center justify-center rounded-md border text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZES[size]} ${styles} ${className}`}
+      {...props}
     >
       {children}
     </button>
   );
+});
+
+/** A real hover/focus tooltip shared by icon-only controls. */
+export function Tooltip({ label, children }: { label: ReactNode; children: ReactNode }) {
+  return (
+    <span className="group/tooltip relative inline-flex">
+      {children}
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute top-full left-1/2 z-50 mt-1.5 -translate-x-1/2 rounded border border-(--border-strong) bg-(--surface-2) px-2 py-1 text-[11px] font-normal whitespace-nowrap text-(--text) opacity-0 shadow-lg transition-opacity group-hover/tooltip:opacity-100 group-focus-within/tooltip:opacity-100"
+      >
+        {label}
+      </span>
+    </span>
+  );
 }
+
+export type IconButtonProps = Omit<ButtonProps, "aria-label" | "children" | "size"> & {
+  "aria-label": string;
+  children: ReactNode;
+  tooltip?: ReactNode;
+};
+
+/** Square 28px icon control with a mandatory accessible name and tooltip. */
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
+  "aria-label": ariaLabel,
+  tooltip,
+  className = "",
+  variant = "ghost",
+  ...props
+}, ref) {
+  if (!ariaLabel?.trim()) {
+    throw new Error("IconButton requires a non-empty aria-label");
+  }
+  return (
+    <Tooltip label={tooltip ?? ariaLabel}>
+      <Button
+        ref={ref}
+        aria-label={ariaLabel}
+        size="md"
+        variant={variant}
+        className={`w-7 !px-0 ${className}`}
+        {...props}
+      />
+    </Tooltip>
+  );
+});
 
 const FOCUSABLE =
   "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
@@ -2087,7 +2163,7 @@ export function Tabs({
       className="inline-flex gap-0.5 rounded-md border border-(--border) bg-(--surface-0) p-0.5"
     >
       {tabs.map((t) => (
-        <button
+        <Button bare
           key={t.id}
           type="button"
           role="tab"
@@ -2104,7 +2180,7 @@ export function Tabs({
           }`}
         >
           {t.label}
-        </button>
+        </Button>
       ))}
     </div>
   );
@@ -2335,7 +2411,7 @@ export function ChipInput({
       {values.length > 0 && (
         <div className="mb-1.5 flex flex-wrap gap-1">
           {values.map((v) => (
-            <button
+            <Button bare
               key={v}
               type="button"
               onClick={() => onChange(values.filter((x) => x !== v))}
@@ -2350,7 +2426,7 @@ export function ChipInput({
               >
                 ×
               </span>
-            </button>
+            </Button>
           ))}
         </div>
       )}
@@ -2435,14 +2511,14 @@ export function ChipInput({
             </ul>,
             document.body,
           )}
-        <button
+        <Button bare
           type="button"
           onClick={() => add(draft)}
           disabled={!draft.trim()}
           className="rounded border border-(--border) px-1.5 py-0.5 text-[11px] text-(--text-dim) hover:bg-(--surface-2) disabled:cursor-not-allowed disabled:opacity-40"
         >
           add
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -2489,13 +2565,13 @@ export function BulkActionBar({
       {onClear && (
         <>
           <div className="h-4 w-px bg-(--border)" />
-          <button
+          <Button bare
             type="button"
             onClick={onClear}
             className="cursor-pointer text-[11px] text-(--text-faint) hover:text-(--text)"
           >
             Clear
-          </button>
+          </Button>
         </>
       )}
     </div>

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -372,9 +372,13 @@ describe("Agents copy chords and hints (WM-233)", () => {
       });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
-      expect(refBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy agent ref · c");
+      expect(
+        refBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+      ).toBe("Copy agent ref · c");
       const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-      expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+      expect(
+        linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+      ).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies agent.ref
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -372,9 +372,9 @@ describe("Agents copy chords and hints (WM-233)", () => {
       });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
-      expect(refBtn.getAttribute("title")).toBe("Copy agent ref · c");
+      expect(refBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy agent ref · c");
       const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-      expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+      expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies agent.ref
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -44,6 +44,7 @@ import { AgentMutationBadge } from "../components/AgentHoverCard";
 import { EMPTY, NOT_APPLICABLE, formatDuration } from "../format";
 import { eventsHash } from "../hash";
 import { setContextActions } from "../palette";
+import { Button as PrimitiveButton } from "../components/ui";
 
 const caps = (a: AgentDef) =>
   [a.capabilities.filesystem, ...(a.capabilities.services ?? [])]
@@ -367,7 +368,8 @@ export function Agents({
                   aria-label="Agent mutation safety"
                 >
                   {AGENT_TABS.map((item, index) => (
-                    <button
+                    <PrimitiveButton
+                      bare
                       key={item}
                       type="button"
                       role="tab"
@@ -389,7 +391,7 @@ export function Agents({
                       >
                         {index + 1}
                       </span>
-                    </button>
+                    </PrimitiveButton>
                   ))}
                 </div>
                 <span className="ml-auto">

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -33,6 +33,7 @@ import type {
   ArtifactInventoryItem,
   StatusView,
 } from "../types";
+import { Button as PrimitiveButton } from "../components/ui";
 
 export { formatBytes };
 
@@ -489,7 +490,8 @@ export function Artifacts({
                     { label: "Orphans", value: true, count: summary.orphans },
                   ] as const
                 ).map((facet) => (
-                  <button
+                  <PrimitiveButton
+                    bare
                     key={facet.label}
                     type="button"
                     role="tab"
@@ -505,7 +507,7 @@ export function Artifacts({
                     <span className="ml-1.5 tabular-nums text-(--text-faint)">
                       {facet.count.toLocaleString()}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 ))}
               </div>
               <span className="ml-auto">
@@ -740,13 +742,14 @@ export function Artifacts({
               aria-label="Breadcrumb"
               className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={closeInspector}
                 className="text-(--text-dim) hover:text-(--accent)"
               >
                 Artifacts
-              </button>
+              </PrimitiveButton>
               <span aria-hidden="true" className="text-(--text-faint)">
                 /
               </span>

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -945,9 +945,9 @@ describe("Events copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(idBtn.getAttribute("title")).toBe("Copy event id · c");
+        expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy event id · c");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies eventId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -945,9 +945,13 @@ describe("Events copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy event id · c");
+        expect(
+          idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy event id · c");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+        expect(
+          linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies eventId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -111,7 +111,8 @@ function FacetChoice({
   onClick: () => void;
 }) {
   return (
-    <PrimitiveButton bare
+    <PrimitiveButton
+      bare
       type="button"
       aria-pressed={active}
       title={value}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -76,6 +76,7 @@ import {
   copyLink,
   shortId,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 function removeTokensFromQuery(
   filter: string,
@@ -110,7 +111,7 @@ function FacetChoice({
   onClick: () => void;
 }) {
   return (
-    <button
+    <PrimitiveButton bare
       type="button"
       aria-pressed={active}
       title={value}
@@ -131,7 +132,7 @@ function FacetChoice({
           {count}
         </span>
       )}
-    </button>
+    </PrimitiveButton>
   );
 }
 
@@ -925,7 +926,8 @@ export function Events({
               {STATUS_TABS.map((t, idx) => {
                 const count = tabCount(t);
                 return (
-                  <button
+                  <PrimitiveButton
+                    bare
                     key={t}
                     type="button"
                     role="tab"
@@ -950,7 +952,7 @@ export function Events({
                     >
                       {idx + 1}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 );
               })}
             </div>
@@ -1287,14 +1289,15 @@ export function Events({
               aria-label="Breadcrumb"
               className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={() => onSelectEvent(null)}
                 className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
                 title="Back to events list"
               >
                 Events
-              </button>
+              </PrimitiveButton>
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -51,6 +51,7 @@ import {
   notify,
   shortId,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 /**
  * The human inbox (WM-286): everything the runtime is waiting on the operator
@@ -744,7 +745,7 @@ export function Inbox({
                   aria-label="Inbox status"
                 >
                   {INBOX_TABS.map((t, idx) => (
-                    <button
+                    <PrimitiveButton bare
                       key={t}
                       type="button"
                       role="tab"
@@ -769,7 +770,7 @@ export function Inbox({
                       >
                         {idx + 1}
                       </span>
-                    </button>
+                    </PrimitiveButton>
                   ))}
                 </div>
                 <span className="ml-auto">
@@ -1033,14 +1034,15 @@ export function Inbox({
               aria-label="Breadcrumb"
               className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={() => onSelectItem(null)}
                 className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
                 title="Back to inbox list"
               >
                 Inbox
-              </button>
+              </PrimitiveButton>
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -745,7 +745,8 @@ export function Inbox({
                   aria-label="Inbox status"
                 >
                   {INBOX_TABS.map((t, idx) => (
-                    <PrimitiveButton bare
+                    <PrimitiveButton
+                      bare
                       key={t}
                       type="button"
                       role="tab"

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -61,7 +61,8 @@ export function SectionTitle({
 
   if (collapsible) {
     return (
-      <PrimitiveButton bare
+      <PrimitiveButton
+        bare
         type="button"
         onClick={onToggle}
         aria-expanded={!collapsed}
@@ -176,7 +177,8 @@ export function StatLegendItem({
       : "";
 
   return (
-    <PrimitiveButton bare
+    <PrimitiveButton
+      bare
       type="button"
       onClick={onClick}
       aria-label={`${fullLabel}: ${value}`}
@@ -684,7 +686,8 @@ function RecentOutcomesStrip({
                     : "var(--text-faint)";
             const label = `${o.runId} · ${o.to} · ${formatRelative(o.at, now)}`;
             return (
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 key={o.seq}
                 type="button"
                 onClick={() => onJumpRun(o.runId)}
@@ -1287,7 +1290,8 @@ export function Overview({
                       <div className="min-w-0">
                         {deadLetters ? (
                           <>
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               type="button"
                               onClick={() =>
                                 deadLetters.events.length > 1
@@ -1328,7 +1332,8 @@ export function Overview({
                               <ul className="mt-2 space-y-1 border-l border-(--border) pl-3">
                                 {deadLetters.events.map((event) => (
                                   <li key={`${event.source}:${event.eventId}`}>
-                                    <PrimitiveButton bare
+                                    <PrimitiveButton
+                                      bare
                                       type="button"
                                       onClick={() =>
                                         onJumpEvents({
@@ -1348,7 +1353,8 @@ export function Overview({
                           </>
                         ) : a.proposalId ? (
                           <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 break-words text-[12px] text-(--hue-warn)">
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               type="button"
                               onClick={primaryLink?.go}
                               className="cursor-pointer hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
@@ -1356,7 +1362,8 @@ export function Overview({
                               expired open
                             </PrimitiveButton>
                             <span className="text-(--text-faint)">·</span>
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               type="button"
                               className="mono cursor-pointer text-[11px] text-(--text-dim) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                               title={`${a.proposalId} — click to copy`}
@@ -1404,7 +1411,8 @@ export function Overview({
                             )}
                           </div>
                         ) : primaryLink ? (
-                          <PrimitiveButton bare
+                          <PrimitiveButton
+                            bare
                             type="button"
                             onClick={primaryLink.go}
                             className="min-w-0 cursor-pointer break-words text-left text-[12px] text-(--hue-warn) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent) sm:truncate"
@@ -1423,7 +1431,8 @@ export function Overview({
                       </div>
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-1">
-                      <PrimitiveButton bare
+                      <PrimitiveButton
+                        bare
                         type="button"
                         onClick={() => copyText(a.text, "anomaly")}
                         className="cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-faint) hover:text-(--text) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
@@ -1432,7 +1441,8 @@ export function Overview({
                       </PrimitiveButton>
                       <span className="flex flex-wrap items-center gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover/anomaly:opacity-100 sm:group-focus-within/anomaly:opacity-100">
                         {a.dismissProposalId && (
-                          <PrimitiveButton bare
+                          <PrimitiveButton
+                            bare
                             type="button"
                             className={quietActionClass}
                             disabled={!connected || reject.isPending}
@@ -1447,7 +1457,8 @@ export function Overview({
                         )}
                         {deadLetters && deadLetters.events.length > 1 ? (
                           <>
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
@@ -1460,7 +1471,8 @@ export function Overview({
                             >
                               Archive all
                             </PrimitiveButton>
-                            <PrimitiveButton bare
+                            <PrimitiveButton
+                              bare
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
@@ -1477,7 +1489,8 @@ export function Overview({
                         ) : (
                           <>
                             {a.archive && (
-                              <PrimitiveButton bare
+                              <PrimitiveButton
+                                bare
                                 type="button"
                                 className={quietActionClass}
                                 disabled={
@@ -1494,7 +1507,8 @@ export function Overview({
                               </PrimitiveButton>
                             )}
                             {a.requeue && (
-                              <PrimitiveButton bare
+                              <PrimitiveButton
+                                bare
                                 type="button"
                                 className={quietActionClass}
                                 disabled={!connected || requeue.isPending}
@@ -1506,7 +1520,8 @@ export function Overview({
                           </>
                         )}
                         {a.releaseWorker && (
-                          <PrimitiveButton bare
+                          <PrimitiveButton
+                            bare
                             type="button"
                             className={quietActionClass}
                             disabled={!connected || resolveAnomaly.isPending}
@@ -1521,7 +1536,8 @@ export function Overview({
                           </PrimitiveButton>
                         )}
                         {a.links.slice(1).map((link) => (
-                          <PrimitiveButton bare
+                          <PrimitiveButton
+                            bare
                             type="button"
                             key={link.label}
                             className={quietActionClass}
@@ -1673,7 +1689,8 @@ export function Overview({
                         : "nothing waiting"}
                   </span>
                 </div>
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={() => onNavigate("inbox")}
                   aria-label={`Waiting on you: ${s.inbox.open} open inbox item${s.inbox.open === 1 ? "" : "s"} — open the inbox`}
@@ -1807,7 +1824,8 @@ export function Overview({
                 <span className="font-semibold text-(--text)">
                   Worker Fleet Capacity{factoryWide ? " · factory-wide" : ""}
                 </span>
-                <PrimitiveButton bare
+                <PrimitiveButton
+                  bare
                   type="button"
                   onClick={() => onNavigate("workers")}
                   aria-label={`worker capacity${factoryWide ? " · factory-wide" : ""}: ${capacity!.running} running of ${capacity!.capacity}, ${capacity!.queued} queued`}

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -29,6 +29,7 @@ import {
   notify,
   shortId,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 const FEED_CAP = 50;
 
@@ -60,7 +61,7 @@ export function SectionTitle({
 
   if (collapsible) {
     return (
-      <button
+      <PrimitiveButton bare
         type="button"
         onClick={onToggle}
         aria-expanded={!collapsed}
@@ -74,7 +75,7 @@ export function SectionTitle({
         </span>
         {label}
         {metaNode}
-      </button>
+      </PrimitiveButton>
     );
   }
 
@@ -175,7 +176,7 @@ export function StatLegendItem({
       : "";
 
   return (
-    <button
+    <PrimitiveButton bare
       type="button"
       onClick={onClick}
       aria-label={`${fullLabel}: ${value}`}
@@ -200,7 +201,7 @@ export function StatLegendItem({
       {factoryWide && (
         <span className="text-[10px] text-(--text-faint)">(all)</span>
       )}
-    </button>
+    </PrimitiveButton>
   );
 }
 
@@ -683,7 +684,7 @@ function RecentOutcomesStrip({
                     : "var(--text-faint)";
             const label = `${o.runId} · ${o.to} · ${formatRelative(o.at, now)}`;
             return (
-              <button
+              <PrimitiveButton bare
                 key={o.seq}
                 type="button"
                 onClick={() => onJumpRun(o.runId)}
@@ -696,7 +697,7 @@ function RecentOutcomesStrip({
                   className="h-4 w-2 rounded-xs opacity-80 transition-all group-hover:scale-125 group-hover:opacity-100 group-hover:ring-1 group-hover:ring-(--text)"
                   style={{ backgroundColor: hue }}
                 />
-              </button>
+              </PrimitiveButton>
             );
           })}
         </div>
@@ -1286,7 +1287,7 @@ export function Overview({
                       <div className="min-w-0">
                         {deadLetters ? (
                           <>
-                            <button
+                            <PrimitiveButton bare
                               type="button"
                               onClick={() =>
                                 deadLetters.events.length > 1
@@ -1322,12 +1323,12 @@ export function Overview({
                               <span className="sm:truncate">
                                 {deadLetters.errorMessage}
                               </span>
-                            </button>
+                            </PrimitiveButton>
                             {expanded && (
                               <ul className="mt-2 space-y-1 border-l border-(--border) pl-3">
                                 {deadLetters.events.map((event) => (
                                   <li key={`${event.source}:${event.eventId}`}>
-                                    <button
+                                    <PrimitiveButton bare
                                       type="button"
                                       onClick={() =>
                                         onJumpEvents({
@@ -1339,7 +1340,7 @@ export function Overview({
                                       title={event.eventId}
                                     >
                                       {shortId(event.eventId)}
-                                    </button>
+                                    </PrimitiveButton>
                                   </li>
                                 ))}
                               </ul>
@@ -1347,15 +1348,15 @@ export function Overview({
                           </>
                         ) : a.proposalId ? (
                           <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 break-words text-[12px] text-(--hue-warn)">
-                            <button
+                            <PrimitiveButton bare
                               type="button"
                               onClick={primaryLink?.go}
                               className="cursor-pointer hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                             >
                               expired open
-                            </button>
+                            </PrimitiveButton>
                             <span className="text-(--text-faint)">·</span>
-                            <button
+                            <PrimitiveButton bare
                               type="button"
                               className="mono cursor-pointer text-[11px] text-(--text-dim) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                               title={`${a.proposalId} — click to copy`}
@@ -1364,7 +1365,7 @@ export function Overview({
                               }
                             >
                               {shortId(a.proposalId)}
-                            </button>
+                            </PrimitiveButton>
                             <span className="text-(--text-faint)">·</span>
                             <span>agent: {a.proposal?.agent ?? EMPTY}</span>
                             <span className="text-(--text-faint)">·</span>
@@ -1403,14 +1404,14 @@ export function Overview({
                             )}
                           </div>
                         ) : primaryLink ? (
-                          <button
+                          <PrimitiveButton bare
                             type="button"
                             onClick={primaryLink.go}
                             className="min-w-0 cursor-pointer break-words text-left text-[12px] text-(--hue-warn) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent) sm:truncate"
                             title={a.text}
                           >
                             {a.text}
-                          </button>
+                          </PrimitiveButton>
                         ) : (
                           <span
                             className="min-w-0 break-words text-[12px] text-(--hue-warn) sm:truncate"
@@ -1422,16 +1423,16 @@ export function Overview({
                       </div>
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-1">
-                      <button
+                      <PrimitiveButton bare
                         type="button"
                         onClick={() => copyText(a.text, "anomaly")}
                         className="cursor-pointer rounded px-1.5 py-1 text-[11px] text-(--text-faint) hover:text-(--text) hover:underline focus-visible:outline-2 focus-visible:outline-(--accent)"
                       >
                         copy
-                      </button>
+                      </PrimitiveButton>
                       <span className="flex flex-wrap items-center gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover/anomaly:opacity-100 sm:group-focus-within/anomaly:opacity-100">
                         {a.dismissProposalId && (
-                          <button
+                          <PrimitiveButton bare
                             type="button"
                             className={quietActionClass}
                             disabled={!connected || reject.isPending}
@@ -1442,11 +1443,11 @@ export function Overview({
                             }}
                           >
                             Reject…
-                          </button>
+                          </PrimitiveButton>
                         )}
                         {deadLetters && deadLetters.events.length > 1 ? (
                           <>
-                            <button
+                            <PrimitiveButton bare
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
@@ -1458,8 +1459,8 @@ export function Overview({
                               }
                             >
                               Archive all
-                            </button>
-                            <button
+                            </PrimitiveButton>
+                            <PrimitiveButton bare
                               type="button"
                               className={quietActionClass}
                               disabled={!connected || bulkDeadLetter.isPending}
@@ -1471,12 +1472,12 @@ export function Overview({
                               }
                             >
                               Requeue all
-                            </button>
+                            </PrimitiveButton>
                           </>
                         ) : (
                           <>
                             {a.archive && (
-                              <button
+                              <PrimitiveButton bare
                                 type="button"
                                 className={quietActionClass}
                                 disabled={
@@ -1490,22 +1491,22 @@ export function Overview({
                                 }
                               >
                                 Archive
-                              </button>
+                              </PrimitiveButton>
                             )}
                             {a.requeue && (
-                              <button
+                              <PrimitiveButton bare
                                 type="button"
                                 className={quietActionClass}
                                 disabled={!connected || requeue.isPending}
                                 onClick={() => requeue.mutate(a.requeue!)}
                               >
                                 Requeue
-                              </button>
+                              </PrimitiveButton>
                             )}
                           </>
                         )}
                         {a.releaseWorker && (
-                          <button
+                          <PrimitiveButton bare
                             type="button"
                             className={quietActionClass}
                             disabled={!connected || resolveAnomaly.isPending}
@@ -1517,17 +1518,17 @@ export function Overview({
                             }
                           >
                             Release lease
-                          </button>
+                          </PrimitiveButton>
                         )}
                         {a.links.slice(1).map((link) => (
-                          <button
+                          <PrimitiveButton bare
                             type="button"
                             key={link.label}
                             className={quietActionClass}
                             onClick={link.go}
                           >
                             {link.label.replace(/^View /, "")}
-                          </button>
+                          </PrimitiveButton>
                         ))}
                       </span>
                     </div>
@@ -1672,7 +1673,7 @@ export function Overview({
                         : "nothing waiting"}
                   </span>
                 </div>
-                <button
+                <PrimitiveButton bare
                   type="button"
                   onClick={() => onNavigate("inbox")}
                   aria-label={`Waiting on you: ${s.inbox.open} open inbox item${s.inbox.open === 1 ? "" : "s"} — open the inbox`}
@@ -1712,7 +1713,7 @@ export function Overview({
                   <span className="mono text-[11px] text-(--text-faint)">
                     g n →
                   </span>
-                </button>
+                </PrimitiveButton>
               </div>
             )}
           </StageCard>
@@ -1806,7 +1807,7 @@ export function Overview({
                 <span className="font-semibold text-(--text)">
                   Worker Fleet Capacity{factoryWide ? " · factory-wide" : ""}
                 </span>
-                <button
+                <PrimitiveButton bare
                   type="button"
                   onClick={() => onNavigate("workers")}
                   aria-label={`worker capacity${factoryWide ? " · factory-wide" : ""}: ${capacity!.running} running of ${capacity!.capacity}, ${capacity!.queued} queued`}
@@ -1819,7 +1820,7 @@ export function Overview({
                   {capacity!.draining > 0
                     ? ` · ${capacity!.draining} draining`
                     : ""}
-                </button>
+                </PrimitiveButton>
               </div>
               {capacity!.queued > 0 && capacity!.limitingFactor && (
                 <div className="mb-2 text-[11px] text-(--hue-warn)">

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -275,9 +275,13 @@ describe("Projects copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(pathBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy repo path · c p");
+        expect(
+          pathBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy repo path · c p");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+        expect(
+          linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies repo name
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -275,9 +275,9 @@ describe("Projects copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(pathBtn.getAttribute("title")).toBe("Copy repo path · c p");
+        expect(pathBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy repo path · c p");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies repo name
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -14,6 +14,7 @@ import { goPrefixActive } from "../goSequence";
 import { setContextActions } from "../palette";
 import type { JanitorResult, RepoItem } from "../types";
 import { ScopeCaption } from "../components/ContextTabs";
+import { Button as PrimitiveButton } from "../components/ui";
 
 const PROJECT_MODES = ["ALL", "DISPATCHABLE", "REPORT_ONLY"] as const;
 type ProjectMode = (typeof PROJECT_MODES)[number];
@@ -509,7 +510,7 @@ export function Projects({
                 aria-label="Project mode"
               >
                 {PROJECT_MODES.map((mode, idx) => (
-                  <button
+                  <PrimitiveButton bare
                     key={mode}
                     type="button"
                     role="tab"
@@ -535,7 +536,7 @@ export function Projects({
                     >
                       {idx + 1}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 ))}
               </div>
               <FilterInput

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -510,7 +510,8 @@ export function Projects({
                 aria-label="Project mode"
               >
                 {PROJECT_MODES.map((mode, idx) => (
-                  <PrimitiveButton bare
+                  <PrimitiveButton
+                    bare
                     key={mode}
                     type="button"
                     role="tab"

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1342,9 +1342,13 @@ describe("Proposals copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy proposal id · c");
+        expect(
+          idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy proposal id · c");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+        expect(
+          linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+        ).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies proposalId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -1342,9 +1342,9 @@ describe("Proposals copy chords and hints (WM-233)", () => {
         });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(idBtn.getAttribute("title")).toBe("Copy proposal id · c");
+        expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy proposal id · c");
         const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+        expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies proposalId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -71,6 +71,7 @@ import {
   copyLink,
   shortId,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 const PROPOSAL_TABS = ["open", "history"] as const;
 type ProposalTab = (typeof PROPOSAL_TABS)[number];
@@ -1065,7 +1066,8 @@ export function Proposals({
                               matchesRepo(p.repos, context),
                           ).length;
                     return (
-                      <button
+                      <PrimitiveButton
+                        bare
                         key={t}
                         type="button"
                         role="tab"
@@ -1086,12 +1088,13 @@ export function Proposals({
                         >
                           {idx + 1}
                         </span>
-                      </button>
+                      </PrimitiveButton>
                     );
                   })}
                 </div>
                 {tab === "open" && expiredCount > 0 && (
-                  <button
+                  <PrimitiveButton
+                    bare
                     type="button"
                     aria-pressed={expiredOnly}
                     onClick={() => setExpiredOnly((v) => !v)}
@@ -1106,7 +1109,7 @@ export function Proposals({
                     <span className="ml-1.5 tabular-nums text-(--text-faint)">
                       {expiredCount}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 )}
                 <span className="ml-auto">
                   <DisplayOptions
@@ -1393,14 +1396,15 @@ export function Proposals({
               aria-label="Breadcrumb"
               className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={() => onSelectProposal(null)}
                 className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
                 title="Back to proposals list"
               >
                 Proposals
-              </button>
+              </PrimitiveButton>
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
@@ -1617,7 +1621,7 @@ export function Proposals({
               </div>
               <div className="flex flex-wrap gap-1.5">
                 {CANNED_REJECTION_REASONS.map((tmpl) => (
-                  <button
+                  <PrimitiveButton bare
                     key={tmpl}
                     type="button"
                     onClick={() => {
@@ -1631,7 +1635,7 @@ export function Proposals({
                     }`}
                   >
                     {tmpl}
-                  </button>
+                  </PrimitiveButton>
                 ))}
               </div>
               <div className="mt-1 flex flex-col gap-2 sm:flex-row">
@@ -1866,7 +1870,7 @@ export function Proposals({
           </div>
           <div className="mb-3 flex flex-wrap gap-1.5">
             {CANNED_REJECTION_REASONS.map((tmpl) => (
-              <button
+              <PrimitiveButton bare
                 key={tmpl}
                 type="button"
                 onClick={() => {
@@ -1880,7 +1884,7 @@ export function Proposals({
                 }`}
               >
                 {tmpl}
-              </button>
+              </PrimitiveButton>
             ))}
           </div>
           <input

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1621,7 +1621,8 @@ export function Proposals({
               </div>
               <div className="flex flex-wrap gap-1.5">
                 {CANNED_REJECTION_REASONS.map((tmpl) => (
-                  <PrimitiveButton bare
+                  <PrimitiveButton
+                    bare
                     key={tmpl}
                     type="button"
                     onClick={() => {
@@ -1870,7 +1871,8 @@ export function Proposals({
           </div>
           <div className="mb-3 flex flex-wrap gap-1.5">
             {CANNED_REJECTION_REASONS.map((tmpl) => (
-              <PrimitiveButton bare
+              <PrimitiveButton
+                bare
                 key={tmpl}
                 type="button"
                 onClick={() => {

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -443,6 +443,34 @@ describe("Runs component harness: selection & filter retention", () => {
     );
   });
 
+  test("tab counts describe the filtered set instead of the unfiltered totals", async () => {
+    const rows = [
+      stubListItem("run_match_active", "RUNNING", { agent: "triage-scan" }),
+      stubListItem("run_match_done", "COMPLETED", { agent: "triage-scan" }),
+      stubListItem("run_other_failed", "FAILED", { agent: "review-scan" }),
+    ];
+
+    await withApi(
+      {
+        runs: async () => ({ runs: rows }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderRuns();
+        await waitFor(() => r.container.querySelector('td[title="run_match_active"]'));
+
+        act(() => {
+          changeInput(r.getByLabelText("Filter runs") as HTMLInputElement, "agent:triage-scan");
+        });
+
+        expect(r.getByRole("tab", { name: /^All 2$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Active 1$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Completed 1$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Failed$/i })).toBeTruthy();
+      },
+    );
+  });
+
   test("switching status tabs clears row selection via onSelectRun(null)", async () => {
     const onSelectRun = mock(() => {});
     const r1 = stubListItem("run_tab_1", "RUNNING");
@@ -751,15 +779,22 @@ describe("Runs copy chords and hints (WM-233)", () => {
         const idBtn = await r.findByRole("button", { name: "Copy run id (c)" });
 
         // Verify icon-action tooltips preserve shortcut discoverability.
-        expect(idBtn.getAttribute("title")).toBe("Copy run id · c");
-        const cliBtn = r.getByRole("button", {
-          name: "Copy CLI inspect command (c i)",
-        });
-        expect(cliBtn.getAttribute("title")).toBe(
-          "Copy CLI inspect command · c i",
+        expect(idBtn).toBeTruthy();
+        expect(
+          r.getByRole("button", { name: "Copy CLI inspect command (c i)" }),
+        ).toBeTruthy();
+        expect(
+          r.getByRole("button", { name: "Copy link (c l)" }),
+        ).toBeTruthy();
+        expect(
+          r.getAllByRole("tooltip").map((tooltip) => tooltip.textContent),
+        ).toEqual(
+          expect.arrayContaining([
+            "Copy run id · c",
+            "Copy CLI inspect command · c i",
+            "Copy link · c l",
+          ]),
         );
-        const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-        expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
 
         // 1. Press 'c' -> copies runId
         fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -457,10 +457,15 @@ describe("Runs component harness: selection & filter retention", () => {
       },
       async () => {
         const r = renderRuns();
-        await waitFor(() => r.container.querySelector('td[title="run_match_active"]'));
+        await waitFor(() =>
+          r.container.querySelector('td[title="run_match_active"]'),
+        );
 
         act(() => {
-          changeInput(r.getByLabelText("Filter runs") as HTMLInputElement, "agent:triage-scan");
+          changeInput(
+            r.getByLabelText("Filter runs") as HTMLInputElement,
+            "agent:triage-scan",
+          );
         });
 
         expect(r.getByRole("tab", { name: /^All 2$/i })).toBeTruthy();
@@ -783,9 +788,7 @@ describe("Runs copy chords and hints (WM-233)", () => {
         expect(
           r.getByRole("button", { name: "Copy CLI inspect command (c i)" }),
         ).toBeTruthy();
-        expect(
-          r.getByRole("button", { name: "Copy link (c l)" }),
-        ).toBeTruthy();
+        expect(r.getByRole("button", { name: "Copy link (c l)" })).toBeTruthy();
         expect(
           r.getAllByRole("tooltip").map((tooltip) => tooltip.textContent),
         ).toEqual(

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -472,7 +472,10 @@ export function Runs({
   );
   const parsed = useMemo(() => parseFilterQuery(filter, RUN_FACETS), [filter]);
   const filteredScoped = useMemo(
-    () => scoped.filter((r) => matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns })),
+    () =>
+      scoped.filter((r) =>
+        matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns }),
+      ),
     [scoped, parsed, staleRuns],
   );
   const visible = useMemo(

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -79,6 +79,7 @@ import {
   copyLink,
   shortId,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 export type RunTab = "ALL" | "ACTIVE" | "COMPLETED" | "FAILED" | "CANCELLED";
 
@@ -470,12 +471,16 @@ export function Runs({
     [statusQ.data],
   );
   const parsed = useMemo(() => parseFilterQuery(filter, RUN_FACETS), [filter]);
+  const filteredScoped = useMemo(
+    () => scoped.filter((r) => matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns })),
+    [scoped, parsed, staleRuns],
+  );
   const visible = useMemo(
     () =>
-      byTab.filter((r) =>
-        matchesFilterQuery(r, parsed, RUN_FACETS, { staleRuns }),
-      ),
-    [byTab, parsed, staleRuns],
+      tab === "ALL"
+        ? filteredScoped
+        : filteredScoped.filter((r) => matchesRunTab(r.state, tab)),
+    [filteredScoped, tab],
   );
 
   // Display options (OPS-493): partition into sections, order inside them,
@@ -691,6 +696,11 @@ export function Runs({
 
   const byState = statusQ.data?.runs?.byState ?? {};
   const tabCount = (t: RunTab) => {
+    if (filter.trim()) {
+      return t === "ALL"
+        ? filteredScoped.length
+        : filteredScoped.filter((r) => matchesRunTab(r.state, t)).length;
+    }
     if (fetchAll) {
       return t === "ALL"
         ? scoped.length
@@ -954,14 +964,15 @@ export function Runs({
                 {RUN_TABS.map((t, idx) => {
                   const count = tabCount(t);
                   return (
-                    <button
+                    <Button
                       key={t}
-                      type="button"
+                      size="sm"
+                      variant="ghost"
                       role="tab"
                       aria-selected={tab === t}
                       onClick={() => selectTab(t)}
                       title={RUN_TAB_TITLES[t]}
-                      className={`shrink-0 rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                      className={`rounded-md ${
                         tab === t
                           ? "bg-(--surface-3) text-(--text)"
                           : "text-(--text-faint) hover:bg-(--surface-1)"
@@ -979,7 +990,7 @@ export function Runs({
                       >
                         {idx + 1}
                       </span>
-                    </button>
+                    </Button>
                   );
                 })}
               </div>
@@ -1246,14 +1257,15 @@ export function Runs({
               aria-label="Breadcrumb"
               className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
             >
-              <button
+              <PrimitiveButton
+                bare
                 type="button"
                 onClick={() => onSelectRun(null)}
                 className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
                 title="Back to runs list"
               >
                 Runs
-              </button>
+              </PrimitiveButton>
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
@@ -1357,7 +1369,6 @@ export function Runs({
               idLabel="run id"
               cli={`bun event-runtime/cli.mjs inspect ${sel.runId}`}
               cliLabel="CLI inspect command"
-              variant="quiet"
             />
           }
           close={<Button onClick={() => onSelectRun(null)}>Close</Button>}

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -529,9 +529,9 @@ describe("Schedules copy chords and hints (WM-233)", () => {
     });
 
     // Verify icon-action tooltips preserve shortcut discoverability.
-    expect(loopBtn.getAttribute("title")).toBe("Copy schedule loop · c");
+    expect(loopBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy schedule loop · c");
     const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-    expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+    expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
     // 1. Press 'c' -> copies loop
     fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -529,9 +529,13 @@ describe("Schedules copy chords and hints (WM-233)", () => {
     });
 
     // Verify icon-action tooltips preserve shortcut discoverability.
-    expect(loopBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy schedule loop · c");
+    expect(
+      loopBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+    ).toBe("Copy schedule loop · c");
     const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-    expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+    expect(
+      linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+    ).toBe("Copy link · c l");
 
     // 1. Press 'c' -> copies loop
     fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -33,6 +33,7 @@ import {
   copyText,
   notify,
 } from "../components/ui";
+import { Button as PrimitiveButton } from "../components/ui";
 
 export type { ScheduleItem, TriggerOutcome };
 
@@ -471,7 +472,7 @@ export function Schedules({
                       ? enabledCount
                       : disabledCount;
                 return (
-                  <button
+                  <PrimitiveButton bare
                     key={scheduleTab}
                     id={`schedule-tab-${scheduleTab}`}
                     type="button"
@@ -490,7 +491,7 @@ export function Schedules({
                     <span className="ml-1.5 tabular-nums text-(--text-faint)">
                       {count}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 );
               })}
             </div>

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -472,7 +472,8 @@ export function Schedules({
                       ? enabledCount
                       : disabledCount;
                 return (
-                  <PrimitiveButton bare
+                  <PrimitiveButton
+                    bare
                     key={scheduleTab}
                     id={`schedule-tab-${scheduleTab}`}
                     type="button"

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -28,6 +28,7 @@ import {
 } from "../subjectJourney";
 import { StateBadge, STATE_HUES } from "../components/ui";
 import type { AdmittedEvent, Proposal, RunDetail, RunListItem } from "../types";
+import { Button as PrimitiveButton } from "../components/ui";
 
 async function fetchTicketJourney(
   ticketId: string,
@@ -231,12 +232,13 @@ function TicketPicker({
           aria-invalid={error}
           className="mono min-w-0 flex-1 rounded-md border border-(--border-strong) bg-(--surface-1) px-3 py-2 text-[13px] outline-none focus:border-(--accent)"
         />
-        <button
+        <PrimitiveButton
+          bare
           type="submit"
           className="rounded-md bg-(--accent) px-4 py-2 text-[12px] font-medium text-(--on-accent)"
         >
           Open
-        </button>
+        </PrimitiveButton>
       </form>
       {error && (
         <div role="alert" className="mt-2 text-[11px] text-(--hue-err)">
@@ -500,13 +502,14 @@ export function Ticket({
           Invalid ticket id <span className="mono">{ticketId}</span>. Use an id
           like WM-542.
         </div>
-        <button
+        <PrimitiveButton
+          bare
           type="button"
           onClick={() => onNavigate("")}
           className="mt-3 text-[12px] text-(--accent) hover:underline"
         >
           Choose another ticket
-        </button>
+        </PrimitiveButton>
       </div>
     );
   }

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -441,9 +441,9 @@ describe("Workers copy chords and hints (WM-233)", () => {
       });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
-      expect(idBtn.getAttribute("title")).toBe("Copy worker id · c");
+      expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy worker id · c");
       const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-      expect(linkBtn.getAttribute("title")).toBe("Copy link · c l");
+      expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies workerId
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -441,9 +441,13 @@ describe("Workers copy chords and hints (WM-233)", () => {
       });
 
       // Verify icon-action tooltips preserve shortcut discoverability.
-      expect(idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy worker id · c");
+      expect(
+        idBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+      ).toBe("Copy worker id · c");
       const linkBtn = r.getByRole("button", { name: "Copy link (c l)" });
-      expect(linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent).toBe("Copy link · c l");
+      expect(
+        linkBtn.parentElement?.querySelector('[role="tooltip"]')?.textContent,
+      ).toBe("Copy link · c l");
 
       // 1. Press 'c' -> copies workerId
       fireEvent.keyDown(document.body, { key: "c" });

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -56,6 +56,7 @@ import {
   shortId,
 } from "../components/ui";
 import { health, WORKER_HUES } from "../workerHealth";
+import { Button as PrimitiveButton } from "../components/ui";
 
 export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
 export type WorkerTab = (typeof WORKER_TABS)[number];
@@ -768,7 +769,7 @@ export function Workers({
                 aria-label="Worker state"
               >
                 {WORKER_TABS.map((t, idx) => (
-                  <button
+                  <PrimitiveButton bare
                     key={t}
                     type="button"
                     role="tab"
@@ -802,7 +803,7 @@ export function Workers({
                     >
                       {idx + 1}
                     </span>
-                  </button>
+                  </PrimitiveButton>
                 ))}
               </div>
               <span className="ml-auto">

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -769,7 +769,8 @@ export function Workers({
                 aria-label="Worker state"
               >
                 {WORKER_TABS.map((t, idx) => (
-                  <PrimitiveButton bare
+                  <PrimitiveButton
+                    bare
                     key={t}
                     type="button"
                     role="tab"


### PR DESCRIPTION
## Summary
- add shared 24/28/32px Button sizing and a mandatory-label, tooltip-backed IconButton
- route production controls through the shared primitive and migrate Runs pane/trace/theme/repo icon actions
- make Runs tab counts follow active filters and align the empty-state Clear filter action
- add regression coverage for control sizing, IconButton accessibility, shared tooltips, and filtered counts

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (846 tests, 0 failures)

UX critique: required — NOT-ASSESSED; two attempts could not launch the isolated Chromium DevTools browser, so no visual approval or screenshot evidence was available. PR intentionally remains draft.

Fixes WM-589