### PR TITLE
fix(event-runtime-web): align detail pane headers

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -687,12 +687,16 @@ export function PaneHeader({
     <div className="shrink-0 border-b border-(--border) px-4 py-3">
       {/* Row 1: Title & Close */}
       <div className="flex items-center justify-between gap-2">
-        <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">{title}</div>
+        <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">
+          {title}
+        </div>
         {close != null && <div className="shrink-0">{close}</div>}
       </div>
       {/* Row 2: Verb Row (≤ 3 bordered buttons) */}
       {actions != null && (
-        <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">{actions}</div>
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">
+          {actions}
+        </div>
       )}
       {/* Row 3: Utility Row (copy/share quiet text line) */}
       {utility != null && (

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -664,7 +664,47 @@ export function ListPane({
   );
 }
 
-/** Pinned title, verb, and utility rows; the spec and payload scroll underneath (WM-209). */
+/**
+ * Shared detail-pane chrome: identity and Close, then verbs, then copy/share.
+ * Keeping these rows here prevents each view from inventing its own spacing or
+ * moving a primary action above the selected record's identity (WM-552).
+ */
+export function PaneHeader({
+  title,
+  actions,
+  utility,
+  close,
+}: {
+  title: ReactNode;
+  actions?: ReactNode;
+  utility?: ReactNode;
+  /** Escape hatch pinned at the top-right, outside the wrapping action row,
+   *  so it stays visible and clickable no matter how many actions the view
+   *  stacks up or how narrow the panel gets (WM-97). */
+  close?: ReactNode;
+}) {
+  return (
+    <div className="shrink-0 border-b border-(--border) px-4 py-3">
+      {/* Row 1: Title & Close */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">{title}</div>
+        {close != null && <div className="shrink-0">{close}</div>}
+      </div>
+      {/* Row 2: Verb Row (≤ 3 bordered buttons) */}
+      {actions != null && (
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">{actions}</div>
+      )}
+      {/* Row 3: Utility Row (copy/share quiet text line) */}
+      {utility != null && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
+          {utility}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Pinned header chrome; the spec and payload scroll underneath (WM-209). */
 export function DetailPane({
   widthClass,
   title,
@@ -677,9 +717,6 @@ export function DetailPane({
   title: ReactNode;
   actions?: ReactNode;
   utility?: ReactNode;
-  /** Escape hatch pinned at the top-right, outside the wrapping action row,
-   *  so it stays visible and clickable no matter how many actions the view
-   *  stacks up or how narrow the panel gets (WM-97). */
   close?: ReactNode;
   children: ReactNode;
 }) {
@@ -687,27 +724,12 @@ export function DetailPane({
     <aside
       className={`${widthClass} flex min-h-0 shrink-0 flex-col border-l border-(--border) bg-(--surface-1)`}
     >
-      <div className="shrink-0 border-b border-(--border) px-4 py-3">
-        {/* Row 1: Title & Close */}
-        <div className="flex items-center justify-between gap-2">
-          <div className="display min-w-0 flex-1 truncate text-[14px] font-semibold">
-            {title}
-          </div>
-          {close != null && <div className="shrink-0">{close}</div>}
-        </div>
-        {/* Row 2: Verb Row (≤ 3 bordered buttons) */}
-        {actions != null && (
-          <div className="mt-2 flex flex-wrap items-center justify-between gap-1.5">
-            {actions}
-          </div>
-        )}
-        {/* Row 3: Utility Row (copy/share quiet text line) */}
-        {utility != null && (
-          <div className="mt-2 flex flex-wrap items-center gap-x-2 text-[11px] text-(--text-faint)">
-            {utility}
-          </div>
-        )}
-      </div>
+      <PaneHeader
+        title={title}
+        actions={actions}
+        utility={utility}
+        close={close}
+      />
       <div className="min-h-0 flex-1 overflow-auto p-4">{children}</div>
     </aside>
   );

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -297,11 +297,15 @@ describe("Agents detail pane (WM-211)", () => {
     const agent = stubAgent("dispatch");
     await withAgents([agent], async () => {
       const view = renderAgents(agent.ref);
-      const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+      const breadcrumb = await view.findByRole("navigation", {
+        name: "Breadcrumb",
+      });
 
       expect(breadcrumb.textContent).toContain("Agents/");
       expect(breadcrumb.textContent).toContain("dispatch@1");
-      expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+      expect(view.container.querySelector("aside")?.className).toContain(
+        "w-[440px]",
+      );
     });
   });
 

--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -293,6 +293,18 @@ describe("Agents table keyboard navigation (WM-732)", () => {
 });
 
 describe("Agents detail pane (WM-211)", () => {
+  test("renders the shared Agents breadcrumb in the standard pane width (WM-552)", async () => {
+    const agent = stubAgent("dispatch");
+    await withAgents([agent], async () => {
+      const view = renderAgents(agent.ref);
+      const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+
+      expect(breadcrumb.textContent).toContain("Agents/");
+      expect(breadcrumb.textContent).toContain("dispatch@1");
+      expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+    });
+  });
+
   test("declared tier, exact override, and the per-route resolved model are all readable", async () => {
     const agents = [
       stubAgent("pi-smoke", {

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -651,7 +651,10 @@ export function Agents({
         <DetailPane
           widthClass="w-[440px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectAgent(null)}
@@ -663,7 +666,10 @@ export function Agents({
               <span className="text-(--text-faint)" aria-hidden="true">
                 /
               </span>
-              <span className="min-w-0 truncate font-semibold text-(--text)" aria-current="page">
+              <span
+                className="min-w-0 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
                 <span className="mono truncate" title={sel.ref}>
                   {shortId(sel.ref)}
                 </span>

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -38,6 +38,7 @@ import {
   Th,
   copyText,
   copyLink,
+  shortId,
 } from "../components/ui";
 import { ScopeCaption } from "../components/ContextTabs";
 import { AgentMutationBadge } from "../components/AgentHoverCard";
@@ -648,15 +649,28 @@ export function Agents({
 
       {sel && (
         <DetailPane
-          widthClass="w-full lg:w-[520px]"
+          widthClass="w-[440px]"
           title={
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="mono truncate" title={sel.ref}>
-                {sel.ref}
+            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+              <button
+                type="button"
+                onClick={() => onSelectAgent(null)}
+                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                title="Back to agents list"
+              >
+                Agents
+              </button>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
               </span>
-              <CopyActions id={sel.ref} idLabel="agent ref" />
-            </div>
+              <span className="min-w-0 truncate font-semibold text-(--text)" aria-current="page">
+                <span className="mono truncate" title={sel.ref}>
+                  {shortId(sel.ref)}
+                </span>
+              </span>
+            </nav>
           }
+          utility={<CopyActions id={sel.ref} idLabel="agent ref" />}
           close={<Button onClick={() => onSelectAgent(null)}>Close</Button>}
         >
           <Section title="Definition" icons>

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -544,6 +544,15 @@ describe("Schedules copy chords and hints (WM-233)", () => {
 });
 
 describe("Schedules action shortcut badge (WM-236)", () => {
+  test("renders the shared Schedules breadcrumb in the standard pane width (WM-552)", async () => {
+    const view = renderSchedules({ focusScheduleLoop: "loop-enabled-running" });
+    const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+
+    expect(breadcrumb.textContent).toContain("Schedules/");
+    expect(breadcrumb.textContent).toContain("loop-enabled-running");
+    expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+  });
+
   test("detail pane 'Run now…' button renders 'r' shortcut hint badge with aria-hidden", async () => {
     const { container } = renderWithClient(
       <StatefulSchedules connected={true} initialLoop="loop-enabled-running" />,

--- a/event-runtime/web/src/views/Schedules.test.tsx
+++ b/event-runtime/web/src/views/Schedules.test.tsx
@@ -546,11 +546,15 @@ describe("Schedules copy chords and hints (WM-233)", () => {
 describe("Schedules action shortcut badge (WM-236)", () => {
   test("renders the shared Schedules breadcrumb in the standard pane width (WM-552)", async () => {
     const view = renderSchedules({ focusScheduleLoop: "loop-enabled-running" });
-    const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+    const breadcrumb = await view.findByRole("navigation", {
+      name: "Breadcrumb",
+    });
 
     expect(breadcrumb.textContent).toContain("Schedules/");
     expect(breadcrumb.textContent).toContain("loop-enabled-running");
-    expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+    expect(view.container.querySelector("aside")?.className).toContain(
+      "w-[440px]",
+    );
   });
 
   test("detail pane 'Run now…' button renders 'r' shortcut hint badge with aria-hidden", async () => {

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -702,7 +702,10 @@ export function Schedules({
         <DetailPane
           widthClass="w-[440px]"
           title={
-            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
               <button
                 type="button"
                 onClick={() => onSelectSchedule(null)}

--- a/event-runtime/web/src/views/Schedules.tsx
+++ b/event-runtime/web/src/views/Schedules.tsx
@@ -32,6 +32,7 @@ import {
   copyLink,
   copyText,
   notify,
+  shortId,
 } from "../components/ui";
 
 export type { ScheduleItem, TriggerOutcome };
@@ -699,27 +700,40 @@ export function Schedules({
 
       {sel && (
         <DetailPane
-          widthClass="w-[520px]"
+          widthClass="w-[440px]"
           title={
-            <span className="flex min-w-0 items-center gap-2">
-              <span className="mono truncate" title={sel.loop}>
-                {sel.loop}
+            <nav aria-label="Breadcrumb" className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal">
+              <button
+                type="button"
+                onClick={() => onSelectSchedule(null)}
+                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                title="Back to schedules list"
+              >
+                Schedules
+              </button>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
               </span>
-              {sel.approval === "auto" && (
-                <span
-                  className="rounded border px-1.5 py-0.5 text-[11px] font-semibold tracking-wide uppercase"
-                  style={{
-                    color: "var(--hue-warn)",
-                    borderColor:
-                      "color-mix(in oklch, var(--hue-warn) 40%, var(--border))",
-                    background:
-                      "color-mix(in oklch, var(--hue-warn) 12%, transparent)",
-                  }}
-                >
-                  auto
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
+                <ScheduleStateBadge
+                  state={scheduleState(sel)}
+                  hue={
+                    sel.error || sel.stopped
+                      ? "var(--hue-err)"
+                      : sel.enabled
+                        ? "var(--hue-ok)"
+                        : "var(--text-faint)"
+                  }
+                  title={`Schedule state: ${scheduleState(sel)}`}
+                />
+                <span className="mono truncate" title={sel.loop}>
+                  {shortId(sel.loop)}
                 </span>
-              )}
-            </span>
+              </span>
+            </nav>
           }
           actions={
             <Button

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -460,18 +460,34 @@ describe("Workers Open run action shortcut badge (WM-236)", () => {
   test("uses the shared breadcrumb and compacts adapters, labels, and field names (WM-552)", async () => {
     const worker: Worker = {
       ...stubWorker("worker_30596_413d70b7", "idle"),
-      adapters: ["claude", "pi", "codex", "gemini", "command", "actions", "fake"],
+      adapters: [
+        "claude",
+        "pi",
+        "codex",
+        "gemini",
+        "command",
+        "actions",
+        "fake",
+      ],
       labels: { sandbox: "gondolin" },
     };
     await withWorkers([worker], async () => {
       const view = renderWithClient(
-        <Workers context={{ kind: "all" }} focusWorkerId={worker.workerId} onSelectWorker={noop} />,
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId={worker.workerId}
+          onSelectWorker={noop}
+        />,
       );
-      const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+      const breadcrumb = await view.findByRole("navigation", {
+        name: "Breadcrumb",
+      });
 
       expect(breadcrumb.textContent).toContain("Workers/");
-      expect(breadcrumb.textContent).toContain("worker_30596");
-      expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+      expect(breadcrumb.textContent).toContain("worker_413d70b7");
+      expect(view.container.querySelector("aside")?.className).toContain(
+        "w-[440px]",
+      );
 
       const adapters = view.getByRole("group", { name: "Worker adapters" });
       expect(adapters.querySelectorAll("span")).toHaveLength(7);
@@ -486,6 +502,38 @@ describe("Workers Open run action shortcut badge (WM-236)", () => {
       expect(paneText).not.toContain("workerId");
       expect(paneText).not.toContain("currentRun");
       expect(paneText).not.toContain("startedAt");
+    });
+  });
+
+  test("breadcrumb stays distinct for two workers sharing the same supervisor pid (WM-552)", async () => {
+    const workerA = stubWorker("worker_2909182_2e08ba86", "idle");
+    const workerB = stubWorker("worker_2909182_474a477f", "idle");
+    await withWorkers([workerA, workerB], async () => {
+      const viewA = renderWithClient(
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId={workerA.workerId}
+          onSelectWorker={noop}
+        />,
+      );
+      const breadcrumbA = await viewA.findByRole("navigation", {
+        name: "Breadcrumb",
+      });
+      expect(breadcrumbA.textContent).toContain("worker_2e08ba86");
+      viewA.unmount();
+
+      const viewB = renderWithClient(
+        <Workers
+          context={{ kind: "all" }}
+          focusWorkerId={workerB.workerId}
+          onSelectWorker={noop}
+        />,
+      );
+      const breadcrumbB = await viewB.findByRole("navigation", {
+        name: "Breadcrumb",
+      });
+      expect(breadcrumbB.textContent).toContain("worker_474a477f");
+      expect(breadcrumbB.textContent).not.toBe(breadcrumbA.textContent);
     });
   });
 

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -457,6 +457,38 @@ describe("Workers copy chords and hints (WM-233)", () => {
 });
 
 describe("Workers Open run action shortcut badge (WM-236)", () => {
+  test("uses the shared breadcrumb and compacts adapters, labels, and field names (WM-552)", async () => {
+    const worker: Worker = {
+      ...stubWorker("worker_30596_413d70b7", "idle"),
+      adapters: ["claude", "pi", "codex", "gemini", "command", "actions", "fake"],
+      labels: { sandbox: "gondolin" },
+    };
+    await withWorkers([worker], async () => {
+      const view = renderWithClient(
+        <Workers context={{ kind: "all" }} focusWorkerId={worker.workerId} onSelectWorker={noop} />,
+      );
+      const breadcrumb = await view.findByRole("navigation", { name: "Breadcrumb" });
+
+      expect(breadcrumb.textContent).toContain("Workers/");
+      expect(breadcrumb.textContent).toContain("worker_30596");
+      expect(view.container.querySelector("aside")?.className).toContain("w-[440px]");
+
+      const adapters = view.getByRole("group", { name: "Worker adapters" });
+      expect(adapters.querySelectorAll("span")).toHaveLength(7);
+      expect(adapters.textContent).toContain("claude");
+      expect(adapters.textContent).toContain("fake");
+
+      const paneText = view.container.querySelector("aside")?.textContent ?? "";
+      expect(paneText).toContain("worker ID");
+      expect(paneText).toContain("current run");
+      expect(paneText).toContain("started at");
+      expect(paneText).toContain("sandboxgondolin");
+      expect(paneText).not.toContain("workerId");
+      expect(paneText).not.toContain("currentRun");
+      expect(paneText).not.toContain("startedAt");
+    });
+  });
+
   test("detail pane renders 'Open run' action button with 'o' shortcut badge when worker has currentRun", async () => {
     const workerWithRun: Worker = {
       ...stubWorker("w_busy_1", "busy"),

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -40,7 +40,6 @@ import {
   CopyActions,
   DetailPane,
   FilterInput,
-  JsonBlock,
   JumpLink,
   KV,
   ListEmpty,
@@ -1099,17 +1098,36 @@ export function Workers({
 
       {sel && (
         <DetailPane
-          widthClass="w-[460px]"
+          widthClass="w-[440px]"
           title={
-            <span className="flex min-w-0 items-center gap-2">
-              <StateBadge
-                state={workerDisplayState(sel)}
-                hues={WORKER_STATE_HUES}
-              />
-              <span className="mono truncate" title={sel.workerId}>
-                {sel.workerId}
+            <nav
+              aria-label="Breadcrumb"
+              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
+            >
+              <button
+                type="button"
+                onClick={() => onSelectWorker(null)}
+                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                title="Back to workers list"
+              >
+                Workers
+              </button>
+              <span className="text-(--text-faint)" aria-hidden="true">
+                /
               </span>
-            </span>
+              <span
+                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                aria-current="page"
+              >
+                <StateBadge
+                  state={workerDisplayState(sel)}
+                  hues={WORKER_STATE_HUES}
+                />
+                <span className="mono truncate" title={sel.workerId}>
+                  {shortId(sel.workerId)}
+                </span>
+              </span>
+            </nav>
           }
           actions={
             sel.currentRun ? (
@@ -1149,7 +1167,7 @@ export function Workers({
           {sel.currentRun && (
             <Section title="Active Run" icons>
               <KV
-                k="runId"
+                k="run ID"
                 v={
                   <JumpLink
                     onClick={() => openRun(sel.currentRun!)}
@@ -1220,7 +1238,7 @@ export function Workers({
           </Section>
 
           <Section title="Process" icons>
-            <KV k="workerId" v={sel.workerId} />
+            <KV k="worker ID" v={sel.workerId} />
             <KV k="host" v={sel.host} />
             <KV k="pid" v={String(sel.pid)} />
             <KV
@@ -1239,7 +1257,7 @@ export function Workers({
               }
             />
             <KV
-              k="currentRun"
+              k="current run"
               v={
                 sel.currentRun ? (
                   <JumpLink
@@ -1254,7 +1272,7 @@ export function Workers({
               }
             />
             <KV
-              k="startedAt"
+              k="started at"
               v={
                 <span title={sel.startedAt}>
                   {formatRelative(sel.startedAt, now)}
@@ -1263,7 +1281,7 @@ export function Workers({
             />
             {sel.stoppedAt && (
               <KV
-                k="stoppedAt"
+                k="stopped at"
                 v={
                   <span title={sel.stoppedAt}>
                     {formatRelative(sel.stoppedAt, now)}
@@ -1279,14 +1297,14 @@ export function Workers({
                 No adapters declared — this worker claims nothing.
               </div>
             ) : (
-              <div className="rounded-md border border-(--border) px-3 py-1">
+              <div className="flex flex-wrap gap-1.5" role="group" aria-label="Worker adapters">
                 {sel.adapters.map((a) => (
-                  <div
+                  <span
                     key={a}
-                    className="mono border-b border-(--border) py-1.5 last:border-0"
+                    className="mono rounded-full bg-(--surface-2) px-2 py-0.5 text-[11px] text-(--text-dim)"
                   >
                     {a}
-                  </div>
+                  </span>
                 ))}
               </div>
             )}
@@ -1297,7 +1315,11 @@ export function Workers({
               Placement labels the worker declared at registration — what a
               run&apos;s placement constraints are matched against.
             </div>
-            <JsonBlock value={sel.labels} />
+            {Object.keys(sel.labels).length === 0 ? (
+              <div className="text-(--text-faint)">No placement labels declared.</div>
+            ) : (
+              Object.entries(sel.labels).map(([key, value]) => <KV key={key} k={key} v={value} />)
+            )}
           </Section>
         </DetailPane>
       )}

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -56,6 +56,22 @@ import {
 } from "../components/ui";
 import { health, WORKER_HUES } from "../workerHealth";
 
+/**
+ * Short display form of a worker id: `worker_<pid>_<hex>` → `worker_<hex>`
+ * (WM-552 follow-up). `shortId()` assumes a single-underscore `type_hexbody`
+ * shape (correct for run/event ids) and would keep the *pid* segment here,
+ * which collides for every worker spawned by the same supervisor process.
+ * Worker ids carry two underscores, so this keeps the trailing hash segment
+ * — the part that actually varies between workers — instead. Ids that don't
+ * match the `type_pid_hex` shape fall back to `shortId()` unchanged.
+ */
+export function shortWorkerId(id: string): string {
+  const parts = id.split("_");
+  if (parts.length < 3) return shortId(id);
+  const hex = parts[parts.length - 1];
+  return `${parts[0]}_${hex.length <= 8 ? hex : hex.slice(0, 8)}`;
+}
+
 export const WORKER_TABS = ["ALL", "LIVE", "STOPPED"] as const;
 export type WorkerTab = (typeof WORKER_TABS)[number];
 export type WorkerDisplayState = ReturnType<typeof health> | "draining";
@@ -1124,7 +1140,7 @@ export function Workers({
                   hues={WORKER_STATE_HUES}
                 />
                 <span className="mono truncate" title={sel.workerId}>
-                  {shortId(sel.workerId)}
+                  {shortWorkerId(sel.workerId)}
                 </span>
               </span>
             </nav>
@@ -1297,7 +1313,11 @@ export function Workers({
                 No adapters declared — this worker claims nothing.
               </div>
             ) : (
-              <div className="flex flex-wrap gap-1.5" role="group" aria-label="Worker adapters">
+              <div
+                className="flex flex-wrap gap-1.5"
+                role="group"
+                aria-label="Worker adapters"
+              >
                 {sel.adapters.map((a) => (
                   <span
                     key={a}
@@ -1316,9 +1336,13 @@ export function Workers({
               run&apos;s placement constraints are matched against.
             </div>
             {Object.keys(sel.labels).length === 0 ? (
-              <div className="text-(--text-faint)">No placement labels declared.</div>
+              <div className="text-(--text-faint)">
+                No placement labels declared.
+              </div>
             ) : (
-              Object.entries(sel.labels).map(([key, value]) => <KV key={key} k={key} v={value} />)
+              Object.entries(sel.labels).map(([key, value]) => (
+                <KV key={key} k={key} v={value} />
+              ))
             )}
           </Section>
         </DetailPane>


### PR DESCRIPTION
## Summary
- extract shared `PaneHeader` chrome for consistent identity, verb, and copy rows
- align Agents, Schedules, and Workers detail panes to 440px breadcrumb headers
- compact Workers adapters and labels and humanize process field names
- add breadcrumb, width, and worker-detail regression coverage

## Verification
- `cd event-runtime/web && bun run build && bun test` — pass (845 tests)

UX critique: required — NOT-ASSESSED (isolated Chromium exited before DevTools became available; PR remains draft)

Out-of-scope canonical Proposals/Runs 460px width drift filed as WM-685.

Fixes WM-552