### PR TITLE
feat(event-runtime-web): add operational metrics page

### DIFF
--- a/event-runtime/lib/api-proposals.test.mjs
+++ b/event-runtime/lib/api-proposals.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { makeServer } from "./api-test-helpers.mjs";
+
+describe("metrics proposal drill-down filters (WM-282)", () => {
+  const now = Date.parse("2026-08-18T10:00:00.000Z");
+  const from = "2026-08-18T08:00:00.000Z";
+  const to = "2026-08-18T10:00:00.000Z";
+
+  function insertProposal(
+    db,
+    id,
+    { status, createdAt, decidedAt = null, ttl = 3600 },
+  ) {
+    db.query(
+      `INSERT INTO proposals
+         (id, event_source, event_id, decision, status, created_at, ttl_seconds, decided_at, spec_json)
+       VALUES (?, 'test', ?, 'run', ?, ?, ?, ?, '{}')`,
+    ).run(id, `event-${id}`, status, createdAt, ttl, decidedAt);
+  }
+
+  test("decision population includes recorded and truthful virtual expiry timestamps", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      insertProposal(s.db, "proposal-approved", {
+        status: "approved",
+        createdAt: "2026-08-18T08:00:00.000Z",
+        decidedAt: "2026-08-18T08:30:00.000Z",
+      });
+      insertProposal(s.db, "proposal-expired-open", {
+        status: "open",
+        createdAt: "2026-08-18T07:30:00.000Z",
+        ttl: 3600,
+      });
+      insertProposal(s.db, "proposal-future-open", {
+        status: "open",
+        createdAt: "2026-08-18T09:30:00.000Z",
+        ttl: 3600,
+      });
+
+      const approved = await fetch(
+        s.url(
+          `/proposals?status=all&population=decision&from=${from}&to=${to}&decisionStatus=approved`,
+        ),
+      );
+      expect(approved.status).toBe(200);
+      expect(
+        (await approved.json()).proposals.map((proposal) => proposal.id),
+      ).toEqual(["proposal-approved"]);
+
+      const expired = await fetch(
+        s.url(
+          `/proposals?status=all&population=decision&from=${from}&to=${to}&decisionStatus=expired`,
+        ),
+      );
+      expect(expired.status).toBe(200);
+      const rows = (await expired.json()).proposals;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: "proposal-expired-open",
+        status: "expired",
+        expired: true,
+      });
+      expect(rows[0].decided_at).toBe("2026-08-18T08:30:00.000Z");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("rejects incomplete and unknown proposal populations", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      const incomplete = await fetch(
+        s.url("/proposals?status=all&population=decision"),
+      );
+      expect(incomplete.status).toBe(422);
+      expect((await incomplete.json()).error).toBe("incomplete_time_filter");
+      const unknown = await fetch(
+        s.url(`/proposals?status=all&population=usage&from=${from}&to=${to}`),
+      );
+      expect(unknown.status).toBe(422);
+      expect((await unknown.json()).error).toBe("invalid_population");
+    } finally {
+      s.close();
+    }
+  });
+});

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -71,22 +71,46 @@ function proposalView(row) {
   };
 }
 
