### PR TITLE
feat(event-runtime-web): add recent chains inventory (WM-537)

### DIFF
--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1363,10 +1363,42 @@ layer spacing because chains are long and thin.
   the chain. Positions are reused across the 3 s poll while node/edge
   identity is unchanged (§10.13's identity rule).
 
-It is a drill-in like `#/run/:id`, not a nav item: you arrive from an event
-or a run, never cold.
+The trace remains a drill-in like `#/run/:id`, but the Chains inventory below
+also makes it discoverable without first knowing an event or run id.
 
-### 10.16 Settings (read-only) (`#/settings`, `g c`) — WM-704
+### 10.16 Chains list (`#/chains`, `g l`) — WM-537
+
+The Chains inventory answers “what chains ran recently, what is still active,
+and where did one fail?” before the operator knows an instance id. The control
+API exposes `GET /chains?window=24h&limit=100`, one summary per correlation
+key, newest activity first. A summary names the origin event (the event without
+a `causationId`, falling back to the earliest admitted event), event/run counts,
+derived-event hop depth, run-state tally, last activity, and the union of repos
+named by its events and runs. The trace's fallback key rule still applies:
+events without `correlationId` use their own `eventId`.
+
+- **Useful journeys by default.** A root with one event and no run is returned
+  as `single: true`; the list hides those rows initially and exposes a counted
+  **Single-event roots** toggle. This keeps intake noise available without
+  letting it bury multi-step work.
+- **Operator slicing.** The token filter understands `type:`, `repo:`, and
+  `state:`, plus `is:active` (queued/executing runs) and `is:failed`
+  (failed/timed-out/refused runs). Display options group and sort by chain
+  status, origin type, or repo. Repo context tabs apply the same `repos` union
+  as Events and Runs.
+- **Trace is one click away.** Rows show origin type/source, short root id, hop
+  depth, event/run counts, state badges, last activity, and repos; selecting a
+  row opens `#/chain/:correlationId`. `/` focuses the filter and `j`/`k` +
+  Enter provide the standard list keyboard path.
+
+No Overview tile was added in this slice: the existing status payload has no
+chain tally, so a tile would add a second 3-second dashboard poll rather than
+reuse a cheap slot. The dedicated nav entry and list avoid that cost.
+
+Chains takes `g l` ("chain link") rather than its natural `g c`: Settings
+(WM-704) claimed `g c` for its config allow-list first.
+
+### 10.17 Settings (read-only) (`#/settings`, `g c`) — WM-704
 
 `GET /config` gathers the factory's file-backed configuration into one
 allow-listed inventory. Settings renders it as a VS Code-shaped section tree

--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -133,7 +133,9 @@ function maxChainDepth(events, runs) {
       parentEventByRun.set(run.runId, eventKey(run.eventSource, run.eventId));
     }
   }
