### PR TITLE
feat(event-runtime): require inbox resolve reasons

### DIFF
--- a/event-runtime/lib/api-inbox.mjs
+++ b/event-runtime/lib/api-inbox.mjs
@@ -70,7 +70,14 @@ export async function handleInboxApiRoute({
     ) {
       return send(422, { error: "body must be an object" });
     }
-    if (
+    if (verb === "resolve") {
+      if (
+        typeof parsed.value.reason !== "string" ||
+        parsed.value.reason.trim() === ""
+      ) {
+        return send(422, { error: "reason must be a non-empty string" });
+      }
+    } else if (
       parsed.value.reason !== undefined &&
       typeof parsed.value.reason !== "string"
     ) {
@@ -80,7 +87,11 @@ export async function handleInboxApiRoute({
       const item =
         verb === "ack"
           ? ackInboxItem(db, id, { now: nowMs })
-          : resolveInboxItem(db, id, { now: nowMs, resolvedBy: actor });
+          : resolveInboxItem(db, id, {
+              now: nowMs,
+              resolvedBy: actor,
+              reason: parsed.value.reason.trim(),
+            });
       return send(200, { item });
     } catch (err) {
       const status = String(err.message).startsWith("unknown inbox item")

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -95,16 +95,33 @@ describe("human inbox API (WM-285)", () => {
       listed = await (await fetch(s.url("/inbox?status=acked"))).json();
       expect(listed.items).toHaveLength(1);
 
+      for (const reason of [undefined, "", "   "]) {
+        const invalid = await fetch(s.url(`/inbox/${body.item.id}/resolve`), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(reason === undefined ? {} : { reason }),
+        });
+        expect(invalid.status).toBe(422);
+        expect((await invalid.json()).error).toBe(
+          "reason must be a non-empty string",
+        );
+      }
+
       const resolved = await fetch(s.url(`/inbox/${body.item.id}/resolve`), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ reason: "handled" }),
       });
       expect(resolved.status).toBe(200);
-      expect((await resolved.json()).item.resolvedBy).toBe("operator");
-      expect(
-        (await (await fetch(s.url("/inbox?status=resolved"))).json()).items,
-      ).toHaveLength(1);
+      expect((await resolved.json()).item).toMatchObject({
+        resolvedBy: "operator",
+        resolvedReason: "handled",
+      });
+      const resolvedItems = (
+        await (await fetch(s.url("/inbox?status=resolved"))).json()
+      ).items;
+      expect(resolvedItems).toHaveLength(1);
+      expect(resolvedItems[0].resolvedReason).toBe("handled");
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -235,7 +235,8 @@ describe("human inbox API (WM-285)", () => {
       // The fresh request is pending, so a bare resolve is still refused.
       const resolved = await fetch(s.url(`/inbox/${id}/resolve`), {
         method: "POST",
-        body: "{}",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reason: "manual dismissal" }),
       });
       expect(resolved.status).toBe(409);
 

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -267,6 +267,19 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 7,
+    name: "inbox_resolved_reason",
+    up(db) {
+      const columns = db
+        .query(`PRAGMA table_info(inbox_items)`)
+        .all()
+        .map((row) => row.name);
+      if (!columns.includes("resolved_reason")) {
+        db.exec(`ALTER TABLE inbox_items ADD COLUMN resolved_reason TEXT;`);
+      }
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -214,6 +214,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       "decided_at",
       "decided_by",
       "dedupe_key",
+      "resolved_reason",
     ]);
     upgraded.close();
   });
@@ -236,12 +237,13 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       .query("PRAGMA table_info(inbox_items)")
       .all()
       .map((row) => row.name);
