### PR TITLE
fix(event-runtime-web): guard partial query data

### DIFF
--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -65,7 +65,7 @@ function renderApp() {
   // Scope queries to the sidebar landmark: views render their own controls
   // (Overview has a "Graph" button too) and must not satisfy nav assertions.
   const sidebar = within(utils.getByRole("navigation", { name: "Primary" }));
-  return { ...utils, sidebar };
+  return { ...utils, sidebar, queryClient };
 }
 
 beforeEach(() => {
@@ -124,6 +124,26 @@ afterEach(() => {
   goPrefix.armedAt = 0;
   cleanup();
   globalThis.fetch = realFetch;
+});
+
+describe("cold query rendering (WM-266)", () => {
+  test("keeps the shell available before the initial status query resolves", () => {
+    const { sidebar } = renderApp();
+    expect(sidebar.getByRole("button", { name: "Overview" })).toBeTruthy();
+  });
+
+  test("treats missing nested status sections as empty badge data", async () => {
+    currentStatus = {} as StatusView;
+    const { sidebar, queryClient } = renderApp();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["status"])?.status).toBe("success");
+    });
+
+    expect(sidebar.getByRole("button", { name: "Proposals" })).toBeTruthy();
+    expect(sidebar.getByRole("button", { name: "Runs" })).toBeTruthy();
+    expect(sidebar.getByRole("button", { name: "Artifacts" })).toBeTruthy();
+  });
 });
 
 describe("sidebar navigation accessibility", () => {

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -353,20 +353,20 @@ export function App() {
     queryFn: api.status,
     ...refetchIntervals.primary,
   });
-  const openProposals = status.data?.proposals.open ?? 0;
-  const activeRuns = Object.entries(status.data?.runs.byState ?? {})
+  const openProposals = status.data?.proposals?.open ?? 0;
+  const activeRuns = Object.entries(status.data?.runs?.byState ?? {})
     .filter(([s]) => ["QUEUED", "LEASED", "RUNNING", "VERIFYING"].includes(s))
     .reduce((sum, [, n]) => sum + (n ?? 0), 0);
   const eventAttention =
-    (status.data?.events.human_needed ?? 0) +
-    (status.data?.events.dead_lettered ?? 0);
+    (status.data?.events?.human_needed ?? 0) +
+    (status.data?.events?.dead_lettered ?? 0);
   const scopedNav = context.kind === "repo";
   const scopedRunsNav = context.kind !== "all";
-  const busyWorkers = status.data?.workers.busy ?? 0;
-  const staleWorkers = status.data?.workers.stale ?? 0;
+  const busyWorkers = status.data?.workers?.busy ?? 0;
+  const staleWorkers = status.data?.workers?.stale ?? 0;
   // null until the first status lands: reading "no workers" off a pending
   // fetch is the same false alarm as flashing "unreachable" on first load.
-  const liveWorkers = status.data?.workers.live ?? null;
+  const liveWorkers = status.data?.workers?.live ?? null;
   const stoppedSchedulesCount = (
     (status.data?.anomalies as any)?.stoppedSchedules ?? []
   ).length;
@@ -392,9 +392,9 @@ export function App() {
     projects: { count: 0, hue: "var(--accent)" },
     agents: { count: 0, hue: "var(--accent)" },
     artifacts: {
-      count: status.data?.artifacts.orphans ?? 0,
+      count: status.data?.artifacts?.orphans ?? 0,
       hue: "var(--hue-warn)",
-      title: `${status.data?.artifacts.orphans ?? 0} orphan artifact${status.data?.artifacts.orphans === 1 ? "" : "s"} (unreferenced)`,
+      title: `${status.data?.artifacts?.orphans ?? 0} orphan artifact${status.data?.artifacts?.orphans === 1 ? "" : "s"} (unreferenced)`,
     },
     schedules:
       stoppedSchedulesCount > 0

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -46,7 +46,7 @@ const COMMON_KINDS = ["report", "log", "transcript", "ci-log"];
 function kindsOf(artifact: ArtifactInventoryItem): string[] {
   return [
     ...new Set(
-      artifact.references.flatMap((reference) => reference.kind ?? []),
+      (artifact.references ?? []).flatMap((reference) => reference.kind ?? []),
     ),
   ];
 }
@@ -84,7 +84,9 @@ const ARTIFACTS_DISPLAY: DisplayConfig<ArtifactInventoryItem> = {
       key: "references",
       label: "Referenced by",
       get: (artifact) =>
-        artifact.references.map((reference) => reference.runId).join(", "),
+        (artifact.references ?? [])
+          .map((reference) => reference.runId)
+          .join(", "),
       column: "references",
     },
   ],
@@ -106,7 +108,7 @@ function matchesSearch(
   if (!term) return true;
   return [
     artifact.sha256,
-    ...artifact.references.flatMap((reference) => [
+    ...(artifact.references ?? []).flatMap((reference) => [
       reference.runId,
       reference.kind,
       reference.agent,
@@ -330,7 +332,9 @@ export function Artifacts({
   const linkedEvents = (eventsQ.data?.events ?? []) as LinkedEvent[];
   const producerRunIds = useMemo(
     () =>
-      new Set(selected?.references.map((reference) => reference.runId) ?? []),
+      new Set(
+        selected?.references?.map((reference) => reference.runId) ?? [],
+      ),
     [selected],
   );
   const consumers = useMemo(
@@ -368,7 +372,7 @@ export function Artifacts({
   const producerAgent: AgentDef | undefined = useMemo(() => {
     const refs =
       selected?.references
-        .map((reference) => reference.agent)
+        ?.map((reference) => reference.agent)
         .filter(Boolean) ?? [];
     const defs = agentsQ.data?.agents ?? [];
     for (const ref of refs) {
@@ -410,7 +414,13 @@ export function Artifacts({
     }),
     [artifacts],
   );
-  const summary: StatusView["artifacts"] = metrics ?? fallbackMetrics;
+  const summary: StatusView["artifacts"] = {
+    files: metrics?.files ?? fallbackMetrics.files,
+    bytes: metrics?.bytes ?? fallbackMetrics.bytes,
+    orphans: metrics?.orphans ?? fallbackMetrics.orphans,
+    orphanBytes: metrics?.orphanBytes ?? fallbackMetrics.orphanBytes,
+    at: metrics?.at,
+  };
   const filtered = Boolean(
     filters.kind || filters.orphan != null || filters.search.trim(),
   );
@@ -664,9 +674,9 @@ export function Artifacts({
                   )}
                   {shown.has("references") && (
                     <td className="border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
-                      {artifact.references.length > 0 ? (
+                      {(artifact.references?.length ?? 0) > 0 ? (
                         <div className="flex flex-nowrap gap-2">
-                          {artifact.references.map((reference) => (
+                          {(artifact.references ?? []).map((reference) => (
                             <JumpLink
                               key={`${reference.runId}:${reference.kind ?? "unknown"}`}
                               onClick={() => onJumpRun(reference.runId)}
@@ -822,7 +832,7 @@ export function Artifacts({
                       Producing runs
                     </div>
                     <div className="mt-1.5 flex flex-wrap gap-2">
-                      {selected.references.length ? (
+                      {selected.references?.length ? (
                         selected.references.map((reference) => (
                           <JumpLink
                             key={`${reference.runId}:${reference.kind ?? "unknown"}`}

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -332,9 +332,7 @@ export function Artifacts({
   const linkedEvents = (eventsQ.data?.events ?? []) as LinkedEvent[];
   const producerRunIds = useMemo(
     () =>
-      new Set(
-        selected?.references?.map((reference) => reference.runId) ?? [],
-      ),
+      new Set(selected?.references?.map((reference) => reference.runId) ?? []),
     [selected],
   );
   const consumers = useMemo(

--- a/event-runtime/web/src/views/Graph.tsx
+++ b/event-runtime/web/src/views/Graph.tsx
@@ -316,7 +316,7 @@ export function Graph({
   const staleFocus = missingFocusNode(graph?.nodes, focusNodeId, graphLoaded);
   const agentDef =
     selected?.kind === "agent"
-      ? registry.data?.agents.find((a) => a.ref === selected.label)
+      ? registry.data?.agents?.find((a) => a.ref === selected.label)
       : undefined;
 
   const pendingC = useRef<number>(0);

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -1219,20 +1219,17 @@ describe("buildAnomalyRows (WM-205)", () => {
 
 describe("Overview 4-Band layout & telemetry (WM-205)", () => {
   test("renders empty stage fallbacks for a partial cold status response (WM-266)", async () => {
-    await withApi(
-      { status: async () => ({}) as StatusView },
-      async () => {
-        const r = renderOverview();
+    await withApi({ status: async () => ({}) as StatusView }, async () => {
+      const r = renderOverview();
 
-        await waitFor(() => {
-          expect(r.getByText("Worker Fleet Capacity")).toBeTruthy();
-        });
-        expect(r.getByText("no events yet")).toBeTruthy();
-        expect(r.getByText("nothing in flight")).toBeTruthy();
-        expect(r.getAllByText("no terminal runs").length).toBeGreaterThan(0);
-        expect(r.container.textContent).toContain("0 files");
-      },
-    );
+      await waitFor(() => {
+        expect(r.getByText("Worker Fleet Capacity")).toBeTruthy();
+      });
+      expect(r.getByText("no events yet")).toBeTruthy();
+      expect(r.getByText("nothing in flight")).toBeTruthy();
+      expect(r.getAllByText("no terminal runs").length).toBeGreaterThan(0);
+      expect(r.container.textContent).toContain("0 files");
+    });
   });
 
   test("renders nominal status banner when no anomalies are present", async () => {

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -20,7 +20,7 @@ import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
-import { changeInput } from "../test-render";
+import { changeInput, withApi } from "../test-render";
 import type {
   AdmittedEvent,
   EventFocus,
@@ -1218,6 +1218,23 @@ describe("buildAnomalyRows (WM-205)", () => {
 });
 
 describe("Overview 4-Band layout & telemetry (WM-205)", () => {
+  test("renders empty stage fallbacks for a partial cold status response (WM-266)", async () => {
+    await withApi(
+      { status: async () => ({}) as StatusView },
+      async () => {
+        const r = renderOverview();
+
+        await waitFor(() => {
+          expect(r.getByText("Worker Fleet Capacity")).toBeTruthy();
+        });
+        expect(r.getByText("no events yet")).toBeTruthy();
+        expect(r.getByText("nothing in flight")).toBeTruthy();
+        expect(r.getAllByText("no terminal runs").length).toBeGreaterThan(0);
+        expect(r.container.textContent).toContain("0 files");
+      },
+    );
+  });
+
   test("renders nominal status banner when no anomalies are present", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -760,7 +760,9 @@ const ATTENTION_KEYS = new Set([
 ]);
 
 /** Keep a resolved-but-partial status response on the same safe fallback path as an empty cache. */
-function normalizeStatus(status: StatusView | undefined): StatusView | undefined {
+function normalizeStatus(
+  status: StatusView | undefined,
+): StatusView | undefined {
   if (!status) return undefined;
   return {
     ...status,
@@ -992,7 +994,7 @@ export function Overview({
     reject.mutate({ proposalId: rejectingProposalId, why: rejectReason });
   };
 
-  const s = normalizeStatus(status.data);
+  const s = useMemo(() => normalizeStatus(status.data), [status.data]);
   const anomalies = s?.anomalies;
   const proposalsById = useMemo(() => {
     return new Map<string, Proposal>(
@@ -1206,7 +1208,7 @@ export function Overview({
     (s?.workers?.live ?? 0) - (s?.workers?.busy ?? 0),
   );
   const capacity = s
-    ? ({
+    ? {
         running: s.workers.busy,
         capacity: s.workers.live,
         queued: s.runs.byState.QUEUED ?? 0,
@@ -1221,7 +1223,7 @@ export function Overview({
         limitingFactor: null,
         ...(s.capacity ?? {}),
         classes: s.capacity?.classes ?? [],
-      })
+      }
     : null;
   const jumpToWorkerHealth = (health: WorkerHealthFilter) => {
     if (onJumpWorkers) onJumpWorkers(health);

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -588,10 +588,10 @@ export function buildAnomalyRows(
       ],
     });
   }
-  if (anomalies.noWorkers && (s?.runs.byState?.QUEUED ?? 0) > 0) {
+  if (anomalies.noWorkers && (s?.runs?.byState?.QUEUED ?? 0) > 0) {
     rows.push({
       kind: "capacity",
-      text: `${s?.runs.byState?.QUEUED ?? 0} queued runs and no live worker available to claim them`,
+      text: `${s?.runs?.byState?.QUEUED ?? 0} queued runs and no live worker available to claim them`,
       links: [
         { label: "View workers", go: () => callbacks.onNavigate("workers") },
       ],
@@ -758,6 +758,48 @@ const ATTENTION_KEYS = new Set([
   "expired",
   "stale",
 ]);
+
+/** Keep a resolved-but-partial status response on the same safe fallback path as an empty cache. */
+function normalizeStatus(status: StatusView | undefined): StatusView | undefined {
+  if (!status) return undefined;
+  return {
+    ...status,
+    env: status.env ?? { name: "unknown", home: "", adapter: null },
+    events: status.events ?? {},
+    proposals: status.proposals ?? { open: 0, expired: 0 },
+    runs: { ...(status.runs ?? {}), byState: status.runs?.byState ?? {} },
+    workers: {
+      ...(status.workers ?? {}),
+      live: status.workers?.live ?? 0,
+      busy: status.workers?.busy ?? 0,
+      stale: status.workers?.stale ?? 0,
+    },
+    artifacts: {
+      ...(status.artifacts ?? {}),
+      files: status.artifacts?.files ?? 0,
+      bytes: status.artifacts?.bytes ?? 0,
+      orphans: status.artifacts?.orphans ?? 0,
+      orphanBytes: status.artifacts?.orphanBytes ?? 0,
+    },
+    anomalies: {
+      ...(status.anomalies ?? {}),
+      expiredOpenProposals: status.anomalies?.expiredOpenProposals ?? [],
+      staleLeases: status.anomalies?.staleLeases ?? 0,
+      unpublishedOutbox: status.anomalies?.unpublishedOutbox ?? 0,
+      deadLettered: status.anomalies?.deadLettered ?? [],
+      stalledWorkers: status.anomalies?.stalledWorkers ?? [],
+      noWorkers: status.anomalies?.noWorkers ?? false,
+      ambiguousOpenProposals: status.anomalies?.ambiguousOpenProposals ?? [],
+    },
+    inbox: status.inbox
+      ? {
+          ...status.inbox,
+          open: status.inbox.open ?? 0,
+          acked: status.inbox.acked ?? 0,
+        }
+      : undefined,
+  };
+}
 
 /**
  * Overview (webui spec §4.1 + doc §10.4, pipeline OPS-360, WM-205) — the unified StageCard dashboard:
@@ -950,7 +992,7 @@ export function Overview({
     reject.mutate({ proposalId: rejectingProposalId, why: rejectReason });
   };
 
-  const s = status.data;
+  const s = normalizeStatus(status.data);
   const anomalies = s?.anomalies;
   const proposalsById = useMemo(() => {
     return new Map<string, Proposal>(
@@ -985,7 +1027,7 @@ export function Overview({
   ]);
 
   const hasAnomalies = anomalyRows.length > 0;
-  const deadLetterEventCount = anomalies?.deadLettered.length ?? 0;
+  const deadLetterEventCount = anomalies?.deadLettered?.length ?? 0;
   const anomalyRowRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   const deadLetterGroupKey = (group: DeadLetterGroup) =>
@@ -1091,7 +1133,7 @@ export function Overview({
   const proposalOpen =
     context.kind === "repo"
       ? scopedCount(openProposals, context, { repos: (p) => p.repos })
-      : (s?.proposals.open ?? 0);
+      : (s?.proposals?.open ?? 0);
   const proposalExpired =
     context.kind === "repo"
       ? scopedCount(
@@ -1099,11 +1141,11 @@ export function Overview({
           context,
           { repos: (p) => p.repos },
         )
-      : (s?.proposals.expired ?? 0);
+      : (s?.proposals?.expired ?? 0);
   const eventValue = (k: string, factory: number) =>
     eventTally ? (eventTally[k] ?? 0) : factory;
   const runValue = (k: RunState) =>
-    runTally ? (runTally[k] ?? 0) : (s?.runs.byState[k] ?? 0);
+    runTally ? (runTally[k] ?? 0) : (s?.runs?.byState?.[k] ?? 0);
 
   const groupedFeed = useMemo(
     () => groupJournalEntries(feed.entries),
@@ -1126,7 +1168,7 @@ export function Overview({
   const eventSegs: Segment[] = activeEventKeys.map((k) => ({
     key: k,
     label: k,
-    value: eventValue(k, s?.events[k] ?? 0),
+    value: eventValue(k, s?.events?.[k] ?? 0),
     hue: EVENT_STATUS_HUES[k],
   }));
   const intakeTotal = eventSegs.reduce((a, x) => a + x.value, 0);
@@ -1161,10 +1203,10 @@ export function Overview({
   const okTotal = terminalSegs.find((x) => x.key === "COMPLETED")?.value ?? 0;
   const idleWorkers = Math.max(
     0,
-    (s?.workers.live ?? 0) - (s?.workers.busy ?? 0),
+    (s?.workers?.live ?? 0) - (s?.workers?.busy ?? 0),
   );
   const capacity = s
-    ? (s.capacity ?? {
+    ? ({
         running: s.workers.busy,
         capacity: s.workers.live,
         queued: s.runs.byState.QUEUED ?? 0,
@@ -1177,7 +1219,8 @@ export function Overview({
         supervisor: "absent" as const,
         source: "live-workers" as const,
         limitingFactor: null,
-        classes: [],
+        ...(s.capacity ?? {}),
+        classes: s.capacity?.classes ?? [],
       })
     : null;
   const jumpToWorkerHealth = (health: WorkerHealthFilter) => {

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -143,6 +143,23 @@ describe("Projects unscoped caption (WM-157)", () => {
 });
 
 describe("Projects Clean Reclaimable Apply (WM-157)", () => {
+  test("normalizes a partial janitor result before rendering counts (WM-266)", async () => {
+    await withApi(
+      {
+        repos: async () => ({ repos: [repo()] }),
+        janitor: async (name: string) => ({ repo: name, apply: false, actor: "janitor" }) as JanitorResult,
+      },
+      async () => {
+        const r = await openJanitor();
+        fireEvent.click(r.getByRole("button", { name: "Run Dry Janitor" }));
+        await waitFor(() => {
+          expect(r.getByText("0 reclaimable")).toBeTruthy();
+        });
+        expect(r.getByText("Nothing to reclaim")).toBeTruthy();
+      },
+    );
+  });
+
   test("Apply stays disabled and confirm does not open when dry found nothing", async () => {
     await withApi(
       {

--- a/event-runtime/web/src/views/Projects.test.tsx
+++ b/event-runtime/web/src/views/Projects.test.tsx
@@ -147,7 +147,8 @@ describe("Projects Clean Reclaimable Apply (WM-157)", () => {
     await withApi(
       {
         repos: async () => ({ repos: [repo()] }),
-        janitor: async (name: string) => ({ repo: name, apply: false, actor: "janitor" }) as JanitorResult,
+        janitor: async (name: string) =>
+          ({ repo: name, apply: false, actor: "janitor" }) as JanitorResult,
       },
       async () => {
         const r = await openJanitor();

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -307,7 +307,9 @@ export function Projects({
       setConfirmOpen(false);
       setConfirmInput("");
       queryClient.invalidateQueries({ queryKey: ["repos"] });
-      notify(`Cleaned ${normalized.removed.length} worktrees for ${normalized.repo}`);
+      notify(
+        `Cleaned ${normalized.removed.length} worktrees for ${normalized.repo}`,
+      );
     },
     onError: (err: ApiError) => {
       notify(`Janitor apply failed: ${err.message}`, "err");

--- a/event-runtime/web/src/views/Projects.tsx
+++ b/event-runtime/web/src/views/Projects.tsx
@@ -59,6 +59,20 @@ const defaultProjectOrder = (a: RepoItem, b: RepoItem) =>
     sensitivity: "base",
   });
 
+/** API clients can briefly expose a partial mutation result while caches update. */
+function normalizeJanitorResult(result: JanitorResult): JanitorResult {
+  return {
+    ...result,
+    reclaimable: result.reclaimable ?? [],
+    kept: result.kept ?? [],
+    named: result.named ?? [],
+    unknown: result.unknown ?? [],
+    removed: result.removed ?? [],
+    refused: result.refused ?? [],
+    held: result.held ?? [],
+  };
+}
+
 const PROJECTS_SORT: DisplayConfig<RepoItem> = {
   view: "projects-table-sort",
   groups: [],
@@ -272,10 +286,11 @@ export function Projects({
   const dryMutation = useMutation({
     mutationFn: (name: string) => api.janitor(name, false),
     onSuccess: (res) => {
-      setDryResult(res);
+      const normalized = normalizeJanitorResult(res);
+      setDryResult(normalized);
       setApplyResult(null);
       notify(
-        `Dry run complete: ${res.reclaimable.length} reclaimable worktrees found`,
+        `Dry run complete: ${normalized.reclaimable.length} reclaimable worktrees found`,
       );
     },
     onError: (err: ApiError) => {
@@ -287,11 +302,12 @@ export function Projects({
   const applyMutation = useMutation({
     mutationFn: (name: string) => api.janitor(name, true),
     onSuccess: (res) => {
-      setApplyResult(res);
+      const normalized = normalizeJanitorResult(res);
+      setApplyResult(normalized);
       setConfirmOpen(false);
       setConfirmInput("");
       queryClient.invalidateQueries({ queryKey: ["repos"] });
-      notify(`Cleaned ${res.removed.length} worktrees for ${res.repo}`);
+      notify(`Cleaned ${normalized.removed.length} worktrees for ${normalized.repo}`);
     },
     onError: (err: ApiError) => {
       notify(`Janitor apply failed: ${err.message}`, "err");
@@ -887,7 +903,7 @@ export function Projects({
                       (sel.reportOnly && !sel.hasWorktreeDown)
                     }
                     onClick={() => {
-                      if (!dryResult?.reclaimable.length) return;
+                      if (!dryResult?.reclaimable?.length) return;
                       setConfirmInput("");
                       setConfirmOpen(true);
                     }}
@@ -1154,7 +1170,7 @@ export function Projects({
         </DetailPane>
       )}
 
-      {confirmOpen && sel && (dryResult?.reclaimable.length ?? 0) > 0 && (
+      {confirmOpen && sel && (dryResult?.reclaimable?.length ?? 0) > 0 && (
         <Dialog
           title={`Clean Worktrees for ${sel.name}`}
           onClose={() => {
@@ -1170,7 +1186,7 @@ export function Projects({
               </code>{" "}
               on{" "}
               <strong>
-                {dryResult?.reclaimable.length ?? 0} reclaimable worktrees
+                {dryResult?.reclaimable?.length ?? 0} reclaimable worktrees
               </strong>
               . Worktrees with uncommitted changes will be safely refused.
             </div>

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1815,7 +1815,7 @@ export function Proposals({
                 <KV k="adapter" v={p.spec?.adapter} />
                 <KV
                   k="capabilities"
-                  v={p.spec?.capabilities.join(", ") || "none"}
+                  v={p.spec?.capabilities?.join(", ") || "none"}
                 />
                 <KV k="timeout" v={`${p.spec?.timeoutSeconds}s`} />
                 <KV k="attempts" v={String(p.spec?.maxAttempts)} />

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -37,17 +37,16 @@ function renderRunFull(runId: string, connected = true) {
 
 describe("RunFull layout (WM-194)", () => {
   test("keeps the loading fallback when run detail resolves without a run (WM-266)", async () => {
-    await withApi(
-      { run: async () => ({}) as RunDetail },
-      async () => {
-        const r = renderRunFull("run_partial_detail");
+    await withApi({ run: async () => ({}) as RunDetail }, async () => {
+      const r = renderRunFull("run_partial_detail");
 
-        await waitFor(() => {
-          expect(r.queryClient.getQueryState(["run", "run_partial_detail"])?.status).toBe("success");
-        });
-        expect(r.getByText("Loading run…")).toBeTruthy();
-      },
-    );
+      await waitFor(() => {
+        expect(
+          r.queryClient.getQueryState(["run", "run_partial_detail"])?.status,
+        ).toBe("success");
+      });
+      expect(r.getByText("Loading run…")).toBeTruthy();
+    });
   });
 
   test("centers the capped trace container on wide viewports", async () => {

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -36,6 +36,20 @@ function renderRunFull(runId: string, connected = true) {
 }
 
 describe("RunFull layout (WM-194)", () => {
+  test("keeps the loading fallback when run detail resolves without a run (WM-266)", async () => {
+    await withApi(
+      { run: async () => ({}) as RunDetail },
+      async () => {
+        const r = renderRunFull("run_partial_detail");
+
+        await waitFor(() => {
+          expect(r.queryClient.getQueryState(["run", "run_partial_detail"])?.status).toBe("success");
+        });
+        expect(r.getByText("Loading run…")).toBeTruthy();
+      },
+    );
+  });
+
   test("centers the capped trace container on wide viewports", async () => {
     const runId = "run_centered_trace";
     const detail = createRunDetailFixture({

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -208,9 +208,9 @@ export function RunFull({
 
   const canApprove = Boolean(
     selProposal &&
-      selProposal.status === "open" &&
-      selProposal.decision === "run" &&
-      d?.run?.state === "PROPOSED",
+    selProposal.status === "open" &&
+    selProposal.decision === "run" &&
+    d?.run?.state === "PROPOSED",
   );
 
   // Verbs: Esc back to list, x cancel, c copy id, c i / c c copy CLI inspect command, c l copy link.

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -118,7 +118,10 @@ export function RunFull({
     return map;
   }, [listQ.data]);
 
-  const d = detail.data;
+  // A query can resolve with a partial payload while caches hydrate. Treat a
+  // detail without its root run as unpopulated so every guarded d.run access
+  // below stays on the loading/fallback path.
+  const d = detail.data?.run ? detail.data : undefined;
   const attemptsExhausted = d
     ? d.run.attempts >= d.run.spec.maxAttempts
     : false;
@@ -205,9 +208,9 @@ export function RunFull({
 
   const canApprove = Boolean(
     selProposal &&
-    selProposal.status === "open" &&
-    selProposal.decision === "run" &&
-    d?.run.state === "PROPOSED",
+      selProposal.status === "open" &&
+      selProposal.decision === "run" &&
+      d?.run?.state === "PROPOSED",
   );
 
   // Verbs: Esc back to list, x cancel, c copy id, c i / c c copy CLI inspect command, c l copy link.
@@ -334,8 +337,8 @@ export function RunFull({
     return () => setContextActions([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    d?.run.runId,
-    d?.run.state,
+    d?.run?.runId,
+    d?.run?.state,
     attemptsExhausted,
     connected,
     canApprove,

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -738,9 +738,9 @@ export function Runs({
 
   const canApprove = Boolean(
     selProposal &&
-      selProposal.status === "open" &&
-      selProposal.decision === "run" &&
-      (sel?.state === "PROPOSED" || d?.run?.state === "PROPOSED"),
+    selProposal.status === "open" &&
+    selProposal.decision === "run" &&
+    (sel?.state === "PROPOSED" || d?.run?.state === "PROPOSED"),
   );
 
   const pendingC = useRef<number>(0);

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -460,7 +460,7 @@ export function Runs({
   const staleRuns = useMemo(
     () =>
       new Set(
-        (statusQ.data?.anomalies.stalledWorkers ?? []).map((w) => w.runId),
+        (statusQ.data?.anomalies?.stalledWorkers ?? []).map((w) => w.runId),
       ),
     [statusQ.data],
   );
@@ -684,7 +684,7 @@ export function Runs({
     },
   });
 
-  const byState = statusQ.data?.runs.byState ?? {};
+  const byState = statusQ.data?.runs?.byState ?? {};
   const tabCount = (t: RunTab) => {
     if (fetchAll) {
       return t === "ALL"
@@ -717,7 +717,10 @@ export function Runs({
   };
   useTabKeys(RUN_TABS, tab, selectTab);
 
-  const d = detail.data;
+  // A query can resolve with a partial payload while caches hydrate. Treat a
+  // detail without its root run as unpopulated so every guarded d.run access
+  // below stays on the loading/fallback path.
+  const d = detail.data?.run ? detail.data : undefined;
   const attemptsExhausted = d
     ? d.run.attempts >= d.run.spec.maxAttempts
     : false;
@@ -725,19 +728,19 @@ export function Runs({
   const selProposal = useMemo(() => {
     if (sel?.runId && proposalByRunId.has(sel.runId))
       return proposalByRunId.get(sel.runId)!;
-    if (d?.run.runId && proposalByRunId.has(d.run.runId))
+    if (d?.run?.runId && proposalByRunId.has(d.run.runId))
       return proposalByRunId.get(d.run.runId)!;
     return null;
-  }, [sel?.runId, d?.run.runId, proposalByRunId]);
+  }, [sel?.runId, d?.run?.runId, proposalByRunId]);
 
   /** Agent behind the selected proposal — drives the approve dialog's risk card. */
   const approveAgent = useProposalAgent(selProposal);
 
   const canApprove = Boolean(
     selProposal &&
-    selProposal.status === "open" &&
-    selProposal.decision === "run" &&
-    (sel?.state === "PROPOSED" || d?.run.state === "PROPOSED"),
+      selProposal.status === "open" &&
+      selProposal.decision === "run" &&
+      (sel?.state === "PROPOSED" || d?.run?.state === "PROPOSED"),
   );
 
   const pendingC = useRef<number>(0);
@@ -908,8 +911,8 @@ export function Runs({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     sel?.runId,
-    d?.run.runId,
-    d?.run.state,
+    d?.run?.runId,
+    d?.run?.state,
     attemptsExhausted,
     connected,
     canApprove,


### PR DESCRIPTION
## Summary
- make nested React Query status/detail reads safe during pending and partial hydration
- normalize Overview, janitor, and artifact fallbacks before rendering
- add cold/partial response regression coverage for App, Overview, Projects, and RunFull

## Verification
- `bun test event-runtime/web` — 847 pass, 0 fail
- `cd event-runtime/web && bunx tsc --noEmit` — pass
- `cd event-runtime/web && bun run build` — pass

UX critique: required — NOT-ASSESSED; isolated Chromium exited before DevTools became available on both review attempts. PR intentionally remains draft.

Fixes WM-266