### PR TITLE
chore(web): consolidate timeline reason helpers

### DIFF
--- a/event-runtime/web/src/chainTimeline.test.ts
+++ b/event-runtime/web/src/chainTimeline.test.ts
@@ -4,7 +4,7 @@ import {
   buildChainTimeline,
   chainNeedsRevisit,
   chainViewModeFromQuery,
-  coveringSchedule,
+  nextScheduledRetry,
   formatDelta,
   formatUntil,
   humanizeRunReason,
@@ -255,8 +255,8 @@ describe("buildChainTimeline", () => {
     const { rows } = build();
     const next = rows.at(-1)!;
     expect(next.kind).toBe("next");
-    expect(next.actor).toBe("merge-factory");
-    expect(next.what).toMatch(/^re-examines at \d{2}:\d{2} \(in 8m 30s\)$/);
+    expect(next.actor).toBeNull();
+    expect(next.what).toMatch(/^next: merge-factory · re-examines at \d{2}:\d{2} \(in 8m 30s\)$/);
     expect(next.refs).toEqual([{ kind: "schedule", label: "merge-factory", id: "merge-factory" }]);
     expect(next.muted).toBe(true);
   });
@@ -310,8 +310,8 @@ describe("buildChainTimeline", () => {
     });
     const noop = rows.find((r) => r.badge === "noop")!;
     expect(noop.actor).toBe("planner");
-    expect(noop.what).toBe("the ticket is already assigned");
-    expect(noop.reason).toEqual({ text: "the ticket is already assigned", raw: "ticket_assigned" });
+    expect(noop.what).toBe("Ticket is already assigned");
+    expect(noop.reason).toEqual({ text: "Ticket is already assigned", raw: "ticket_assigned" });
     expect(noop.nodeId).toBe(`event:chain:${FIX_EVENT}`);
     expect(rows.at(-1)!.kind).toBe("next");
   });
