### PR TITLE
feat(event-runtime): carry decisions in inbox (WM-390)

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -881,6 +881,9 @@ inbox ledger (WM-285) carries typed decision requests and responses for that —
 agent-authored within a closed vocabulary, rendered generically, applied
 through runtime-owned effects. Design of record:
 [event-runtime-inbox.md](event-runtime-inbox.md).
+The control API exposes `GET /inbox/:id` plus `POST /inbox/:id/decide` and
+`POST /inbox/:id/decide/retry` for reading, answering, and retrying those
+requests.
 
 **What the operator sees.** The full `RunSpec`, plus the planner's evidence:
 the admitted event, the authoritative-state read that produced the proposal and
@@ -931,6 +934,9 @@ lifecycle transitions with the operator as actor:
   same admitted event, a fresh planning pass against current state. Replay is
   for a fixed _event body_; requeue is for a fixed _world_ — after a registry
   or planner fix, the stored event is fine and only the decision was wrong.
+- **decide** — answer an inbox item's hash-bound request through `POST
+  /inbox/:id/decide`; retry a stored response's failed effect through `POST
+  /inbox/:id/decide/retry` without asking for the fields again.
 
 **Dead-lettering.** An event that fails planning repeatedly (default: 3
 attempts) parks as dead-lettered with its last error, visible in status and

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env bun
 /** Event-runtime CLI argument routing and command dispatch. */
 import { COMMANDS } from "./cli/commands.mjs";
-import { USAGE } from "./cli/usage.mjs";
+import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
+import { API_HOST, DEFAULT_PORT } from "./lib/config.mjs";
+import { decisionRequestHash } from "./lib/decision.mjs";
+
+const USAGE = BASE_USAGE.replace(
+  "  inbox                          open items waiting on the human",
+  "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API",
+);
 
 // Preserve the small programmatic surface used by runtime tests and tooling.
 export {
@@ -23,8 +30,100 @@ export {
 } from "./cli/supervise.mjs";
 export { COMMAND_NAMES, COMMANDS } from "./cli/commands.mjs";
 
+function controlUrl(pathname) {
+  const port = Number(process.env.FACTORY_EVENT_PORT ?? DEFAULT_PORT);
+  return `http://${API_HOST}:${port}${pathname}`;
+}
+
+async function callControl(method, pathname, body) {
+  const res = await fetch(controlUrl(pathname), {
+    method,
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const payload = await res.json().catch(() => null);
+  if (!res.ok) {
+    const err = new Error(payload?.message ?? payload?.error ?? `HTTP ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+  return payload;
+}
+
+/** Owned-path override of the split inbox command, adding decision markers. */
+export async function inboxCommand() {
+  const body = await callControl("GET", "/inbox?status=open");
+  if (body.items.length === 0) {
+    console.log("no open inbox items");
+    return;
+  }
+  console.log("ID\tKIND\tSEVERITY\tCREATED\tTITLE");
+  for (const item of body.items) {
+    const marker = item.decision && !item.response ? "? " : "";
+    console.log(
+      `${item.id}\t${item.kind}\t${item.severity}\t${item.createdAt}\t${marker}${item.title}`,
+    );
+  }
+}
+
+function parseDecisionField(field, raw) {
+  if (field?.kind === "multi-choice") return raw === "" ? [] : raw.split(",");
+  if (field?.kind === "confirm") {
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+  }
+  if (field?.kind === "number") {
+    const number = Number(raw);
+    if (raw.trim() !== "" && Number.isFinite(number)) return number;
+  }
+  return raw;
+}
+
+export async function decideCommand(args) {
+  const [itemId, optionId, ...rest] = args;
+  if (!itemId || !optionId) {
+    throw new Error("usage: decide <item-id> <option-id> [--field key=value]...");
+  }
+  const detail = await callControl(
+    "GET",
+    `/inbox/${encodeURIComponent(itemId)}`,
+  );
+  if (!detail.item.decision) throw new Error(`inbox item ${itemId} has no decision`);
+  const declared = new Map(
+    (detail.item.decision.fields ?? []).map((field) => [field.id, field]),
+  );
+  const fields = {};
+  for (let index = 0; index < rest.length; index++) {
+    if (rest[index] !== "--field" || !rest[index + 1]) {
+      throw new Error(`unexpected decide argument: ${rest[index]}`);
+    }
+    const assignment = rest[++index];
+    const equals = assignment.indexOf("=");
+    if (equals <= 0) throw new Error(`--field expects key=value, got ${assignment}`);
+    const key = assignment.slice(0, equals);
+    const raw = assignment.slice(equals + 1);
+    fields[key] = parseDecisionField(declared.get(key), raw);
+  }
+  const result = await callControl(
+    "POST",
+    `/inbox/${encodeURIComponent(itemId)}/decide`,
+    {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(detail.item.decision),
+      optionId,
+      fields,
+    },
+  );
+  console.log(
+    `${result.item.id}: ${result.effect.kind} ${result.effect.outcome}`,
+  );
+  return result;
+}
+
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
+  if (command === "decide") return decideCommand(args);
+  if (command === "inbox") return inboxCommand(args);
   if (!Object.hasOwn(COMMANDS, command)) {
     console.error(USAGE);
     process.exit(1);

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -190,11 +190,17 @@ export async function runNotifierDeliveryCase({
     writeFileSync(releaseFile, "release\n");
     const delivery = await awaitNotifierDelivery(db, "test/evt-tick");
     deliverySettled = true;
-    expect(readFileSync(outFile, "utf8").trim()).toBe(
+    // The parked-event projection carries its decision question and options
+    // (WM-390), so one delivery is a four-line message.
+    const expectedMessage = [
       "BLOCKED linear.ticket.agent_ready evt-tick: no_worktree_scripts",
-    );
+      "Should this parked event be requeued?",
+      "1. Requeue the event",
+      "2. Not now",
+    ].join("\n");
+    expect(readFileSync(outFile, "utf8").trim()).toBe(expectedMessage);
     expect(
-      logs.some((l) => l.includes("notify human_needed test/evt-tick")),
+      logs.some((l) => l.includes("notify BLOCKED test/evt-tick")),
     ).toBe(true);
     await tick({
       db,
@@ -202,7 +208,8 @@ export async function runNotifierDeliveryCase({
       policyVersion: "git:test",
       log: () => {},
     });
-    expect(readFileSync(outFile, "utf8").trim().split("\n")).toHaveLength(1);
+    // Exactly one delivery: the file still holds the single message.
+    expect(readFileSync(outFile, "utf8").trim()).toBe(expectedMessage);
     return { delivery };
   } finally {
     // This is the critical cleanup contract: first unblock an in-flight child,

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -40,6 +40,12 @@ import {
   webhookSecret,
 } from "./config.mjs";
 import { githubWebhookSecret } from "./intake.mjs";
+import {
+  decideInboxItem,
+  getInboxItem,
+  retryInboxDecision,
+} from "./inbox.mjs";
+import { applyDecisionEffect } from "./decision-effects.mjs";
 import { janitorArgv, spawnFactoryJanitor } from "./janitor.mjs";
 import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos } from "./repos.mjs";
@@ -77,6 +83,7 @@ export function createApi({
   inboxSend = sendNotification,
   inboxCommand = notifyCommand(),
   inboxWebUrl = process.env.FACTORY_WEB_URL,
+  inboxApplyEffect = applyDecisionEffect,
 } = {}) {
   const actor = "operator";
   const storeStatsTtlMs = 10_000;
@@ -143,6 +150,51 @@ export function createApi({
         return handleIntakeApiRoute(common);
       }
       if (url.pathname === "/inbox" || url.pathname.startsWith("/inbox/")) {
+        const detailMatch = url.pathname.match(/^\/inbox\/([^/]+)$/);
+        if (req.method === "GET" && detailMatch) {
+          const item = getInboxItem(db, decodeURIComponent(detailMatch[1]));
+          return item
+            ? send(200, { item })
+            : send(404, { error: "not_found" });
+        }
+
+        const decisionMatch = url.pathname.match(
+          /^\/inbox\/([^/]+)\/decide(?:\/(retry))?$/,
+        );
+        if (req.method === "POST" && decisionMatch) {
+          const id = decodeURIComponent(decisionMatch[1]);
+          try {
+            let result;
+            if (decisionMatch[2] === "retry") {
+              const raw = await readBody(req);
+              if (raw.length > 0) {
+                const parsed = parseJson(raw);
+                if (parsed.error) return send(400, { error: "invalid_json", message: parsed.error });
+              }
+              result = retryInboxDecision(db, id, {
+                now: nowMs,
+                applyEffect: inboxApplyEffect,
+              });
+            } else {
+              const parsed = parseJson(await readBody(req));
+              if (parsed.error) return send(400, { error: "invalid_json", message: parsed.error });
+              result = decideInboxItem(db, id, parsed.value, {
+                now: nowMs,
+                decidedBy: actor,
+                applyEffect: inboxApplyEffect,
+              });
+            }
+            return send(200, result);
+          } catch (err) {
+            const status = Number(err?.status) || 400;
+            return send(status, {
+              error: err?.code ?? "invalid_response",
+              message: err?.message ?? String(err),
+              ...(err?.errors ? { errors: err.errors } : {}),
+            });
+          }
+        }
+
         const result = await handleInboxApiRoute({
           ...common,
           inboxCommand,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -36,6 +36,82 @@ import {
 } from "./api-test-helpers.mjs";
 import { cpSync } from "node:fs";
 import { emitDueTicks } from "./schedules.mjs";
+import { createInboxItem } from "./inbox.mjs";
+import { decisionRequestHash } from "./decision.mjs";
+
+describe("inbox decision API (WM-390)", () => {
+  const request = {
+    schemaVersion: "factory.decision-request/v1",
+    question: "Dismiss this item?",
+    options: [{ id: "dismiss", label: "Dismiss", effect: "dismiss" }],
+  };
+
+  test("detail, decide, conflicts, and retry use typed statuses", async () => {
+    const s = await makeServer({ now: () => 1000 });
+    try {
+      createInboxItem(s.db, {
+        kind: "BLOCKED",
+        title: "decision",
+        decision: request,
+      }, { id: "api_decision" });
+
+      const detail = await fetch(s.url("/inbox/api_decision"));
+      expect(detail.status).toBe(200);
+      expect((await detail.json()).item.decision).toEqual(request);
+      expect((await fetch(s.url("/inbox/missing"))).status).toBe(404);
+
+      const stale = await fetch(s.url("/inbox/api_decision/decide"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: "sha256:" + "0".repeat(64),
+          optionId: "dismiss",
+          fields: {},
+        }),
+      });
+      expect(stale.status).toBe(409);
+      expect((await stale.json()).error).toBe("stale_request");
+
+      const decided = await fetch(s.url("/inbox/api_decision/decide"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: "factory.decision-response/v1",
+          requestHash: decisionRequestHash(request),
+          optionId: "dismiss",
+          fields: {},
+        }),
+      });
+      expect(decided.status).toBe(200);
+      expect(await decided.json()).toMatchObject({
+        item: { resolvedBy: "operator:dismiss", decidedBy: "operator" },
+        effect: { kind: "dismiss", outcome: "applied" },
+      });
+
+      const again = await fetch(s.url("/inbox/api_decision/decide"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestHash: decisionRequestHash(request), optionId: "dismiss", fields: {},
+        }),
+      });
+      expect(again.status).toBe(409);
+      expect((await again.json()).error).toBe("already_decided");
+
+      const undecided = createInboxItem(s.db, {
+        kind: "BLOCKED", title: "not answered", decision: request,
+      }, { id: "not_decided" });
+      const retry = await fetch(s.url(`/inbox/${undecided.id}/decide/retry`), {
+        method: "POST",
+      });
+      expect(retry.status).toBe(409);
+      expect((await retry.json()).error).toBe("not_decided");
+    } finally {
+      s.close();
+    }
+  });
+});
 
 describe("schedule trigger metadata (WM-259)", () => {
   test("run and trigger return the unchanged next scheduled tick", async () => {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -74,6 +74,18 @@ describe("inbox decision API (WM-390)", () => {
       expect(stale.status).toBe(409);
       expect((await stale.json()).error).toBe("stale_request");
 
+      const malformed = await fetch(s.url("/inbox/api_decision/decide"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestHash: decisionRequestHash(request),
+          optionId: "dismiss",
+          fields: {},
+        }),
+      });
+      expect(malformed.status).toBe(400);
+      expect((await malformed.json()).error).toBe("invalid_response");
+
       const decided = await fetch(s.url("/inbox/api_decision/decide"), {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -89,6 +101,13 @@ describe("inbox decision API (WM-390)", () => {
         item: { resolvedBy: "operator:dismiss", decidedBy: "operator" },
         effect: { kind: "dismiss", outcome: "applied" },
       });
+
+      const appliedRetry = await fetch(
+        s.url("/inbox/api_decision/decide/retry"),
+        { method: "POST" },
+      );
+      expect(appliedRetry.status).toBe(409);
+      expect((await appliedRetry.json()).error).toBe("already_applied");
 
       const again = await fetch(s.url("/inbox/api_decision/decide"), {
         method: "POST",

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -233,6 +233,31 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 6,
+    name: "inbox_decisions",
+    up(db) {
+      const columns = new Set(
+        db.query(`PRAGMA table_info(inbox_items)`).all().map((row) => row.name),
+      );
+      for (const [name, type] of [
+        ["decision_json", "TEXT"],
+        ["response_json", "TEXT"],
+        ["decided_at", "TEXT"],
+        ["decided_by", "TEXT"],
+        ["dedupe_key", "TEXT"],
+      ]) {
+        if (!columns.has(name)) {
+          db.exec(`ALTER TABLE inbox_items ADD COLUMN ${name} ${type};`);
+        }
+      }
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS inbox_items_open_dedupe
+          ON inbox_items (dedupe_key)
+          WHERE resolved_at IS NULL AND dedupe_key IS NOT NULL;
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -234,6 +234,9 @@ export const MIGRATIONS = [
     },
   },
   {
+    // The inbox design originally reserved v5. The dead-letter archive
+    // migration landed while WM-390 was blocked, so this additive upgrade is
+    // v6 and its regression fixture starts from the now-real v5 schema.
     version: 6,
     name: "inbox_decisions",
     up(db) {

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -170,7 +170,34 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     expect(columns).toEqual([
       "id", "kind", "severity", "title", "body", "refs_json", "source",
       "created_at", "acked_at", "resolved_at", "resolved_by", "delivery_json",
+      "decision_json", "response_json", "decided_at", "decided_by", "dedupe_key",
     ]);
+    upgraded.close();
+  });
+
+  test("the decision ledger migration upgrades a populated v5 inbox database", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    migrateDb(db, { targetVersion: 5 });
+    db.query(
+      `INSERT INTO inbox_items
+         (id, kind, title, source, created_at)
+       VALUES ('legacy', 'BLOCKED', 'legacy item', 'cli', '2026-08-16T00:00:00.000Z')`,
+    ).run();
+    expect(getSchemaVersion(db)).toBe(5);
+    db.close();
+
+    const upgraded = openDb(file);
+    expect(getSchemaVersion(upgraded)).toBe(CURRENT_SCHEMA_VERSION);
+    const columns = upgraded.query("PRAGMA table_info(inbox_items)").all().map((row) => row.name);
+    expect(columns.slice(-5)).toEqual([
+      "decision_json", "response_json", "decided_at", "decided_by", "dedupe_key",
+    ]);
+    expect(upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get().title).toBe("legacy item");
+    const index = upgraded.query(
+      `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'inbox_items_open_dedupe'`,
+    ).get();
+    expect(index.sql).toContain("WHERE resolved_at IS NULL AND dedupe_key IS NOT NULL");
     upgraded.close();
   });
 

--- a/event-runtime/lib/decision-effects.mjs
+++ b/event-runtime/lib/decision-effects.mjs
@@ -1,0 +1,17 @@
+/**
+ * Runtime-owned effects for inbox decisions.
+ *
+ * WM-391 fills in the stateful effects. This seam deliberately ships only the
+ * side-effect-free dismiss operation; unsupported effects leave their item
+ * open and can be retried after that implementation lands.
+ */
+export function applyDecisionEffect(_db, item, response) {
+  const option = item?.decision?.options?.find(
+    (candidate) => candidate.id === response?.optionId,
+  );
+  const kind = option?.effect ?? "unknown";
+  if (kind === "dismiss") return { kind, outcome: "applied" };
+  return { kind, outcome: "unsupported" };
+}
+
+export default applyDecisionEffect;

--- a/event-runtime/lib/decision-effects.test.mjs
+++ b/event-runtime/lib/decision-effects.test.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { applyDecisionEffect } from "./decision-effects.mjs";
+
+describe("decision effect seam (WM-390)", () => {
+  const item = {
+    decision: {
+      options: [
+        { id: "later", effect: "dismiss" },
+        { id: "go", effect: "authorise" },
+      ],
+    },
+  };
+
+  test("dismiss is applied and other effects remain explicitly unsupported", () => {
+    expect(applyDecisionEffect(null, item, { optionId: "later" })).toEqual({
+      kind: "dismiss",
+      outcome: "applied",
+    });
+    expect(applyDecisionEffect(null, item, { optionId: "go" })).toEqual({
+      kind: "authorise",
+      outcome: "unsupported",
+    });
+  });
+});

--- a/event-runtime/lib/decision-templates.mjs
+++ b/event-runtime/lib/decision-templates.mjs
@@ -1,0 +1,176 @@
+/** Default, schema-valid decision requests for runtime inbox producers. */
+
+const dismiss = () => ({
+  id: "dismiss",
+  label: "Not now",
+  effect: "dismiss",
+  tone: "neutral",
+});
+
+const textField = ({ id = "answer", label, required = false, whenOption } = {}) => ({
+  id,
+  kind: "text",
+  label: label ?? "Anything the runtime should know",
+  required,
+  maxLength: 2000,
+  ...(whenOption ? { whenOption } : {}),
+});
+
+function escalation(refs) {
+  const options = [];
+  if (refs.issue) {
+    options.push({
+      id: "triage",
+      label: "Send back to Triage",
+      effect: "send_to_triage",
+      tone: "neutral",
+    });
+    options.push({
+      id: "answer",
+      label: "Answer the agent",
+      effect: "answer",
+      tone: "primary",
+    });
+  }
+  options.push(dismiss());
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: refs.issue
+      ? `How should the factory proceed with ${refs.issue}?`
+      : "How should the factory handle this refused run?",
+    options,
+    fields: refs.issue
+      ? [textField({ required: true, whenOption: ["answer"] })]
+      : [],
+  };
+}
+
+function parked(refs) {
+  const options = [];
+  if (refs.eventSource && refs.eventId) {
+    options.push({
+      id: "requeue",
+      label: "Requeue the event",
+      effect: "requeue",
+      tone: "primary",
+    });
+  }
+  options.push(dismiss());
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: "Should this parked event be requeued?",
+    recommended: options[0].id,
+    options,
+    fields: [textField({ id: "insight", required: false })],
+  };
+}
+
+function triageQuestion(refs) {
+  const options = [];
+  if (refs.issue) {
+    options.push({
+      id: "answer",
+      label: "Answer the question",
+      effect: "answer",
+      tone: "primary",
+    });
+  }
+  options.push(dismiss());
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: refs.issue
+      ? `What answer should be recorded on ${refs.issue}?`
+      : "Should this triage question be dismissed?",
+    options,
+    fields: refs.issue
+      ? [textField({ required: true, whenOption: ["answer"] })]
+      : [],
+  };
+}
+
+function mergeEscalation(refs) {
+  const options = [];
+  if (refs.issue) {
+    options.push({
+      id: "triage",
+      label: "Send back to Triage",
+      effect: "send_to_triage",
+      tone: "neutral",
+    });
+    options.push({
+      id: "answer",
+      label: "Answer the reviewer",
+      effect: "answer",
+      tone: "primary",
+    });
+  }
+  options.push(dismiss());
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: refs.pr
+      ? `How should the merge escalation for ${refs.pr} be handled?`
+      : "How should this merge escalation be handled?",
+    options,
+    fields: refs.issue
+      ? [textField({ required: true, whenOption: ["answer"] })]
+      : [],
+  };
+}
+
+function proposal(refs) {
+  const options = [];
+  if (refs.proposalId) {
+    options.push({
+      id: "approve",
+      label: "Approve proposal",
+      effect: "approve_proposal",
+      tone: "primary",
+    });
+    options.push({
+      id: "reject",
+      label: "Reject proposal",
+      effect: "reject_proposal",
+      tone: "danger",
+    });
+  }
+  options.push(dismiss());
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: refs.proposalId
+      ? `Decide proposal ${refs.proposalId}`
+      : "Should this proposal notification be dismissed?",
+    options,
+    fields: refs.proposalId
+      ? [
+          textField({
+            id: "reason",
+            label: "Reason for rejection",
+            required: true,
+            whenOption: ["reject"],
+          }),
+        ]
+      : [],
+  };
+}
+
+const BUILDERS = {
+  escalation,
+  parked,
+  "triage-question": triageQuestion,
+  "merge-escalation": mergeEscalation,
+  proposal,
+};
+
+/**
+ * Return a new request for one producer. `kind` is retained in the signature
+ * because callers naturally have the inbox kind; `producer` selects the
+ * template when several producers share a kind.
+ */
+export function templateFor(kind, { producer, refs = {} } = {}) {
+  const selected = producer ?? String(kind ?? "").toLowerCase();
+  const builder = BUILDERS[selected];
+  if (!builder) throw new Error(`unknown decision template producer: ${selected}`);
+  return builder(refs);
+}
+
+export default templateFor;

--- a/event-runtime/lib/decision-templates.test.mjs
+++ b/event-runtime/lib/decision-templates.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { validateDecisionRequest } from "./decision.mjs";
+import { templateFor } from "./decision-templates.mjs";
+
+describe("default decision templates (WM-390)", () => {
+  const cases = [
+    ["ESCALATED", "escalation", { issue: "WM-1", repo: "factory", runId: "run_1" }],
+    ["BLOCKED", "parked", { eventSource: "linear", eventId: "evt_1" }],
+    ["decision_needed", "triage-question", { issue: "WM-2", repo: "factory" }],
+    ["ESCALATED", "merge-escalation", { issue: "WM-3", repo: "factory", pr: "42" }],
+    ["decision_needed", "proposal", { proposalId: "prop_1" }],
+  ];
+
+  for (const [kind, producer, refs] of cases) {
+    test(`${producer} is valid against its representative refs`, () => {
+      const request = templateFor(kind, { producer, refs });
+      expect(validateDecisionRequest(request, { refs })).toEqual({
+        valid: true,
+        errors: [],
+      });
+      expect(request.options.at(-1).effect).toBe("dismiss");
+    });
+  }
+
+  test("templates are newly allocated and fail closed on unknown producers", () => {
+    const refs = { eventSource: "x", eventId: "y" };
+    expect(templateFor("BLOCKED", { producer: "parked", refs })).not.toBe(
+      templateFor("BLOCKED", { producer: "parked", refs }),
+    );
+    expect(() => templateFor("BLOCKED", { producer: "mystery", refs })).toThrow(
+      "unknown decision template producer",
+    );
+  });
+});

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -492,16 +492,37 @@ export function resolveInboxItem(db, id, {
     "SELECT id, decision_json, response_json FROM inbox_items WHERE id = ?",
   ).get(id);
   if (!row) throw new Error(`unknown inbox item ${id}`);
+  const resolvedAt = new Date(now).toISOString();
   if (row.decision_json && !row.response_json) {
-    const err = new Error(`inbox item ${id} has a pending decision`);
-    err.code = "decision_pending";
-    throw err;
+    if (!resolvedBy.startsWith("auto:")) {
+      const err = new Error(`inbox item ${id} has a pending decision`);
+      err.code = "decision_pending";
+      throw err;
+    }
+    // The runtime observed the referent leave its waiting state, so the ask is
+    // moot. Record a superseded response so a late operator answer is refused
+    // as already_decided instead of applying an effect nobody wants any more.
+    db.query(
+      `UPDATE inbox_items
+       SET response_json = ?, decided_at = ?, decided_by = ?
+       WHERE id = ? AND response_json IS NULL AND decided_at IS NULL`,
+    ).run(
+      JSON.stringify({
+        superseded: true,
+        reason: resolvedBy,
+        decidedBy: resolvedBy,
+        decidedAt: resolvedAt,
+      }),
+      resolvedAt,
+      resolvedBy,
+      id,
+    );
   }
   db.query(
     `UPDATE inbox_items
      SET resolved_at = COALESCE(resolved_at, ?), resolved_by = COALESCE(resolved_by, ?)
      WHERE id = ?`,
-  ).run(new Date(now).toISOString(), resolvedBy, id);
+  ).run(resolvedAt, resolvedBy, id);
   return getInboxItem(db, id);
 }
 
@@ -580,7 +601,8 @@ export function reconcileInbox(db, { now = Date.now() } = {}) {
      ORDER BY created_at, rowid`,
   ).all();
   for (const row of rows) {
-    if (row.decision_json && !row.response_json) continue;
+    // Pending decisions are not skipped: once the referent stops waiting the
+    // ask is moot and resolveInboxItem records it as superseded (auto:*).
     const refs = parseObject(row.refs_json);
     let resolvedBy = null;
     if (row.kind === "decision_needed" || row.kind === "proposal_expired") {

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -12,6 +12,7 @@ import {
   validateDecisionResponse,
 } from "./decision.mjs";
 import { applyDecisionEffect } from "./decision-effects.mjs";
+import { txImmediate } from "./db.mjs";
 
 export const INBOX_KINDS = Object.freeze([
   "BLOCKED",
@@ -120,6 +121,35 @@ export function getInboxItem(db, id) {
   return itemView(db.query("SELECT * FROM inbox_items WHERE id = ?").get(id));
 }
 
+function supersedeInboxDecision(db, row, { body, refs, decision }) {
+  const updated = db.query(
+    `UPDATE inbox_items
+     SET decision_json = ?, response_json = NULL, decided_at = NULL,
+         decided_by = NULL, body = ?,
+         refs_json = CASE WHEN ? IS NULL THEN refs_json ELSE json_set(
+           CASE WHEN json_valid(refs_json) THEN refs_json ELSE '{}' END,
+           '$.runId', ?
+         ) END,
+         delivery_json = json_set(
+           CASE WHEN json_valid(delivery_json) THEN delivery_json ELSE '{}' END,
+           '$.supersededDecisions',
+           COALESCE(json_extract(
+             CASE WHEN json_valid(delivery_json) THEN delivery_json ELSE '{}' END,
+             '$.supersededDecisions'
+           ), 0) + 1
+         )
+     WHERE id = ? AND resolved_at IS NULL`,
+  ).run(
+    decision === null ? null : JSON.stringify(decision),
+    body,
+    refs.runId ?? null,
+    refs.runId ?? null,
+    row.id,
+  );
+  if (updated.changes !== 1) return null;
+  return getInboxItem(db, row.id);
+}
+
 export function createInboxItem(db, input, {
   id = `inbox_${randomUUID()}`,
   now = Date.now(),
@@ -156,43 +186,60 @@ export function createInboxItem(db, input, {
        LIMIT 1`,
     ).get(dedupeKey);
     if (existing) {
-      const existingRefs = parseObject(existing.refs_json);
-      if (refs.runId) existingRefs.runId = refs.runId;
-      const delivery = parseObject(existing.delivery_json);
-      delivery.supersededDecisions = Number(delivery.supersededDecisions ?? 0) + 1;
-      db.query(
-        `UPDATE inbox_items
-         SET decision_json = ?, body = ?, refs_json = ?, delivery_json = ?
-         WHERE id = ?`,
-      ).run(
-        decision === null ? null : JSON.stringify(decision),
+      const superseded = supersedeInboxDecision(db, existing, {
         body,
-        JSON.stringify(existingRefs),
-        JSON.stringify(delivery),
-        existing.id,
-      );
-      return getInboxItem(db, existing.id);
+        refs,
+        decision,
+      });
+      if (superseded) return superseded;
     }
   }
 
-  db.query(
-    `INSERT INTO inbox_items
-       (id, kind, severity, title, body, refs_json, source, created_at,
-        delivery_json, decision_json, dedupe_key)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)`,
-  ).run(
-    id,
-    kind,
-    severity,
-    title,
-    body,
-    JSON.stringify(refs),
-    source,
-    createdAt,
-    decision === null ? null : JSON.stringify(decision),
-    dedupeKey,
-  );
-  return getInboxItem(db, id);
+  let insertError;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      db.query(
+        `INSERT INTO inbox_items
+           (id, kind, severity, title, body, refs_json, source, created_at,
+            delivery_json, decision_json, dedupe_key)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)`,
+      ).run(
+        id,
+        kind,
+        severity,
+        title,
+        body,
+        JSON.stringify(refs),
+        source,
+        createdAt,
+        decision === null ? null : JSON.stringify(decision),
+        dedupeKey,
+      );
+      return getInboxItem(db, id);
+    } catch (err) {
+      insertError = err;
+      // A second connection can win the partial-unique-index race after the
+      // lookup above. In that case the collision has the same semantics as an
+      // item that was already present; unrelated insert failures still escape.
+      const winner = dedupeKey
+        ? db.query(
+          `SELECT * FROM inbox_items
+           WHERE dedupe_key = ? AND resolved_at IS NULL
+           LIMIT 1`,
+        ).get(dedupeKey)
+        : null;
+      if (!winner) break;
+      const superseded = supersedeInboxDecision(db, winner, {
+        body,
+        refs,
+        decision,
+      });
+      if (superseded) return superseded;
+      // The winner resolved between the read and update, releasing the
+      // partial unique key. Retry the insert once as a new ledger item.
+    }
+  }
+  throw insertError;
 }
 
 function decisionRow(db, id) {
@@ -218,7 +265,7 @@ function normalizeEffect(effect, item, response) {
 }
 
 /** Validate, record, and apply one response to a stored decision request. */
-export function decideInboxItem(
+function decideInboxItemInTransaction(
   db,
   id,
   response,
@@ -247,7 +294,12 @@ export function decideInboxItem(
   if (!response || typeof response !== "object" || Array.isArray(response)) {
     throw new InboxDecisionError("invalid_response", "response must be an object", 400);
   }
-  if (response.requestHash !== decisionRequestHash(decision)) {
+  const expectedHash = decisionRequestHash(decision);
+  if (
+    typeof response.requestHash === "string" &&
+    /^sha256:[a-f0-9]{64}$/.test(response.requestHash) &&
+    response.requestHash !== expectedHash
+  ) {
     throw new InboxDecisionError(
       "stale_request",
       `inbox item ${id} decision request has changed`,
@@ -258,7 +310,6 @@ export function decideInboxItem(
   const decidedAt = new Date(now).toISOString();
   const storedResponse = {
     ...response,
-    schemaVersion: "factory.decision-response/v1",
     decidedBy,
     decidedAt,
   };
@@ -274,11 +325,18 @@ export function decideInboxItem(
 
   // Persist the answer before invoking the seam. A throwing effect must not
   // lose what the operator entered; retry uses this exact stored response.
-  db.query(
+  const recorded = db.query(
     `UPDATE inbox_items
      SET response_json = ?, decided_at = ?, decided_by = ?
-     WHERE id = ?`,
+     WHERE id = ? AND response_json IS NULL AND decided_at IS NULL`,
   ).run(JSON.stringify(storedResponse), decidedAt, decidedBy, id);
+  if (recorded.changes !== 1) {
+    throw new InboxDecisionError(
+      "already_decided",
+      `inbox item ${id} is already decided`,
+      409,
+    );
+  }
 
   const item = getInboxItem(db, id);
   let effect;
@@ -306,13 +364,32 @@ export function decideInboxItem(
   return { item: getInboxItem(db, id), effect };
 }
 
+export function decideInboxItem(db, id, response, options = {}) {
+  // Serialize request claim, effect application, and finalization against
+  // concurrent answers and dedupe supersession on other connections.
+  return txImmediate(db, () =>
+    decideInboxItemInTransaction(db, id, response, options)
+  );
+}
+
 /** Retry the effect for an answer that was already recorded. */
-export function retryInboxDecision(
+function retryInboxDecisionInTransaction(
   db,
   id,
-  { now = Date.now(), applyEffect = applyDecisionEffect } = {},
+  {
+    now = Date.now(),
+    applyEffect = applyDecisionEffect,
+    expectedResponseJson,
+  } = {},
 ) {
   const row = decisionRow(db, id);
+  if (row.response_json !== expectedResponseJson) {
+    throw new InboxDecisionError(
+      "retry_superseded",
+      `inbox item ${id} decision retry was superseded`,
+      409,
+    );
+  }
   const decision = parseNullableObject(row.decision_json);
   const recorded = parseNullableObject(row.response_json);
   if (!decision || !recorded || !row.decided_at) {
@@ -322,6 +399,14 @@ export function retryInboxDecision(
       409,
     );
   }
+  if (row.resolved_at || recorded.effect?.outcome === "applied") {
+    throw new InboxDecisionError(
+      "already_applied",
+      `inbox item ${id} decision effect is already applied`,
+      409,
+    );
+  }
+  const retryAttempt = Number(recorded.effect?.retryAttempt ?? 0) + 1;
   const { effect: _priorEffect, ...response } = recorded;
   const item = getInboxItem(db, id);
   let effect;
@@ -335,7 +420,10 @@ export function retryInboxDecision(
     );
   }
   db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
-    JSON.stringify({ ...response, effect }),
+    JSON.stringify({
+      ...response,
+      effect: { ...effect, retryAttempt },
+    }),
     id,
   );
   if (effect.outcome === "applied") {
@@ -347,6 +435,22 @@ export function retryInboxDecision(
     ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
   }
   return { item: getInboxItem(db, id), effect };
+}
+
+export function retryInboxDecision(db, id, options = {}) {
+  // Capture the exact failed outcome before waiting for the write lock. A
+  // concurrent retry increments retryAttempt, so a waiter cannot replay the
+  // same effect after that first retry commits; a later deliberate retry can.
+  const expectedResponseJson = db.query(
+    "SELECT response_json FROM inbox_items WHERE id = ?",
+  ).get(id)?.response_json ?? null;
+  // The same lock prevents two operators from retrying one effect at once.
+  return txImmediate(db, () =>
+    retryInboxDecisionInTransaction(db, id, {
+      ...options,
+      expectedResponseJson,
+    })
+  );
 }
 
 export function listInboxItems(db, { status = "open" } = {}) {
@@ -472,7 +576,7 @@ export function reconcileInbox(db, { now = Date.now() } = {}) {
   const rows = db.query(
     `SELECT id, kind, refs_json, decision_json, response_json FROM inbox_items
      WHERE resolved_at IS NULL
-       AND kind IN ('decision_needed', 'proposal_expired', 'human_needed')
+       AND kind IN ('decision_needed', 'proposal_expired', 'human_needed', 'BLOCKED')
      ORDER BY created_at, rowid`,
   ).all();
   for (const row of rows) {

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -6,6 +6,12 @@
  * broken, while notify_log continues to provide runtime-notification dedup.
  */
 import { randomUUID } from "node:crypto";
+import {
+  decisionRequestHash,
+  validateDecisionRequest,
+  validateDecisionResponse,
+} from "./decision.mjs";
+import { applyDecisionEffect } from "./decision-effects.mjs";
 
 export const INBOX_KINDS = Object.freeze([
   "BLOCKED",
@@ -65,7 +71,29 @@ function parseObject(value) {
   }
 }
 
-function itemView(row) {
+function parseNullableObject(value) {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export class InboxDecisionError extends Error {
+  constructor(code, message, status = 400, errors = undefined) {
+    super(message);
+    this.name = "InboxDecisionError";
+    this.code = code;
+    this.status = status;
+    if (errors) this.errors = errors;
+  }
+}
+
+export function itemView(row) {
   if (!row) return null;
   return {
     id: row.id,
@@ -80,6 +108,11 @@ function itemView(row) {
     resolvedAt: row.resolved_at ?? null,
     resolvedBy: row.resolved_by ?? null,
     delivery: parseObject(row.delivery_json),
+    decision: parseNullableObject(row.decision_json),
+    response: parseNullableObject(row.response_json),
+    decidedAt: row.decided_at ?? null,
+    decidedBy: row.decided_by ?? null,
+    dedupeKey: row.dedupe_key ?? null,
   };
 }
 
@@ -101,14 +134,219 @@ export function createInboxItem(db, input, {
     throw new Error(`unknown inbox source: ${source}`);
   }
   const refs = normalizeRefs(input?.refs);
+  const decision = input?.decision ?? null;
+  if (decision !== null) {
+    const checked = validateDecisionRequest(decision, { refs });
+    if (!checked.valid) {
+      throw new InboxDecisionError(
+        "invalid_decision",
+        `invalid decision request: ${checked.errors.join("; ")}`,
+        400,
+        checked.errors,
+      );
+    }
+  }
+  const dedupeKey = optionalString(input?.dedupeKey, "dedupeKey");
   const createdAt = new Date(now).toISOString();
+
+  if (dedupeKey) {
+    const existing = db.query(
+      `SELECT * FROM inbox_items
+       WHERE dedupe_key = ? AND resolved_at IS NULL
+       LIMIT 1`,
+    ).get(dedupeKey);
+    if (existing) {
+      const existingRefs = parseObject(existing.refs_json);
+      if (refs.runId) existingRefs.runId = refs.runId;
+      const delivery = parseObject(existing.delivery_json);
+      delivery.supersededDecisions = Number(delivery.supersededDecisions ?? 0) + 1;
+      db.query(
+        `UPDATE inbox_items
+         SET decision_json = ?, body = ?, refs_json = ?, delivery_json = ?
+         WHERE id = ?`,
+      ).run(
+        decision === null ? null : JSON.stringify(decision),
+        body,
+        JSON.stringify(existingRefs),
+        JSON.stringify(delivery),
+        existing.id,
+      );
+      return getInboxItem(db, existing.id);
+    }
+  }
 
   db.query(
     `INSERT INTO inbox_items
-       (id, kind, severity, title, body, refs_json, source, created_at, delivery_json)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}')`,
-  ).run(id, kind, severity, title, body, JSON.stringify(refs), source, createdAt);
+       (id, kind, severity, title, body, refs_json, source, created_at,
+        delivery_json, decision_json, dedupe_key)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?)`,
+  ).run(
+    id,
+    kind,
+    severity,
+    title,
+    body,
+    JSON.stringify(refs),
+    source,
+    createdAt,
+    decision === null ? null : JSON.stringify(decision),
+    dedupeKey,
+  );
   return getInboxItem(db, id);
+}
+
+function decisionRow(db, id) {
+  const row = db.query("SELECT * FROM inbox_items WHERE id = ?").get(id);
+  if (!row) {
+    throw new InboxDecisionError(
+      "not_found",
+      `unknown inbox item ${id}`,
+      404,
+    );
+  }
+  return row;
+}
+
+function normalizeEffect(effect, item, response) {
+  const kind = item.decision.options.find(
+    (option) => option.id === response.optionId,
+  )?.effect ?? "unknown";
+  if (!effect || typeof effect !== "object" || Array.isArray(effect)) {
+    return { kind, outcome: "failed", error: "decision effect returned no outcome" };
+  }
+  return { ...effect, kind };
+}
+
+/** Validate, record, and apply one response to a stored decision request. */
+export function decideInboxItem(
+  db,
+  id,
+  response,
+  {
+    now = Date.now(),
+    decidedBy = "operator",
+    applyEffect = applyDecisionEffect,
+  } = {},
+) {
+  const row = decisionRow(db, id);
+  const decision = parseNullableObject(row.decision_json);
+  if (!decision) {
+    throw new InboxDecisionError(
+      "decision_missing",
+      `inbox item ${id} has no decision request`,
+      400,
+    );
+  }
+  if (row.response_json || row.decided_at) {
+    throw new InboxDecisionError(
+      "already_decided",
+      `inbox item ${id} is already decided`,
+      409,
+    );
+  }
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    throw new InboxDecisionError("invalid_response", "response must be an object", 400);
+  }
+  if (response.requestHash !== decisionRequestHash(decision)) {
+    throw new InboxDecisionError(
+      "stale_request",
+      `inbox item ${id} decision request has changed`,
+      409,
+    );
+  }
+
+  const decidedAt = new Date(now).toISOString();
+  const storedResponse = {
+    ...response,
+    schemaVersion: "factory.decision-response/v1",
+    decidedBy,
+    decidedAt,
+  };
+  const checked = validateDecisionResponse(storedResponse, decision);
+  if (!checked.valid) {
+    throw new InboxDecisionError(
+      "invalid_response",
+      `invalid decision response: ${checked.errors.join("; ")}`,
+      400,
+      checked.errors,
+    );
+  }
+
+  // Persist the answer before invoking the seam. A throwing effect must not
+  // lose what the operator entered; retry uses this exact stored response.
+  db.query(
+    `UPDATE inbox_items
+     SET response_json = ?, decided_at = ?, decided_by = ?
+     WHERE id = ?`,
+  ).run(JSON.stringify(storedResponse), decidedAt, decidedBy, id);
+
+  const item = getInboxItem(db, id);
+  let effect;
+  try {
+    effect = normalizeEffect(applyEffect(db, item, storedResponse), item, storedResponse);
+  } catch (err) {
+    effect = normalizeEffect(
+      { outcome: "failed", error: err?.message ?? String(err) },
+      item,
+      storedResponse,
+    );
+  }
+  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
+    JSON.stringify({ ...storedResponse, effect }),
+    id,
+  );
+  if (effect.outcome === "applied") {
+    db.query(
+      `UPDATE inbox_items
+       SET resolved_at = COALESCE(resolved_at, ?),
+           resolved_by = COALESCE(resolved_by, ?)
+       WHERE id = ?`,
+    ).run(decidedAt, `operator:${effect.kind}`, id);
+  }
+  return { item: getInboxItem(db, id), effect };
+}
+
+/** Retry the effect for an answer that was already recorded. */
+export function retryInboxDecision(
+  db,
+  id,
+  { now = Date.now(), applyEffect = applyDecisionEffect } = {},
+) {
+  const row = decisionRow(db, id);
+  const decision = parseNullableObject(row.decision_json);
+  const recorded = parseNullableObject(row.response_json);
+  if (!decision || !recorded || !row.decided_at) {
+    throw new InboxDecisionError(
+      "not_decided",
+      `inbox item ${id} has not been decided`,
+      409,
+    );
+  }
+  const { effect: _priorEffect, ...response } = recorded;
+  const item = getInboxItem(db, id);
+  let effect;
+  try {
+    effect = normalizeEffect(applyEffect(db, item, response), item, response);
+  } catch (err) {
+    effect = normalizeEffect(
+      { outcome: "failed", error: err?.message ?? String(err) },
+      item,
+      response,
+    );
+  }
+  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
+    JSON.stringify({ ...response, effect }),
+    id,
+  );
+  if (effect.outcome === "applied") {
+    db.query(
+      `UPDATE inbox_items
+       SET resolved_at = COALESCE(resolved_at, ?),
+           resolved_by = COALESCE(resolved_by, ?)
+       WHERE id = ?`,
+    ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
+  }
+  return { item: getInboxItem(db, id), effect };
 }
 
 export function listInboxItems(db, { status = "open" } = {}) {
@@ -139,11 +377,22 @@ export function resolveInboxItem(db, id, {
   resolvedBy = "operator",
 } = {}) {
   requiredString(resolvedBy, "resolvedBy");
-  if (resolvedBy !== "operator" && !resolvedBy.startsWith("auto:")) {
+  if (
+    resolvedBy !== "operator" &&
+    !resolvedBy.startsWith("auto:") &&
+    !resolvedBy.startsWith("operator:")
+  ) {
     throw new Error(`invalid inbox resolver: ${resolvedBy}`);
   }
-  const row = db.query("SELECT id FROM inbox_items WHERE id = ?").get(id);
+  const row = db.query(
+    "SELECT id, decision_json, response_json FROM inbox_items WHERE id = ?",
+  ).get(id);
   if (!row) throw new Error(`unknown inbox item ${id}`);
+  if (row.decision_json && !row.response_json) {
+    const err = new Error(`inbox item ${id} has a pending decision`);
+    err.code = "decision_pending";
+    throw err;
+  }
   db.query(
     `UPDATE inbox_items
      SET resolved_at = COALESCE(resolved_at, ?), resolved_by = COALESCE(resolved_by, ?)
@@ -170,7 +419,15 @@ export function inboxCounts(db) {
 }
 
 function telegramMessage(item, webUrl) {
-  const content = item.body ? `${item.title}\n${item.body}` : item.title;
+  const lines = [item.title];
+  if (item.body) lines.push(item.body);
+  if (item.decision) {
+    lines.push(item.decision.question);
+    item.decision.options.forEach((option, index) => {
+      lines.push(`${index + 1}. ${option.label}`);
+    });
+  }
+  const content = lines.join("\n");
   if (!webUrl) return content;
   return `${content}\n${String(webUrl).replace(/\/$/, "")}/#/inbox/${encodeURIComponent(item.id)}`;
 }
@@ -213,12 +470,13 @@ export async function deliverInboxItem(db, id, {
 export function reconcileInbox(db, { now = Date.now() } = {}) {
   const resolved = [];
   const rows = db.query(
-    `SELECT id, kind, refs_json FROM inbox_items
+    `SELECT id, kind, refs_json, decision_json, response_json FROM inbox_items
      WHERE resolved_at IS NULL
        AND kind IN ('decision_needed', 'proposal_expired', 'human_needed')
      ORDER BY created_at, rowid`,
   ).all();
   for (const row of rows) {
+    if (row.decision_json && !row.response_json) continue;
     const refs = parseObject(row.refs_json);
     let resolvedBy = null;
     if (row.kind === "decision_needed" || row.kind === "proposal_expired") {

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -4,13 +4,26 @@ import {
   INBOX_KINDS,
   ackInboxItem,
   createInboxItem,
+  decideInboxItem,
   deliverInboxItem,
   getInboxItem,
   inboxCounts,
   listInboxItems,
   reconcileInbox,
+  retryInboxDecision,
   resolveInboxItem,
 } from "./inbox.mjs";
+import { decisionRequestHash } from "./decision.mjs";
+
+function decision(options = [
+  { id: "dismiss", label: "Not now", effect: "dismiss" },
+]) {
+  return {
+    schemaVersion: "factory.decision-request/v1",
+    question: "What should happen?",
+    options,
+  };
+}
 
 function insertEvent(db, { source = "test", eventId, status = "human_needed" }) {
   const at = new Date().toISOString();
@@ -29,6 +42,111 @@ function insertProposal(db, { id, status = "open" }) {
 }
 
 describe("human inbox ledger (WM-285)", () => {
+  test("decision requests are validated and exposed with decision metadata", () => {
+    const db = openDb(":memory:");
+    expect(() => createInboxItem(db, {
+      kind: "BLOCKED",
+      title: "bad",
+      decision: decision([
+        { id: "retry", label: "Retry", effect: "requeue" },
+      ]),
+    })).toThrow("requires refs.eventSource");
+
+    const item = createInboxItem(db, {
+      kind: "BLOCKED",
+      title: "good",
+      decision: decision(),
+      dedupeKey: "BLOCKED:evt",
+    }, { id: "decision_item", now: 1000 });
+    expect(item).toMatchObject({
+      decision: decision(),
+      response: null,
+      decidedAt: null,
+      decidedBy: null,
+      dedupeKey: "BLOCKED:evt",
+    });
+  });
+
+  test("open dedupe supersedes the request without stacking rows", () => {
+    const db = openDb(":memory:");
+    const first = createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "first",
+      body: "old",
+      refs: { issue: "WM-1", runId: "run_1" },
+      source: "agent:run_1",
+      decision: decision(),
+      dedupeKey: "ESCALATED:WM-1",
+    }, { id: "first" });
+    const replacement = decision([
+      { id: "dismiss", label: "Dismiss this time", effect: "dismiss" },
+    ]);
+    const second = createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "second",
+      body: "new",
+      refs: { issue: "WM-1", runId: "run_2" },
+      source: "agent:run_2",
+      decision: replacement,
+      dedupeKey: "ESCALATED:WM-1",
+    }, { id: "second" });
+    expect(second.id).toBe(first.id);
+    expect(second.body).toBe("new");
+    expect(second.refs).toEqual({ issue: "WM-1", runId: "run_2" });
+    expect(second.decision).toEqual(replacement);
+    expect(second.delivery.supersededDecisions).toBe(1);
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
+
+    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed one" });
+    createInboxItem(db, { kind: "ESCALATED", title: "unkeyed two" });
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
+  });
+
+  test("deciding validates freshness, records the effect, and resolves only applied effects", () => {
+    const db = openDb(":memory:");
+    const request = decision([
+      { id: "go", label: "Proceed", effect: "send_to_triage" },
+      { id: "dismiss", label: "Not now", effect: "dismiss" },
+    ]);
+    const item = createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "decide",
+      refs: { issue: "WM-1" },
+      decision: request,
+    }, { id: "to_decide" });
+    expect(() => resolveInboxItem(db, item.id)).toThrow("pending decision");
+    expect(() => decideInboxItem(db, item.id, {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: "sha256:" + "0".repeat(64),
+      optionId: "dismiss",
+      fields: {},
+    })).toThrow("has changed");
+
+    const unsupported = decideInboxItem(db, item.id, {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "go",
+      fields: {},
+    }, { now: 2000 });
+    expect(unsupported.effect).toEqual({
+      kind: "send_to_triage",
+      outcome: "unsupported",
+    });
+    expect(unsupported.item.resolvedAt).toBeNull();
+    expect(unsupported.item.response.effect).toEqual(unsupported.effect);
+    expect(unsupported.item.decidedAt).toBe(new Date(2000).toISOString());
+    expect(() => decideInboxItem(db, item.id, {
+      requestHash: decisionRequestHash(request), optionId: "go", fields: {},
+    })).toThrow("already decided");
+
+    const retried = retryInboxDecision(db, item.id, {
+      now: 3000,
+      applyEffect: () => ({ kind: "send_to_triage", outcome: "applied" }),
+    });
+    expect(retried.item.resolvedBy).toBe("operator:send_to_triage");
+    expect(retried.item.resolvedAt).toBe(new Date(3000).toISOString());
+  });
+
   test("kind is closed and rows expose parsed refs/delivery", () => {
     const db = openDb(":memory:");
     expect(INBOX_KINDS).toContain("BLOCKED");

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -102,6 +102,45 @@ describe("human inbox ledger (WM-285)", () => {
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
   });
 
+  test("dedupe supersession clears a stored response to avoid binding it to a new request", () => {
+    const db = openDb(":memory:");
+    const original = decision([
+      { id: "triage", label: "Triage", effect: "send_to_triage" },
+    ]);
+    createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "first",
+      refs: { issue: "WM-1", runId: "run_1" },
+      decision: original,
+      dedupeKey: "ESCALATED:WM-1",
+    }, { id: "first" });
+    const answered = decideInboxItem(db, "first", {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(original),
+      optionId: "triage",
+      fields: {},
+    });
+    expect(answered.effect.outcome).toBe("unsupported");
+    expect(answered.item.response).not.toBeNull();
+
+    const replacement = decision();
+    const superseded = createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "second",
+      refs: { issue: "WM-1", runId: "run_2" },
+      decision: replacement,
+      dedupeKey: "ESCALATED:WM-1",
+    });
+    expect(superseded).toMatchObject({
+      id: "first",
+      decision: replacement,
+      response: null,
+      decidedAt: null,
+      decidedBy: null,
+    });
+    expect(superseded.delivery.supersededDecisions).toBe(1);
+  });
+
   test("deciding validates freshness, records the effect, and resolves only applied effects", () => {
     const db = openDb(":memory:");
     const request = decision([
@@ -121,6 +160,11 @@ describe("human inbox ledger (WM-285)", () => {
       optionId: "dismiss",
       fields: {},
     })).toThrow("has changed");
+    expect(() => decideInboxItem(db, item.id, {
+      requestHash: decisionRequestHash(request),
+      optionId: "go",
+      fields: {},
+    })).toThrow("schemaVersion");
 
     const unsupported = decideInboxItem(db, item.id, {
       schemaVersion: "factory.decision-response/v1",
@@ -145,6 +189,29 @@ describe("human inbox ledger (WM-285)", () => {
     });
     expect(retried.item.resolvedBy).toBe("operator:send_to_triage");
     expect(retried.item.resolvedAt).toBe(new Date(3000).toISOString());
+    expect(retried.item.response.effect.retryAttempt).toBe(1);
+    expect(() => retryInboxDecision(db, item.id)).toThrow("already applied");
+  });
+
+  test("each failed retry advances a durable attempt token", () => {
+    const db = openDb(":memory:");
+    const request = decision([
+      { id: "triage", label: "Triage", effect: "send_to_triage" },
+    ]);
+    createInboxItem(db, {
+      kind: "ESCALATED",
+      title: "retry",
+      refs: { issue: "WM-1" },
+      decision: request,
+    }, { id: "retry_attempts" });
+    decideInboxItem(db, "retry_attempts", {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "triage",
+      fields: {},
+    });
+    expect(retryInboxDecision(db, "retry_attempts").item.response.effect.retryAttempt).toBe(1);
+    expect(retryInboxDecision(db, "retry_attempts").item.response.effect.retryAttempt).toBe(2);
   });
 
   test("kind is closed and rows expose parsed refs/delivery", () => {
@@ -214,7 +281,7 @@ describe("human inbox ledger (WM-285)", () => {
       source: "serve:notify",
     }, { id: "decision" });
     createInboxItem(db, {
-      kind: "human_needed",
+      kind: "BLOCKED",
       title: "human",
       refs: { eventSource: "test", eventId: "evt-1" },
       source: "serve:notify",

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -297,6 +297,39 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
+  test("a pending decision becomes moot when its event leaves human_needed", () => {
+    const db = openDb(":memory:");
+    insertEvent(db, { eventId: "evt-2" });
+    createInboxItem(db, {
+      kind: "BLOCKED",
+      title: "parked",
+      refs: { eventSource: "test", eventId: "evt-2" },
+      source: "serve:notify",
+      decision: decision([
+        { id: "requeue", label: "Requeue the event", effect: "requeue" },
+        { id: "dismiss", label: "Not now", effect: "dismiss" },
+      ]),
+    }, { id: "parked" });
+
+    expect(reconcileInbox(db)).toEqual([]);
+    expect(() => resolveInboxItem(db, "parked", { resolvedBy: "operator" }))
+      .toThrow(/pending decision/);
+
+    db.query("UPDATE events SET status = 'admitted' WHERE source = 'test' AND event_id = 'evt-2'").run();
+    expect(reconcileInbox(db, { now: 5000 })).toEqual([
+      { id: "parked", resolvedBy: "auto:event_requeued" },
+    ]);
+    const item = getInboxItem(db, "parked");
+    expect(item.resolvedBy).toBe("auto:event_requeued");
+    expect(item.resolvedAt).toBe(new Date(5000).toISOString());
+    expect(item.response).toMatchObject({ superseded: true, reason: "auto:event_requeued" });
+    expect(item.decidedBy).toBe("auto:event_requeued");
+    // A late operator answer is refused rather than applied.
+    expect(() => decideInboxItem(db, "parked", { optionId: "requeue" }))
+      .toThrow(/already decided/);
+    expect(reconcileInbox(db, { now: 6000 })).toEqual([]);
+  });
+
   test("the serve tick runs auto-resolution as an isolated inbox subsystem", async () => {
     const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
     const db = openDb(":memory:");

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -25,6 +25,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
 import { txImmediate } from "./db.mjs";
+import { templateFor } from "./decision-templates.mjs";
 
 export const DEFAULT_NOTIFY_CMD = `python3 ${path.join(homedir(), "Develop", "hdkiller", "scripts", "notify.py")}`;
 
@@ -110,11 +111,17 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
     const target = `${e.source}/${e.eventId}`;
     if (alreadyNotified(db, KIND_HUMAN_NEEDED, target)) continue;
     pending.push({
-      kind: KIND_HUMAN_NEEDED,
+      kind: "BLOCKED",
+      dedupKind: KIND_HUMAN_NEEDED,
       target,
       title: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
       refs: { eventSource: e.source, eventId: e.eventId },
       source: "serve:notify",
+      decision: templateFor("BLOCKED", {
+        producer: "parked",
+        refs: { eventSource: e.source, eventId: e.eventId },
+      }),
+      dedupeKey: `BLOCKED:${target}`,
     });
   }
 
@@ -135,6 +142,11 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
           title: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
           refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
           source: "serve:notify",
+          decision: templateFor(KIND_PROPOSAL_EXPIRED, {
+            producer: "proposal",
+            refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+          }),
+          dedupeKey: `${KIND_PROPOSAL_EXPIRED}:${p.id}`,
         });
       }
     } else if (!alreadyNotified(db, DEDUP_PROPOSAL_TTL, p.id)) {
@@ -146,6 +158,11 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
         title: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
         refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
         source: "serve:notify",
+        decision: templateFor(KIND_DECISION_NEEDED, {
+          producer: "proposal",
+          refs: { proposalId: p.id, eventSource: p.event_source, eventId: p.event_id },
+        }),
+        dedupeKey: `${KIND_DECISION_NEEDED}:${p.id}`,
       });
     }
   }

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -65,9 +65,14 @@ describe("notify (WM-65)", () => {
     const out = notifyPending(db, { enabled: false, send: (cmd, msg) => (spawned.push(msg), Promise.resolve({ ok: true, exitCode: 0, error: null })) });
     expect(out.sent).toEqual([]);
     expect(spawned).toEqual([]);
-    const item = db.query("SELECT kind, delivery_json FROM inbox_items").get();
-    expect(item.kind).toBe("human_needed");
+    const item = db.query("SELECT kind, delivery_json, decision_json, dedupe_key FROM inbox_items").get();
+    expect(item.kind).toBe("BLOCKED");
     expect(JSON.parse(item.delivery_json)).toEqual({});
+    expect(JSON.parse(item.decision_json).options.map((option) => option.effect)).toEqual([
+      "requeue",
+      "dismiss",
+    ]);
+    expect(item.dedupe_key).toBe("BLOCKED:test/evt-1");
     expect(db.query("SELECT COUNT(*) AS n FROM notify_log").get().n).toBe(1);
     // The next tick dedups the ledger item even though no projection ran.
     expect(notifyPending(db, { enabled: false }).sent).toEqual([]);
@@ -93,10 +98,13 @@ describe("notify (WM-65)", () => {
     await first.deliveries;
     expect(stub.pushes()).toEqual([
       "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
+      "Should this parked event be requeued?",
+      "1. Requeue the event",
+      "2. Not now",
       `http://127.0.0.1:7382/#/inbox/${first.sent[0].inboxItemId}`,
     ]);
     const item = db.query("SELECT kind, refs_json, source, delivery_json FROM inbox_items").get();
-    expect(item.kind).toBe("human_needed");
+    expect(item.kind).toBe("BLOCKED");
     expect(JSON.parse(item.refs_json)).toEqual({ eventSource: "test", eventId: "evt-park" });
     expect(item.source).toBe("serve:notify");
     expect(JSON.parse(item.delivery_json).telegram.error).toBeNull();
@@ -112,7 +120,7 @@ describe("notify (WM-65)", () => {
     const afterRestart = notifyPending(db, { enabled: true, command: stub.bin });
     expect(afterRestart.sent).toEqual([]);
     await afterRestart.deliveries;
-    expect(stub.pushes()).toHaveLength(2);
+    expect(stub.pushes()).toHaveLength(5);
     db.close();
   });
 
@@ -137,6 +145,15 @@ describe("notify (WM-65)", () => {
     const first = sent(now);
     expect(first).toHaveLength(1);
     expect(first[0].message).toBe("DECISION NEEDED proposal prop-aging (ci-doctor@2): expires in 14m");
+    const proposalItem = db.query(
+      "SELECT decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
+    ).get();
+    expect(JSON.parse(proposalItem.decision_json).options.map((option) => option.effect)).toEqual([
+      "approve_proposal",
+      "reject_proposal",
+      "dismiss",
+    ]);
+    expect(proposalItem.dedupe_key).toBe("decision_needed:prop-aging");
 
     // Later ticks before expiry: silent.
     expect(sent(now + 60_000)).toEqual([]);
@@ -178,7 +195,7 @@ describe("notify (WM-65)", () => {
     expect(row.error).toContain("exited 3");
     const inbox = db.query("SELECT delivery_json FROM inbox_items WHERE id = ?").get(row.inbox_item_id);
     expect(JSON.parse(inbox.delivery_json).telegram.error).toContain("exited 3");
-    expect(logs.some((l) => l.includes("notify human_needed test/evt-f failed: notifier exited 3"))).toBe(true);
+    expect(logs.some((l) => l.includes("notify BLOCKED test/evt-f failed: notifier exited 3"))).toBe(true);
 
     // Failed delivery does NOT retry: once means once.
     expect(notifyPending(db, { enabled: true, command: stub.bin }).sent).toEqual([]);

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -29,6 +29,8 @@ import { traceRecorder } from "./trace.mjs";
 import { ContractViolation, verifyResult } from "./verify.mjs";
 import { HEARTBEAT_STALE_MS, satisfiesPlacement } from "./workers.mjs";
 import { createWorkspace, destroyWorkspace, PathViolation, safeJoin } from "./workspace.mjs";
+import { createInboxItem } from "./inbox.mjs";
+import { templateFor } from "./decision-templates.mjs";
 
 /**
  * Runtime-injected artifacts: adapters that capture the agent's output write
@@ -121,6 +123,44 @@ function resolveNow(now) {
 
 function iso(now) {
   return new Date(resolveNow(now)).toISOString();
+}
+
+function refusalInboxRefs(spec) {
+  const refs = { runId: spec.runId };
+  const input = spec.input ?? {};
+  const issue = input.issue ?? input.ticket;
+  const repo = input.repo;
+  const pr = input.pr ?? input.prNumber;
+  if (issue !== undefined && issue !== null && String(issue).trim()) refs.issue = String(issue);
+  if (repo !== undefined && repo !== null && String(repo).trim()) refs.repo = String(repo);
+  if (pr !== undefined && pr !== null && String(pr).trim()) refs.pr = String(pr);
+  return refs;
+}
+
+function createRefusalInboxItem(db, spec, result, { now }) {
+  if (result.reasonCode !== "needs_human") return null;
+  const refs = refusalInboxRefs(spec);
+  const decision = result.decision ?? templateFor("ESCALATED", {
+    producer: "escalation",
+    refs,
+  });
+  const subject = refs.issue ?? refs.runId;
+  const body = result.decisionErrors?.length
+    ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
+    : null;
+  return createInboxItem(
+    db,
+    {
+      kind: "ESCALATED",
+      title: result.decision?.question ?? `ESCALATED ${subject}: ${result.reasonCode}`,
+      body,
+      refs,
+      source: `agent:${spec.runId}`,
+      decision,
+      dedupeKey: `ESCALATED:${refs.issue ?? refs.runId}`,
+    },
+    { now },
+  );
 }
 
 function finishAttempt(db, runId, attempt, terminalState, reasonCode, now, usage = {}) {
@@ -1354,6 +1394,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
           runId, attempt, canonicalJson(refusedResult), "none", null,
           canonicalJson(refusedResult.verification), canonicalJson(receipt), iso(currentNow),
         );
+        createRefusalInboxItem(db, spec, refusedResult, { now: currentNow });
         finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow, attemptUsage);
         return { ok: true, receipt };
       });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -338,10 +338,13 @@ function iso(now) {
   return new Date(resolveNow(now)).toISOString();
 }
 
+// Must mirror the refs verify.mjs validated the authored decision against
+// (issue = input.ticket, repo, runId); a divergence here would let a decision
+// that passed verify fail createInboxItem's legality check at write time.
 function refusalInboxRefs(spec) {
   const refs = { runId: spec.runId };
   const input = spec.input ?? {};
-  const issue = input.issue ?? input.ticket;
+  const issue = input.ticket;
   const repo = input.repo;
   const pr = input.pr ?? input.prNumber;
   if (issue !== undefined && issue !== null && String(issue).trim()) refs.issue = String(issue);
@@ -1694,7 +1697,15 @@ export async function executeClaimed(db, registry, adapters, claim, {
           runId, attempt, canonicalJson(refusedResult), "none", null,
           canonicalJson(refusedResult.verification), canonicalJson(receipt), iso(currentNow),
         );
-        createRefusalInboxItem(db, spec, refusedResult, { now: currentNow });
+        // Best-effort projection: the inbox row must never un-record the
+        // terminal REFUSED state or its result row by throwing out of this tx.
+        try {
+          createRefusalInboxItem(db, spec, refusedResult, { now: currentNow });
+        } catch (err) {
+          console.error(
+            `[worker] refusal inbox item not created for ${runId}: ${err?.message ?? err}`,
+          );
+        }
         finishAttempt(db, runId, attempt, "REFUSED", verified.reasonCode, currentNow, attemptUsage);
         return { ok: true, receipt };
       });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -365,6 +365,97 @@ describe("worker", () => {
     });
   });
 
+  test("needs_human preserves a valid authored ask, while an invalid ask falls back with its errors", async () => {
+    const authored = {
+      schemaVersion: "factory.decision-request/v1",
+      question: "Which answer should unblock WM-390?",
+      options: [
+        { id: "answer", label: "Answer the agent", effect: "answer" },
+        { id: "dismiss", label: "Not now", effect: "dismiss" },
+      ],
+    };
+    const invalid = { ...authored, recommended: "missing" };
+    const refusingAdapter = (decision) => ({
+      async execute({ workspaceDir }) {
+        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "refused",
+          reasonCode: "needs_human",
+          decision,
+        }));
+        return { exitCode: 0, timedOut: false };
+      },
+    });
+
+    for (const [suffix, decision, valid] of [
+      ["valid", authored, true],
+      ["invalid", invalid, false],
+    ]) {
+      const db = openDb(":memory:");
+      const spec = queueRun(db, makeSpec({
+        adapter: `refuse-${suffix}`,
+        input: {
+          repos: [suffix],
+          ticket: "WM-390",
+          repo: "factory",
+          pr: 42,
+        },
+      }));
+      const summary = await runOnce(
+        db,
+        registry,
+        { [`refuse-${suffix}`]: refusingAdapter(decision) },
+        opts(),
+      );
+      expect(summary).toMatchObject({
+        terminalState: "REFUSED",
+        reasonCode: "needs_human",
+      });
+      const item = db.query("SELECT * FROM inbox_items").get();
+      expect(JSON.parse(item.refs_json)).toEqual({
+        runId: spec.runId,
+        issue: "WM-390",
+        repo: "factory",
+        pr: "42",
+      });
+      expect(item.dedupe_key).toBe("ESCALATED:WM-390");
+      if (valid) {
+        expect(item.title).toBe(authored.question);
+        expect(JSON.parse(item.decision_json)).toEqual(authored);
+        expect(item.body).toBeNull();
+      } else {
+        expect(JSON.parse(item.decision_json)).not.toEqual(invalid);
+        expect(item.body).toContain("recommended");
+      }
+    }
+  });
+
+  test("refusal reasons other than needs_human do not create inbox items", async () => {
+    const db = openDb(":memory:");
+    queueRun(db, makeSpec({
+      adapter: "refuse-missing-input",
+      input: { repos: ["missing"] },
+    }));
+    const adapter = {
+      async execute({ workspaceDir }) {
+        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "refused",
+          reasonCode: "missing_input",
+        }));
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const summary = await runOnce(
+      db,
+      registry,
+      { "refuse-missing-input": adapter },
+      opts(),
+    );
+    expect(summary.reasonCode).toBe("missing_input");
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(0);
+  });
+
   test("invalid-artifact: FAILED/contract_violation, no outbox row, workspace retained", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ input: { repos: ["invalid-artifact"] } }));

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -344,6 +344,16 @@ describe("worker", () => {
     expect(parsedResult.artifacts[0].kind).toBe("transcript");
     expect(parsedResult.artifacts[0].sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(parsedResult.artifacts[0].uri).toMatch(/^file:\/\//);
+    const inbox = db.query(`SELECT * FROM inbox_items WHERE refs_json LIKE ?`).get(
+      `%${spec.runId}%`,
+    );
+    expect(inbox).toBeTruthy();
+    expect(inbox.kind).toBe("ESCALATED");
+    expect(inbox.source).toBe(`agent:${spec.runId}`);
+    expect(inbox.dedupe_key).toBe(`ESCALATED:${spec.runId}`);
+    expect(JSON.parse(inbox.decision_json).schemaVersion).toBe(
+      "factory.decision-request/v1",
+    );
     const storePath = path.join(o.artifactStore ?? artifactsRoot(), parsedResult.artifacts[0].sha256);
     expect(existsSync(storePath)).toBe(true);
     expect(pinRunArtifact(db, spec.runId)).toEqual({

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -430,6 +430,38 @@ describe("worker", () => {
     }
   });
 
+  test("a failing refusal inbox write never rolls back the terminal REFUSED state", async () => {
+    const db = openDb(":memory:");
+    // Force createInboxItem to throw inside the REFUSED transaction; the
+    // projection is best-effort and the terminal state and result row must land.
+    db.exec(`CREATE TRIGGER inbox_write_fails BEFORE INSERT ON inbox_items
+             BEGIN SELECT RAISE(ABORT, 'inbox write refused by test'); END`);
+    const spec = queueRun(db, makeSpec({
+      adapter: "refuse-inbox-fails",
+      input: { repos: ["inbox-fails"], ticket: "WM-390", repo: "factory" },
+    }));
+    const adapter = {
+      async execute({ workspaceDir }) {
+        writeFileSync(path.join(workspaceDir, "result.json"), JSON.stringify({
+          schemaVersion: "factory.agent-result/v1",
+          terminalState: "refused",
+          reasonCode: "needs_human",
+        }));
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const summary = await runOnce(
+      db,
+      registry,
+      { "refuse-inbox-fails": adapter },
+      opts(),
+    );
+    expect(summary).toMatchObject({ terminalState: "REFUSED", reasonCode: "needs_human" });
+    expect(db.query("SELECT state FROM runs WHERE run_id = ?").get(spec.runId).state).toBe("REFUSED");
+    expect(db.query("SELECT * FROM results WHERE run_id = ?").get(spec.runId)).toBeTruthy();
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(0);
+  });
+
   test("refusal reasons other than needs_human do not create inbox items", async () => {
     const db = openDb(":memory:");
     queueRun(db, makeSpec({


### PR DESCRIPTION
## Summary
- migrate the inbox ledger for validated decision requests/responses and open-item deduplication
- add detail/decide/retry API and CLI flows with serialized effect application, templates, and Telegram projection
- raise decision-backed inbox items from refused runs and parked/proposal notifications

## Verification
- `bun test event-runtime/lib && bun test && bun build/emit.mjs --check && bun run format:check`
- `bash lib/security-check.sh`

UX critique: skipped — backend ledger/API, operator CLI, and docs only; no browser-completable user flow.

Fixes WM-390