-  const byId = new Map(events.map((event) => [eventKey(event.source, event.eventId), event]));
+  const byId = new Map(
+    events.map((event) => [eventKey(event.source, event.eventId), event]),
+  );
   const memo = new Map();
 
   function depth(key, visiting = new Set()) {
@@ -157,7 +159,8 @@ function maxChainDepth(events, runs) {
 }
 
 function chainSummary(view) {
-  const origin = view.events.find((event) => !event.causationId) ?? view.events[0];
+  const origin =
+    view.events.find((event) => !event.causationId) ?? view.events[0];
   const states = {};
   const repos = new Set();
   let lastActivityAt = origin.admittedAt;
@@ -190,7 +193,14 @@ function chainSummary(view) {
 }
 
 /** Recent chain instances, newest activity first. */
-export function chainsView(db, { windowMs = DEFAULT_WINDOW_MS, limit = DEFAULT_LIMIT, nowMs = Date.now() } = {}) {
+export function chainsView(
+  db,
+  {
+    windowMs = DEFAULT_WINDOW_MS,
+    limit = DEFAULT_LIMIT,
+    nowMs = Date.now(),
+  } = {},
+) {
   const cutoff = new Date(nowMs - windowMs).toISOString();
   // Find recent keys in SQL before expanding each complete trace. Run activity
   // counts even when the last event is old, including a causation parent run.
@@ -230,7 +240,11 @@ export function chainsView(db, { windowMs = DEFAULT_WINDOW_MS, limit = DEFAULT_L
     .map(({ chain_key }) => chainView(db, chain_key))
     .filter(Boolean)
     .map(chainSummary)
-    .sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt) || a.correlationId.localeCompare(b.correlationId));
+    .sort(
+      (a, b) =>
+        b.lastActivityAt.localeCompare(a.lastActivityAt) ||
+        a.correlationId.localeCompare(b.correlationId),
+    );
 }
 
 function windowMs(value) {
@@ -246,16 +260,30 @@ function rowLimit(value) {
   if (value == null || value === "") return DEFAULT_LIMIT;
   if (!/^\d+$/.test(value)) return null;
   const result = Number(value);
-  return Number.isSafeInteger(result) && result >= 1 && result <= MAX_LIMIT ? result : null;
+  return Number.isSafeInteger(result) && result >= 1 && result <= MAX_LIMIT
+    ? result
+    : null;
 }
 
 export function handleChainApiRoute({ route, url, send, db, nowMs }) {
   if (route === "GET /chains") {
     const parsedWindow = windowMs(url.searchParams.get("window"));
     const parsedLimit = rowLimit(url.searchParams.get("limit"));
-    if (parsedWindow == null) return send(400, { error: "window must be a positive duration such as 24h" });
-    if (parsedLimit == null) return send(400, { error: `limit must be an integer from 1 to ${MAX_LIMIT}` });
-    return send(200, { chains: chainsView(db, { windowMs: parsedWindow, limit: parsedLimit, nowMs }) });
+    if (parsedWindow == null)
+      return send(400, {
+        error: "window must be a positive duration such as 24h",
+      });
+    if (parsedLimit == null)
+      return send(400, {
+        error: `limit must be an integer from 1 to ${MAX_LIMIT}`,
+      });
+    return send(200, {
+      chains: chainsView(db, {
+        windowMs: parsedWindow,
+        limit: parsedLimit,
+        nowMs,
+      }),
+    });
   }
   const match = url.pathname.match(/^\/chain\/([^/]+)$/);
   if (!match || route !== `GET ${url.pathname}`) return false;

--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -11,6 +11,10 @@
  */
 import { repoNamesFromInput } from "./api-runs.mjs";
 
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
 /** The id that names an event's chain: its correlation id, else its own id. */
 export function chainKeyOf(event) {
   return (
@@ -120,7 +124,139 @@ export function chainView(db, correlationId) {
   return { correlationId, events, runs };
 }
 
-export function handleChainApiRoute({ route, url, send, db }) {
+/** Number of derived-event hops from the origin to the deepest event. */
+function maxChainDepth(events, runs) {
+  const eventKey = (source, eventId) => `${source}\0${eventId}`;
+  const parentEventByRun = new Map();
+  for (const run of runs) {
+    if (run.eventSource && run.eventId) {
+      parentEventByRun.set(run.runId, eventKey(run.eventSource, run.eventId));
+    }
+  }
+  const byId = new Map(events.map((event) => [eventKey(event.source, event.eventId), event]));
+  const memo = new Map();
+
+  function depth(key, visiting = new Set()) {
+    if (memo.has(key)) return memo.get(key);
+    const event = byId.get(key);
+    if (!event?.causationId) return 0;
+    if (visiting.has(key)) return 0;
+    const parentEventKey = parentEventByRun.get(event.causationId);
+    if (!parentEventKey || !byId.has(parentEventKey)) return 1;
+    visiting.add(key);
+    const value = depth(parentEventKey, visiting) + 1;
+    visiting.delete(key);
+    memo.set(key, value);
+    return value;
+  }
+
+  return events.reduce(
+    (max, event) => Math.max(max, depth(eventKey(event.source, event.eventId))),
+    0,
+  );
+}
+
+function chainSummary(view) {
+  const origin = view.events.find((event) => !event.causationId) ?? view.events[0];
+  const states = {};
+  const repos = new Set();
+  let lastActivityAt = origin.admittedAt;
+  for (const event of view.events) {
+    if (event.admittedAt > lastActivityAt) lastActivityAt = event.admittedAt;
+    for (const repo of event.repos) repos.add(repo);
+  }
+  for (const run of view.runs) {
+    states[run.state] = (states[run.state] ?? 0) + 1;
+    if (run.updated_at > lastActivityAt) lastActivityAt = run.updated_at;
+    for (const repo of run.repos) repos.add(repo);
+  }
+  return {
+    correlationId: view.correlationId,
+    origin: {
+      source: origin.source,
+      eventId: origin.eventId,
+      type: origin.type,
+      subject: origin.subject,
+      admittedAt: origin.admittedAt,
+    },
+    eventCount: view.events.length,
+    runCount: view.runs.length,
+    maxDepth: maxChainDepth(view.events, view.runs),
+    states,
+    lastActivityAt,
+    repos: [...repos].sort(),
+    single: view.events.length === 1 && view.runs.length === 0,
+  };
+}
+
+/** Recent chain instances, newest activity first. */
+export function chainsView(db, { windowMs = DEFAULT_WINDOW_MS, limit = DEFAULT_LIMIT, nowMs = Date.now() } = {}) {
+  const cutoff = new Date(nowMs - windowMs).toISOString();
+  // Find recent keys in SQL before expanding each complete trace. Run activity
+  // counts even when the last event is old, including a causation parent run.
+  const candidates = db
+    .query(
+      `WITH event_activity AS (
+         SELECT COALESCE(correlation_id, event_id) AS chain_key,
+                MAX(admitted_at) AS event_last
+         FROM events
+         GROUP BY COALESCE(correlation_id, event_id)
+       ), proposal_activity AS (
+         SELECT COALESCE(e.correlation_id, e.event_id) AS chain_key,
+                MAX(r.updated_at) AS run_last
+         FROM events e
+         JOIN proposals p ON p.event_source = e.source AND p.event_id = e.event_id
+         JOIN runs r ON r.run_id = p.run_id
+         GROUP BY COALESCE(e.correlation_id, e.event_id)
+       ), causation_activity AS (
+         SELECT COALESCE(e.correlation_id, e.event_id) AS chain_key,
+                MAX(r.updated_at) AS cause_last
+         FROM events e
+         JOIN runs r ON r.run_id = e.causation_id
+         GROUP BY COALESCE(e.correlation_id, e.event_id)
+       )
+       SELECT ea.chain_key,
+              MAX(ea.event_last, COALESCE(pa.run_last, ''), COALESCE(ca.cause_last, '')) AS last_activity
+       FROM event_activity ea
+       LEFT JOIN proposal_activity pa ON pa.chain_key = ea.chain_key
+       LEFT JOIN causation_activity ca ON ca.chain_key = ea.chain_key
+       WHERE MAX(ea.event_last, COALESCE(pa.run_last, ''), COALESCE(ca.cause_last, '')) >= ?
+       ORDER BY last_activity DESC, ea.chain_key ASC
+       LIMIT ?`,
+    )
+    .all(cutoff, limit);
+
+  return candidates
+    .map(({ chain_key }) => chainView(db, chain_key))
+    .filter(Boolean)
+    .map(chainSummary)
+    .sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt) || a.correlationId.localeCompare(b.correlationId));
+}
+
+function windowMs(value) {
+  if (value == null || value === "") return DEFAULT_WINDOW_MS;
+  const match = /^(\d+)(m|h|d)$/.exec(value);
+  if (!match) return null;
+  const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[match[2]];
+  const result = Number(match[1]) * unit;
+  return Number.isSafeInteger(result) && result > 0 ? result : null;
+}
+
+function rowLimit(value) {
+  if (value == null || value === "") return DEFAULT_LIMIT;
+  if (!/^\d+$/.test(value)) return null;
+  const result = Number(value);
+  return Number.isSafeInteger(result) && result >= 1 && result <= MAX_LIMIT ? result : null;
+}
+
+export function handleChainApiRoute({ route, url, send, db, nowMs }) {
+  if (route === "GET /chains") {
+    const parsedWindow = windowMs(url.searchParams.get("window"));
+    const parsedLimit = rowLimit(url.searchParams.get("limit"));
+    if (parsedWindow == null) return send(400, { error: "window must be a positive duration such as 24h" });
+    if (parsedLimit == null) return send(400, { error: `limit must be an integer from 1 to ${MAX_LIMIT}` });
+    return send(200, { chains: chainsView(db, { windowMs: parsedWindow, limit: parsedLimit, nowMs }) });
+  }
   const match = url.pathname.match(/^\/chain\/([^/]+)$/);
   if (!match || route !== `GET ${url.pathname}`) return false;
   const correlationId = decodeURIComponent(match[1]);

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -220,3 +220,122 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     expect((await fetch(s.url("/chain/"))).status).not.toBe(200);
   });
 });
+
+describe("GET /chains (WM-537)", () => {
+  let s;
+  const now = Date.UTC(2026, 7, 17, 14, 0);
+  const t = (hour, minute = 0) => new Date(Date.UTC(2026, 7, 17, hour, minute)).toISOString();
+
+  function insertRun(db, runId, state, at, eventId, repo) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+    ).run(
+      runId,
+      `${runId}-key`,
+      JSON.stringify({ agent: "test@1", adapter: "fake", input: { repo } }),
+      `sha256:${runId}`,
+      state,
+      at,
+      at,
+    );
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, ?, 'run', 'approved', ?, 600)`,
+    ).run(`prop-${runId}`, eventId, runId, at);
+  }
+
+  beforeAll(async () => {
+    s = await makeServer({ now: () => now });
+    await s.client.replay(envelope({
+      eventId: "origin-alpha",
+      correlationId: "corr-alpha",
+      occurredAt: t(12),
+      payload: { repo: "factory" },
+    }));
+    insertRun(s.db, "run-alpha", "COMPLETED", t(12, 5), "origin-alpha", "factory");
+    expect(admitChainEvent(s.db, registry, envelope({
+      eventId: "alpha-child",
+      source: "chain",
+      type: "factory.child.requested",
+      correlationId: "corr-alpha",
+      causationId: "run-alpha",
+      occurredAt: t(12, 10),
+      payload: { repo: "factory" },
+    })).admitted).toBe(true);
+
+    await s.client.replay(envelope({
+      eventId: "origin-bravo",
+      correlationId: null,
+      type: "factory.bravo.requested",
+      occurredAt: t(12, 20),
+      payload: { repo: "bravo" },
+    }));
+    insertRun(s.db, "run-bravo", "RUNNING", t(12, 25), "origin-bravo", "bravo");
+
+    await s.client.replay(envelope({
+      eventId: "single-charlie",
+      correlationId: null,
+      type: "factory.charlie.requested",
+      occurredAt: t(12, 30),
+      payload: { repo: "charlie" },
+    }));
+    await s.client.replay(envelope({
+      eventId: "outside-window",
+      correlationId: null,
+      occurredAt: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+    }));
+    // Intake stamps admitted_at from the injected clock; make this fixture's
+    // chronology explicit so the endpoint's window/order assertions are real.
+    s.db.query(`UPDATE events SET admitted_at = occurred_at`).run();
+  });
+  afterAll(() => s.close());
+
+  test("lists recent chains newest first with origins, depth, tallies, singles, and cutoff", async () => {
+    const res = await fetch(s.url("/chains?window=2h&limit=100"));
+    expect(res.status).toBe(200);
+    const { chains } = await res.json();
+    expect(chains.map((chain) => chain.correlationId)).toEqual([
+      "single-charlie",
+      "origin-bravo",
+      "corr-alpha",
+    ]);
+    expect(chains.find((chain) => chain.correlationId === "outside-window")).toBeUndefined();
+    expect(chains[0]).toMatchObject({
+      correlationId: "single-charlie",
+      origin: {
+        source: "test",
+        eventId: "single-charlie",
+        type: "factory.charlie.requested",
+      },
+      eventCount: 1,
+      runCount: 0,
+      maxDepth: 0,
+      states: {},
+      repos: ["charlie"],
+      single: true,
+    });
+    expect(chains[1]).toMatchObject({
+      correlationId: "origin-bravo",
+      runCount: 1,
+      states: { RUNNING: 1 },
+      repos: ["bravo"],
+      single: false,
+    });
+    expect(chains[2]).toMatchObject({
+      correlationId: "corr-alpha",
+      eventCount: 2,
+      runCount: 1,
+      maxDepth: 1,
+      states: { COMPLETED: 1 },
+      repos: ["factory"],
+    });
+  });
+
+  test("validates window and limit and applies the limit", async () => {
+    expect((await fetch(s.url("/chains?window=soon"))).status).toBe(400);
+    expect((await fetch(s.url("/chains?limit=0"))).status).toBe(400);
+    const body = await (await fetch(s.url("/chains?window=2h&limit=2"))).json();
+    expect(body.chains).toHaveLength(2);
+  });
+});

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -224,7 +224,8 @@ describe("GET /chain/:correlationId (WM-527)", () => {
 describe("GET /chains (WM-537)", () => {
   let s;
   const now = Date.UTC(2026, 7, 17, 14, 0);
-  const t = (hour, minute = 0) => new Date(Date.UTC(2026, 7, 17, hour, minute)).toISOString();
+  const t = (hour, minute = 0) =>
+    new Date(Date.UTC(2026, 7, 17, hour, minute)).toISOString();
 
   function insertRun(db, runId, state, at, eventId, repo) {
     db.query(
@@ -247,44 +248,65 @@ describe("GET /chains (WM-537)", () => {
 
   beforeAll(async () => {
     s = await makeServer({ now: () => now });
-    await s.client.replay(envelope({
-      eventId: "origin-alpha",
-      correlationId: "corr-alpha",
-      occurredAt: t(12),
-      payload: { repo: "factory" },
-    }));
-    insertRun(s.db, "run-alpha", "COMPLETED", t(12, 5), "origin-alpha", "factory");
-    expect(admitChainEvent(s.db, registry, envelope({
-      eventId: "alpha-child",
-      source: "chain",
-      type: "factory.child.requested",
-      correlationId: "corr-alpha",
-      causationId: "run-alpha",
-      occurredAt: t(12, 10),
-      payload: { repo: "factory" },
-    })).admitted).toBe(true);
+    await s.client.replay(
+      envelope({
+        eventId: "origin-alpha",
+        correlationId: "corr-alpha",
+        occurredAt: t(12),
+        payload: { repo: "factory" },
+      }),
+    );
+    insertRun(
+      s.db,
+      "run-alpha",
+      "COMPLETED",
+      t(12, 5),
+      "origin-alpha",
+      "factory",
+    );
+    expect(
+      admitChainEvent(
+        s.db,
+        registry,
+        envelope({
+          eventId: "alpha-child",
+          source: "chain",
+          type: "factory.child.requested",
+          correlationId: "corr-alpha",
+          causationId: "run-alpha",
+          occurredAt: t(12, 10),
+          payload: { repo: "factory" },
+        }),
+      ).admitted,
+    ).toBe(true);
 
-    await s.client.replay(envelope({
-      eventId: "origin-bravo",
-      correlationId: null,
-      type: "factory.bravo.requested",
-      occurredAt: t(12, 20),
-      payload: { repo: "bravo" },
-    }));
+    await s.client.replay(
+      envelope({
+        eventId: "origin-bravo",
+        correlationId: null,
+        type: "factory.bravo.requested",
+        occurredAt: t(12, 20),
+        payload: { repo: "bravo" },
+      }),
+    );
     insertRun(s.db, "run-bravo", "RUNNING", t(12, 25), "origin-bravo", "bravo");
 
-    await s.client.replay(envelope({
-      eventId: "single-charlie",
-      correlationId: null,
-      type: "factory.charlie.requested",
-      occurredAt: t(12, 30),
-      payload: { repo: "charlie" },
-    }));
-    await s.client.replay(envelope({
-      eventId: "outside-window",
-      correlationId: null,
-      occurredAt: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
-    }));
+    await s.client.replay(
+      envelope({
+        eventId: "single-charlie",
+        correlationId: null,
+        type: "factory.charlie.requested",
+        occurredAt: t(12, 30),
+        payload: { repo: "charlie" },
+      }),
+    );
+    await s.client.replay(
+      envelope({
+        eventId: "outside-window",
+        correlationId: null,
+        occurredAt: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+      }),
+    );
     // Intake stamps admitted_at from the injected clock; make this fixture's
     // chronology explicit so the endpoint's window/order assertions are real.
     s.db.query(`UPDATE events SET admitted_at = occurred_at`).run();
@@ -300,7 +322,9 @@ describe("GET /chains (WM-537)", () => {
       "origin-bravo",
       "corr-alpha",
     ]);
-    expect(chains.find((chain) => chain.correlationId === "outside-window")).toBeUndefined();
+    expect(
+      chains.find((chain) => chain.correlationId === "outside-window"),
+    ).toBeUndefined();
     expect(chains[0]).toMatchObject({
       correlationId: "single-charlie",
       origin: {

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -244,7 +244,7 @@ export function createApi({
         const result = handleMetricsApiRoute(common);
         if (result !== false) return result;
       }
-      if (url.pathname.startsWith("/chain/")) {
+      if (url.pathname === "/chains" || url.pathname.startsWith("/chain/")) {
         const result = handleChainApiRoute(common);
         if (result !== false) return result;
       }

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { App } from "./App";
+import { App, navIsCurrent } from "./App";
 import { goPrefix } from "./goSequence";
 import { NAV } from "./nav";
 import type { StatusView } from "./types";
@@ -127,6 +127,13 @@ afterEach(() => {
 });
 
 describe("sidebar navigation accessibility", () => {
+  test("detail routes keep their parent navigation entry current", () => {
+    expect(navIsCurrent("runs", "run")).toBe(true);
+    expect(navIsCurrent("tickets", "prs")).toBe(true);
+    expect(navIsCurrent("chains", "chain")).toBe(true);
+    expect(navIsCurrent("events", "chain")).toBe(false);
+  });
+
   test("every NAV entry is a button whose accessible name is exactly its label", async () => {
     const { sidebar } = renderApp();
     // Wait for the status fixture to land so badge-carrying entries (Events 6,

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -85,6 +85,9 @@ const Artifacts = lazy(() =>
 const Graph = lazy(() =>
   import("./views/Graph").then((m) => ({ default: m.Graph })),
 );
+const Chains = lazy(() =>
+  import("./views/Chains").then((m) => ({ default: m.Chains })),
+);
 const Chain = lazy(() =>
   import("./views/Chain").then((m) => ({ default: m.Chain })),
 );
@@ -243,6 +246,8 @@ export function App() {
     : null;
   const focusGraphNode = view === "graph" ? (route[1] ?? null) : null;
   const focusSettingsSection = view === "settings" ? (route[1] ?? null) : null;
+  const chainsStateFilter =
+    view === "chains" ? hashSearch(window.location.hash).get("state") : null;
   // `#/chain/:correlationId[/:nodeId]` — the chain trace (WM-527); node
   // selection rides the hash so a pasted link lands on the same node.
   const chainId = view === "chain" ? (route[1] ?? null) : null;
@@ -386,6 +391,7 @@ export function App() {
       title: `${inboxOpen} inbox item${inboxOpen === 1 ? "" : "s"} waiting on you`,
     },
     events: { count: scopedNav ? 0 : eventAttention, hue: "var(--accent)" },
+    chains: { count: 0, hue: "var(--accent)" },
     proposals: { count: scopedNav ? 0 : openProposals, hue: "var(--accent)" },
     runs: { count: scopedRunsNav ? 0 : activeRuns, hue: "var(--accent)" },
     tickets: { count: 0, hue: "var(--accent)" },
@@ -817,6 +823,20 @@ export function App() {
                   connected={connected}
                   focusRepoName={focusRepoName}
                   onSelectRepo={(name) => navigate(hashPath("projects", name))}
+                />
+              </Suspense>
+            ) : view === "chains" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading chains…
+                  </div>
+                }
+              >
+                <Chains
+                  context={context}
+                  initialStateFilter={chainsStateFilter}
+                  onOpenChain={(correlationId) => jumpToChain(correlationId)}
                 />
               </Suspense>
             ) : view === "chain" && chainId ? (

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -54,6 +54,15 @@ const isWorkerHealthFilter = (
 ): value is WorkerHealthFilter =>
   value === "live" || value === "busy" || value === "stale";
 
+export function navIsCurrent(key: NavKey, view?: string): boolean {
+  return (
+    key === view ||
+    (key === "runs" && view === "run") ||
+    (key === "tickets" && view === "prs") ||
+    (key === "chains" && view === "chain")
+  );
+}
+
 type NavBadge = {
   count: number;
   hue: string;
@@ -647,23 +656,18 @@ export function App() {
           <div className="flex-1 px-2">
             {NAV.map((n) => {
               const badge = navBadges[n.key];
+              const current = navIsCurrent(n.key, view);
               return (
                 <button
                   key={n.key}
                   type="button"
-                  aria-current={
-                    view === n.key ||
-                    (n.key === "runs" && view === "run") ||
-                    (n.key === "tickets" && view === "prs")
-                      ? "page"
-                      : undefined
-                  }
+                  aria-current={current ? "page" : undefined}
                   aria-describedby={
                     badge.count > 0 ? `nav-badge-${n.key}` : undefined
                   }
                   onClick={() => navigate(n.key)}
                   className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] ${
-                    view === n.key || (n.key === "runs" && view === "run")
+                    current
                       ? "bg-(--surface-3) font-medium text-(--text)"
                       : "text-(--text-dim) hover:bg-(--surface-2)"
                   }`}
@@ -828,9 +832,7 @@ export function App() {
             ) : view === "chains" ? (
               <Suspense
                 fallback={
-                  <div className="p-5 text-(--text-faint)">
-                    Loading chains…
-                  </div>
+                  <div className="p-5 text-(--text-faint)">Loading chains…</div>
                 }
               >
                 <Chains
@@ -1175,9 +1177,7 @@ export function GoPrefixHint({
             </span>
             <span className="text-(--text-dim)">then</span>
             {NAV.map((n) => {
-              const isCurrent =
-                n.key === currentView ||
-                (n.key === "runs" && currentView === "run");
+              const isCurrent = navIsCurrent(n.key, currentView);
               if (isCurrent) {
                 return (
                   <span

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -2,6 +2,7 @@ import type {
   AdmittedEvent,
   AgentsView,
   ArtifactInventoryItem,
+  ChainListItem,
   ChainView,
   ApproveOutcome,
   CancelOutcome,
@@ -236,6 +237,12 @@ export const api = {
   // Every event + run under one correlation id (WM-527); 404 when unknown.
   chain: (correlationId: string) =>
     call<ChainView>("GET", `/chain/${encodeURIComponent(correlationId)}`),
+  // Recent chain summaries, newest activity first (WM-537).
+  chains: (window = "24h", limit = 100) =>
+    call<{ chains: ChainListItem[] }>(
+      "GET",
+      `/chains?window=${encodeURIComponent(window)}&limit=${limit}`,
+    ),
   // Configured factory repositories (config/repos.yaml) — context tabs open from this list.
   repos: () => call<{ repos: RepoItem[] }>("GET", "/repos"),
   // Janitor worktree scan and cleanup (apply: false for dry run, apply: true for teardown)

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -6,11 +6,13 @@
 // In-flight context chord (WM-235). Number keys 1–6 belong to an undecided
 // DecisionCard whenever one is on screen (capture-phase window listener, so
 // Inbox's 1–4 status tabs never see them); with no open card the tabs keep
-// their existing binding.
+// their existing binding. Chains rides `g l` ("chain link"): its natural `c`
+// went to Settings (WM-704, config) first (WM-537).
 export const NAV = [
   { key: "overview", label: "Overview", go: "o" },
   { key: "inbox", label: "Inbox", go: "n" },
   { key: "events", label: "Events", go: "e" },
+  { key: "chains", label: "Chains", go: "l" },
   { key: "proposals", label: "Proposals", go: "p" },
   { key: "runs", label: "Runs", go: "r" },
   { key: "tickets", label: "Tickets", go: "k" },

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -300,6 +300,7 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       events: [],
       runs: [],
     })),
+    chains: mock(async (_window = "24h", _limit = 100) => ({ chains: [] })),
     proposals: mock(async () => ({ proposals: [] as Proposal[] })),
     proposalHistory: mock(async (_status = "all") => ({
       proposals: [] as Proposal[],

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -123,6 +123,25 @@ export interface ChainView {
   runs: ChainRun[];
 }
 
+/** One recent chain summary (`GET /chains`, WM-537). */
+export interface ChainListItem {
+  correlationId: string;
+  origin: {
+    source: string;
+    eventId: string;
+    type: string;
+    subject: string | null;
+    admittedAt: string;
+  };
+  eventCount: number;
+  runCount: number;
+  maxDepth: number;
+  states: Partial<Record<RunState, number>>;
+  lastActivityAt: string;
+  repos: string[];
+  single: boolean;
+}
+
 export interface RunListItem {
   runId: string;
   state: RunState;

--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -1,0 +1,124 @@
+import "../test-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { ChainListItem } from "../types";
+import { changeInput, renderWithClient, restoreApi, withApi } from "../test-render";
+import { Chains } from "./Chains";
+
+afterEach(() => {
+  cleanup();
+  restoreApi();
+  localStorage.clear();
+});
+
+const at = (minute: number) => new Date(Date.UTC(2026, 7, 17, 12, minute)).toISOString();
+
+function chain(overrides: Partial<ChainListItem> & Pick<ChainListItem, "correlationId">): ChainListItem {
+  return {
+    origin: {
+      source: "github",
+      eventId: `event-${overrides.correlationId}`,
+      type: "pull_request.opened",
+      subject: "factory",
+      admittedAt: at(0),
+    },
+    eventCount: 2,
+    runCount: 1,
+    maxDepth: 1,
+    states: { COMPLETED: 1 },
+    lastActivityAt: at(10),
+    repos: ["factory"],
+    single: false,
+    ...overrides,
+  };
+}
+
+const rows = [
+  chain({ correlationId: "corr-active", states: { RUNNING: 1 }, lastActivityAt: at(30) }),
+  chain({
+    correlationId: "corr-failed",
+    origin: {
+      source: "linear",
+      eventId: "event-failed",
+      type: "factory.work.requested",
+      subject: "WM-537",
+      admittedAt: at(5),
+    },
+    states: { FAILED: 1 },
+    repos: ["other"],
+    lastActivityAt: at(20),
+  }),
+  chain({
+    correlationId: "single-root",
+    origin: {
+      source: "test",
+      eventId: "event-single",
+      type: "factory.single.requested",
+      subject: null,
+      admittedAt: at(15),
+    },
+    eventCount: 1,
+    runCount: 0,
+    maxDepth: 0,
+    states: {},
+    repos: ["factory"],
+    single: true,
+  }),
+];
+
+function renderChains(overrides: Partial<React.ComponentProps<typeof Chains>> = {}) {
+  return renderWithClient(
+    <Chains
+      context={{ kind: "all" }}
+      initialStateFilter={null}
+      onOpenChain={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+describe("Chains list (WM-537)", () => {
+  test("renders grouped summaries, hides single roots by default, and opens the trace", async () => {
+    const onOpenChain = mock(() => {});
+    await withApi({ chains: async () => ({ chains: rows }) }, async () => {
+      const view = renderChains({ onOpenChain });
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+      });
+      expect(view.container.querySelector('[data-chain-id="corr-failed"]')).toBeTruthy();
+      expect(view.container.querySelector('[data-chain-id="single-root"]')).toBeNull();
+      expect(view.getByRole("button", { name: "Single-event roots 1" }).getAttribute("aria-pressed")).toBe("false");
+      expect(view.getByText("active")).toBeTruthy();
+      expect(view.getByText("failed")).toBeTruthy();
+
+      fireEvent.click(view.container.querySelector('[data-chain-id="corr-active"]')!);
+      expect(onOpenChain).toHaveBeenCalledWith("corr-active");
+
+      fireEvent.click(view.getByRole("button", { name: "Single-event roots 1" }));
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-chain-id="single-root"]')).toBeTruthy();
+      });
+    });
+  });
+
+  test("supports state/is filters and repo operator context", async () => {
+    await withApi({ chains: async () => ({ chains: rows }) }, async () => {
+      const view = renderChains({ context: { kind: "repo", name: "factory" } });
+      const input = view.getByLabelText("Filter chains") as HTMLInputElement;
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+      });
+      expect(view.container.querySelector('[data-chain-id="corr-failed"]')).toBeNull();
+      expect(view.getByText(/Scoped to/)).toBeTruthy();
+
+      changeInput(input, "is:failed");
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeNull();
+      });
+      changeInput(input, "state:running");
+      await waitFor(() => {
+        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+      });
+    });
+  });
+});

--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -2,7 +2,12 @@ import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import type { ChainListItem } from "../types";
-import { changeInput, renderWithClient, restoreApi, withApi } from "../test-render";
+import {
+  changeInput,
+  renderWithClient,
+  restoreApi,
+  withApi,
+} from "../test-render";
 import { Chains } from "./Chains";
 
 afterEach(() => {
@@ -11,9 +16,12 @@ afterEach(() => {
   localStorage.clear();
 });
 
-const at = (minute: number) => new Date(Date.UTC(2026, 7, 17, 12, minute)).toISOString();
+const at = (minute: number) =>
+  new Date(Date.UTC(2026, 7, 17, 12, minute)).toISOString();
 
-function chain(overrides: Partial<ChainListItem> & Pick<ChainListItem, "correlationId">): ChainListItem {
+function chain(
+  overrides: Partial<ChainListItem> & Pick<ChainListItem, "correlationId">,
+): ChainListItem {
   return {
     origin: {
       source: "github",
@@ -34,7 +42,11 @@ function chain(overrides: Partial<ChainListItem> & Pick<ChainListItem, "correlat
 }
 
 const rows = [
-  chain({ correlationId: "corr-active", states: { RUNNING: 1 }, lastActivityAt: at(30) }),
+  chain({
+    correlationId: "corr-active",
+    states: { RUNNING: 1 },
+    lastActivityAt: at(30),
+  }),
   chain({
     correlationId: "corr-failed",
     origin: {
@@ -66,7 +78,9 @@ const rows = [
   }),
 ];
 
-function renderChains(overrides: Partial<React.ComponentProps<typeof Chains>> = {}) {
+function renderChains(
+  overrides: Partial<React.ComponentProps<typeof Chains>> = {},
+) {
   return renderWithClient(
     <Chains
       context={{ kind: "all" }}
@@ -83,20 +97,36 @@ describe("Chains list (WM-537)", () => {
     await withApi({ chains: async () => ({ chains: rows }) }, async () => {
       const view = renderChains({ onOpenChain });
       await waitFor(() => {
-        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
       });
-      expect(view.container.querySelector('[data-chain-id="corr-failed"]')).toBeTruthy();
-      expect(view.container.querySelector('[data-chain-id="single-root"]')).toBeNull();
-      expect(view.getByRole("button", { name: "Single-event roots 1" }).getAttribute("aria-pressed")).toBe("false");
+      expect(
+        view.container.querySelector('[data-chain-id="corr-failed"]'),
+      ).toBeTruthy();
+      expect(
+        view.container.querySelector('[data-chain-id="single-root"]'),
+      ).toBeNull();
+      expect(
+        view
+          .getByRole("button", { name: "Single-event roots 1" })
+          .getAttribute("aria-pressed"),
+      ).toBe("false");
       expect(view.getByText("active")).toBeTruthy();
       expect(view.getByText("failed")).toBeTruthy();
 
-      fireEvent.click(view.container.querySelector('[data-chain-id="corr-active"]')!);
+      fireEvent.click(
+        view.container.querySelector('[data-chain-id="corr-active"]')!,
+      );
       expect(onOpenChain).toHaveBeenCalledWith("corr-active");
 
-      fireEvent.click(view.getByRole("button", { name: "Single-event roots 1" }));
+      fireEvent.click(
+        view.getByRole("button", { name: "Single-event roots 1" }),
+      );
       await waitFor(() => {
-        expect(view.container.querySelector('[data-chain-id="single-root"]')).toBeTruthy();
+        expect(
+          view.container.querySelector('[data-chain-id="single-root"]'),
+        ).toBeTruthy();
       });
     });
   });
@@ -106,18 +136,69 @@ describe("Chains list (WM-537)", () => {
       const view = renderChains({ context: { kind: "repo", name: "factory" } });
       const input = view.getByLabelText("Filter chains") as HTMLInputElement;
       await waitFor(() => {
-        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
       });
-      expect(view.container.querySelector('[data-chain-id="corr-failed"]')).toBeNull();
+      expect(
+        view.container.querySelector('[data-chain-id="corr-failed"]'),
+      ).toBeNull();
       expect(view.getByText(/Scoped to/)).toBeTruthy();
 
       changeInput(input, "is:failed");
       await waitFor(() => {
-        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeNull();
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeNull();
       });
       changeInput(input, "state:running");
       await waitFor(() => {
-        expect(view.container.querySelector('[data-chain-id="corr-active"]')).toBeTruthy();
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  test("syncs query-derived state changes and never opens a filtered-out selection", async () => {
+    const onOpenChain = mock(() => {});
+    await withApi({ chains: async () => ({ chains: rows }) }, async () => {
+      const view = renderChains({ initialStateFilter: "running", onOpenChain });
+      const input = view.getByLabelText("Filter chains") as HTMLInputElement;
+      await waitFor(() => {
+        expect(input.value).toBe("state:running");
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeTruthy();
+      });
+
+      fireEvent.keyDown(document.body, { key: "j" });
+      expect(
+        view.container
+          .querySelector('[data-chain-id="corr-active"]')
+          ?.getAttribute("aria-selected"),
+      ).toBe("true");
+      changeInput(input, "type:does-not-exist");
+      await waitFor(() => {
+        expect(
+          view.container.querySelector('[data-chain-id="corr-active"]'),
+        ).toBeNull();
+      });
+      fireEvent.keyDown(document.body, { key: "Enter" });
+      expect(onOpenChain).not.toHaveBeenCalled();
+
+      view.rerender(
+        <Chains
+          context={{ kind: "all" }}
+          initialStateFilter="failed"
+          onOpenChain={onOpenChain}
+        />,
+      );
+      await waitFor(() => {
+        expect(input.value).toBe("state:failed");
+        expect(
+          view.container.querySelector('[data-chain-id="corr-failed"]'),
+        ).toBeTruthy();
       });
     });
   });

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
@@ -17,7 +17,13 @@ import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import type { FilterFacets } from "../filterQuery";
 import { matchesFilterQuery, parseFilterQuery } from "../filterQuery";
-import { tableTokens, useDisplayOptions, useListKeys, useNow, useTableWindow } from "../hooks";
+import {
+  tableTokens,
+  useDisplayOptions,
+  useListKeys,
+  useNow,
+  useTableWindow,
+} from "../hooks";
 import type { ChainListItem, RunState } from "../types";
 import {
   Ago,
@@ -32,13 +38,24 @@ import {
   shortId,
 } from "../components/ui";
 
-const ACTIVE_STATES = new Set<RunState>(["QUEUED", "LEASED", "RUNNING", "VERIFYING"]);
+const ACTIVE_STATES = new Set<RunState>([
+  "QUEUED",
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+]);
 const FAILED_STATES = new Set<RunState>(["FAILED", "TIMED_OUT", "REFUSED"]);
 
-export type ChainStatus = "active" | "failed" | "completed" | "cancelled" | "no runs" | "other";
+export type ChainStatus =
+  "active" | "failed" | "completed" | "cancelled" | "no runs" | "other";
 
-export function chainHasState(chain: ChainListItem, states: ReadonlySet<RunState>): boolean {
-  return Object.entries(chain.states).some(([state, count]) => (count ?? 0) > 0 && states.has(state as RunState));
+export function chainHasState(
+  chain: ChainListItem,
+  states: ReadonlySet<RunState>,
+): boolean {
+  return Object.entries(chain.states).some(
+    ([state, count]) => (count ?? 0) > 0 && states.has(state as RunState),
+  );
 }
 
 export function chainStatus(chain: ChainListItem): ChainStatus {
@@ -88,7 +105,17 @@ const CHAIN_FACETS: FilterFacets<ChainListItem> = {
     ...Object.keys(chain.states),
   ],
   values: {
-    state: ["queued", "leased", "running", "verifying", "completed", "failed", "timed_out", "refused", "cancelled"],
+    state: [
+      "queued",
+      "leased",
+      "running",
+      "verifying",
+      "completed",
+      "failed",
+      "timed_out",
+      "refused",
+      "cancelled",
+    ],
   },
 };
 
@@ -103,18 +130,61 @@ const CHAINS_DISPLAY: DisplayConfig<ChainListItem> = {
       hue: STATUS_HUES,
     },
     { key: "type", label: "Origin type", get: (chain) => chain.origin.type },
-    { key: "repo", label: "Repo", get: (chain) => chain.repos.join(", ") || "unscoped" },
+    {
+      key: "repo",
+      label: "Repo",
+      get: (chain) => chain.repos.join(", ") || "unscoped",
+    },
   ],
   subGroups: ["type", "repo", "status"],
   sorts: [
-    { key: "origin", label: "Origin", get: (chain) => chain.origin.type, column: "origin" },
-    { key: "root", label: "Root event", get: (chain) => chain.origin.eventId, column: "root" },
-    { key: "depth", label: "Depth", get: (chain) => chain.maxDepth, defaultDir: "desc", column: "depth" },
-    { key: "events", label: "Events", get: (chain) => chain.eventCount, defaultDir: "desc", column: "events" },
-    { key: "runs", label: "Runs", get: (chain) => chain.runCount, defaultDir: "desc", column: "runs" },
+    {
+      key: "origin",
+      label: "Origin",
+      get: (chain) => chain.origin.type,
+      column: "origin",
+    },
+    {
+      key: "root",
+      label: "Root event",
+      get: (chain) => chain.origin.eventId,
+      column: "root",
+    },
+    {
+      key: "depth",
+      label: "Depth",
+      get: (chain) => chain.maxDepth,
+      defaultDir: "desc",
+      column: "depth",
+    },
+    {
+      key: "events",
+      label: "Events",
+      get: (chain) => chain.eventCount,
+      defaultDir: "desc",
+      column: "events",
+    },
+    {
+      key: "runs",
+      label: "Runs",
+      get: (chain) => chain.runCount,
+      defaultDir: "desc",
+      column: "runs",
+    },
     { key: "status", label: "States", get: chainStatus, column: "states" },
-    { key: "activity", label: "Last activity", get: (chain) => chain.lastActivityAt, defaultDir: "desc", column: "activity" },
-    { key: "repo", label: "Repos", get: (chain) => chain.repos.join(", "), column: "repos" },
+    {
+      key: "activity",
+      label: "Last activity",
+      get: (chain) => chain.lastActivityAt,
+      defaultDir: "desc",
+      column: "activity",
+    },
+    {
+      key: "repo",
+      label: "Repos",
+      get: (chain) => chain.repos.join(", "),
+      column: "repos",
+    },
   ],
   columns: [
     { key: "origin", label: "Origin", always: true },
@@ -139,28 +209,41 @@ export function Chains({
   onOpenChain: (correlationId: string) => void;
 }) {
   const now = useNow();
-  const [filter, setFilter] = useState(() => initialStateFilter ? `state:${initialStateFilter}` : "");
+  const [filter, setFilter] = useState(() =>
+    initialStateFilter ? `state:${initialStateFilter}` : "",
+  );
   const [showSingles, setShowSingles] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  useEffect(() => {
+    setFilter(initialStateFilter ? `state:${initialStateFilter}` : "");
+  }, [initialStateFilter]);
   const list = useQuery({
     queryKey: ["chains", "24h", 100],
     queryFn: () => api.chains("24h", 100),
     refetchInterval: 3000,
   });
-  const parsed = useMemo(() => parseFilterQuery(filter, CHAIN_FACETS), [filter]);
+  const parsed = useMemo(
+    () => parseFilterQuery(filter, CHAIN_FACETS),
+    [filter],
+  );
   const scoped = useMemo(
-    () => (list.data?.chains ?? []).filter((chain) =>
-      matchesRepo(chain.repos, context) &&
-      (context.kind !== "inflight" || chainHasState(chain, ACTIVE_STATES)),
-    ),
+    () =>
+      (list.data?.chains ?? []).filter(
+        (chain) =>
+          matchesRepo(chain.repos, context) &&
+          (context.kind !== "inflight" || chainHasState(chain, ACTIVE_STATES)),
+      ),
     [list.data, context],
   );
   const withoutSingles = useMemo(
-    () => showSingles ? scoped : scoped.filter((chain) => !chain.single),
+    () => (showSingles ? scoped : scoped.filter((chain) => !chain.single)),
     [scoped, showSingles],
   );
   const visible = useMemo(
-    () => withoutSingles.filter((chain) => matchesFilterQuery(chain, parsed, CHAIN_FACETS, undefined)),
+    () =>
+      withoutSingles.filter((chain) =>
+        matchesFilterQuery(chain, parsed, CHAIN_FACETS, undefined),
+      ),
     [withoutSingles, parsed],
   );
   const [display, setDisplay] = useDisplayOptions(CHAINS_DISPLAY);
@@ -168,7 +251,10 @@ export function Chains({
     () => buildSections(visible, CHAINS_DISPLAY, display),
     [visible, display],
   );
-  const flat = useMemo(() => flattenSections(sections, display.collapsed), [sections, display.collapsed]);
+  const flat = useMemo(
+    () => flattenSections(sections, display.collapsed),
+    [sections, display.collapsed],
+  );
   const cols = visibleColumns(CHAINS_DISPLAY, display);
   const show = useMemo(() => new Set(cols.map((column) => column.key)), [cols]);
   const tokens = tableTokens(sections, display.collapsed, grouped(display));
@@ -178,13 +264,15 @@ export function Chains({
     (chain) => chain.correlationId,
     JSON.stringify([filter, showSingles, context, display]),
   );
-  const selectedIndex = flat.findIndex((chain) => chain.correlationId === selectedId);
+  const selectedIndex = flat.findIndex(
+    (chain) => chain.correlationId === selectedId,
+  );
   useListKeys({
     count: flat.length,
     selected: selectedIndex,
     onSelect: (index) => setSelectedId(flat[index]?.correlationId ?? null),
-    onOpen: () => selectedId && onOpenChain(selectedId),
-    onClose: () => filter ? setFilter("") : setSelectedId(null),
+    onOpen: () => selectedIndex >= 0 && selectedId && onOpenChain(selectedId),
+    onClose: () => (filter ? setFilter("") : setSelectedId(null)),
   });
 
   const hiddenSingles = scoped.filter((chain) => chain.single).length;
@@ -194,11 +282,13 @@ export function Chains({
         <>
           <h1 className="display mb-1 text-lg font-semibold">Chains</h1>
           <p className="mb-3 text-[11px] text-(--text-faint)">
-            Correlated event and run journeys with activity in the last 24 hours.
+            Correlated event and run journeys with activity in the last 24
+            hours.
           </p>
           {context.kind === "repo" && (
             <p className="mb-3 text-[11px] text-(--text-faint)">
-              Scoped to <span className="mono">{context.name}</span> — only chains naming this repo.
+              Scoped to <span className="mono">{context.name}</span> — only
+              chains naming this repo.
             </p>
           )}
           <div className="flex flex-wrap items-center gap-2">
@@ -207,13 +297,20 @@ export function Chains({
               aria-pressed={showSingles}
               onClick={() => setShowSingles((value) => !value)}
               className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
-                showSingles ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+                showSingles
+                  ? "bg-(--surface-3) text-(--text)"
+                  : "text-(--text-faint) hover:bg-(--surface-1)"
               }`}
             >
               Single-event roots{hiddenSingles > 0 ? ` ${hiddenSingles}` : ""}
             </button>
             <span className="ml-auto">
-              <DisplayOptions config={CHAINS_DISPLAY} state={display} onChange={setDisplay} rows={scoped} />
+              <DisplayOptions
+                config={CHAINS_DISPLAY}
+                state={display}
+                onChange={setDisplay}
+                rows={scoped}
+              />
             </span>
             <FilterInput
               value={filter}
@@ -231,18 +328,35 @@ export function Chains({
         <thead>
           <tr className="text-left text-[11px] text-(--text-faint)">
             {cols.map((column) => {
-              const sort = CHAINS_DISPLAY.sorts.find((item) => item.column === column.key);
-              const isCustom = column.isCustom || column.key.startsWith("custom:");
+              const sort = CHAINS_DISPLAY.sorts.find(
+                (item) => item.column === column.key,
+              );
+              const isCustom =
+                column.isCustom || column.key.startsWith("custom:");
               const path = column.key.replace(/^custom:/, "");
-              const current = isCustom ? display.sortBy === column.key : sort && display.sortBy === sort.key;
+              const current = isCustom
+                ? display.sortBy === column.key
+                : sort && display.sortBy === sort.key;
               return (
                 <Th
                   key={column.key}
                   label={column.label}
                   dir={current ? display.sortDir : null}
                   naturalDir={sort?.defaultDir ?? "asc"}
-                  onSort={sort || isCustom ? () => setDisplay((state) => cycleColumnSort(CHAINS_DISPLAY, state, column.key)) : undefined}
-                  onRemove={isCustom ? () => setDisplay((state) => removeCustomColumn(state, path)) : undefined}
+                  onSort={
+                    sort || isCustom
+                      ? () =>
+                          setDisplay((state) =>
+                            cycleColumnSort(CHAINS_DISPLAY, state, column.key),
+                          )
+                      : undefined
+                  }
+                  onRemove={
+                    isCustom
+                      ? () =>
+                          setDisplay((state) => removeCustomColumn(state, path))
+                      : undefined
+                  }
                 />
               );
             })}
@@ -258,7 +372,9 @@ export function Chains({
                   colSpan={cols.length}
                   section={section}
                   collapsed={display.collapsed.includes(section.key)}
-                  onToggle={() => setDisplay((state) => toggleCollapsed(state, section.key))}
+                  onToggle={() =>
+                    setDisplay((state) => toggleCollapsed(state, section.key))
+                  }
                   sub={sub}
                 />
               );
@@ -274,36 +390,94 @@ export function Chains({
                 className={`cursor-pointer hover:bg-(--surface-1) ${selected ? "row-selected" : ""}`}
               >
                 <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
-                  <div className="truncate text-(--text-dim)" title={chain.origin.type}>{chain.origin.type}</div>
-                  <div className="mono truncate text-[10px] text-(--text-faint)" title={chain.origin.source}>{chain.origin.source}</div>
+                  <div
+                    className="truncate text-(--text-dim)"
+                    title={chain.origin.type}
+                  >
+                    {chain.origin.type}
+                  </div>
+                  <div
+                    className="mono truncate text-[10px] text-(--text-faint)"
+                    title={chain.origin.source}
+                  >
+                    {chain.origin.source}
+                  </div>
                 </td>
                 {show.has("root") && (
-                  <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5" title={chain.origin.eventId}>
+                  <td
+                    className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5"
+                    title={chain.origin.eventId}
+                  >
                     {shortId(chain.origin.eventId)}
                   </td>
                 )}
-                {show.has("depth") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.maxDepth}</td>}
-                {show.has("events") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.eventCount}</td>}
-                {show.has("runs") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.runCount}</td>}
+                {show.has("depth") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    {chain.maxDepth}
+                  </td>
+                )}
+                {show.has("events") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    {chain.eventCount}
+                  </td>
+                )}
+                {show.has("runs") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
+                    {chain.runCount}
+                  </td>
+                )}
                 {show.has("states") && (
                   <td className="border-b border-(--border) px-3 py-1.5">
                     <div className="flex flex-wrap gap-1">
                       {Object.entries(chain.states).map(([state, count]) =>
-                        count ? <StateBadge key={state} state={`${state} ${count}`} hues={{ [`${state} ${count}`]: STATE_HUES[state] }} dot={false} /> : null,
+                        count ? (
+                          <StateBadge
+                            key={state}
+                            state={`${state} ${count}`}
+                            hues={{ [`${state} ${count}`]: STATE_HUES[state] }}
+                            dot={false}
+                          />
+                        ) : null,
                       )}
-                      {chain.runCount === 0 && <span className="text-(--text-faint)">—</span>}
+                      {chain.runCount === 0 && (
+                        <span className="text-(--text-faint)">—</span>
+                      )}
                     </div>
                   </td>
                 )}
-                {show.has("activity") && <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"><Ago iso={chain.lastActivityAt} now={now} /></td>}
-                {show.has("repos") && <td className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)" title={chain.repos.join(", ")}>{chain.repos.join(", ") || "—"}</td>}
-                {cols.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
-                  <CustomCell key={column.key} row={chain} path={column.key.replace(/^custom:/, "")} />
-                ))}
+                {show.has("activity") && (
+                  <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)">
+                    <Ago iso={chain.lastActivityAt} now={now} />
+                  </td>
+                )}
+                {show.has("repos") && (
+                  <td
+                    className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)"
+                    title={chain.repos.join(", ")}
+                  >
+                    {chain.repos.join(", ") || "—"}
+                  </td>
+                )}
+                {cols
+                  .filter(
+                    (column) =>
+                      column.isCustom || column.key.startsWith("custom:"),
+                  )
+                  .map((column) => (
+                    <CustomCell
+                      key={column.key}
+                      row={chain}
+                      path={column.key.replace(/^custom:/, "")}
+                    />
+                  ))}
               </tr>
             );
           })}