-    expect(columns.slice(-5)).toEqual([
+    expect(columns.slice(-6)).toEqual([
       "decision_json",
       "response_json",
       "decided_at",
       "decided_by",
       "dedupe_key",
+      "resolved_reason",
     ]);
     expect(
       upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get()

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -120,7 +120,8 @@ export function itemView(row) {
     ackedAt: row.acked_at ?? null,
     resolvedAt: row.resolved_at ?? null,
     resolvedBy: row.resolved_by ?? null,
-    delivery,
+    resolvedReason: row.resolved_reason ?? null,
+    delivery: parseObject(row.delivery_json),
     decision: parseNullableObject(row.decision_json),
     response: parseNullableObject(row.response_json),
     responseHistory: Array.isArray(responseHistory) ? responseHistory : [],
@@ -628,9 +629,10 @@ export function ackInboxItem(db, id, { now = Date.now() } = {}) {
 export function resolveInboxItem(
   db,
   id,
-  { now = Date.now(), resolvedBy = "operator" } = {},
+  { now = Date.now(), resolvedBy = "operator", reason } = {},
 ) {
   requiredString(resolvedBy, "resolvedBy");
+  const resolvedReason = optionalString(reason, "reason");
   if (
     resolvedBy !== "operator" &&
     !resolvedBy.startsWith("auto:") &&
@@ -672,9 +674,11 @@ export function resolveInboxItem(
   }
   db.query(
     `UPDATE inbox_items
-     SET resolved_at = COALESCE(resolved_at, ?), resolved_by = COALESCE(resolved_by, ?)
+     SET resolved_at = COALESCE(resolved_at, ?),
+         resolved_by = COALESCE(resolved_by, ?),
+         resolved_reason = COALESCE(resolved_reason, ?)
      WHERE id = ?`,
-  ).run(resolvedAt, resolvedBy, id);
+  ).run(resolvedAt, resolvedBy, resolvedReason, id);
   return getInboxItem(db, id);
 }
 

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -336,10 +336,18 @@ describe("human inbox ledger (WM-285)", () => {
     expect(ackInboxItem(db, "one", { now: 3000 }).ackedAt).toBe(
       new Date(3000).toISOString(),
     );
-    expect(
-      resolveInboxItem(db, "two", { now: 4000, resolvedBy: "operator" })
-        .resolvedBy,
-    ).toBe("operator");
+    const resolved = resolveInboxItem(db, "two", {
+      now: 4000,
+      resolvedBy: "operator",
+      reason: "  Follow-up completed  ",
+    });
+    expect(resolved).toMatchObject({
+      resolvedBy: "operator",
+      resolvedReason: "  Follow-up completed  ",
+    });
+    expect(getInboxItem(db, "two").resolvedReason).toBe(
+      "  Follow-up completed  ",
+    );
     expect(listInboxItems(db, { status: "open" }).map((i) => i.id)).toEqual([]);
     expect(listInboxItems(db, { status: "acked" }).map((i) => i.id)).toEqual([
       "one",

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -266,11 +266,12 @@ export const api = {
       {},
     ),
   // Resolve = "dealt with"; idempotent on the ledger, 404 unknown item.
-  resolveInbox: (id: string, reason?: string) =>
+  // A non-empty reason is required (WM-604) — the API rejects blanks with 422.
+  resolveInbox: (id: string, reason: string) =>
     call<{ item: InboxItem }>(
       "POST",
       `/inbox/${encodeURIComponent(id)}/resolve`,
-      reason ? { reason } : {},
+      { reason },
     ),
   // The schedule registry: recurring loops, cadence, timing, and health.
   schedules: () => call<{ schedules: ScheduleItem[] }>("GET", "/schedules"),

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -794,6 +794,8 @@ export interface InboxItem {
   ackedAt: string | null;
   resolvedAt: string | null;
   resolvedBy: string | null;
+  /** Resolution audit note; absent only in fixtures or responses from pre-migration runtimes. */
+  resolvedReason?: string | null;
   delivery: InboxDelivery;
   decision?: DecisionRequest | null;
   response?: InboxDecisionResponse | null;

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -45,6 +45,7 @@ function item(
     ackedAt: null,
     resolvedAt: null,
     resolvedBy: null,
+    resolvedReason: null,
     delivery: {},
     ...overrides,
   };
@@ -275,9 +276,16 @@ beforeEach(() => {
     ledger = ledger.map((it) => (it.id === id ? { ...it, ackedAt: T2 } : it));
     return { item: ledger.find((it) => it.id === id)! };
   });
-  api.resolveInbox = mock(async (id: string) => {
+  api.resolveInbox = mock(async (id: string, reason: string) => {
     ledger = ledger.map((it) =>
-      it.id === id ? { ...it, resolvedAt: T2, resolvedBy: "operator" } : it,
+      it.id === id
+        ? {
+            ...it,
+            resolvedAt: T2,
+            resolvedBy: "operator",
+            resolvedReason: reason,
+          }
+        : it,
     );
     return { item: ledger.find((it) => it.id === id)! };
   });
@@ -559,7 +567,7 @@ describe("Inbox view", () => {
     expect(view.queryByRole("button", { name: /^Ack(?:\s|$)/ })).toBeNull();
   });
 
-  test("x opens the resolve confirm; Enter resolves", async () => {
+  test("x opens the resolve dialog; Enter requires a reason before resolving", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_open_1" });
     await waitFor(() => view.getByRole("button", { name: /Resolve…/ }));
     act(() => {
@@ -573,8 +581,31 @@ describe("Inbox view", () => {
         new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
       );
     });
+    expect(api.resolveInbox).not.toHaveBeenCalled();
+    expect(view.getByRole("dialog")).toBeTruthy();
+
+    act(() => {
+      changeInput(
+        view.getByLabelText("Resolution reason"),
+        "Handled after operator follow-up",
+      );
+    });
     await waitFor(() =>
-      expect(api.resolveInbox).toHaveBeenCalledWith("inbox_open_1"),
+      expect(
+        (view.getByRole("button", { name: "Resolve" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false),
+    );
+    act(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await waitFor(() =>
+      expect(api.resolveInbox).toHaveBeenCalledWith(
+        "inbox_open_1",
+        "Handled after operator follow-up",
+      ),
     );
     await waitFor(() => expect(view.queryByRole("dialog")).toBeNull());
     await waitFor(() =>
@@ -582,6 +613,7 @@ describe("Inbox view", () => {
         "Resolved",
       ),
     );
+    expect(view.getByText(/Handled after operator follow-up/)).toBeTruthy();
   });
 
   test("select-all selects every visible actionable inbox item", async () => {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -106,6 +106,13 @@ const OTHER_GROUP: InboxGroup = {
   kinds: [],
 };
 
+const INBOX_RESOLVE_REASONS = [
+  "Handled manually",
+  "No longer actionable",
+  "Superseded",
+  "Duplicate",
+] as const;
+
 export function groupOf(kind: string): InboxGroup {
   return INBOX_GROUPS.find((g) => g.kinds.includes(kind)) ?? OTHER_GROUP;
 }
@@ -425,6 +432,8 @@ export function Inbox({
   const [bulkAcking, setBulkAcking] = useState(false);
   const [bulkResolving, setBulkResolving] = useState(false);
   const [bulkResolveOpen, setBulkResolveOpen] = useState(false);
+  const [bulkResolveReason, setBulkResolveReason] = useState("");
+  const bulkResolveReasonRef = useRef<HTMLTextAreaElement>(null);
   const headerCheckboxRef = useRef<HTMLInputElement>(null);
   const pendingStar = useRef(0);
 
@@ -508,11 +517,15 @@ export function Inbox({
     onError: (err) => notify(`Ack failed: ${(err as Error).message}`, "err"),
   });
   const [confirmResolve, setConfirmResolve] = useState(false);
+  const [resolveReason, setResolveReason] = useState("");
+  const resolveReasonRef = useRef<HTMLTextAreaElement>(null);
   const resolve = useMutation({
-    mutationFn: (id: string) => api.resolveInbox(id),
-    onSuccess: (_out, id) => {
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      api.resolveInbox(id, reason),
+    onSuccess: (_out, { id }) => {
       invalidate();
       setConfirmResolve(false);
+      setResolveReason("");
       notify(`Resolved ${shortId(id)}`, "ok");
     },
     onError: (err) =>
@@ -531,6 +544,17 @@ export function Inbox({
     connected &&
     itemStatus(sel) !== "resolved" &&
     !resolve.isPending;
+  const canSubmitResolve = canResolve && resolveReason.trim().length > 0;
+
+  const openResolve = () => {
+    setResolveReason("");
+    setConfirmResolve(true);
+  };
+
+  const openBulkResolve = () => {
+    setBulkResolveReason("");
+    setBulkResolveOpen(true);
+  };
 
   const handleBulkAck = async () => {
     if (!connected || bulkAcking || ackableSelected.length === 0) return;
@@ -552,13 +576,20 @@ export function Inbox({
   };
 
   const handleBulkResolve = async () => {
-    if (!connected || bulkResolving || resolvableSelected.length === 0) return;
+    const reason = bulkResolveReason.trim();
+    if (
+      !connected ||
+      bulkResolving ||
+      resolvableSelected.length === 0 ||
+      !reason
+    )
+      return;
     setBulkResolving(true);
     let done = 0;
     let failed = 0;
     for (const item of resolvableSelected) {
       try {
-        await api.resolveInbox(item.id);
+        await api.resolveInbox(item.id, reason);
         done++;
       } catch {
         failed++;
@@ -568,6 +599,7 @@ export function Inbox({
     setSelectedIds(new Set());
     setBulkResolving(false);
     setBulkResolveOpen(false);
+    setBulkResolveReason("");
     notify(`Resolve: ${done} done / ${failed} failed`, failed ? "err" : "ok");
   };
 
@@ -581,13 +613,14 @@ export function Inbox({
         bulkResolveOpen &&
         connected &&
         !bulkResolving &&
-        resolvableSelected.length > 0
+        resolvableSelected.length > 0 &&
+        bulkResolveReason.trim()
       ) {
         e.preventDefault();
         void handleBulkResolve();
-      } else if (confirmResolve && sel && canResolve) {
+      } else if (confirmResolve && sel && canSubmitResolve) {
         e.preventDefault();
-        resolve.mutate(sel.id);
+        resolve.mutate({ id: sel.id, reason: resolveReason.trim() });
       }
     };
     window.addEventListener("keydown", onKey);
@@ -596,10 +629,12 @@ export function Inbox({
     confirmResolve,
     bulkResolveOpen,
     sel,
-    canResolve,
+    canSubmitResolve,
     resolve,
+    resolveReason,
     connected,
     bulkResolving,
+    bulkResolveReason,
     resolvableSelected,
   ]);
 
@@ -641,7 +676,7 @@ export function Inbox({
         if (!starActive && canAck && sel) ack.mutate(sel.id);
       },
       x: () => {
-        if (canResolve) setConfirmResolve(true);
+        if (canResolve) openResolve();
       },
     },
   });
@@ -699,7 +734,7 @@ export function Inbox({
         if (!connected || bulkResolving || resolvableSelected.length === 0)
           return;
         e.preventDefault();
-        setBulkResolveOpen(true);
+        openBulkResolve();
       }
     }
 
@@ -1066,10 +1101,7 @@ export function Inbox({
           actions={
             !sel.decision && itemStatus(sel) !== "resolved" ? (
               <div className="flex items-center gap-1.5">
-                <Button
-                  disabled={!canResolve}
-                  onClick={() => setConfirmResolve(true)}
-                >
+                <Button disabled={!canResolve} onClick={openResolve}>
                   Resolve…{" "}
                   <span
                     className="mono ml-1 text-(--text-faint)"
@@ -1114,7 +1146,15 @@ export function Inbox({
               <KV k="acked" v={<Ago iso={sel.ackedAt} now={now} />} />
             )}
             {sel.resolvedAt && (
-              <KV k="resolved" v={<Ago iso={sel.resolvedAt} now={now} />} />
+              <KV
+                k="resolved"
+                v={
+                  <span>
+                    <Ago iso={sel.resolvedAt} now={now} />
+                    {sel.resolvedReason && <> · {sel.resolvedReason}</>}
+                  </span>
+                }
+              />
             )}
             {sel.resolvedBy && <KV k="resolved by" v={sel.resolvedBy} />}
             <KV
@@ -1264,7 +1304,7 @@ export function Inbox({
             disabled={
               !connected || bulkResolving || resolvableSelected.length === 0
             }
-            onClick={() => setBulkResolveOpen(true)}
+            onClick={openBulkResolve}
           >
             Resolve…
             <span
@@ -1287,13 +1327,19 @@ export function Inbox({
             They leave Open or Acked and stay in the ledger under Resolved. This
             does not act on their underlying runs, proposals, or PRs.
           </p>
+          <ResolveReasonField
+            value={bulkResolveReason}
+            onChange={setBulkResolveReason}
+            inputRef={bulkResolveReasonRef}
+          />
           <div className="flex justify-end gap-2">
             <Button onClick={() => setBulkResolveOpen(false)}>Cancel</Button>
             <Button
               variant="primary"
-              disabled={!connected || bulkResolving}
+              disabled={
+                !connected || bulkResolving || !bulkResolveReason.trim()
+              }
               onClick={() => void handleBulkResolve()}
-              autoFocus
             >
               {bulkResolving
                 ? "Resolving…"
@@ -1313,12 +1359,19 @@ export function Inbox({
             It leaves Open and Acked and stays in the ledger under Resolved.
             This does not act on the underlying run, proposal or PR.
           </p>
+          <ResolveReasonField
+            value={resolveReason}
+            onChange={setResolveReason}
+            inputRef={resolveReasonRef}
+          />
           <div className="flex justify-end gap-2">
             <Button onClick={() => setConfirmResolve(false)}>Cancel</Button>
             <Button
               variant="primary"
-              disabled={!canResolve}
-              onClick={() => resolve.mutate(sel.id)}
+              disabled={!canSubmitResolve}
+              onClick={() =>
+                resolve.mutate({ id: sel.id, reason: resolveReason.trim() })
+              }
               autoFocus
             >
               Resolve
@@ -1326,6 +1379,56 @@ export function Inbox({
           </div>
         </Dialog>
       )}
+    </div>
+  );
+}
+
+function ResolveReasonField({
+  value,
+  onChange,
+  inputRef,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+}) {
+  return (
+    <div className="mb-4">
+      <div className="mb-2 text-[11px] font-medium text-(--text-faint)">
+        Common reasons
+      </div>
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {INBOX_RESOLVE_REASONS.map((reason) => (
+          <button
+            key={reason}
+            type="button"
+            onClick={() => {
+              onChange(reason);
+              inputRef.current?.focus();
+            }}
+            className={`rounded border px-2 py-0.5 text-[11px] transition-colors ${
+              value === reason
+                ? "border-(--accent) bg-(--surface-3) text-(--text)"
+                : "border-(--border) bg-(--surface-1) text-(--text-dim) hover:bg-(--surface-2)"
+            }`}
+          >
+            {reason}
+          </button>
+        ))}
+      </div>
+      <label className="block text-[11px] font-medium text-(--text-faint)">
+        Resolution reason
+        <textarea
+          ref={inputRef}
+          autoFocus
+          required
+          rows={3}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Reason required — resolutions are audit records"
+          className="mt-1 w-full resize-y rounded-md border border-(--border-strong) bg-(--surface-0) px-2.5 py-1.5 text-[12px] text-(--text) outline-none focus:border-(--accent)"
+        />
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a retry-safe schema migration and ledger projection for persisted inbox resolution reasons
- require a non-empty reason in the resolve API and return it from GET /inbox
- add required single/bulk resolve reason controls, templates, and resolved-reason detail display

## Verification
- `bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/api-inbox.test.mjs && cd event-runtime/web && bun test src/views/Inbox.test.tsx`
- `cd event-runtime/web && bun run build`

UX critique: required — NOT-ASSESSED; isolated Chromium exited before DevTools became available, so the live flow could not be visually driven. PR remains draft.

Fixes WM-604