### PR TITLE
fix(worker): bound the adapter runaway backstop by policy, not 24.8 days (WM-692)

### DIFF
--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV as CLAUDE_PUSH_CREDENTIAL_ENV } from "./claude.mjs";
+import { adapterExecuteTimeoutMs, DYNAMIC_DEADLINE_ADAPTERS, LEASE_GRACE_SECONDS } from "../worker.mjs";
 import {
   buildAgyArgv,
   CliNotFoundError,
@@ -280,6 +281,25 @@ describe("buildAgyArgv", () => {
       timeoutMs: 2_000,
     });
     expect(argv[argv.indexOf("--print-timeout") + 1]).toBe("1s");
+  });
+
+  test("print-timeout under a dynamic-deadline run is bounded by policy, not ~2×10⁶ s (WM-692)", () => {
+    // agy is a dynamic-deadline adapter, so the worker's `timeoutMs` — the
+    // value that becomes `--print-timeout` out of process — must stay a real
+    // backstop for a wedged child rather than a 24.8-day sentinel.
+    expect(DYNAMIC_DEADLINE_ADAPTERS.has("agy")).toBe(true);
+    const maxRunMinutes = 90;
+    const timeoutMs = adapterExecuteTimeoutMs({
+      adapterKey: "agy",
+      spec: { timeoutSeconds: 1_800 },
+      maxRunMinutes,
+    });
+    const argv = buildAgyArgv({ prompt: "x", def: {}, model: "default", workspaceDir: "/w", timeoutMs });
+    const printSeconds = Number.parseInt(argv[argv.indexOf("--print-timeout") + 1], 10);
+    expect(Number.isFinite(printSeconds)).toBe(true);
+    expect(printSeconds).toBeGreaterThanOrEqual(1_800);
+    expect(printSeconds).toBeLessThanOrEqual(maxRunMinutes * 60 + LEASE_GRACE_SECONDS);
+    expect(printSeconds).toBeLessThan(1_000_000);
   });
 
   test("model and effort parameters", () => {

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1,6 +1,4 @@
 /** Event, proposal, run, journal, outbox, and worker-action endpoints. */
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import { artifactHead } from "./api-artifacts.mjs";
 import { FACTORY_ROOT } from "./config.mjs";
 import { runUsage } from "./db.mjs";
@@ -16,22 +14,14 @@ import {
   attemptDeadline,
   cancelRun,
   extendRunDeadline,
+  policyMaxRunMinutes,
   releaseStalledWorkerLease,
   retryRun,
 } from "./worker.mjs";
 
 export const MAX_EXTENSION_SECONDS = 3600;
 
-export function policyMaxRunMinutes(root = FACTORY_ROOT) {
-  try {
-    const value = Bun.YAML.parse(
-      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
-    )?.limits?.max_run_minutes;
-    return Number.isFinite(value) && value > 0 ? Number(value) : null;
-  } catch {
-    return null;
-  }
-}
+export { policyMaxRunMinutes };
 
 function extensionRefusal(send, status, code, detail = {}) {
   return send(status, {
@@ -335,6 +325,9 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
   };
 }
 
+/** States whose attempt deadline is live and render-relevant on the run list. */
+const IN_FLIGHT_STATES = new Set(["LEASED", "RUNNING", "VERIFYING"]);
+
 function runsView(db, state) {
   const where = state ? `WHERE r.state = ?` : ``;
   const rows = db
@@ -366,7 +359,9 @@ function runsView(db, state) {
       model: spec.model ?? null,
       startedAt: row.started_at ?? null,
       leaseExpiresAt: row.lease_expires_at ?? null,
-      deadlineAt: row.attempts > 0
+      // Two extra queries per row: only worth it while the deadline can
+      // still move (WM-692). Terminal rows on this 2s-polled list get null.
+      deadlineAt: row.attempts > 0 && IN_FLIGHT_STATES.has(row.state)
         ? (() => {
             const deadline = attemptDeadline(db, row.run_id, row.attempts, spec);
             return Number.isFinite(deadline) ? new Date(deadline).toISOString() : null;
@@ -513,6 +508,7 @@ export async function handleRunApiRoute({
   policyVersion,
   artifactsDir,
   onEvent,
+  policyRoot = FACTORY_ROOT,
 }) {
   if (route === "GET /events") {
     return send(200, {
@@ -669,7 +665,7 @@ export async function handleRunApiRoute({
     if (!row) return extensionRefusal(send, 404, "unknown_run", { runId });
 
     const override = body.override === true;
-    const maxMinutes = policyMaxRunMinutes();
+    const maxMinutes = policyMaxRunMinutes(policyRoot);
     if (!override && !Number.isFinite(maxMinutes)) {
       return extensionRefusal(send, 409, "run_limit_policy_unavailable");
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -37,6 +37,21 @@ import {
 
 describe("run deadline extension (WM-566)", () => {
   const start = Date.parse("2026-08-12T10:00:00Z");
+  // The policy cap the extend endpoint enforces, owned by this suite rather
+  // than by the live config/policy.yaml (WM-692).
+  const MAX_RUN_MINUTES = 60;
+  function policyRootWith(maxRunMinutes) {
+    const root = mkdtempSync(path.join(os.tmpdir(), "evrt-policy-"));
+    mkdirSync(path.join(root, "config"));
+    if (maxRunMinutes !== null) {
+      writeFileSync(
+        path.join(root, "config", "policy.yaml"),
+        `limits:\n  max_run_minutes: ${maxRunMinutes}\n`,
+      );
+    }
+    return root;
+  }
+  const policyRoot = policyRootWith(MAX_RUN_MINUTES);
 
   function insertAttempt(db, runId, { state = "RUNNING", timeoutSeconds = 60, adapter = "fake" } = {}) {
     const spec = {
@@ -66,7 +81,7 @@ describe("run deadline extension (WM-566)", () => {
   }
 
   test("extends a running deadline, lease, and audited lifecycle", async () => {
-    const s = await makeServer({ now: () => start + 10_000 });
+    const s = await makeServer({ now: () => start + 10_000, policyRoot });
     try {
       insertAttempt(s.db, "run-extend-happy");
       const outcome = await s.client.extend("run-extend-happy", 900);
@@ -97,17 +112,22 @@ describe("run deadline extension (WM-566)", () => {
   });
 
   test("returns typed terminal refusals for state, policy cap, and per-call bound", async () => {
-    const s = await makeServer({ now: () => start });
+    const s = await makeServer({ now: () => start, policyRoot });
     try {
       insertAttempt(s.db, "run-extend-queued", { state: "QUEUED" });
       const wrongState = await rejection(s.client.extend("run-extend-queued", 60));
       expect(wrongState.status).toBe(409);
       expect(wrongState.body.refusal).toMatchObject({ code: "run_not_extendable", retryable: false });
 
-      insertAttempt(s.db, "run-extend-cap", { timeoutSeconds: 5_390 });
+      // Ten seconds short of the cap: a 20s extension crosses started_at + max_run_minutes.
+      insertAttempt(s.db, "run-extend-cap", { timeoutSeconds: MAX_RUN_MINUTES * 60 - 10 });
       const capped = await rejection(s.client.extend("run-extend-cap", 20));
       expect(capped.status).toBe(409);
-      expect(capped.body.refusal).toMatchObject({ code: "policy_run_limit", retryable: false });
+      expect(capped.body.refusal).toMatchObject({
+        code: "policy_run_limit",
+        retryable: false,
+        maxDeadlineAt: new Date(start + MAX_RUN_MINUTES * 60_000).toISOString(),
+      });
       expect((await s.client.extend("run-extend-cap", 20, { override: true })).override).toBe(true);
 
       insertAttempt(s.db, "run-extend-actions", { adapter: "actions" });
@@ -126,6 +146,67 @@ describe("run deadline extension (WM-566)", () => {
         retryable: false,
         maxSeconds: 3_600,
       }));
+    } finally {
+      s.close();
+    }
+  });
+
+  test("without a readable max_run_minutes only override may extend", async () => {
+    const s = await makeServer({ now: () => start, policyRoot: policyRootWith(null) });
+    try {
+      insertAttempt(s.db, "run-extend-nopolicy");
+      const refused = await rejection(s.client.extend("run-extend-nopolicy", 60));
+      expect(refused.status).toBe(409);
+      expect(refused.body.refusal).toMatchObject({ code: "run_limit_policy_unavailable", retryable: false });
+      expect((await s.client.extend("run-extend-nopolicy", 60, { override: true })).extended).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("run list deadlines (WM-692)", () => {
+  const start = Date.parse("2026-08-12T10:00:00Z");
+  function insertRun(db, runId, state) {
+    const spec = {
+      schemaVersion: "factory.run-spec/v1",
+      runId,
+      agent: "factory-status-report@1",
+      input: { repos: ["ok"] },
+      workspace: { type: "ephemeral" },
+      adapter: "fake",
+      outputContract: "factory.status-report/v1",
+      timeoutSeconds: 60,
+      maxAttempts: 1,
+      idempotencyKey: `idem-${runId}`,
+    };
+    const at = new Date(start).toISOString();
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'sha256:test', ?, 1, ?, ?)`,
+    ).run(runId, spec.idempotencyKey, JSON.stringify(spec), state, at, at);
+    db.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, started_at, lease_expires_at)
+       VALUES (?, 1, 1, 'worker-test', ?, ?)`,
+    ).run(runId, at, new Date(start + 180_000).toISOString());
+  }
+
+  test("GET /runs computes deadlineAt only for in-flight rows", async () => {
+    const s = await makeServer({ now: () => start });
+    try {
+      for (const state of ["LEASED", "RUNNING", "VERIFYING", "COMPLETED", "FAILED", "TIMED_OUT", "CANCELLED"]) {
+        insertRun(s.db, `run-list-${state}`, state);
+      }
+      const { runs } = await s.client.runs();
+      const byState = Object.fromEntries(runs.map((r) => [r.state, r]));
+      const deadline = new Date(start + 60_000).toISOString();
+      for (const state of ["LEASED", "RUNNING", "VERIFYING"]) {
+        expect(byState[state].deadlineAt).toBe(deadline);
+      }
+      for (const state of ["COMPLETED", "FAILED", "TIMED_OUT", "CANCELLED"]) {
+        expect(byState[state].deadlineAt).toBeNull();
+        expect(byState[state].startedAt).toBe(new Date(start).toISOString());
+      }
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -34,6 +34,7 @@ import { storeStats } from "./artifacts.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
+  FACTORY_ROOT,
   artifactsRoot,
   environmentName,
   runtimeHome,
@@ -84,6 +85,8 @@ export function createApi({
   inboxCommand = notifyCommand(),
   inboxWebUrl = process.env.FACTORY_WEB_URL,
   inboxApplyEffect = applyDecisionEffect,
+  // Root of the config/policy.yaml the run endpoints consult (tests point it elsewhere).
+  policyRoot = FACTORY_ROOT,
 } = {}) {
   const actor = "operator";
   const storeStatsTtlMs = 10_000;
@@ -231,6 +234,7 @@ export function createApi({
         const result = await handleRunApiRoute({
           ...common,
           artifactsDir: artifactsRoot(env?.home),
+          policyRoot,
         });
         if (result !== false) return result;
       }

--- a/event-runtime/lib/sandbox/gondolin.test.mjs
+++ b/event-runtime/lib/sandbox/gondolin.test.mjs
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { adapterExecuteTimeoutMs, DYNAMIC_DEADLINE_ADAPTERS, LEASE_GRACE_SECONDS } from "../worker.mjs";
 import {
+  KILL_GRACE_MS,
   MIN_NODE_MAJOR,
   nodeVersionSatisfies,
   parseEvents,
@@ -107,6 +109,25 @@ describe("NDJSON protocol", () => {
   test("a malformed line is skipped rather than killing the run", () => {
     const { events } = parseEvents('not json\n{"type":"exit","exitCode":3}\n');
     expect(events).toEqual([{ type: "exit", exitCode: 3 }]);
+  });
+});
+
+describe("guest timeout under a dynamic-deadline run (WM-692)", () => {
+  test("the guest request timeout and the runner kill timer are bounded by policy", () => {
+    // `pi` and sandboxed `command` forward the worker's `timeoutMs` into the
+    // guest request and arm `setTimeout(kill, timeoutMs + KILL_GRACE_MS)`;
+    // that timer is what stops a wedged runner from pinning the run slot.
+    for (const adapterKey of ["pi", "command"]) {
+      expect(DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)).toBe(true);
+      const maxRunMinutes = 90;
+      const timeoutMs = adapterExecuteTimeoutMs({ adapterKey, spec: { timeoutSeconds: 1_800 }, maxRunMinutes });
+      const ceilingMs = maxRunMinutes * 60_000 + LEASE_GRACE_SECONDS * 1000;
+      expect(timeoutMs).toBeGreaterThanOrEqual(1_800_000);
+      expect(timeoutMs).toBeLessThanOrEqual(ceilingMs);
+      expect(timeoutMs + KILL_GRACE_MS).toBeLessThanOrEqual(ceilingMs + KILL_GRACE_MS);
+      expect(timeoutMs + KILL_GRACE_MS).toBeLessThan(2 ** 31 - 1);
+      expect(timeoutMs).toBeLessThan(24 * 60 * 60_000);
+    }
   });
 });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -43,15 +43,42 @@ const RUNTIME_ARTIFACTS = [{ kind: "transcript", path: ".transcript.json" }];
 export const LEASE_GRACE_SECONDS = 120;
 
 /**
- * Process adapters keep their own TERM/KILL timer. Give adapters that honor
- * AbortSignal a ceiling above any normal policy window; the worker's durable
- * DB-backed deadline monitor is the authoritative timer and can move while an
- * attempt is running.
+ * Adapters that honor AbortSignal, so the worker's durable DB-backed deadline
+ * monitor — not the adapter's own TERM/KILL timer — is the authoritative
+ * timer and can move while an attempt is running (WM-566). Their `timeoutMs`
+ * is only a runaway backstop, but it must be a real one: agy forwards it out
+ * of process as `--print-timeout` and the gondolin guest timer uses it to
+ * stop a wedged runner from pinning the run slot open (WM-692).
  */
-const DYNAMIC_ADAPTER_TIMEOUT_MS = 2_147_000_000;
-const DYNAMIC_DEADLINE_ADAPTERS = new Set([
+export const DYNAMIC_DEADLINE_ADAPTERS = new Set([
   "agy", "claude", "command", "cursor", "fake", "pi",
 ]);
+
+/** `limits.max_run_minutes` from config/policy.yaml, or null when unavailable. */
+export function policyMaxRunMinutes(root = FACTORY_ROOT) {
+  try {
+    const value = Bun.YAML.parse(
+      readFileSync(path.join(root, "config", "policy.yaml"), "utf8"),
+    )?.limits?.max_run_minutes;
+    return Number.isFinite(value) && value > 0 ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The `timeoutMs` handed to `adapter.execute`. Dynamic-deadline adapters get
+ * the policy ceiling: no non-override extension can move a deadline past
+ * `started_at + max_run_minutes`, so `max(budget, max_run_minutes) + lease
+ * grace` keeps every policy-bounded extension alive while still bounding a
+ * wedged child. Every other adapter keeps its exact run budget.
+ */
+export function adapterExecuteTimeoutMs({ adapterKey, spec, maxRunMinutes = policyMaxRunMinutes() }) {
+  const budgetMs = spec.timeoutSeconds * 1000;
+  if (!DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)) return budgetMs;
+  const policyMs = Number.isFinite(maxRunMinutes) && maxRunMinutes > 0 ? maxRunMinutes * 60_000 : 0;
+  return Math.max(budgetMs, policyMs) + LEASE_GRACE_SECONDS * 1000;
+}
 const DEADLINE_POLL_MS = 100;
 
 function deadlineEventFromReason(reason, type) {
@@ -1003,7 +1030,7 @@ const ACTIVE_EXECUTIONS = new Map();
  */
 export async function executeClaimed(db, registry, adapters, claim, {
   workspacesRoot, artifactStore = artifactsRoot(), now = () => Date.now(), policyVersion = "unknown", adapterOverride, env = {},
-  dispatch, resolveLinearKey = resolveLinearApiKey,
+  dispatch, resolveLinearKey = resolveLinearApiKey, policyRoot = FACTORY_ROOT,
 } = {}) {
   const { runId, attempt, fencingToken, spec } = claim;
   const owner = db
@@ -1473,9 +1500,7 @@ export async function executeClaimed(db, registry, adapters, claim, {
         spec,
         def,
         workspaceDir,
-        timeoutMs: DYNAMIC_DEADLINE_ADAPTERS.has(adapterKey)
-          ? DYNAMIC_ADAPTER_TIMEOUT_MS
-          : spec.timeoutSeconds * 1000,
+        timeoutMs: adapterExecuteTimeoutMs({ adapterKey, spec, maxRunMinutes: policyMaxRunMinutes(policyRoot) }),
         env,
         onTrace,
         onUsage,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -18,9 +18,10 @@ import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import { transcriptSessionId } from "./transcripts.mjs";
 import {
-  acquireClaimLock, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
-  createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath,
-  executeClaimed, classifyFailureCause, expireRunDeadline, extendRunDeadline, reapExpiredLeases, releaseClaimLock, repositoryIsClean,
+  acquireClaimLock, adapterExecuteTimeoutMs, cancelRun, claimNext, CODE_RELOAD_EXIT, codeStamp, codeStampFiles, codeStampRoot,
+  createReloadWatcher, DEFAULT_MAX_ENVIRONMENT_RETRIES, defaultLocksDir, dispatchLockPath, DYNAMIC_DEADLINE_ADAPTERS,
+  executeClaimed, classifyFailureCause, expireRunDeadline, extendRunDeadline, LEASE_GRACE_SECONDS, policyMaxRunMinutes,
+  reapExpiredLeases, releaseClaimLock, repositoryIsClean,
   repositoryStatus, resolveLinearApiKey, retryRun, runLinearCli, runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases, writeWorkerLease } from "../../lib/worker-leases.mjs";
@@ -585,6 +586,57 @@ describe("worker", () => {
     ]);
     expect(db.query(`SELECT lease_expires_at FROM attempts WHERE run_id = ?`).get(spec.runId).lease_expires_at)
       .toBe(new Date(T0 + 121_050).toISOString());
+  });
+
+  test("a dynamic-deadline adapter's timeoutMs is bounded by policy, not 24.8 days (WM-692)", async () => {
+    const db = openDb(":memory:");
+    const seen = [];
+    const recording = {
+      async execute(options) {
+        seen.push(options);
+        return fake.execute(options);
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 5 }));
+    expect(DYNAMIC_DEADLINE_ADAPTERS.has(spec.adapter)).toBe(true);
+    const liveMaxMinutes = policyMaxRunMinutes();
+    expect(liveMaxMinutes).toBeGreaterThan(0);
+
+    const summary = await runOnce(db, registry, { fake: recording }, opts());
+    expect(summary.terminalState).toBe("COMPLETED");
+    expect(seen).toHaveLength(1);
+    // The ceiling every policy-bounded extension can reach, and nothing beyond it.
+    const ceilingMs = liveMaxMinutes * 60_000 + LEASE_GRACE_SECONDS * 1000;
+    expect(seen[0].timeoutMs).toBeGreaterThanOrEqual(spec.timeoutSeconds * 1000);
+    expect(seen[0].timeoutMs).toBeLessThanOrEqual(ceilingMs);
+    expect(seen[0].timeoutMs).toBe(ceilingMs);
+  });
+
+  test("the adapter backstop follows the policy root it is given (WM-692)", async () => {
+    const db = openDb(":memory:");
+    const policyRoot = freshRoot();
+    mkdirSync(path.join(policyRoot, "config"));
+    writeFileSync(path.join(policyRoot, "config", "policy.yaml"), "limits:\n  max_run_minutes: 3\n");
+    const seen = [];
+    const recording = {
+      async execute(options) {
+        seen.push(options.timeoutMs);
+        return fake.execute(options);
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "fake", timeoutSeconds: 5 }));
+    await runOnce(db, registry, { fake: recording }, opts({ policyRoot }));
+    expect(seen).toEqual([3 * 60_000 + LEASE_GRACE_SECONDS * 1000]);
+
+    // A budget above the policy ceiling still gets its whole budget plus grace,
+    // and an adapter outside the dynamic set keeps its exact budget.
+    expect(adapterExecuteTimeoutMs({ adapterKey: "fake", spec: { ...spec, timeoutSeconds: 600 }, maxRunMinutes: 3 }))
+      .toBe(600_000 + LEASE_GRACE_SECONDS * 1000);
+    expect(adapterExecuteTimeoutMs({ adapterKey: "actions", spec: { ...spec, timeoutSeconds: 600 }, maxRunMinutes: 3 }))
+      .toBe(600_000);
+    // No policy at all: fall back to the run budget plus grace, never to a sentinel.
+    expect(adapterExecuteTimeoutMs({ adapterKey: "fake", spec, maxRunMinutes: null }))
+      .toBe(spec.timeoutSeconds * 1000 + LEASE_GRACE_SECONDS * 1000);
   });
 
   test("expiry wins atomically and refuses extension throughout adapter kill grace (WM-566)", async () => {


### PR DESCRIPTION
Fixes WM-692

## What

#552 (WM-566) set `timeoutMs` for every dynamic-deadline adapter (`agy`, `claude`, `command`, `cursor`, `fake`, `pi`) to `2_147_000_000` ms (~24.8 days). agy forwards that out of process as `--print-timeout`, and gondolin's guest request + `setTimeout(kill, timeoutMs + KILL_GRACE_MS)` timer (which is what stops a wedged runner from pinning a run slot) both lost their backstop for every run.

The bound is now derived from policy, for dynamic-deadline adapters only:

```
timeoutMs = max(spec.timeoutSeconds * 1000, max_run_minutes * 60_000) + LEASE_GRACE_SECONDS * 1000
```

(= 90 min + 120 s = 5_520_000 ms under the live policy). No non-`override` extension can move a deadline past `started_at + max_run_minutes`, so every policy-bounded extension still completes; the in-process deadline monitor is untouched. Non-dynamic adapters keep their exact budget. If `max_run_minutes` is unreadable, the fallback is `budget + grace`, never a sentinel.

- `worker.mjs`: `adapterExecuteTimeoutMs()` + `policyMaxRunMinutes(root)` now live here (api-runs re-exports the latter); `executeClaimed` takes `policyRoot`; `DYNAMIC_ADAPTER_TIMEOUT_MS` deleted.
- `api-runs.mjs`: `runsView` computes `deadlineAt` only for LEASED/RUNNING/VERIFYING rows; extend handler calls `policyMaxRunMinutes(policyRoot)`.
- `api.mjs`: `createApi({ policyRoot })` threaded into `handleRunApiRoute`.
- Tests: worker (bound ≤ `max_run_minutes*60_000 + LEASE_GRACE_SECONDS*1000`, and follows a supplied `policyRoot`), agy (`--print-timeout` bounded, ≥ budget, < 10⁶ s), gondolin (guest timeout / kill timer bounded), api-runs (own policy fixture with `max_run_minutes: 60` replacing the `5_390` coupling; `run_limit_policy_unavailable` when unreadable; `deadlineAt` null on terminal rows).

## Handoff

Verification:
```
bun test event-runtime/lib/worker.test.mjs event-runtime/lib/adapters/agy.test.mjs event-runtime/lib/sandbox/gondolin.test.mjs event-runtime/lib/api-runs.test.mjs
 159 pass / 0 fail
bun build/emit.mjs --check
 ok — 90 generated files match shared/
bun test event-runtime/lib/api*.test.mjs
 100 pass / 0 fail
```
Fail-before confirmed: with `origin/develop` sources under the new tests, 6 fail (worker/agy/gondolin on the new exports; api-runs `policy_run_limit` fixture, `run_limit_policy_unavailable`, and `deadlineAt` on terminal rows). A probe of the worker assertion alone against old code saw `timeoutMs = 2147000000` vs expected `<= 5520000`.

Files: `event-runtime/lib/worker.mjs`, `event-runtime/lib/worker.test.mjs`, `event-runtime/lib/api-runs.mjs`, `event-runtime/lib/api-runs.test.mjs`, `event-runtime/lib/api.mjs`, `event-runtime/lib/adapters/agy.test.mjs`, `event-runtime/lib/sandbox/gondolin.test.mjs`.

Risks: an `override: true` extension past `max_run_minutes + 120 s` will now be cut short by the adapter backstop (agy quits itself; others are TERM/KILLed) — that is the intended trade for restoring a real backstop. `api.mjs` is touched (one option threaded) beyond the ticket's owned paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbwfbMXmBnJy2gKsLtzDCz