-          <TableWindowFooter colSpan={cols.length} range={[windowStart, windowEnd, tokens.length]} move={moveWindow} />
+          <TableWindowFooter
+            colSpan={cols.length}
+            range={[windowStart, windowEnd, tokens.length]}
+            move={moveWindow}
+          />
           {visible.length === 0 && (
             <ListEmpty
               colSpan={cols.length}
@@ -311,7 +485,13 @@ export function Chains({
               filtered={withoutSingles.length > 0}
               onClear={filter ? () => setFilter("") : undefined}
               noun="chains"
-              empty={context.kind === "repo" ? `No chains for ${context.name}.` : showSingles ? "No chains in the last 24 hours." : "No multi-step chains in the last 24 hours."}
+              empty={
+                context.kind === "repo"
+                  ? `No chains for ${context.name}.`
+                  : showSingles
+                    ? "No chains in the last 24 hours."
+                    : "No multi-step chains in the last 24 hours."
+              }
               escHint={Boolean(filter)}
             />
           )}

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -1,0 +1,322 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { api } from "../api";
+import type { OperatorContext } from "../context";
+import { matchesRepo } from "../context";
+import {
+  buildSections,
+  cycleColumnSort,
+  flattenSections,
+  grouped,
+  removeCustomColumn,
+  toggleCollapsed,
+  visibleColumns,
+  type DisplayConfig,
+} from "../displayOptions";
+import { DisplayOptions } from "../components/DisplayOptions";
+import { CustomCell } from "../components/CustomCell";
+import type { FilterFacets } from "../filterQuery";
+import { matchesFilterQuery, parseFilterQuery } from "../filterQuery";
+import { tableTokens, useDisplayOptions, useListKeys, useNow, useTableWindow } from "../hooks";
+import type { ChainListItem, RunState } from "../types";
+import {
+  Ago,
+  FilterInput,
+  GroupHeaderRow,
+  ListEmpty,
+  ListPane,
+  STATE_HUES,
+  StateBadge,
+  TableWindowFooter,
+  Th,
+  shortId,
+} from "../components/ui";
+
+const ACTIVE_STATES = new Set<RunState>(["QUEUED", "LEASED", "RUNNING", "VERIFYING"]);
+const FAILED_STATES = new Set<RunState>(["FAILED", "TIMED_OUT", "REFUSED"]);
+
+export type ChainStatus = "active" | "failed" | "completed" | "cancelled" | "no runs" | "other";
+
+export function chainHasState(chain: ChainListItem, states: ReadonlySet<RunState>): boolean {
+  return Object.entries(chain.states).some(([state, count]) => (count ?? 0) > 0 && states.has(state as RunState));
+}
+
+export function chainStatus(chain: ChainListItem): ChainStatus {
+  if (chainHasState(chain, FAILED_STATES)) return "failed";
+  if (chainHasState(chain, ACTIVE_STATES)) return "active";
+  if (chain.runCount === 0) return "no runs";
+  if ((chain.states.CANCELLED ?? 0) === chain.runCount) return "cancelled";
+  if ((chain.states.COMPLETED ?? 0) === chain.runCount) return "completed";
+  return "other";
+}
+
+const STATUS_HUES: Record<ChainStatus, string> = {
+  active: "var(--hue-info)",
+  failed: "var(--hue-err)",
+  completed: "var(--hue-ok)",
+  cancelled: "var(--hue-idle)",
+  "no runs": "var(--hue-idle)",
+  other: "var(--hue-warn)",
+};
+
+const CHAIN_FACETS: FilterFacets<ChainListItem> = {
+  fields: {
+    type: (chain) => chain.origin.type,
+    repo: (chain) => chain.repos,
+    state: (chain) => Object.keys(chain.states),
+    source: (chain) => chain.origin.source,
+    event: (chain) => chain.origin.eventId,
+    id: (chain) => chain.correlationId,
+  },
+  flags: {
+    active: {
+      help: "A chain with a queued or executing run.",
+      test: (chain) => chainHasState(chain, ACTIVE_STATES),
+    },
+    failed: {
+      help: "A chain with a failed, timed-out, or refused run.",
+      test: (chain) => chainHasState(chain, FAILED_STATES),
+    },
+  },
+  text: (chain) => [
+    chain.correlationId,
+    chain.origin.eventId,
+    chain.origin.type,
+    chain.origin.source,
+    chain.origin.subject,
+    ...chain.repos,
+    ...Object.keys(chain.states),
+  ],
+  values: {
+    state: ["queued", "leased", "running", "verifying", "completed", "failed", "timed_out", "refused", "cancelled"],
+  },
+};
+
+const CHAINS_DISPLAY: DisplayConfig<ChainListItem> = {
+  view: "chains",
+  groups: [
+    {
+      key: "status",
+      label: "Status",
+      get: chainStatus,
+      order: ["active", "failed", "other", "completed", "cancelled", "no runs"],
+      hue: STATUS_HUES,
+    },
+    { key: "type", label: "Origin type", get: (chain) => chain.origin.type },
+    { key: "repo", label: "Repo", get: (chain) => chain.repos.join(", ") || "unscoped" },
+  ],
+  subGroups: ["type", "repo", "status"],
+  sorts: [
+    { key: "origin", label: "Origin", get: (chain) => chain.origin.type, column: "origin" },
+    { key: "root", label: "Root event", get: (chain) => chain.origin.eventId, column: "root" },
+    { key: "depth", label: "Depth", get: (chain) => chain.maxDepth, defaultDir: "desc", column: "depth" },
+    { key: "events", label: "Events", get: (chain) => chain.eventCount, defaultDir: "desc", column: "events" },
+    { key: "runs", label: "Runs", get: (chain) => chain.runCount, defaultDir: "desc", column: "runs" },
+    { key: "status", label: "States", get: chainStatus, column: "states" },
+    { key: "activity", label: "Last activity", get: (chain) => chain.lastActivityAt, defaultDir: "desc", column: "activity" },
+    { key: "repo", label: "Repos", get: (chain) => chain.repos.join(", "), column: "repos" },
+  ],
+  columns: [
+    { key: "origin", label: "Origin", always: true },
+    { key: "root", label: "Root event" },
+    { key: "depth", label: "Depth" },
+    { key: "events", label: "Events" },
+    { key: "runs", label: "Runs" },
+    { key: "states", label: "States" },
+    { key: "activity", label: "Last activity" },
+    { key: "repos", label: "Repos" },
+  ],
+  defaults: { groupBy: "status", sortBy: "activity", sortDir: "desc" },
+};
+
+export function Chains({
+  context,
+  initialStateFilter,
+  onOpenChain,
+}: {
+  context: OperatorContext;
+  initialStateFilter?: string | null;
+  onOpenChain: (correlationId: string) => void;
+}) {
+  const now = useNow();
+  const [filter, setFilter] = useState(() => initialStateFilter ? `state:${initialStateFilter}` : "");
+  const [showSingles, setShowSingles] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const list = useQuery({
+    queryKey: ["chains", "24h", 100],
+    queryFn: () => api.chains("24h", 100),
+    refetchInterval: 3000,
+  });
+  const parsed = useMemo(() => parseFilterQuery(filter, CHAIN_FACETS), [filter]);
+  const scoped = useMemo(
+    () => (list.data?.chains ?? []).filter((chain) =>
+      matchesRepo(chain.repos, context) &&
+      (context.kind !== "inflight" || chainHasState(chain, ACTIVE_STATES)),
+    ),
+    [list.data, context],
+  );
+  const withoutSingles = useMemo(
+    () => showSingles ? scoped : scoped.filter((chain) => !chain.single),
+    [scoped, showSingles],
+  );
+  const visible = useMemo(
+    () => withoutSingles.filter((chain) => matchesFilterQuery(chain, parsed, CHAIN_FACETS, undefined)),
+    [withoutSingles, parsed],
+  );
+  const [display, setDisplay] = useDisplayOptions(CHAINS_DISPLAY);
+  const sections = useMemo(
+    () => buildSections(visible, CHAINS_DISPLAY, display),
+    [visible, display],
+  );
+  const flat = useMemo(() => flattenSections(sections, display.collapsed), [sections, display.collapsed]);
+  const cols = visibleColumns(CHAINS_DISPLAY, display);
+  const show = useMemo(() => new Set(cols.map((column) => column.key)), [cols]);
+  const tokens = tableTokens(sections, display.collapsed, grouped(display));
+  const [windowTokens, windowStart, windowEnd, moveWindow] = useTableWindow(
+    tokens,
+    selectedId,
+    (chain) => chain.correlationId,
+    JSON.stringify([filter, showSingles, context, display]),
+  );
+  const selectedIndex = flat.findIndex((chain) => chain.correlationId === selectedId);
+  useListKeys({
+    count: flat.length,
+    selected: selectedIndex,
+    onSelect: (index) => setSelectedId(flat[index]?.correlationId ?? null),
+    onOpen: () => selectedId && onOpenChain(selectedId),
+    onClose: () => filter ? setFilter("") : setSelectedId(null),
+  });
+
+  const hiddenSingles = scoped.filter((chain) => chain.single).length;
+  return (
+    <ListPane
+      chrome={
+        <>
+          <h1 className="display mb-1 text-lg font-semibold">Chains</h1>
+          <p className="mb-3 text-[11px] text-(--text-faint)">
+            Correlated event and run journeys with activity in the last 24 hours.
+          </p>
+          {context.kind === "repo" && (
+            <p className="mb-3 text-[11px] text-(--text-faint)">
+              Scoped to <span className="mono">{context.name}</span> — only chains naming this repo.
+            </p>
+          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              aria-pressed={showSingles}
+              onClick={() => setShowSingles((value) => !value)}
+              className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                showSingles ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:bg-(--surface-1)"
+              }`}
+            >
+              Single-event roots{hiddenSingles > 0 ? ` ${hiddenSingles}` : ""}
+            </button>
+            <span className="ml-auto">
+              <DisplayOptions config={CHAINS_DISPLAY} state={display} onChange={setDisplay} rows={scoped} />
+            </span>
+            <FilterInput
+              value={filter}
+              onChange={setFilter}
+              placeholder="type:… repo:… state:… is:active"
+              label="Filter chains"
+              query={parsed}
+              facets={CHAIN_FACETS}
+            />
+          </div>
+        </>
+      }
+    >
+      <table className="w-full table-fixed border-separate border-spacing-0">
+        <thead>
+          <tr className="text-left text-[11px] text-(--text-faint)">
+            {cols.map((column) => {
+              const sort = CHAINS_DISPLAY.sorts.find((item) => item.column === column.key);
+              const isCustom = column.isCustom || column.key.startsWith("custom:");
+              const path = column.key.replace(/^custom:/, "");
+              const current = isCustom ? display.sortBy === column.key : sort && display.sortBy === sort.key;
+              return (
+                <Th
+                  key={column.key}
+                  label={column.label}
+                  dir={current ? display.sortDir : null}
+                  naturalDir={sort?.defaultDir ?? "asc"}
+                  onSort={sort || isCustom ? () => setDisplay((state) => cycleColumnSort(CHAINS_DISPLAY, state, column.key)) : undefined}
+                  onRemove={isCustom ? () => setDisplay((state) => removeCustomColumn(state, path)) : undefined}
+                />
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {windowTokens.map((token) => {
+            if (token.length === 2) {
+              const [section, sub] = token;
+              return (
+                <GroupHeaderRow
+                  key={`group:${section.key}`}
+                  colSpan={cols.length}
+                  section={section}
+                  collapsed={display.collapsed.includes(section.key)}
+                  onToggle={() => setDisplay((state) => toggleCollapsed(state, section.key))}
+                  sub={sub}
+                />
+              );
+            }
+            const chain = token[0];
+            const selected = chain.correlationId === selectedId;
+            return (
+              <tr
+                key={chain.correlationId}
+                data-chain-id={chain.correlationId}
+                aria-selected={selected}
+                onClick={() => onOpenChain(chain.correlationId)}
+                className={`cursor-pointer hover:bg-(--surface-1) ${selected ? "row-selected" : ""}`}
+              >
+                <td className="max-w-56 border-b border-(--border) px-3 py-1.5">
+                  <div className="truncate text-(--text-dim)" title={chain.origin.type}>{chain.origin.type}</div>
+                  <div className="mono truncate text-[10px] text-(--text-faint)" title={chain.origin.source}>{chain.origin.source}</div>
+                </td>
+                {show.has("root") && (
+                  <td className="mono max-w-28 truncate border-b border-(--border) px-3 py-1.5" title={chain.origin.eventId}>
+                    {shortId(chain.origin.eventId)}
+                  </td>
+                )}
+                {show.has("depth") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.maxDepth}</td>}
+                {show.has("events") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.eventCount}</td>}
+                {show.has("runs") && <td className="border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">{chain.runCount}</td>}
+                {show.has("states") && (
+                  <td className="border-b border-(--border) px-3 py-1.5">
+                    <div className="flex flex-wrap gap-1">
+                      {Object.entries(chain.states).map(([state, count]) =>
+                        count ? <StateBadge key={state} state={`${state} ${count}`} hues={{ [`${state} ${count}`]: STATE_HUES[state] }} dot={false} /> : null,
+                      )}
+                      {chain.runCount === 0 && <span className="text-(--text-faint)">—</span>}
+                    </div>
+                  </td>
+                )}
+                {show.has("activity") && <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-faint)"><Ago iso={chain.lastActivityAt} now={now} /></td>}
+                {show.has("repos") && <td className="mono max-w-36 truncate border-b border-(--border) px-3 py-1.5 text-(--text-faint)" title={chain.repos.join(", ")}>{chain.repos.join(", ") || "—"}</td>}
+                {cols.filter((column) => column.isCustom || column.key.startsWith("custom:")).map((column) => (
+                  <CustomCell key={column.key} row={chain} path={column.key.replace(/^custom:/, "")} />
+                ))}
+              </tr>
+            );
+          })}
+          <TableWindowFooter colSpan={cols.length} range={[windowStart, windowEnd, tokens.length]} move={moveWindow} />
+          {visible.length === 0 && (
+            <ListEmpty
+              colSpan={cols.length}
+              query={list}
+              filtered={withoutSingles.length > 0}
+              onClear={filter ? () => setFilter("") : undefined}
+              noun="chains"
+              empty={context.kind === "repo" ? `No chains for ${context.name}.` : showSingles ? "No chains in the last 24 hours." : "No multi-step chains in the last 24 hours."}
+              escHint={Boolean(filter)}
+            />
+          )}
+        </tbody>
+      </table>
+    </ListPane>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GET /chains` recent-chain summaries with origins, depth/count/state tallies, activity, repos, and single-root detection
- add the `#/chains` grouped operator view with context scoping, display controls, filter tokens, keyboard navigation, and trace drill-in
- add endpoint/render/navigation coverage and document the new inventory
- skip the optional Overview tile because the current Overview layout has no cheap tile slot

## Verification
- `bun test event-runtime/lib/api-chain.test.mjs event-runtime/web/src && cd event-runtime/web && bun run build`
- 843 tests passed; TypeScript and Vite production build passed

UX critique: required — NOT-ASSESSED; isolated Chromium exited before DevTools became available, so the verified implementation remains draft pending browser review.

Fixes WM-537