@@ -333,7 +333,7 @@ describe("buildChainTimeline", () => {
 
 describe("helpers", () => {
   test("humanizeRunReason keeps the suffix and de-snakes unknown codes", () => {
-    expect(humanizeRunReason("auto_approved:chain-policy@1")).toEqual({ text: "auto-approved: chain-policy@1", raw: "auto_approved:chain-policy@1" });
+    expect(humanizeRunReason("auto_approved:chain-policy@1")).toEqual({ text: "Auto-approved — chain-policy@1", raw: "auto_approved:chain-policy@1" });
     expect(humanizeRunReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
     expect(humanizeRunReason(null)).toBeNull();
   });
@@ -357,11 +357,11 @@ describe("helpers", () => {
     expect(specInputRefs(null)).toEqual([]);
   });
 
-  test("coveringSchedule ignores disabled/stopped loops and matches repo", () => {
+  test("nextScheduledRetry ignores disabled/stopped loops and matches repo", () => {
     const origin = chain().events[0];
-    expect(coveringSchedule(origin, [schedule({ stopped: true })])).toBeNull();
-    expect(coveringSchedule(origin, [schedule({ repo: null })])?.loop).toBe("merge-factory");
-    expect(coveringSchedule(origin, [schedule({ eventType: "factory.work.requested" })])).toBeNull();
+    expect(nextScheduledRetry(origin, [schedule({ stopped: true })])).toBeNull();
+    expect(nextScheduledRetry(origin, [schedule({ repo: null })])?.loop).toBe("merge-factory");
+    expect(nextScheduledRetry(origin, [schedule({ eventType: "factory.work.requested" })])).toBeNull();
   });
 
   test("view mode persists and ?view= parses", () => {

--- a/event-runtime/web/src/chainTimeline.ts
+++ b/event-runtime/web/src/chainTimeline.ts
@@ -13,7 +13,7 @@
  */
 import type { ScheduleItem } from "./api";
 import { eventNodeId, runNodeId } from "./graph/chainModel";
-import { formatDuration } from "./subjectJourney";
+import { humanizeReason } from "./reasons";
 import type { ChainEvent, ChainRun, ChainView, InboxItem, LifecycleEvent, Proposal, RunDetail } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -62,67 +62,6 @@ function defaultStorage(): StorageLike | null {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Reasons. Local table until WM-594 lands `src/reasons.ts` (humanizeReason);
-// this folds into that map on rebase.
-// ---------------------------------------------------------------------------
-
-export const RUN_REASONS: Record<string, string> = {
-  // lifecycle actors' own reasons
-  planned: "planned",
-  claimed: "claimed",
-  started: "started",
-  ok: "completed",
-  auto_approved: "auto-approved",
-  approved: "approved",
-  observed: "observed — nothing to do",
-  duplicate_run: "a run for this input already exists",
-  previous_run_in_flight: "the previous run is still in flight",
-  proposal_expired: "the proposal expired before anyone approved it",
-  needs_human: "needs a human decision",
-  attempts_exhausted: "attempts are exhausted",
-  timeout: "timed out",
-  cancelled: "cancelled by the operator",
-  // planner refusals (lib/planner.mjs)
-  capacity_full: "capacity is full for this repo",
-  ticket_assigned: "the ticket is already assigned",
-  ticket_dispatch_already_live: "a dispatch is already live for this ticket",
-  same_ticket_worktree_held: "the ticket worktree is still held",
-  ticket_escalated: "the ticket is escalated",
-  ticket_not_agent_ready: "the ticket is not agent-ready",
-  ticket_not_found: "the ticket was not found in Linear",
-  ticket_not_todo: "the ticket is not in Todo",
-  ticket_security: "the ticket is security-labelled — humans only",
-  owned_paths_overlap: "owned paths overlap a live run",
-  owned_paths_not_closed: "owned paths are not a closed set",
-  owned_paths_unknown: "owned paths are unknown",
-  no_worktree_scripts: "the repo ships no worktree scripts",
-  repo_report_only: "the repo is report-only",
-  repo_unconfigured: "the repo is not configured for Linear",
-  merge_fix_pr_moved: "PR head moved after the plan",
-  merge_fix_pr_not_found: "the PR was not found",
-  merge_fix_pr_not_open: "the PR is no longer open",
-  merge_fix_pr_read_failed: "the PR could not be read from GitHub",
-  merge_fix_run_active: "another run is already working on this PR",
-  merge_fix_run_check_failed: "could not check for competing runs",
-  merge_fix_owned_paths_moved: "the fix touches paths outside the ticket's owned paths",
-  merge_fix_owned_paths_unknown: "the ticket's owned paths could not be parsed",
-  merge_fix_ticket_escalated: "the ticket is escalated",
-  merge_fix_ticket_not_found: "the ticket was not found in Linear",
-  merge_fix_ticket_read_failed: "the ticket could not be read from Linear",
-  merge_fix_ticket_security: "the ticket is security-labelled — humans only",
-  merge_fix_ticket_state: "the ticket is not In Review / In Progress",
-  // worker / verify (lib/worker.mjs, lib/verify.mjs)
-  agent_definition_mismatch: "the agent definition changed since the plan",
-  claim_lock_contention: "another worker held the claim lock",
-  claim_lock_starvation: "could not win the claim lock",
-  contract_violation: "the output violated its contract",
-  linear_unconfigured: "Linear is not configured",
-  unknown_adapter: "unknown adapter",
-  workspace_integrity_violation: "the workspace was modified outside the run",
-  worktree_gate_unknown: "the worktree gate could not decide",
-};
-
 export interface HumanReason {
   text: string;
   raw: string;
@@ -133,11 +72,13 @@ export interface HumanReason {
  * as a mono-ish tail. Unknown codes are de-snaked rather than hidden.
  */
 export function humanizeRunReason(reason: string | null | undefined): HumanReason | null {
-  if (!reason) return null;
-  const [code, ...suffix] = reason.split(":");
-  const words = RUN_REASONS[code] ?? code.replaceAll("_", " ").trim();
-  const tail = suffix.join(":").trim();
-  return { text: tail ? `${words}: ${tail}` : words, raw: reason };
+  const human = humanizeReason(reason);
+  if (!human.raw) return null;
+  // The chain is showing the plan that this particular run consumed.
+  const text = reason?.split(":", 1)[0] === "merge_fix_pr_moved"
+    ? human.text.replace("since the plan", "after the plan")
+    : human.text;
+  return { text, raw: human.raw };
 }
 
 // ---------------------------------------------------------------------------
@@ -221,14 +162,23 @@ export function formatDelta(deltaMs: number | null): string {
   if (deltaMs == null || !Number.isFinite(deltaMs) || deltaMs < 0) return "";
   if (deltaMs === 0) return "+0s";
   if (deltaMs < 1000) return "+<1s";
-  return `+${formatDuration(deltaMs)}`;
+  return `+${formatTimelineDuration(deltaMs)}`;
+}
+
+function formatTimelineDuration(valueMs: number): string {
+  const seconds = Math.round(valueMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ""}`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h${minutes % 60 ? ` ${minutes % 60}m` : ""}`;
 }
 
 /** `in 9m`, `now`, `overdue by 3m`. */
 export function formatUntil(atMs: number, now: number): string {
   const diff = atMs - now;
   if (Math.abs(diff) < 30_000) return "now";
-  return diff > 0 ? `in ${formatDuration(diff)}` : `overdue by ${formatDuration(-diff)}`;
+  return diff > 0 ? `in ${formatTimelineDuration(diff)}` : `overdue by ${formatTimelineDuration(-diff)}`;
 }
 
 /** Ticket + PR references named by a run's spec input (merge-fix, dispatch, …). */
@@ -523,18 +473,45 @@ export function chainOriginEvent(chain: Pick<ChainView, "events">): ChainEvent |
   return [...pool].sort((a, b) => a.admittedAt.localeCompare(b.admittedAt))[0] ?? null;
 }
 
-/** The enabled schedule that will re-emit this chain's origin event, if any. */
-export function coveringSchedule(origin: ChainEvent | null, schedules: ScheduleItem[]): ScheduleItem | null {
+export interface ScheduledRetryOrigin {
+  type: string;
+  repos: readonly string[];
+}
+
+export interface ScheduledRetrySchedule {
+  loop: string;
+  repo: string | null;
+  eventType: string;
+  nextDue: string | null;
+  enabled: boolean;
+  stopped?: boolean;
+}
+
+/** The next enabled schedule that will re-emit an origin event. */
+export function nextScheduledRetry<T extends ScheduledRetrySchedule>(
+  origin: ScheduledRetryOrigin | null,
+  schedules: readonly T[],
+): T | null {
   if (!origin) return null;
   const candidates = schedules.filter(
     (s) =>
       s.enabled &&
       !s.stopped &&
+      s.nextDue != null &&
       s.eventType === origin.type &&
       (s.repo == null || origin.repos.length === 0 || origin.repos.includes(s.repo)),
   );
   candidates.sort((a, b) => (a.nextDue ?? "￿").localeCompare(b.nextDue ?? "￿"));
   return candidates[0] ?? null;
+}
+
+/** Shared timeline/journey wording for a scheduled retry. */
+export function scheduledRetryLabel(retry: ScheduledRetrySchedule, now = Date.now()): string {
+  const dueMs = ms(retry.nextDue);
+  const clock = dueMs == null
+    ? retry.nextDue ?? "unknown time"
+    : new Date(dueMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  return `next: ${retry.loop} · re-examines at ${clock}${dueMs == null ? "" : ` (${formatUntil(dueMs, now)})`}`;
 }
 
 /** Whether the chain ended somewhere a loop or a human must revisit. */
@@ -563,17 +540,15 @@ function inboxItemFor(chain: ChainView, inbox: InboxItem[]): InboxItem | null {
 function nextStepRow(chain: ChainView, schedules: ScheduleItem[], inbox: InboxItem[], now: number): ChainTimelineRow | null {
   if (!chainNeedsRevisit(chain)) return null;
   const origin = chainOriginEvent(chain);
-  const schedule = coveringSchedule(origin, schedules);
+  const schedule = nextScheduledRetry(origin, schedules);
   const base = { id: "next", kind: "next" as const, nodeId: null, deltaMs: null, hues: "muted" as const, reason: null, muted: true };
   if (schedule && schedule.nextDue) {
-    const dueMs = ms(schedule.nextDue);
-    const clock = dueMs == null ? schedule.nextDue : new Date(dueMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
     return {
       ...base,
       at: schedule.nextDue,
       badge: "next",
-      actor: schedule.loop,
-      what: `re-examines at ${clock}${dueMs == null ? "" : ` (${formatUntil(dueMs, now)})`}`,
+      actor: null,
+      what: scheduledRetryLabel(schedule, now),
       refs: [{ kind: "schedule", label: schedule.loop, id: schedule.loop }],
     };
   }

--- a/event-runtime/web/src/reasons.test.ts
+++ b/event-runtime/web/src/reasons.test.ts
@@ -41,6 +41,35 @@ describe("humanizeReason (WM-594)", () => {
     }
   });
 
+  test("every reason code referenced by the timeline and journey fixtures has a shared phrase", () => {
+    for (const code of [
+      "planned",
+      "claimed",
+      "started",
+      "ok",
+      "auto_approved",
+      "approved",
+      "observed",
+      "duplicate_run",
+      "previous_run_in_flight",
+      "proposal_expired",
+      "needs_human",
+      "attempts_exhausted",
+      "timeout",
+      "cancelled",
+      "ticket_assigned",
+      "owned_paths_overlap",
+      "merge_fix_pr_moved",
+      "merge_fix_pr_read_failed",
+      "merge_fix_run_check_failed",
+      "merge_fix_ticket_read_failed",
+      "merge_apply_pr_moved",
+      "merge_apply_base_moved",
+    ]) {
+      expect(REASONS[code], code).toBeTruthy();
+    }
+  });
+
   test("unknown codes fall back to the code with underscores dropped, suffix kept as detail", () => {
     expect(humanizeReason("some_new_code")).toEqual({ text: "some new code", raw: "some_new_code" });
     expect(humanizeReason("some_new_code:extra_detail").text).toBe("some new code — extra detail");

--- a/event-runtime/web/src/reasons.ts
+++ b/event-runtime/web/src/reasons.ts
@@ -15,6 +15,12 @@
 
 /** Head codes → sentence-cased phrase. Suffix fragments are appended after ` — `. */
 export const REASONS: Record<string, string> = {
+  // run lifecycle actors
+  planned: "Planned",
+  claimed: "Claimed",
+  started: "Started",
+  auto_approved: "Auto-approved",
+  approved: "Approved",
   // planner: dispatch gate (lib/planner.mjs worktreeDispatchAutoEligibility)
   owned_paths_overlap: "Owned paths overlap",
   owned_paths_unknown: "Owned paths unknown",
@@ -71,13 +77,18 @@ export const REASONS: Record<string, string> = {
   merge_fix_pr_moved: "PR head moved since the plan",
   merge_fix_pr_not_open: "PR is no longer open",
   merge_fix_pr_not_found: "PR not found",
+  merge_fix_pr_read_failed: "PR could not be read from GitHub",
   merge_fix_run_active: "A merge-fix run is already active",
+  merge_fix_run_check_failed: "Could not check for competing merge-fix runs",
   merge_fix_owned_paths_moved: "PR touches paths outside Owned Paths",
   merge_fix_owned_paths_unknown: "Owned paths unknown",
   merge_fix_ticket_state: "Ticket is not in a merge-fix state",
   merge_fix_ticket_escalated: "Ticket is escalated",
   merge_fix_ticket_security: "Ticket is security-labelled",
   merge_fix_ticket_not_found: "Ticket not found",
+  merge_fix_ticket_read_failed: "Ticket could not be read from Linear",
+  merge_apply_pr_moved: "PR head moved since the plan",
+  merge_apply_base_moved: "Base moved since the plan",
   // worker / verify (lib/worker.mjs, lib/verify.mjs, adapters)
   needs_human: "Needs human",
   missing_input: "Missing input",

--- a/event-runtime/web/src/subjectJourney.test.ts
+++ b/event-runtime/web/src/subjectJourney.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildTicketJourney,
   formatDuration,
-  humanizeReason,
   parsePrRef,
   prNumbersIn,
   scanVerdictFor,
@@ -14,6 +13,7 @@ import {
   type SubjectJourneySource,
   type TicketJourneySource,
 } from "./subjectJourney";
+import { humanizeReason } from "./reasons";
 
 const lifecycle = (runId: string, start: string, end: string) => [
   {
@@ -229,8 +229,8 @@ describe("ticket journey helpers", () => {
   });
 
   test("humanizes known and unknown reason codes", () => {
-    expect(humanizeReason("ticket_assigned")).toBe("Ticket is already assigned");
-    expect(humanizeReason("foreign_reason:WM-1")).toBe("Foreign reason — WM-1");
+    expect(humanizeReason("ticket_assigned").text).toBe("Ticket is already assigned");
+    expect(humanizeReason("foreign_reason:WM-1").text).toBe("foreign reason — WM-1");
   });
 });
 
@@ -373,7 +373,7 @@ describe("subjectJourney(pr)", () => {
     // The refusal is the last run activity → it is the blocking reason, and the schedule tells when the loop comes back.
     expect(journey.blockingReason).toBe("PR head moved since the scan (merge_fix_pr_moved)");
     expect(journey.nextVisit).toEqual({ loop: "merge-factory", at: "2026-08-17T19:30:00.000Z" });
-    expect(labels.at(-1)).toMatch(/^next: merge-factory at \d\d:\d\d$/);
+    expect(labels.at(-1)).toMatch(/^next: merge-factory · re-examines at \d\d:\d\d \(/);
     expect(journey.nextAction).toContain("Waiting: PR head moved since the scan");
     expect(journey.nextAction).toContain("merge-factory revisits at");
     // PR opened row links out to GitHub on a PR journey.

--- a/event-runtime/web/src/subjectJourney.ts
+++ b/event-runtime/web/src/subjectJourney.ts
@@ -6,6 +6,9 @@
  * `SubjectJourneySource` and hand it over.
  */
 
+import { nextScheduledRetry, scheduledRetryLabel } from "./chainTimeline";
+import { REASONS, humanizeReason } from "./reasons";
+
 export const TICKET_ID_PATTERN = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
 
 /** `#541`, `PR 541`, `pr:541`, `pull/541`, `541` — what an operator types for a PR. */
@@ -242,43 +245,21 @@ export interface SubjectJourney {
 /** @deprecated name kept for the WM-595 callers — same shape as `SubjectJourney`. */
 export type TicketJourney = SubjectJourney;
 
-const KNOWN_REASONS: Record<string, string> = {
-  owned_paths_overlap: "Owned paths overlap",
-  ticket_assigned: "Ticket is already assigned",
-  ticket_dispatch_already_live: "A dispatch is already live",
-  same_ticket_worktree_held: "The ticket worktree is still held",
-  proposal_expired: "The proposal expired",
-  needs_human: "Human input is required",
-  attempts_exhausted: "Attempts are exhausted",
-  merge_fix_pr_moved: "PR head moved since the scan",
-  merge_fix_pr_not_open: "PR is no longer open",
-  merge_fix_pr_not_found: "PR not found",
-  merge_fix_run_active: "Another run holds the PR",
-  merge_fix_round_exhausted: "Fix rounds exhausted",
-  merge_fix_ticket_state: "Ticket state does not allow a fix",
-  merge_fix_owned_paths_moved: "Owned paths changed since the scan",
-  merge_fix_not_mechanical_or_in_scope: "Finding is not mechanical or in scope",
-  merge_apply_pr_moved: "PR head moved since the plan",
-  merge_apply_base_moved: "Base moved since the plan",
-};
-
-/**
- * Human-readable planner reason while preserving identifiers in the suffix.
- * Local fallback until `reasons.ts` (WM-594) lands — see the WM-640 Handoff.
- */
-export function humanizeReason(reason: string | null | undefined): string | null {
-  if (!reason) return null;
-  const [code, ...suffix] = reason.split(":");
-  const words = KNOWN_REASONS[code] ?? code.replaceAll("_", " ").replace(/^./, (c) => c.toUpperCase());
-  return suffix.length ? `${words} — ${suffix.join(" · ")}` : words;
+function reasonText(reason: string | null | undefined): string | null {
+  const human = humanizeReason(reason);
+  if (!human.raw) return null;
+  // A PR journey anchors this refusal to the scan that observed the old head.
+  return reason?.split(":", 1)[0] === "merge_fix_pr_moved"
+    ? human.text.replace("since the plan", "since the scan")
+    : human.text;
 }
 
 /** `Human text (raw_code)` — for refusal rows, where the code is the search key. */
 function humanizeWithCode(reason: string | null | undefined): string | null {
-  const text = humanizeReason(reason);
+  const text = reasonText(reason);
   if (!text || !reason) return null;
   const code = reason.split(":")[0];
-  return KNOWN_REASONS[code] ? `${text} (${code})` : text;
+  return REASONS[code] ? `${text} (${code})` : text;
 }
 
 function validDate(value: string | null | undefined): number | null {
@@ -690,7 +671,7 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
   for (const event of source.events) {
     const proposal = proposalFor(event, source.proposals);
     const decision = proposal?.decision ?? (event.status === "planned" ? "planned" : event.status);
-    const reason = humanizeReason(proposal?.reason);
+    const reason = reasonText(proposal?.reason);
     const dispatch = /dispatch/i.test(event.type);
     const agentReady = /agent[-_. ]?ready/i.test(event.type) || /agent[-_. ]?ready/i.test(JSON.stringify(event.envelope));
     const at = timeOf(event.occurredAt, event.admittedAt);
@@ -951,13 +932,19 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
     .sort((a, b) => a.created_at.localeCompare(b.created_at))
     .at(-1);
 
-  // The next scheduled visit — computed locally from the schedule registry
-  // until chainTimeline.ts (WM-639) offers the helper; see the WM-640 Handoff.
   const repo = repoOfSource(source);
   const loopType = kind === "pr" ? /^factory\.merge\.requested$/ : /^factory\.(work|dispatch)\.requested$/;
-  const nextSchedule = (source.schedules ?? [])
-    .filter((schedule) => schedule.enabled && schedule.nextDue && loopType.test(schedule.eventType) && (!repo || schedule.repo === repo))
-    .sort((a, b) => (validDate(a.nextDue) ?? 0) - (validDate(b.nextDue) ?? 0))[0];
+  const retryOriginType = [...source.events]
+    .filter((event) => loopType.test(event.type))
+    .sort((a, b) => timeOf(a.occurredAt, a.admittedAt).localeCompare(timeOf(b.occurredAt, b.admittedAt)))[0]?.type ??
+    (source.schedules ?? [])
+      .filter((schedule) => loopType.test(schedule.eventType))
+      .sort((a, b) => (validDate(a.nextDue) ?? Infinity) - (validDate(b.nextDue) ?? Infinity))[0]?.eventType ??
+    (kind === "pr" ? "factory.merge.requested" : "factory.work.requested");
+  const nextSchedule = nextScheduledRetry(
+    { type: retryOriginType, repos: repo ? [repo] : [] },
+    source.schedules ?? [],
+  );
   const nextVisit = nextSchedule?.nextDue ? { loop: nextSchedule.loop, at: nextSchedule.nextDue } : null;
   const merged = timeline.some((item) => item.kind === "merge" && /^merged/.test(item.label));
   const ticketWaiting = kind === "ticket" && (latestNoop != null || /^(todo|backlog)$/i.test(subject.state ?? ""));
@@ -966,8 +953,8 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
       id: `schedule:${nextVisit.loop}`,
       kind: "schedule",
       at: nextVisit.at,
-      label: `next: ${nextVisit.loop} at ${clock(nextVisit.at)}`,
-      detail: `${nextSchedule!.eventType} will revisit this ${kind === "pr" ? "PR" : "ticket"}`,
+      label: scheduledRetryLabel(nextSchedule!),
+      detail: `next: ${nextVisit.loop} at ${clock(nextVisit.at)} · ${nextSchedule!.eventType} will revisit this ${kind === "pr" ? "PR" : "ticket"}`,
       href: `#/schedules/${encodeURIComponent(nextVisit.loop)}`,
       durationMs: null,
     });
@@ -986,7 +973,7 @@ export function subjectJourney(kind: SubjectKind, id: string, source: SubjectJou
   const lastRun = [...source.runs].sort((a, b) => resultAt(a).localeCompare(resultAt(b))).at(-1);
   const lastRefusal = lastRun ? refusalOf(lastRun) : null;
   const blockingReason =
-    humanizeReason(latestNoop?.reason) ??
+    reasonText(latestNoop?.reason) ??
     (kind === "pr" && lastRefusal ? humanizeWithCode(lastRefusal.code) : null);
   const awaitingApproval = [...source.proposals]
     .filter((proposal) => proposal.status === "open" && proposal.decision === "run")


### PR DESCRIPTION
## Summary
- fold chain timeline and subject journey reason vocabularies into `reasons.ts`
- share scheduled-retry selection and wording across both timeline presenters
- cover fixture reason codes and retry presentation with focused tests

## Verification
- `cd event-runtime/web && bun run build && bun test` — 862 pass, 0 fail

UX critique: skipped — internal operator/admin maintenance consolidation; no new user-completable flow

Fixes WM-642