-function proposalHistory(db, status) {
-  const rows = status
-    ? db
-        .query(
-          `SELECT * FROM proposals WHERE status = ? ORDER BY created_at DESC, rowid DESC`,
-        )
-        .all(status)
-    : db
-        .query(`SELECT * FROM proposals ORDER BY created_at DESC, rowid DESC`)
-        .all();
-  return rows.map((row) =>
-    proposalView({
-      ...row,
-      spec: row.spec_json ? JSON.parse(row.spec_json) : null,
-    }),
-  );
+function proposalHistory(db, status, filters = {}) {
+  const filteredDecision = filters.population === "decision";
+  const rows =
+    status && !filteredDecision
+      ? db
+          .query(
+            `SELECT * FROM proposals WHERE status = ? ORDER BY created_at DESC, rowid DESC`,
+          )
+          .all(status)
+      : db
+          .query(`SELECT * FROM proposals ORDER BY created_at DESC, rowid DESC`)
+          .all();
+  return rows.flatMap((row) => {
+    let decisionAt = row.decided_at ?? null;
+    let effectiveStatus = row.status;
+    if (filteredDecision && row.status === "open") {
+      const expiresAt =
+        Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
+      if (Number.isFinite(expiresAt) && expiresAt < filters.nowMs) {
+        decisionAt = new Date(expiresAt).toISOString();
+        effectiveStatus = "expired";
+      }
+    }
+    if (filteredDecision) {
+      const at = Date.parse(decisionAt ?? "");
+      if (!Number.isFinite(at) || at < filters.fromMs || at >= filters.toMs)
+        return [];
+      if (filters.decisionStatus && effectiveStatus !== filters.decisionStatus)
+        return [];
+    }
+    return [
+      proposalView({
+        ...row,
+        status: effectiveStatus,
+        decided_at: decisionAt,
+        expired: effectiveStatus === "expired",
+        spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+      }),
+    ];
+  });
 }
 
 function eventsView(db, status) {
@@ -369,8 +393,115 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
 /** States whose attempt deadline is live and render-relevant on the run list. */
 const IN_FLIGHT_STATES = new Set(["LEASED", "RUNNING", "VERIFYING"]);
 
-function runsView(db, state) {
-  const where = state ? `WHERE r.state = ?` : ``;
+const RUN_POPULATIONS = new Set([
+  "created",
+  "terminal",
+  "started",
+  "retried",
+  "leased",
+  "finished",
+  "usage",
+]);
+
+class ListQueryError extends Error {
+  constructor(error, details = {}) {
+    super(error);
+    this.body = { error, ...details };
+  }
+}
+
+function listFilters(url, { proposal = false, nowMs = Date.now() } = {}) {
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  const population = url.searchParams.get("population");
+  if (!from && !to && !population) return {};
+  if (!from || !to || !population) {
+    throw new ListQueryError("incomplete_time_filter", {
+      required: ["from", "to", "population"],
+    });
+  }
+  const fromMs = Date.parse(from);
+  const toMs = Date.parse(to);
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || fromMs >= toMs) {
+    throw new ListQueryError("invalid_time_filter", { from, to });
+  }
+  const valid = proposal ? new Set(["decision"]) : RUN_POPULATIONS;
+  if (!valid.has(population)) {
+    throw new ListQueryError("invalid_population", {
+      population,
+      valid: [...valid],
+    });
+  }
+  return { from, to, fromMs, toMs, population, nowMs };
+}
+
+function runsView(db, filters = {}) {
+  const { state, agent, from, to, population } = filters;
+  const clauses = [];
+  const params = [];
+  if (agent) {
+    clauses.push(`json_extract(r.spec_json, '$.agent') = ?`);
+    params.push(agent);
+  }
+  if (!population || population === "created") {
+    if (state) {
+      clauses.push("r.state = ?");
+      params.push(state);
+    }
+    if (population === "created") {
+      clauses.push("r.created_at >= ? AND r.created_at < ?");
+      params.push(from, to);
+    }
+  } else if (population === "terminal") {
+    clauses.push(
+      `EXISTS (
+        SELECT 1 FROM lifecycle_events metric_event
+        WHERE metric_event.run_id = r.run_id
+          AND metric_event.at >= ? AND metric_event.at < ?
+          AND metric_event.to_state IN ('COMPLETED', 'FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')
+          ${state ? "AND metric_event.to_state = ?" : ""}
+      )`,
+    );
+    params.push(from, to, ...(state ? [state] : []));
+  } else if (population === "started" || population === "leased") {
+    clauses.push(
+      `EXISTS (
+        SELECT 1 FROM lifecycle_events metric_event
+        WHERE metric_event.run_id = r.run_id
+          AND metric_event.to_state = ?
+          AND metric_event.at >= ? AND metric_event.at < ?
+      )`,
+    );
+    params.push(population === "started" ? "RUNNING" : "LEASED", from, to);
+  } else if (population === "retried") {
+    clauses.push(
+      `EXISTS (
+        SELECT 1 FROM attempts metric_attempt
+        WHERE metric_attempt.run_id = r.run_id AND metric_attempt.attempt > 1
+          AND metric_attempt.started_at >= ? AND metric_attempt.started_at < ?
+      )`,
+    );
+    params.push(from, to);
+  } else if (population === "finished") {
+    clauses.push(
+      `EXISTS (
+        SELECT 1 FROM attempts metric_attempt
+        WHERE metric_attempt.run_id = r.run_id
+          AND metric_attempt.finished_at >= ? AND metric_attempt.finished_at < ?
+      )`,
+    );
+    params.push(from, to);
+  } else if (population === "usage") {
+    clauses.push(
+      `EXISTS (
+        SELECT 1 FROM run_usage metric_usage
+        WHERE metric_usage.run_id = r.run_id
+          AND metric_usage.recorded_at >= ? AND metric_usage.recorded_at < ?
+      )`,
+    );
+    params.push(from, to);
+  }
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
   const rows = db
     .query(
       `SELECT r.*, a.reason_code, a.terminal_state AS attempt_terminal,
@@ -381,7 +512,7 @@ function runsView(db, state) {
        ${where}
        ORDER BY r.created_at DESC, r.rowid DESC`,
     )
-    .all(...(state ? [state] : []));
+    .all(...params);
   return rows.map((row) => {
     const spec = JSON.parse(row.spec_json);
     return {
@@ -570,13 +701,26 @@ export async function handleRunApiRoute({
 
   if (route === "GET /proposals") {
     const status = url.searchParams.get("status");
-    if (status)
+    try {
+      const filters = {
+        ...listFilters(url, { proposal: true, nowMs }),
+        decisionStatus: url.searchParams.get("decisionStatus") ?? undefined,
+      };
+      if (status || filters.population)
+        return send(200, {
+          proposals: proposalHistory(
+            db,
+            status === "all" ? null : status,
+            filters,
+          ),
+        });
       return send(200, {
-        proposals: proposalHistory(db, status === "all" ? null : status),
+        proposals: openProposals(db, { now: nowMs }).map(proposalView),
       });
-    return send(200, {
-      proposals: openProposals(db, { now: nowMs }).map(proposalView),
-    });
+    } catch (err) {
+      if (err instanceof ListQueryError) return send(422, err.body);
+      throw err;
+    }
   }
 
   if (route === "GET /journal") {
@@ -688,7 +832,17 @@ export async function handleRunApiRoute({
       if (!journey) return send(422, { error: "ticket must look like WM-123" });
       return send(200, journey);
     }
-    return send(200, { runs: runsView(db, url.searchParams.get("state")) });
+    try {
+      const filters = {
+        ...listFilters(url, { nowMs }),
+        state: url.searchParams.get("state") ?? undefined,
+        agent: url.searchParams.get("agent") ?? undefined,
+      };
+      return send(200, { runs: runsView(db, filters) });
+    } catch (err) {
+      if (err instanceof ListQueryError) return send(422, err.body);
+      throw err;
+    }
   }
 
   const runExtend = url.pathname.match(/^\/runs\/([^/]+)\/extend$/);

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -291,6 +291,96 @@ describe("repoNamesFromInput (OPS-356)", () => {
   });
 });
 
+describe("metrics run drill-down filters (WM-282)", () => {
+  const now = Date.parse("2026-08-18T10:00:00.000Z");
+  const from = "2026-08-18T08:00:00.000Z";
+  const to = "2026-08-18T09:00:00.000Z";
+
+  function insertRun(db, runId, agent) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 0, '2026-08-18T07:00:00.000Z', '2026-08-18T09:30:00.000Z')`,
+    ).run(
+      runId,
+      `idem-${runId}`,
+      JSON.stringify({
+        agent,
+        adapter: "fake",
+        input: {},
+        maxAttempts: 2,
+        timeoutSeconds: 60,
+      }),
+    );
+  }
+
+  test("terminal population uses lifecycle time/state rather than the run's current state", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      insertRun(s.db, "run-historical-failure", "dispatch@1");
+      insertRun(s.db, "run-outside", "dispatch@1");
+      s.db
+        .query(
+          `INSERT INTO lifecycle_events (run_id, from_state, to_state, actor, at, record_hash)
+         VALUES (?, 'RUNNING', 'FAILED', 'test', ?, ?)`,
+        )
+        .run(
+          "run-historical-failure",
+          "2026-08-18T08:30:00.000Z",
+          "hash-failed",
+        );
+      s.db
+        .query(
+          `INSERT INTO lifecycle_events (run_id, from_state, to_state, actor, at, record_hash)
+         VALUES (?, 'RUNNING', 'FAILED', 'test', ?, ?)`,
+        )
+        .run("run-outside", "2026-08-18T09:30:00.000Z", "hash-outside");
+
+      const res = await fetch(
+        s.url(`/runs?population=terminal&from=${from}&to=${to}&state=FAILED`),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).runs.map((run) => run.runId)).toEqual([
+        "run-historical-failure",
+      ]);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("usage population composes exact time and agent dimensions; malformed filters are typed", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      insertRun(s.db, "run-agent-a", "dispatch@1");
+      insertRun(s.db, "run-agent-b", "merge@1");
+      for (const runId of ["run-agent-a", "run-agent-b"]) {
+        s.db
+          .query(
+            `INSERT INTO run_usage
+             (run_id, attempt, adapter, input_tokens, output_tokens, cache_creation_input_tokens,
+              cache_read_input_tokens, cost_usd, recorded_at)
+           VALUES (?, 1, 'fake', 1, 0, 0, 0, 0.1, '2026-08-18T08:15:00.000Z')`,
+          )
+          .run(runId);
+      }
+      const filtered = await fetch(
+        s.url(
+          `/runs?population=usage&from=${from}&to=${to}&agent=${encodeURIComponent("dispatch@1")}`,
+        ),
+      );
+      expect(filtered.status).toBe(200);
+      expect((await filtered.json()).runs.map((run) => run.runId)).toEqual([
+        "run-agent-a",
+      ]);
+
+      const malformed = await fetch(s.url("/runs?population=usage"));
+      expect(malformed.status).toBe(422);
+      expect((await malformed.json()).error).toBe("incomplete_time_filter");
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("list views carry repos[] (OPS-356)", () => {
   test("GET /events exposes repos from payload; unscoped is []", async () => {
     const s = await makeServer();

--- a/event-runtime/web/src/App.test.tsx
+++ b/event-runtime/web/src/App.test.tsx
@@ -9,12 +9,12 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { App, navIsCurrent } from "./App";
+import { App, listSelectionPath, navIsCurrent } from "./App";
 import { goPrefix } from "./goSequence";
 import { refetchIntervals } from "./hooks";
 import { NAV } from "./nav";
 import { createProposalFixture } from "./test-render";
-import type { Proposal, StatusView } from "./types";
+import type { MetricsView, Proposal, StatusView } from "./types";
 
 const ENV = { name: "dev", home: "/tmp/factory", adapter: null };
 
@@ -43,6 +43,24 @@ const HEALTH = { ok: true, policyVersion: "test", env: ENV };
 // One approvable open proposal, so the proposals route renders the detail pane
 // whose Approve button carries the health-derived tooltip (WM-738).
 const OPEN_PROPOSAL_ID = "prop_health_wiring";
+
+const EMPTY_METRICS: MetricsView = {
+  window: "24h",
+  bucket: "1h",
+  buckets: [],
+  series: {
+    "runs.outcomes": {},
+    "runs.started": { total: [] },
+    "latency.queue_wait": { p50: [], p95: [] },
+    "latency.execution": { p50: [], p95: [] },
+    "spend.cost": {},
+    "spend.tokens": {},
+    "proposals.decisions": {},
+    "proposals.time_to_decision": { p50: [], p95: [] },
+    "events.intake": {},
+    "attempts.retries": { total: [] },
+  },
+};
 let currentStatus = STATUS;
 // "pending" never resolves, which is what a first load looks like before
 // /api/health answers; "error" is a runtime that answered with a failure.
@@ -124,6 +142,7 @@ beforeEach(() => {
       });
     }
     if (url.includes("/api/repos")) return jsonResponse({ repos: [] });
+    if (url.includes("/api/metrics")) return jsonResponse(EMPTY_METRICS);
     if (url.includes("/api/runs?ticket=")) {
       const ticket =
         new URL(url, "http://localhost").searchParams.get("ticket") ?? "WM-0";
@@ -353,6 +372,18 @@ describe("responsive primary navigation (WM-175)", () => {
       utils.getByRole("navigation", { name: "Primary" }).getAttribute("id"),
     ).toBe("primary-navigation");
   });
+});
+
+test("metrics list selections preserve the reproducible drill-down query", () => {
+  const hash =
+    "#/runs?from=2026-08-18T08%3A00%3A00.000Z&to=2026-08-18T09%3A00%3A00.000Z&population=terminal&state=FAILED&project=factory";
+  expect(listSelectionPath("runs", "run_1", hash)).toBe(
+    "runs/run_1?from=2026-08-18T08%3A00%3A00.000Z&to=2026-08-18T09%3A00%3A00.000Z&population=terminal&state=FAILED",
+  );
+  expect(listSelectionPath("runs", null, hash)).toStartWith("runs?from=");
+  expect(listSelectionPath("proposals", "prop_1", "#/proposals")).toBe(
+    "proposals/prop_1",
+  );
 });
 
 describe("bottom status bar", () => {
@@ -685,6 +716,13 @@ describe("context strip fast jump chords (WM-235)", () => {
       fireEvent.keyDown(document.body, { key: "r" });
     });
     expect(window.location.hash).toBe("#/runs");
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: "g" });
+      fireEvent.keyDown(document.body, { key: "m" });
+    });
+    expect(window.location.hash).toBe("#/metrics");
+    expect(await utils.findByRole("heading", { name: "Metrics" })).toBeTruthy();
 
     act(() => {
       fireEvent.keyDown(document.body, { key: "g" });

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -95,8 +95,24 @@ function NavCount({ id, badge }: { id: string; badge: NavBadge }) {
   );
 }
 
+export function listSelectionPath(
+  view: "runs" | "proposals",
+  id: string | null,
+  hash: string,
+) {
+  const path = hashPath(view, id);
+  const query = hashSearch(hash);
+  if (!query.has("population") || !query.has("from") || !query.has("to"))
+    return path;
+  query.delete("project");
+  return `${path}?${query.toString()}`;
+}
+
 const Artifacts = lazy(() =>
   import("./views/Artifacts").then((m) => ({ default: m.Artifacts })),
+);
+const Metrics = lazy(() =>
+  import("./views/Metrics").then((m) => ({ default: m.Metrics })),
 );
 const Graph = lazy(() =>
   import("./views/Graph").then((m) => ({ default: m.Graph })),
@@ -455,6 +471,7 @@ export function App() {
   const inboxOpen = status.data?.inbox?.open ?? 0;
   const navBadges: Record<NavKey, NavBadge> = {
     overview: { count: 0, hue: "var(--accent)" },
+    metrics: { count: 0, hue: "var(--accent)" },
     // Open = not even acked yet. Warn hue: every one of these is a human's
     // turn, which is exactly what the amber wash means everywhere else.
     inbox: {
@@ -884,7 +901,11 @@ export function App() {
                   context={context}
                   onRunQueued={jumpToRun}
                   focusProposalId={focusProposalId}
-                  onSelectProposal={(id) => navigate(hashPath("proposals", id))}
+                  onSelectProposal={(id) =>
+                    navigate(
+                      listSelectionPath("proposals", id, window.location.hash),
+                    )
+                  }
                   focusExpired={focusExpired}
                   onFocusExpiredConsumed={() => setFocusExpired(false)}
                   onJumpAgent={jumpToAgent}
@@ -913,7 +934,9 @@ export function App() {
                 connected={connected}
                 context={context}
                 focusRunId={focusRunId}
-                onSelectRun={(id) => navigate(hashPath("runs", id))}
+                onSelectRun={(id) =>
+                  navigate(listSelectionPath("runs", id, window.location.hash))
+                }
                 onOpenFull={openRunFull}
                 focusState={focusRunState}
                 onFocusStateConsumed={() => setFocusRunState(null)}
@@ -1094,6 +1117,16 @@ export function App() {
                   }
                   onJumpRun={jumpToRun}
                 />
+              </Suspense>
+            ) : view === "metrics" ? (
+              <Suspense
+                fallback={
+                  <div className="p-5 text-(--text-faint)">
+                    Loading metrics…
+                  </div>
+                }
+              >
+                <Metrics />
               </Suspense>
             ) : view === "events" ? (
               <Events

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -12,6 +12,9 @@ import type {
   InboxItem,
   InboxStatus,
   JournalView,
+  MetricsBreakdownView,
+  MetricsView,
+  MetricsWindow,
   OutboxRow,
   JanitorResult,
   Proposal,
@@ -86,6 +89,76 @@ export interface RepoItem extends BaseRepoItem {
 
 type CachedResponse = { etag: string; body: unknown };
 const responseCache = new Map<string, CachedResponse>();
+
+export type RunListFilters = {
+  state?: string;
+  from?: string;
+  to?: string;
+  population?:
+    | "created"
+    | "terminal"
+    | "started"
+    | "retried"
+    | "leased"
+    | "finished"
+    | "usage";
+  agent?: string;
+};
+
+export type ProposalListFilters = {
+  from?: string;
+  to?: string;
+  population?: "decision";
+  decisionStatus?: string;
+};
+
+function withQuery(path: string, values: Record<string, string | undefined>) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(values))
+    if (value) query.set(key, value);
+  return query.size > 0 ? `${path}?${query.toString()}` : path;
+}
+
+export function fetchRuns(filters: RunListFilters = {}) {
+  return call<{ runs: RunListItem[] }>("GET", withQuery("/runs", filters));
+}
+
+export function fetchProposalHistory(
+  status = "all",
+  filters: ProposalListFilters = {},
+) {
+  return call<{ proposals: Proposal[] }>(
+    "GET",
+    withQuery("/proposals", {
+      status,
+      from: filters.from,
+      to: filters.to,
+      population: filters.population,
+      decisionStatus: filters.decisionStatus,
+    }),
+  );
+}
+
+export function fetchMetrics(window: MetricsWindow, bucket: string) {
+  return call<MetricsView>("GET", withQuery("/metrics", { window, bucket }));
+}
+
+export function fetchMetricsBreakdown(
+  window: MetricsWindow,
+  by: string,
+  metric: string,
+  limit?: number,
+) {
+  return call<MetricsBreakdownView>(
+    "GET",
+    withQuery("/metrics/breakdown", {
+      window,
+      by,
+      metric,
+      limit: limit == null ? undefined : String(limit),
+    }),
+  );
+}
 
 async function call<T>(
   method: string,
@@ -168,11 +241,8 @@ export const api = {
     ),
   proposals: () => call<{ proposals: Proposal[] }>("GET", "/proposals"),
   // Full decision history (?status=all), newest first — read-only audit view.
-  proposalHistory: (status = "all") =>
-    call<{ proposals: Proposal[] }>(
-      "GET",
-      `/proposals?status=${encodeURIComponent(status)}`,
-    ),
+  proposalHistory: (status = "all", filters: ProposalListFilters = {}) =>
+    fetchProposalHistory(status, filters),
   approve: (id: string) =>
     call<ApproveOutcome>(
       "POST",
@@ -185,11 +255,8 @@ export const api = {
       `/proposals/${encodeURIComponent(id)}/reject`,
       { reason },
     ),
-  runs: (state?: string) =>
-    call<{ runs: RunListItem[] }>(
-      "GET",
-      `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`,
-    ),
+  runs: (state?: string, filters: RunListFilters = {}) =>
+    fetchRuns(state ? { ...filters, state } : filters),
   run: (id: string) =>
     call<RunDetail>("GET", `/runs/${encodeURIComponent(id)}`),
   // Live agent trace, ascending by seq; `since` is the last seen seq (incremental).

--- a/event-runtime/web/src/components/Charts.test.tsx
+++ b/event-runtime/web/src/components/Charts.test.tsx
@@ -1,0 +1,110 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { Band, Sparkline, StackedBars } from "./Charts";
+
+afterEach(cleanup);
+
+describe("Sparkline", () => {
+  test("names empty, single-point, and linked series without inventing a flat line", () => {
+    const empty = render(<Sparkline values={[]} label="No retries" />);
+    expect(
+      empty.getByRole("img", { name: "No retries" }).getAttribute("data-empty"),
+    ).toBe("true");
+    expect(empty.container.querySelector("polyline")).toBeNull();
+    empty.unmount();
+
+    const one = render(
+      <Sparkline
+        values={[3]}
+        label="Retries"
+        linkForPoint={() => ({
+          href: "#/runs?population=retried",
+          label: "3 retries",
+        })}
+      />,
+    );
+    expect(one.container.querySelectorAll("[data-point]")).toHaveLength(1);
+    expect(
+      one.getByRole("link", { name: "3 retries" }).getAttribute("href"),
+    ).toContain("population=retried");
+    expect(one.container.querySelector("polyline")).toBeNull();
+  });
+});
+
+describe("StackedBars", () => {
+  test("renders plain arrays, empty data, and accessible segment links", () => {
+    const empty = render(<StackedBars bars={[]} label="No outcomes" />);
+    expect(
+      empty
+        .getByRole("img", { name: "No outcomes" })
+        .getAttribute("data-empty"),
+    ).toBe("true");
+    empty.unmount();
+
+    const chart = render(
+      <StackedBars
+        label="Outcome mix"
+        bars={[
+          {
+            key: "now",
+            label: "Now",
+            segments: [
+              { key: "ok", label: "Completed", value: 2, hue: "var(--hue-ok)" },
+              {
+                key: "failed",
+                label: "Failed",
+                value: 1,
+                hue: "var(--hue-err)",
+                link: { href: "#/runs?state=FAILED", label: "1 failed run" },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(chart.container.querySelectorAll("rect[data-segment]")).toHaveLength(
+      2,
+    );
+    expect(chart.getByRole("link", { name: "1 failed run" })).toBeTruthy();
+  });
+});
+
+describe("Band", () => {
+  test("keeps an interior null as a real gap and handles empty/single-point data", () => {
+    const empty = render(<Band values={[]} label="No latency" />);
+    expect(
+      empty.getByRole("img", { name: "No latency" }).getAttribute("data-empty"),
+    ).toBe("true");
+    empty.unmount();
+
+    const single = render(
+      <Band values={[{ p50: 10, p95: 20 }]} label="One latency sample" />,
+    );
+    expect(
+      single.container.querySelectorAll("[data-band-segment]"),
+    ).toHaveLength(1);
+    expect(single.container.querySelectorAll("[data-point]")).toHaveLength(1);
+    single.unmount();
+
+    const gap = render(
+      <Band
+        values={[
+          { p50: 10, p95: 20 },
+          { p50: 12, p95: 24 },
+          { p50: null, p95: null },
+          { p50: 30, p95: 50 },
+          { p50: 32, p95: 60 },
+        ]}
+        label="Execution p50 to p95"
+      />,
+    );
+    expect(gap.container.querySelectorAll("[data-band-segment]")).toHaveLength(
+      2,
+    );
+    expect(
+      gap.container.querySelectorAll("[data-median-segment]"),
+    ).toHaveLength(2);
+    expect(gap.container.querySelectorAll("[data-point]")).toHaveLength(4);
+  });
+});

--- a/event-runtime/web/src/components/Charts.tsx
+++ b/event-runtime/web/src/components/Charts.tsx
@@ -1,0 +1,306 @@
+import { Fragment, type ReactNode } from "react";
+
+const finite = (value: number | null | undefined): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+function scale(values: number[], height: number, pad: number) {
+  const min = values.length > 0 ? Math.min(...values) : 0;
+  const max = values.length > 0 ? Math.max(...values) : 0;
+  const y = (value: number) =>
+    max === min
+      ? height / 2
+      : pad + ((max - value) / (max - min)) * (height - pad * 2);
+  return { min, max, y };
+}
+
+function pointX(index: number, count: number, width: number, pad: number) {
+  return count <= 1
+    ? width / 2
+    : pad + (index / (count - 1)) * (width - pad * 2);
+}
+
+export type ChartLink = {
+  href: string;
+  label: string;
+};
+
+function LinkedMark({
+  link,
+  children,
+}: {
+  link?: ChartLink | null;
+  children: ReactNode;
+}) {
+  if (!link) return <>{children}</>;
+  return (
+    <a href={link.href} aria-label={link.label}>
+      {children}
+    </a>
+  );
+}
+
+export function Sparkline({
+  values,
+  label,
+  hue = "var(--hue-info)",
+  width = 120,
+  height = 32,
+  linkForPoint,
+}: {
+  values: number[];
+  label: string;
+  hue?: string;
+  width?: number;
+  height?: number;
+  linkForPoint?: (index: number, value: number) => ChartLink | null;
+}) {
+  const points = values.filter(finite);
+  const pad = 4;
+  const { y } = scale(points, height, pad);
+  const polyline = values
+    .map(
+      (value, index) =>
+        `${pointX(index, values.length, width, pad)},${y(value)}`,
+    )
+    .join(" ");
+
+  return (
+    <svg
+      role="img"
+      aria-label={label}
+      viewBox={`0 0 ${width} ${height}`}
+      className="h-8 w-full overflow-visible"
+      data-empty={values.length === 0 ? "true" : undefined}
+    >
+      {values.length > 1 && (
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke={hue}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      {values.map((value, index) => {
+        const x = pointX(index, values.length, width, pad);
+        const cy = y(value);
+        const link = linkForPoint?.(index, value);
+        return (
+          <LinkedMark key={index} link={link}>
+            <g
+              data-point={index}
+              className={link ? "cursor-pointer" : undefined}
+            >
+              {link && <circle cx={x} cy={cy} r="6" fill="transparent" />}
+              <circle cx={x} cy={cy} r="2.5" fill={hue} />
+            </g>
+          </LinkedMark>
+        );
+      })}
+    </svg>
+  );
+}
+
+export interface StackedBarSegment {
+  key: string;
+  label: string;
+  value: number;
+  hue: string;
+  link?: ChartLink | null;
+}
+
+export interface StackedBarDatum {
+  key: string;
+  label: string;
+  segments: StackedBarSegment[];
+}
+
+export function StackedBars({
+  bars,
+  label,
+  width = 600,
+  height = 180,
+}: {
+  bars: StackedBarDatum[];
+  label: string;
+  width?: number;
+  height?: number;
+}) {
+  const padX = 8;
+  const padY = 8;
+  const gap = 3;
+  const totals = bars.map((bar) =>
+    bar.segments.reduce((sum, segment) => sum + Math.max(0, segment.value), 0),
+  );
+  const max = Math.max(0, ...totals);
+  const slot =
+    bars.length > 0 ? (width - padX * 2) / bars.length : width - padX * 2;
+  const barWidth = Math.max(1, slot - gap);
+  const drawableHeight = height - padY * 2;
+
+  return (
+    <svg
+      role="img"
+      aria-label={label}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className="h-44 w-full"
+      data-empty={bars.length === 0 || max === 0 ? "true" : undefined}
+    >
+      {bars.map((bar, index) => {
+        const x = padX + index * slot + gap / 2;
+        let used = 0;
+        return (
+          <g key={bar.key} data-bar={bar.key}>
+            {bar.segments.map((segment) => {
+              const value = Math.max(0, segment.value);
+              if (value === 0 || max === 0) return null;
+              const segmentHeight = (value / max) * drawableHeight;
+              const y = height - padY - used - segmentHeight;
+              used += segmentHeight;
+              return (
+                <LinkedMark key={segment.key} link={segment.link}>
+                  <rect
+                    data-segment={segment.key}
+                    x={x}
+                    y={y}
+                    width={barWidth}
+                    height={segmentHeight}
+                    rx="1.5"
+                    fill={segment.hue}
+                    className={
+                      segment.link
+                        ? "cursor-pointer hover:opacity-80"
+                        : undefined
+                    }
+                  >
+                    <title>{`${bar.label} · ${segment.label}: ${segment.value}`}</title>
+                  </rect>
+                </LinkedMark>
+              );
+            })}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export interface BandDatum {
+  p50: number | null;
+  p95: number | null;
+}
+
+function bandRuns(values: BandDatum[]) {
+  const runs: Array<Array<{ index: number; p50: number; p95: number }>> = [];
+  let current: Array<{ index: number; p50: number; p95: number }> = [];
+  values.forEach((value, index) => {
+    if (finite(value.p50) && finite(value.p95)) {
+      current.push({ index, p50: value.p50, p95: value.p95 });
+      return;
+    }
+    if (current.length > 0) runs.push(current);
+    current = [];
+  });
+  if (current.length > 0) runs.push(current);
+  return runs;
+}
+
+export function Band({
+  values,
+  label,
+  hue = "var(--hue-verify)",
+  width = 600,
+  height = 160,
+  linkForPoint,
+}: {
+  values: BandDatum[];
+  label: string;
+  hue?: string;
+  width?: number;
+  height?: number;
+  linkForPoint?: (index: number, value: BandDatum) => ChartLink | null;
+}) {
+  const runs = bandRuns(values);
+  const samples = runs.flatMap((run) =>
+    run.flatMap((point) => [point.p50, point.p95]),
+  );
+  const pad = 8;
+  const { y } = scale(samples, height, pad);
+  const x = (index: number) => pointX(index, values.length, width, pad);
+
+  return (
+    <svg
+      role="img"
+      aria-label={label}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className="h-40 w-full"
+      data-empty={runs.length === 0 ? "true" : undefined}
+    >
+      {runs.map((run, runIndex) => {
+        const upper = run.map((point) => `${x(point.index)},${y(point.p95)}`);
+        const lower = run
+          .slice()
+          .reverse()
+          .map((point) => `${x(point.index)},${y(point.p50)}`);
+        const median = run
+          .map((point) => `${x(point.index)},${y(point.p50)}`)
+          .join(" ");
+        return (
+          <Fragment key={runIndex}>
+            <polygon
+              data-band-segment={runIndex}
+              points={[...upper, ...lower].join(" ")}
+              fill={`color-mix(in oklch, ${hue} 18%, transparent)`}
+              stroke="none"
+            />
+            {run.length > 1 && (
+              <polyline
+                data-median-segment={runIndex}
+                points={median}
+                fill="none"
+                stroke={hue}
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </Fragment>
+        );
+      })}
+      {runs.flatMap((run) =>
+        run.map((point) => {
+          const datum = values[point.index]!;
+          const link = linkForPoint?.(point.index, datum);
+          return (
+            <LinkedMark key={point.index} link={link}>
+              <g
+                data-point={point.index}
+                className={link ? "cursor-pointer" : undefined}
+              >
+                {link && (
+                  <circle
+                    cx={x(point.index)}
+                    cy={y(point.p50)}
+                    r="7"
+                    fill="transparent"
+                  />
+                )}
+                <circle
+                  cx={x(point.index)}
+                  cy={y(point.p50)}
+                  r="3"
+                  fill={hue}
+                />
+              </g>
+            </LinkedMark>
+          );
+        }),
+      )}
+    </svg>
+  );
+}

--- a/event-runtime/web/src/nav.ts
+++ b/event-runtime/web/src/nav.ts
@@ -13,6 +13,7 @@ export type NavGroup = "live" | "work" | "machinery" | "system";
 export const NAV = [
   // Attention / Live Actions (badge-carrying / immediate triage)
   { key: "overview", label: "Overview", go: "o", group: "live" },
+  { key: "metrics", label: "Metrics", go: "m", group: "live" },
   { key: "inbox", label: "Inbox", go: "n", group: "live" },
   { key: "proposals", label: "Proposals", go: "p", group: "live" },
   { key: "runs", label: "Runs", go: "r", group: "live" },

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -173,6 +173,39 @@ export interface RunListItem {
   repos: string[];
 }
 
+export type MetricsWindow = "1h" | "24h" | "7d" | "30d";
+
+export interface MetricsPercentiles {
+  p50: Array<number | null>;
+  p95: Array<number | null>;
+}
+
+export interface MetricsView {
+  window: MetricsWindow;
+  bucket: string;
+  buckets: string[];
+  series: {
+    "runs.outcomes": Record<string, number[]>;
+    "runs.started": { total: number[] };
+    "latency.queue_wait": MetricsPercentiles;
+    "latency.execution": MetricsPercentiles;
+    "spend.cost": Record<string, number[]>;
+    "spend.tokens": Record<string, number[]>;
+    "proposals.decisions": Record<string, number[]>;
+    "proposals.time_to_decision": MetricsPercentiles;
+    "events.intake": Record<string, number[]>;
+    "attempts.retries": { total: number[] };
+  };
+}
+
+export interface MetricsBreakdownView {
+  window: MetricsWindow;
+  by: string;
+  metric: string;
+  limit: number | null;
+  rows: Array<{ key: string; value: number }>;
+}
+
 /** One append-only journal row (GET /journal) — the runtime's activity feed. */
 export interface JournalEntry {
   seq: number;

--- a/event-runtime/web/src/views/Metrics.test.tsx
+++ b/event-runtime/web/src/views/Metrics.test.tsx
@@ -1,0 +1,155 @@
+import "../test-dom";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { Metrics, METRICS_WINDOW_KEY, metricsAreEmpty } from "./Metrics";
+import type { MetricsView } from "../types";
+
+const populated: MetricsView = {
+  window: "24h",
+  bucket: "1h",
+  buckets: ["2026-08-18T08:00:00.000Z", "2026-08-18T09:00:00.000Z"],
+  series: {
+    "runs.outcomes": {
+      COMPLETED: [2, 1],
+      FAILED: [0, 1],
+      REFUSED: [0, 0],
+      TIMED_OUT: [0, 0],
+      CANCELLED: [0, 0],
+    },
+    "runs.started": { total: [2, 2] },
+    "latency.queue_wait": { p50: [1000, 2000], p95: [3000, 4000] },
+    "latency.execution": { p50: [10_000, 12_000], p95: [20_000, 24_000] },
+    "spend.cost": { "dispatch@1": [0.25, 0.5] },
+    "spend.tokens": { "dispatch@1": [100, 200] },
+    "proposals.decisions": {
+      approved: [1, 1],
+      rejected: [0, 1],
+      expired: [0, 0],
+      superseded: [0, 0],
+    },
+    "proposals.time_to_decision": { p50: [5000, 6000], p95: [9000, 10_000] },
+    "events.intake": { admitted: [2, 2] },
+    "attempts.retries": { total: [0, 1] },
+  },
+};
+
+function emptyMetrics(): MetricsView {
+  const zero = [0, 0];
+  const none = [null, null];
+  return {
+    ...populated,
+    series: {
+      "runs.outcomes": {
+        COMPLETED: zero,
+        FAILED: zero,
+        REFUSED: zero,
+        TIMED_OUT: zero,
+        CANCELLED: zero,
+      },
+      "runs.started": { total: zero },
+      "latency.queue_wait": { p50: none, p95: none },
+      "latency.execution": { p50: none, p95: none },
+      "spend.cost": {},
+      "spend.tokens": {},
+      "proposals.decisions": {
+        approved: zero,
+        rejected: zero,
+        expired: zero,
+        superseded: zero,
+      },
+      "proposals.time_to_decision": { p50: none, p95: none },
+      "events.intake": {},
+      "attempts.retries": { total: zero },
+    },
+  };
+}
+
+function renderMetrics() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Metrics />
+    </QueryClientProvider>,
+  );
+}
+
+const realFetch = globalThis.fetch;
+let response: Response;
+let requests: string[];
+
+beforeEach(() => {
+  localStorage.clear();
+  requests = [];
+  response = Response.json(populated);
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    requests.push(String(input));
+    return response.clone();
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+describe("Metrics", () => {
+  test("renders all four live sections and links marks to exact list populations", async () => {
+    const view = renderMetrics();
+    await view.findByRole("heading", { name: "Reliability" });
+    for (const section of ["Latency", "Spend", "Approval gate"]) {
+      expect(view.getByRole("heading", { name: section })).toBeTruthy();
+    }
+    const failed = view.getByRole("link", { name: /1 failed run in/i });
+    expect(failed.getAttribute("href")).toContain("#/runs?");
+    expect(failed.getAttribute("href")).toContain("population=terminal");
+    expect(failed.getAttribute("href")).toContain("state=FAILED");
+    expect(
+      view
+        .getAllByRole("img")
+        .every((chart) => chart.getAttribute("aria-label")),
+    ).toBe(true);
+  });
+
+  test("switches and persists the selected window", async () => {
+    const view = renderMetrics();
+    await view.findByRole("heading", { name: "Reliability" });
+    fireEvent.click(view.getByRole("button", { name: "1h" }));
+    await waitFor(() =>
+      expect(localStorage.getItem(METRICS_WINDOW_KEY)).toBe("1h"),
+    );
+    await waitFor(() =>
+      expect(
+        requests.some(
+          (url) => url.includes("window=1h") && url.includes("bucket=15m"),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  test("distinguishes an empty window from an unreachable API", async () => {
+    response = Response.json(emptyMetrics());
+    const empty = renderMetrics();
+    expect((await empty.findByRole("status")).textContent).toContain(
+      "No activity in this 24h window",
+    );
+    expect(empty.queryAllByRole("img")).toHaveLength(0);
+    empty.unmount();
+
+    response = new Response("offline", { status: 503 });
+    const failed = renderMetrics();
+    expect((await failed.findByRole("alert")).textContent).toContain(
+      "Metrics API unreachable",
+    );
+    expect(failed.queryAllByRole("img")).toHaveLength(0);
+  });
+});
+
+test("metricsAreEmpty treats null latency as missing rather than zero", () => {
+  expect(metricsAreEmpty(emptyMetrics())).toBe(true);
+  const data = emptyMetrics();
+  data.series["latency.execution"].p50[1] = 25;
+  expect(metricsAreEmpty(data)).toBe(false);
+});

--- a/event-runtime/web/src/views/Metrics.tsx
+++ b/event-runtime/web/src/views/Metrics.tsx
@@ -1,0 +1,680 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { fetchMetrics } from "../api";
+import {
+  Band,
+  Sparkline,
+  StackedBars,
+  type BandDatum,
+  type ChartLink,
+  type StackedBarDatum,
+} from "../components/Charts";
+import { SegmentMeter } from "./Overview";
+import type { MetricsView, MetricsWindow } from "../types";
+
+export const METRICS_WINDOW_KEY = "evrt-metrics-window";
+const WINDOWS: MetricsWindow[] = ["1h", "24h", "7d", "30d"];
+const BUCKET: Record<MetricsWindow, string> = {
+  "1h": "15m",
+  "24h": "1h",
+  "7d": "6h",
+  "30d": "24h",
+};
+const BUCKET_MS: Record<string, number> = {
+  "15m": 15 * 60_000,
+  "1h": 60 * 60_000,
+  "6h": 6 * 60 * 60_000,
+  "24h": 24 * 60 * 60_000,
+};
+
+const OUTCOMES = [
+  "COMPLETED",
+  "FAILED",
+  "REFUSED",
+  "TIMED_OUT",
+  "CANCELLED",
+] as const;
+const OUTCOME_HUES: Record<string, string> = {
+  COMPLETED: "var(--hue-ok)",
+  FAILED: "var(--hue-err)",
+  REFUSED: "var(--hue-warn)",
+  TIMED_OUT: "var(--hue-warn)",
+  CANCELLED: "var(--text-faint)",
+};
+const DECISIONS = ["approved", "rejected", "expired", "superseded"] as const;
+const DECISION_HUES: Record<string, string> = {
+  approved: "var(--hue-ok)",
+  rejected: "var(--hue-err)",
+  expired: "var(--hue-warn)",
+  superseded: "var(--hue-verify)",
+};
+
+function readWindow(): MetricsWindow {
+  try {
+    const value = localStorage.getItem(METRICS_WINDOW_KEY);
+    return WINDOWS.includes(value as MetricsWindow)
+      ? (value as MetricsWindow)
+      : "24h";
+  } catch {
+    return "24h";
+  }
+}
+
+const sum = (values: number[] | undefined) =>
+  (values ?? []).reduce(
+    (total, value) => total + (Number.isFinite(value) ? value : 0),
+    0,
+  );
+
+const recordTotal = (record: Record<string, number[]> | undefined) =>
+  Object.values(record ?? {}).reduce((total, values) => total + sum(values), 0);
+
+export function metricsAreEmpty(data: MetricsView): boolean {
+  const count =
+    recordTotal(data.series["runs.outcomes"]) +
+    sum(data.series["runs.started"]?.total) +
+    recordTotal(data.series["spend.cost"]) +
+    recordTotal(data.series["spend.tokens"]) +
+    recordTotal(data.series["proposals.decisions"]) +
+    recordTotal(data.series["events.intake"]) +
+    sum(data.series["attempts.retries"]?.total);
+  const latency = [
+    ...(data.series["latency.queue_wait"]?.p50 ?? []),
+    ...(data.series["latency.execution"]?.p50 ?? []),
+    ...(data.series["proposals.time_to_decision"]?.p50 ?? []),
+  ];
+  return count === 0 && latency.every((value) => value == null);
+}
+
+function timeRange(data: MetricsView, index: number) {
+  const from = data.buckets[index]!;
+  const next = data.buckets[index + 1];
+  const to =
+    next ??
+    new Date(Date.parse(from) + (BUCKET_MS[data.bucket] ?? 0)).toISOString();
+  return { from, to };
+}
+
+function drilldown(
+  view: "runs" | "proposals",
+  data: MetricsView,
+  index: number,
+  values: Record<string, string | undefined>,
+): string {
+  const range = timeRange(data, index);
+  const query = new URLSearchParams({ from: range.from, to: range.to });
+  for (const [key, value] of Object.entries(values))
+    if (value) query.set(key, value);
+  return `#/${view}?${query.toString()}`;
+}
+
+function bucketLabel(iso: string, window: MetricsWindow) {
+  const date = new Date(iso);
+  return date.toLocaleString(undefined, {
+    month: window === "30d" ? "short" : undefined,
+    day: window === "7d" || window === "30d" ? "numeric" : undefined,
+    hour:
+      window === "1h" || window === "24h" || window === "7d"
+        ? "numeric"
+        : undefined,
+    minute: window === "1h" ? "2-digit" : undefined,
+  });
+}
+
+function duration(value: number | null | undefined) {
+  if (value == null || !Number.isFinite(value)) return "not enough samples";
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60_000)
+    return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0)}s`;
+  return `${(value / 60_000).toFixed(1)}m`;
+}
+
+function currency(value: number) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function legend(
+  items: Array<{ label: string; value: number; hue: string }>,
+  format = (value: number) => String(value),
+) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-(--text-faint)">
+      {items.map((item) => (
+        <span key={item.label} className="inline-flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="size-2 rounded-xs"
+            style={{ background: item.hue }}
+          />
+          {item.label}{" "}
+          <span className="tabular-nums text-(--text-dim)">
+            {format(item.value)}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function Card({
+  title,
+  value,
+  children,
+}: {
+  title: string;
+  value?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <article className="min-w-0 rounded-lg border border-(--border) bg-(--surface-1) p-4">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h3 className="text-[12px] font-semibold text-(--text)">{title}</h3>
+        {value && (
+          <span className="mono tabular-nums text-(--text-dim)">{value}</span>
+        )}
+      </div>
+      {children}
+    </article>
+  );
+}
+
+function TimeAxis({ data }: { data: MetricsView }) {
+  if (data.buckets.length === 0) return null;
+  const last = timeRange(data, data.buckets.length - 1).to;
+  return (
+    <div
+      aria-hidden="true"
+      className="mt-1 flex justify-between text-[11px] tabular-nums text-(--text-faint)"
+    >
+      <span>{bucketLabel(data.buckets[0]!, data.window)}</span>
+      <span>{bucketLabel(last, data.window)}</span>
+    </div>
+  );
+}
+
+function BandChart({
+  values,
+  label,
+  hue,
+  linkForPoint,
+}: {
+  values: BandDatum[];
+  label: string;
+  hue: string;
+  linkForPoint: (index: number, value: BandDatum) => ChartLink;
+}) {
+  if (!values.some((value) => value.p50 != null && value.p95 != null)) {
+    return (
+      <div
+        role="status"
+        className="flex h-40 items-center justify-center rounded-md border border-dashed border-(--border) bg-(--surface-0) px-4 text-center text-[12px] text-(--text-faint)"
+      >
+        Not enough samples in any bucket (five are required for percentiles).
+      </div>
+    );
+  }
+  return (
+    <Band values={values} label={label} hue={hue} linkForPoint={linkForPoint} />
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      aria-labelledby={`metrics-${title.toLowerCase().replaceAll(" ", "-")}`}
+      className="space-y-3"
+    >
+      <div>
+        <h2
+          id={`metrics-${title.toLowerCase().replaceAll(" ", "-")}`}
+          className="display text-[15px] font-semibold"
+        >
+          {title}
+        </h2>
+        <p className="mt-0.5 text-[12px] text-(--text-faint)">{description}</p>
+      </div>
+      <div className="grid min-w-0 gap-3 xl:grid-cols-2">{children}</div>
+    </section>
+  );
+}
+
+function outcomeBars(data: MetricsView): StackedBarDatum[] {
+  const series = data.series["runs.outcomes"] ?? {};
+  return data.buckets.map((bucket, index) => ({
+    key: bucket,
+    label: bucketLabel(bucket, data.window),
+    segments: OUTCOMES.map((state) => {
+      const value = series[state]?.[index] ?? 0;
+      return {
+        key: state,
+        label: state.toLowerCase(),
+        value,
+        hue: OUTCOME_HUES[state],
+        link:
+          value > 0
+            ? {
+                href: drilldown("runs", data, index, {
+                  population: "terminal",
+                  state,
+                }),
+                label: `${value} ${state.toLowerCase()} run${value === 1 ? "" : "s"} in ${bucketLabel(bucket, data.window)}`,
+              }
+            : null,
+      };
+    }),
+  }));
+}
+
+function decisionBars(data: MetricsView): StackedBarDatum[] {
+  const series = data.series["proposals.decisions"] ?? {};
+  return data.buckets.map((bucket, index) => ({
+    key: bucket,
+    label: bucketLabel(bucket, data.window),
+    segments: DECISIONS.map((status) => {
+      const value = series[status]?.[index] ?? 0;
+      return {
+        key: status,
+        label: status,
+        value,
+        hue: DECISION_HUES[status],
+        link:
+          value > 0
+            ? {
+                href: drilldown("proposals", data, index, {
+                  population: "decision",
+                  decisionStatus: status,
+                }),
+                label: `${value} ${status} proposal${value === 1 ? "" : "s"} in ${bucketLabel(bucket, data.window)}`,
+              }
+            : null,
+      };
+    }),
+  }));
+}
+
+function spendBars(data: MetricsView): StackedBarDatum[] {
+  const series = data.series["spend.cost"] ?? {};
+  const agents = Object.keys(series).sort(
+    (a, b) => sum(series[b]) - sum(series[a]),
+  );
+  const hues = [
+    "var(--hue-info)",
+    "var(--hue-verify)",
+    "var(--hue-ok)",
+    "var(--hue-warn)",
+  ];
+  return data.buckets.map((bucket, index) => ({
+    key: bucket,
+    label: bucketLabel(bucket, data.window),
+    segments: agents.map((agent, agentIndex) => {
+      const value = series[agent]?.[index] ?? 0;
+      return {
+        key: agent,
+        label: agent,
+        value,
+        hue: hues[agentIndex % hues.length]!,
+        link:
+          value > 0
+            ? {
+                href: drilldown("runs", data, index, {
+                  population: "usage",
+                  agent,
+                }),
+                label: `${currency(value)} spent by ${agent} in ${bucketLabel(bucket, data.window)}`,
+              }
+            : null,
+      };
+    }),
+  }));
+}
+
+function bandValues(
+  data: MetricsView,
+  key:
+    "latency.queue_wait" | "latency.execution" | "proposals.time_to_decision",
+): BandDatum[] {
+  const series = data.series[key];
+  return data.buckets.map((_, index) => ({
+    p50: series?.p50?.[index] ?? null,
+    p95: series?.p95?.[index] ?? null,
+  }));
+}
+
+function runBandLink(
+  data: MetricsView,
+  population: "leased" | "finished",
+  noun: string,
+) {
+  return (index: number, value: BandDatum): ChartLink => ({
+    href: drilldown("runs", data, index, { population }),
+    label: `${noun} in ${bucketLabel(data.buckets[index]!, data.window)}: p50 ${duration(value.p50)}, p95 ${duration(value.p95)}`,
+  });
+}
+
+export function Metrics() {
+  const [window, setWindow] = useState<MetricsWindow>(readWindow);
+  const bucket = BUCKET[window];
+  const query = useQuery({
+    queryKey: ["metrics", window, bucket],
+    queryFn: () => fetchMetrics(window, bucket),
+    refetchInterval: 30_000,
+    retry: false,
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(METRICS_WINDOW_KEY, window);
+    } catch {
+      // Private mode / quota: the selector still works for this load.
+    }
+  }, [window]);
+
+  const data = query.data;
+  const derived = useMemo(() => {
+    if (!data) return null;
+    const outcomes = OUTCOMES.map((state) => ({
+      label: state.toLowerCase(),
+      value: sum(data.series["runs.outcomes"]?.[state]),
+      hue: OUTCOME_HUES[state],
+    }));
+    const decisions = DECISIONS.map((status) => ({
+      label: status,
+      value: sum(data.series["proposals.decisions"]?.[status]),
+      hue: DECISION_HUES[status],
+    }));
+    const started = sum(data.series["runs.started"]?.total);
+    const retries = sum(data.series["attempts.retries"]?.total);
+    const retryRate = data.buckets.map((_, index) => {
+      const denominator = data.series["runs.started"]?.total?.[index] ?? 0;
+      const numerator = data.series["attempts.retries"]?.total?.[index] ?? 0;
+      return denominator === 0 ? 0 : (numerator / denominator) * 100;
+    });
+    const tokens = data.buckets.map((_, index) =>
+      Object.values(data.series["spend.tokens"] ?? {}).reduce(
+        (total, values) => total + (values[index] ?? 0),
+        0,
+      ),
+    );
+    const agents = Object.entries(data.series["spend.cost"] ?? {})
+      .map(([agent, values]) => ({
+        label: agent,
+        value: sum(values),
+      }))
+      .sort((a, b) => b.value - a.value)
+      .map((item, index) => ({
+        ...item,
+        hue: [
+          "var(--hue-info)",
+          "var(--hue-verify)",
+          "var(--hue-ok)",
+          "var(--hue-warn)",
+        ][index % 4]!,
+      }));
+    return { outcomes, decisions, started, retries, retryRate, tokens, agents };
+  }, [data]);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-7xl space-y-7 p-5 pb-12">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="display text-h1 font-semibold">Metrics</h1>
+            <p className="mt-1 text-[12px] text-(--text-faint)">
+              Historical reliability, latency, spend, and approval decisions ·
+              factory-wide
+            </p>
+          </div>
+          <div
+            role="group"
+            aria-label="Metrics window"
+            className="flex rounded-md border border-(--border) bg-(--surface-1) p-0.5"
+          >
+            {WINDOWS.map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={window === value}
+                onClick={() => setWindow(value)}
+                className={`rounded px-2.5 py-1 text-[12px] font-medium ${window === value ? "bg-(--surface-3) text-(--text)" : "text-(--text-faint) hover:text-(--text)"}`}
+              >
+                {value}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {query.isPending ? (
+          <div
+            role="status"
+            className="rounded-lg border border-(--border) bg-(--surface-1) p-5 text-(--text-faint)"
+          >
+            Loading metrics…
+          </div>
+        ) : query.isError ? (
+          <div
+            role="alert"
+            className="rounded-lg border p-5"
+            style={{
+              color: "var(--hue-err)",
+              borderColor:
+                "color-mix(in oklch, var(--hue-err) 35%, var(--border))",
+            }}
+          >
+            <div className="font-medium">Metrics API unreachable</div>
+            <p className="mt-1 text-[12px]">
+              No chart is shown because this is not evidence of an empty window.
+            </p>
+            <button
+              type="button"
+              onClick={() => query.refetch()}
+              className="mt-3 rounded-md border border-current px-2.5 py-1 text-[12px]"
+            >
+              Retry
+            </button>
+          </div>
+        ) : data && metricsAreEmpty(data) ? (
+          <div
+            role="status"
+            className="rounded-lg border border-(--border) bg-(--surface-1) p-5"
+          >
+            <div className="font-medium">
+              No activity in this {window} window
+            </div>
+            <p className="mt-1 text-[12px] text-(--text-faint)">
+              Charts are withheld rather than drawing a fake flat line. Choose a
+              longer window to look further back.
+            </p>
+          </div>
+        ) : data && derived ? (
+          <>
+            <Section
+              title="Reliability"
+              description="Terminal outcome mix and retries per run start. Every mark opens the exact bucket population."
+            >
+              <Card
+                title="Outcome mix"
+                value={`${derived.outcomes.reduce((total, item) => total + item.value, 0)} terminal`}
+              >
+                <StackedBars
+                  bars={outcomeBars(data)}
+                  label={`Outcome mix: ${derived.outcomes.map((item) => `${item.value} ${item.label}`).join(", ")}`}
+                />
+                <TimeAxis data={data} />
+                {legend(derived.outcomes)}
+              </Card>
+              <Card
+                title="Retry rate"
+                value={
+                  derived.started > 0
+                    ? `${((derived.retries / derived.started) * 100).toFixed(1)}%`
+                    : "—"
+                }
+              >
+                <Sparkline
+                  values={derived.retryRate}
+                  label={`Retry rate by ${data.bucket} bucket; ${derived.retries} retries across ${derived.started} starts`}
+                  hue="var(--hue-warn)"
+                  linkForPoint={(index, value) => ({
+                    href: drilldown("runs", data, index, {
+                      population: "retried",
+                    }),
+                    label: `${value.toFixed(1)}% retry rate in ${bucketLabel(data.buckets[index]!, data.window)}`,
+                  })}
+                />
+                <TimeAxis data={data} />
+                <div className="mt-4">
+                  <SegmentMeter
+                    segments={[
+                      {
+                        key: "retry",
+                        label: "Retries",
+                        value: derived.retries,
+                        hue: "var(--hue-warn)",
+                      },
+                      {
+                        key: "first",
+                        label: "First attempts",
+                        value: Math.max(0, derived.started - derived.retries),
+                        hue: "var(--hue-ok)",
+                      },
+                    ]}
+                  />
+                  <p className="mt-2 text-[11px] text-(--text-faint)">
+                    {derived.retries} retries · {derived.started} run starts
+                  </p>
+                </div>
+              </Card>
+            </Section>
+
+            <Section
+              title="Latency"
+              description="p50–p95 bands appear only where a bucket has at least five samples; gaps are never interpolated."
+            >
+              <Card
+                title="Queue wait"
+                value={duration(data.series["latency.queue_wait"]?.p50?.at(-1))}
+              >
+                <BandChart
+                  values={bandValues(data, "latency.queue_wait")}
+                  label="Queue wait latency band, p50 median to p95"
+                  hue="var(--hue-info)"
+                  linkForPoint={runBandLink(data, "leased", "Queue wait")}
+                />
+                <TimeAxis data={data} />
+                <p className="mt-2 text-[11px] text-(--text-faint)">
+                  Band p50 → p95 · null buckets remain visible gaps
+                </p>
+              </Card>
+              <Card
+                title="Execution"
+                value={duration(data.series["latency.execution"]?.p50?.at(-1))}
+              >
+                <BandChart
+                  values={bandValues(data, "latency.execution")}
+                  label="Execution latency band, p50 median to p95"
+                  hue="var(--hue-verify)"
+                  linkForPoint={runBandLink(data, "finished", "Execution")}
+                />
+                <TimeAxis data={data} />
+                <p className="mt-2 text-[11px] text-(--text-faint)">
+                  Completed attempts, measured independently across retries
+                </p>
+              </Card>
+            </Section>
+
+            <Section
+              title="Spend"
+              description="Recorded cost and token volume by agent. Click through to runs with usage recorded in that bucket."
+            >
+              <Card
+                title="Cost by agent"
+                value={currency(
+                  derived.agents.reduce((total, item) => total + item.value, 0),
+                )}
+              >
+                <StackedBars
+                  bars={spendBars(data)}
+                  label={`Cost by agent: ${derived.agents.map((item) => `${item.label} ${currency(item.value)}`).join(", ") || "none"}`}
+                />
+                <TimeAxis data={data} />
+                {legend(derived.agents, currency)}
+              </Card>
+              <Card
+                title="Token volume"
+                value={new Intl.NumberFormat().format(sum(derived.tokens))}
+              >
+                <Sparkline
+                  values={derived.tokens}
+                  label={`${new Intl.NumberFormat().format(sum(derived.tokens))} recorded tokens across the window`}
+                  hue="var(--hue-info)"
+                  linkForPoint={(index, value) => ({
+                    href: drilldown("runs", data, index, {
+                      population: "usage",
+                    }),
+                    label: `${new Intl.NumberFormat().format(value)} tokens in ${bucketLabel(data.buckets[index]!, data.window)}`,
+                  })}
+                />
+                <TimeAxis data={data} />
+                <p className="mt-4 text-[11px] text-(--text-faint)">
+                  Input, output, cache creation, and cache-read tokens recorded
+                  by the runtime
+                </p>
+              </Card>
+            </Section>
+
+            <Section
+              title="Approval gate"
+              description="Time to a human or policy decision and the resulting decision mix."
+            >
+              <Card
+                title="Time to decision"
+                value={duration(
+                  data.series["proposals.time_to_decision"]?.p50?.at(-1),
+                )}
+              >
+                <BandChart
+                  values={bandValues(data, "proposals.time_to_decision")}
+                  label="Proposal time-to-decision band, p50 median to p95"
+                  hue="var(--hue-warn)"
+                  linkForPoint={(index, value) => ({
+                    href: drilldown("proposals", data, index, {
+                      population: "decision",
+                    }),
+                    label: `Proposal decisions in ${bucketLabel(data.buckets[index]!, data.window)}: p50 ${duration(value.p50)}, p95 ${duration(value.p95)}`,
+                  })}
+                />
+                <TimeAxis data={data} />
+                <p className="mt-2 text-[11px] text-(--text-faint)">
+                  From proposal creation to recorded decision
+                </p>
+              </Card>
+              <Card
+                title="Decision mix"
+                value={`${derived.decisions.reduce((total, item) => total + item.value, 0)} decisions`}
+              >
+                <StackedBars
+                  bars={decisionBars(data)}
+                  label={`Decision mix: ${derived.decisions.map((item) => `${item.value} ${item.label}`).join(", ")}`}
+                />
+                <TimeAxis data={data} />
+                {legend(derived.decisions)}
+              </Card>
+            </Section>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/event-runtime/web/src/views/Proposals.test.tsx
+++ b/event-runtime/web/src/views/Proposals.test.tsx
@@ -9,7 +9,11 @@ import {
   test,
 } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { filterOpenProposals, Proposals } from "./Proposals";
+import {
+  filterOpenProposals,
+  proposalDrilldownFilters,
+  Proposals,
+} from "./Proposals";
 import { api } from "../api";
 import {
   changeInput,
@@ -32,6 +36,22 @@ afterEach(() => {
 
 const noop = () => {};
 const NOW = new Date().toISOString();
+
+test("reads a reproducible proposal decision drill-down from the hash", () => {
+  expect(
+    proposalDrilldownFilters(
+      "#/proposals?from=2026-08-18T08%3A00%3A00.000Z&to=2026-08-18T09%3A00%3A00.000Z&population=decision&decisionStatus=expired",
+    ),
+  ).toEqual({
+    from: "2026-08-18T08:00:00.000Z",
+    to: "2026-08-18T09:00:00.000Z",
+    population: "decision",
+    decisionStatus: "expired",
+  });
+  expect(
+    proposalDrilldownFilters("#/proposals?population=decision"),
+  ).toBeNull();
+});
 
 function stubStatus(): StatusView {
   return createStatusFixture({

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api } from "../api";
+import { api, type ProposalListFilters } from "../api";
+import { hashSearch } from "../hash";
 import {
   keyGuard,
   refetchIntervals,
@@ -77,6 +78,21 @@ import { Button as PrimitiveButton } from "../components/ui";
 
 const PROPOSAL_TABS = ["open", "history"] as const;
 type ProposalTab = (typeof PROPOSAL_TABS)[number];
+
+export function proposalDrilldownFilters(
+  hash: string,
+): ProposalListFilters | null {
+  const query = hashSearch(hash);
+  const from = query.get("from");
+  const to = query.get("to");
+  if (!from || !to || query.get("population") !== "decision") return null;
+  return {
+    from,
+    to,
+    population: "decision",
+    decisionStatus: query.get("decisionStatus") ?? undefined,
+  };
+}
 
 function isTypingTarget(target: EventTarget | null): boolean {
   return (
@@ -252,15 +268,19 @@ export function Proposals({
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
-  const [tab, setTab] = useState<ProposalTab>("open");
+  const drilldown = proposalDrilldownFilters(window.location.hash);
+  const drilldownKey = JSON.stringify(drilldown);
+  const [tab, setTab] = useState<ProposalTab>(() =>
+    drilldown ? "history" : "open",
+  );
   const query = useQuery({
     queryKey: ["proposals"],
     queryFn: () => api.proposals(),
     ...refetchIntervals.primary,
   });
   const history = useQuery({
-    queryKey: ["proposals", "history"],
-    queryFn: () => api.proposalHistory("all"),
+    queryKey: ["proposals", "history", drilldownKey],
+    queryFn: () => api.proposalHistory("all", drilldown ?? {}),
     ...refetchIntervals.primary,
   });
   const [expiredOnly, setExpiredOnly] = useState(false);
@@ -1038,6 +1058,24 @@ export function Proposals({
           chrome={
             <>
               <h1 className="display mb-4 text-h1 font-semibold">Proposals</h1>
+              {drilldown && (
+                <div
+                  role="status"
+                  className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-(--border) bg-(--surface-2) px-3 py-2 text-[11px] text-(--text-dim)"
+                >
+                  <span>
+                    Metrics drill-down · decisions
+                    {drilldown.decisionStatus
+                      ? ` · ${drilldown.decisionStatus}`
+                      : ""}{" "}
+                    · {new Date(drilldown.from!).toLocaleString()} →{" "}
+                    {new Date(drilldown.to!).toLocaleString()}
+                  </span>
+                  <a href="#/proposals" className="font-medium text-(--accent)">
+                    Clear metrics filter
+                  </a>
+                </div>
+              )}
               {context.kind === "inflight" && (
                 <ScopeCaption context={context} surface="fleet" />
               )}

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -2,7 +2,7 @@ import "../test-dom";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { useState } from "react";
-import { Runs, statesForRunTab } from "./Runs";
+import { Runs, runDrilldownFilters, statesForRunTab } from "./Runs";
 import {
   changeInput,
   createAgentsFixture,
@@ -33,6 +33,21 @@ afterEach(() => {
 const noop = () => {};
 const FAILURE_REASON = 'contract_violation: $: unknown property "captured"';
 const NOW = new Date().toISOString();
+
+test("reads a complete metrics drill-down contract from the hash", () => {
+  expect(
+    runDrilldownFilters(
+      "#/runs?from=2026-08-18T08%3A00%3A00.000Z&to=2026-08-18T09%3A00%3A00.000Z&population=terminal&state=FAILED",
+    ),
+  ).toEqual({
+    from: "2026-08-18T08:00:00.000Z",
+    to: "2026-08-18T09:00:00.000Z",
+    population: "terminal",
+    state: "FAILED",
+    agent: undefined,
+  });
+  expect(runDrilldownFilters("#/runs?population=terminal")).toBeNull();
+});
 
 function stubListItem(
   runId: string,

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -6,7 +6,8 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { api, ApiError } from "../api";
+import { api, ApiError, type RunListFilters } from "../api";
+import { hashSearch } from "../hash";
 import {
   keyGuard,
   refetchIntervals,
@@ -171,6 +172,33 @@ export function tabForRunState(state: string): RunTab {
   if (state === "COMPLETED") return "COMPLETED";
   if (state === "CANCELLED") return "CANCELLED";
   return "ALL";
+}
+
+const RUN_DRILLDOWN_POPULATIONS = new Set<RunListFilters["population"]>([
+  "created",
+  "terminal",
+  "started",
+  "retried",
+  "leased",
+  "finished",
+  "usage",
+]);
+
+export function runDrilldownFilters(hash: string): RunListFilters | null {
+  const query = hashSearch(hash);
+  const from = query.get("from");
+  const to = query.get("to");
+  const population = query.get("population") as
+    RunListFilters["population"] | null;
+  if (!from || !to || !population || !RUN_DRILLDOWN_POPULATIONS.has(population))
+    return null;
+  return {
+    from,
+    to,
+    population,
+    state: query.get("state") ?? undefined,
+    agent: query.get("agent") ?? undefined,
+  };
 }
 
 /**
@@ -483,6 +511,8 @@ export function Runs({
   const [confirm, setConfirm] = useState<"cancel" | "force-retry" | null>(null);
   const [confirmApprove, setConfirmApprove] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
+  const drilldown = runDrilldownFilters(window.location.hash);
+  const drilldownKey = JSON.stringify(drilldown);
 
   const proposalsQ = useQuery({
     queryKey: ["proposals", "open"],
@@ -500,10 +530,10 @@ export function Runs({
 
   // A project / In-flight filter is client-side; fetching only the active
   // status tab would make every other tab's badge a factory-wide lie.
-  const fetchAll = context.kind !== "all";
+  const fetchAll = context.kind !== "all" || drilldown !== null;
   const list = useQuery({
-    queryKey: ["runs", fetchAll ? "ALL" : tab],
-    queryFn: () => api.runs(),
+    queryKey: ["runs", fetchAll ? "ALL" : tab, drilldownKey],
+    queryFn: () => api.runs(undefined, drilldown ?? {}),
     ...refetchIntervals.primary,
   });
   const statusQ = useQuery({
@@ -1064,6 +1094,24 @@ export function Runs({
         chrome={
           <>
             <h1 className="display mb-4 text-h1 font-semibold">Runs</h1>
+            {drilldown && (
+              <div
+                role="status"
+                className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-(--border) bg-(--surface-2) px-3 py-2 text-[11px] text-(--text-dim)"
+              >
+                <span>
+                  Metrics drill-down ·{" "}
+                  <span className="mono">{drilldown.population}</span>
+                  {drilldown.state ? ` · ${drilldown.state}` : ""}
+                  {drilldown.agent ? ` · ${drilldown.agent}` : ""} ·{" "}
+                  {new Date(drilldown.from!).toLocaleString()} →{" "}
+                  {new Date(drilldown.to!).toLocaleString()}
+                </span>
+                <a href="#/runs" className="font-medium text-(--accent)">
+                  Clear metrics filter
+                </a>
+              </div>
+            )}
 
             {/* `flex-wrap`: the token chips are a full-width item, so they take
             their own line under the tabs and the box instead of squeezing them. */}


### PR DESCRIPTION
## Summary
- add accessible, zero-dependency Sparkline, StackedBars, and p50/p95 Band SVG primitives
- add the live Metrics page with reliability, latency, spend, and approval sections plus persisted windows
- add truthful time/population drill-down contracts for Runs and Proposals and wire `#/metrics` / `g m`

## Verification
- `bun test event-runtime/web event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-proposals.test.mjs` — 878 pass, 0 fail
- `cd event-runtime/web && bun run build` — pass

UX critique: required — NOT-ASSESSED (isolated Chromium exited before Chrome DevTools became available; no browser approval was inferred). PR intentionally remains draft.

Fixes WM-282
